### PR TITLE
Operationalize Chrysalis-Ω as a deterministic 3D byte-ROM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,58 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer, policy gate, and a lossless 3D byte-ROM runtime for its native 64-bit instruction set.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## Run assembly source
+
+```bash
+jarvisx run program.jx
+```
+
+Example program:
+
+```text
+SET A 7
+SET B 5
+ADD C A B
+HALT
+```
+
+## Chrysalis-Ω 3D byte-ROM
+
+Encode Jarvis-X source into a checksum-protected, fixed-address ROM image:
+
+```bash
+jarvisx rom encode program.jx program.jrom --engines 1 --grid 4x4x4
+```
+
+Inspect and verify the image:
+
+```bash
+jarvisx rom inspect program.jrom
+jarvisx rom verify program.jrom
+```
+
+Execute the verified bytecode directly from the ROM image:
+
+```bash
+jarvisx rom run program.jrom
+```
+
+Create a bounded mutation candidate by changing only one `SET` immediate:
+
+```bash
+jarvisx rom mutate program.jrom candidate.jrom --word-index 0 --delta 5
+```
+
+The ROM runtime provides exact big-endian 64-bit bytecode round trips, engine-by-3D-cell addressing, SHA-256 integrity verification, capacity enforcement, atomic persistence, and bounded field-level mutation. It does not depend on a neural model or claim lossless reconstruction from an untrained latent vector.
+
+See [the Chrysalis-Ω byte-ROM specification](docs/CHRYSALIS_OMEGA_BYTE_ROM.md) for the binary layout, equations, integrity rules, and operational guarantees.

--- a/docs/CHRYSALIS_OMEGA_BYTE_ROM.md
+++ b/docs/CHRYSALIS_OMEGA_BYTE_ROM.md
@@ -1,0 +1,227 @@
+# Chrysalis-Ω Deterministic 3D Byte-ROM
+
+## Status
+
+Operational Jarvis-X bytecode storage and execution subsystem.
+
+This implementation replaces the earlier untrained latent reconstruction concept with a deterministic, lossless byte pipeline built around the repository's real 64-bit Jarvis-X instruction set. It does not claim neural compression or unrestricted self-rewriting.
+
+## Runtime pipeline
+
+```text
+Jarvis-X source
+    -> Parser
+    -> Assembler
+    -> unsigned 64-bit instruction words
+    -> JXBC bytecode image
+    -> optional zlib compression
+    -> fixed-capacity engine × X × Y × Z ROM cells
+    -> JXROM3D file
+```
+
+The inverse path verifies the ROM, reconstructs the exact bytecode image, unpacks the instruction words, and only then loads the VM.
+
+## Mathematical model
+
+Let the assembled program be
+
+\[
+W=(w_0,w_1,\ldots,w_{n-1}),\qquad 0\le w_i<2^{64}.
+\]
+
+Each instruction is serialized in network byte order:
+
+\[
+B_i=\operatorname{BE64}(w_i).
+\]
+
+The bytecode image is
+
+\[
+P=\texttt{JXBC}\;\Vert\;v\;\Vert\;n\;\Vert\;B_0\Vert\cdots\Vert B_{n-1}.
+\]
+
+For a ROM geometry with \(G\) engines, dimensions \((X,Y,Z)\), and \(C\) bytes per cell, total capacity is
+
+\[
+K=GXYZC.
+\]
+
+The payload must satisfy
+
+\[
+|P_s|\le K,
+\]
+
+where \(P_s\) is either the raw bytecode image or its compressed representation.
+
+The linear cell index is
+
+\[
+q=(((gX+x)Y+y)Z+z).
+\]
+
+The first byte of that cell is stored at body offset
+
+\[
+o=qC.
+\]
+
+A stored byte offset \(r\) maps back to its cell by
+
+\[
+q=\left\lfloor\frac{r}{C}\right\rfloor,
+\qquad
+u=r\bmod C,
+\]
+
+where \(u\) is the byte position inside the cell.
+
+## Integrity contract
+
+The ROM header stores:
+
+- format magic and version;
+- compression flags;
+- engine and grid dimensions;
+- bytes per cell;
+- stored payload length;
+- uncompressed payload length;
+- SHA-256 of the uncompressed payload.
+
+A ROM is accepted only when:
+
+\[
+V=V_{format}\land V_{capacity}\land V_{padding}\land V_{length}\land V_{sha256}.
+\]
+
+Non-zero padding, malformed sizes, unknown feature flags, decompression failure, and digest mismatch are rejected before execution.
+
+## Binary formats
+
+### JXBC bytecode envelope
+
+All integers are big-endian.
+
+| Field | Size |
+|---|---:|
+| Magic `JXBC` | 4 bytes |
+| Version | 1 byte |
+| Reserved | 3 bytes |
+| Word count | 4 bytes |
+| Instruction words | `count × 8` bytes |
+
+### JXROM3D envelope
+
+| Field | Size |
+|---|---:|
+| Magic `JXROM3D\0` | 8 bytes |
+| Version | 1 byte |
+| Flags | 1 byte |
+| Reserved | 2 bytes |
+| Engines, X, Y, Z | 8 bytes |
+| Cell size | 4 bytes |
+| Stored size | 8 bytes |
+| Raw size | 8 bytes |
+| SHA-256 | 32 bytes |
+| Fixed-capacity ROM body | `G × X × Y × Z × C` bytes |
+
+## CLI
+
+Encode assembly source into a ROM:
+
+```bash
+jarvisx rom encode program.jx program.jrom \
+  --engines 2 \
+  --grid 4x4x4 \
+  --cell-bytes 32
+```
+
+Let the runtime choose the minimum cell size:
+
+```bash
+jarvisx rom encode program.jx program.jrom --grid 4x4x4
+```
+
+Enable compression when it reduces the payload:
+
+```bash
+jarvisx rom encode program.jx program.jrom --compress
+```
+
+Inspect and verify:
+
+```bash
+jarvisx rom inspect program.jrom
+jarvisx rom verify program.jrom
+```
+
+Execute only after verification:
+
+```bash
+jarvisx rom run program.jrom
+```
+
+Extract the exact JXBC bytecode envelope:
+
+```bash
+jarvisx rom extract program.jrom program.jxbc
+```
+
+## Bounded mutation
+
+The mutation command changes only the 16-bit immediate field of one `SET` instruction:
+
+```bash
+jarvisx rom mutate program.jrom candidate.jrom \
+  --word-index 0 \
+  --delta 5
+```
+
+For an instruction word \(w\), the immediate is
+
+\[
+i=(w\gg8)\land 0xffff.
+\]
+
+The candidate is formed as
+
+\[
+w'=\left(w\land\neg(0xffff\ll8)\right)\lor((i+\Delta)\ll8).
+\]
+
+The operation is rejected unless:
+
+- the selected word exists;
+- its opcode is `SET`;
+- the delta is an integer;
+- the resulting immediate remains in `0..65535`;
+- the candidate still fits the declared ROM capacity.
+
+The output candidate receives a new SHA-256 and is independently verifiable. The command does not execute or promote the candidate automatically.
+
+## Operational guarantees
+
+The subsystem provides:
+
+- exact 64-bit instruction round trips;
+- deterministic big-endian serialization;
+- fixed-address 3D cell layout;
+- atomic file replacement on writes;
+- checksum verification before VM execution;
+- capacity enforcement;
+- bounded field-level mutation;
+- no PyTorch or external runtime dependency.
+
+## Non-goals
+
+This implementation does not provide:
+
+- learned latent compression;
+- arbitrary source regeneration;
+- CPython bytecode storage;
+- semantic equivalence proofs for mutated programs;
+- automatic deployment of mutations;
+- physical read-only hardware.
+
+`ROM` denotes the persisted, fixed-layout runtime image. Immutability is enforced at the object and verification layers; the file can still be replaced by an authorized process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/src/jarvisx/chrysalis_rom.py
+++ b/src/jarvisx/chrysalis_rom.py
@@ -1,0 +1,455 @@
+"""Deterministic 3D byte-ROM storage for Jarvis-X bytecode.
+
+The module deliberately uses a lossless byte representation rather than an
+untrained latent model. Jarvis-X instructions are packed as unsigned 64-bit
+words, wrapped in a versioned bytecode image, distributed across a fixed 3D
+ROM geometry, and protected by SHA-256.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+import tempfile
+import zlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+from .assembler import Assembler, OPCODES
+from .core import CodexVM
+from .parser import Parser
+
+PathLike = Union[str, os.PathLike]
+
+_ROM_MAGIC = b"JXROM3D\0"
+_ROM_VERSION = 1
+_ROM_FLAG_COMPRESSED = 0x01
+_ROM_KNOWN_FLAGS = _ROM_FLAG_COMPRESSED
+_ROM_HEADER = struct.Struct(">8sBBH4HIQQ32s")
+
+_BYTECODE_MAGIC = b"JXBC"
+_BYTECODE_VERSION = 1
+_BYTECODE_HEADER = struct.Struct(">4sB3xI")
+_WORD = struct.Struct(">Q")
+_MAX_WORD = (1 << 64) - 1
+_IMMEDIATE_MASK = 0xFFFF << 8
+
+
+class ROMError(Exception):
+    """Base exception for the Chrysalis ROM subsystem."""
+
+
+class ROMFormatError(ROMError):
+    """Raised when a serialized ROM or bytecode image is malformed."""
+
+
+class ROMCapacityError(ROMError):
+    """Raised when a payload does not fit the requested geometry."""
+
+
+class ROMIntegrityError(ROMError):
+    """Raised when payload length or SHA-256 verification fails."""
+
+
+@dataclass(frozen=True)
+class ROMGeometry:
+    """Physical layout of the engine-by-3D-cell ROM array."""
+
+    engines: int
+    x: int
+    y: int
+    z: int
+    cell_bytes: int
+
+    def __post_init__(self) -> None:
+        for name, value, maximum in (
+            ("engines", self.engines, 0xFFFF),
+            ("x", self.x, 0xFFFF),
+            ("y", self.y, 0xFFFF),
+            ("z", self.z, 0xFFFF),
+            ("cell_bytes", self.cell_bytes, 0xFFFFFFFF),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise ValueError("{} must be an integer".format(name))
+            if value < 1 or value > maximum:
+                raise ValueError("{} must be in the range 1..{}".format(name, maximum))
+
+    @property
+    def cells_per_engine(self) -> int:
+        return self.x * self.y * self.z
+
+    @property
+    def cell_count(self) -> int:
+        return self.engines * self.cells_per_engine
+
+    @property
+    def capacity_bytes(self) -> int:
+        return self.cell_count * self.cell_bytes
+
+    def cell_index(self, engine: int, x: int, y: int, z: int) -> int:
+        bounds = (
+            ("engine", engine, self.engines),
+            ("x", x, self.x),
+            ("y", y, self.y),
+            ("z", z, self.z),
+        )
+        for name, value, upper in bounds:
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError("{} coordinate must be an integer".format(name))
+            if value < 0 or value >= upper:
+                raise IndexError("{} coordinate {} outside 0..{}".format(name, value, upper - 1))
+        return (((engine * self.x) + x) * self.y + y) * self.z + z
+
+
+class ChrysalisROM:
+    """Immutable, checksum-protected byte payload distributed over a 3D grid."""
+
+    def __init__(
+        self,
+        geometry: ROMGeometry,
+        body: bytes,
+        stored_size: int,
+        raw_size: int,
+        digest: bytes,
+        compressed: bool = False,
+    ) -> None:
+        if len(body) != geometry.capacity_bytes:
+            raise ROMFormatError(
+                "ROM body is {} bytes; geometry requires {}".format(
+                    len(body), geometry.capacity_bytes
+                )
+            )
+        if stored_size < 0 or stored_size > len(body):
+            raise ROMFormatError("stored payload size exceeds ROM capacity")
+        if raw_size < 0:
+            raise ROMFormatError("raw payload size cannot be negative")
+        if len(digest) != hashlib.sha256().digest_size:
+            raise ROMFormatError("SHA-256 digest must be 32 bytes")
+
+        self.geometry = geometry
+        self._body = bytes(body)
+        self.stored_size = stored_size
+        self.raw_size = raw_size
+        self.digest = bytes(digest)
+        self.compressed = bool(compressed)
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: bytes,
+        engines: int = 1,
+        grid_shape: Tuple[int, int, int] = (4, 4, 4),
+        cell_bytes: Optional[int] = None,
+        compress: bool = False,
+    ) -> "ChrysalisROM":
+        raw = bytes(payload)
+        x, y, z = _validate_grid_shape(grid_shape)
+        cell_count = engines * x * y * z
+        if cell_count < 1:
+            raise ValueError("ROM must contain at least one cell")
+
+        stored = raw
+        compressed = False
+        if compress and raw:
+            candidate = zlib.compress(raw, level=9)
+            if len(candidate) < len(raw):
+                stored = candidate
+                compressed = True
+
+        if cell_bytes is None:
+            cell_bytes = max(1, (len(stored) + cell_count - 1) // cell_count)
+
+        geometry = ROMGeometry(engines, x, y, z, cell_bytes)
+        if len(stored) > geometry.capacity_bytes:
+            raise ROMCapacityError(
+                "payload requires {} bytes but geometry provides {}".format(
+                    len(stored), geometry.capacity_bytes
+                )
+            )
+
+        body = stored + (b"\x00" * (geometry.capacity_bytes - len(stored)))
+        return cls(
+            geometry=geometry,
+            body=body,
+            stored_size=len(stored),
+            raw_size=len(raw),
+            digest=hashlib.sha256(raw).digest(),
+            compressed=compressed,
+        )
+
+    @classmethod
+    def deserialize(cls, data: bytes) -> "ChrysalisROM":
+        serialized = bytes(data)
+        if len(serialized) < _ROM_HEADER.size:
+            raise ROMFormatError("serialized ROM is shorter than its header")
+
+        (
+            magic,
+            version,
+            flags,
+            reserved,
+            engines,
+            x,
+            y,
+            z,
+            cell_bytes,
+            stored_size,
+            raw_size,
+            digest,
+        ) = _ROM_HEADER.unpack_from(serialized)
+
+        if magic != _ROM_MAGIC:
+            raise ROMFormatError("invalid ROM magic")
+        if version != _ROM_VERSION:
+            raise ROMFormatError("unsupported ROM version {}".format(version))
+        if reserved != 0:
+            raise ROMFormatError("reserved ROM header bits must be zero")
+        if flags & ~_ROM_KNOWN_FLAGS:
+            raise ROMFormatError("ROM uses unknown feature flags")
+
+        geometry = ROMGeometry(engines, x, y, z, cell_bytes)
+        expected_size = _ROM_HEADER.size + geometry.capacity_bytes
+        if len(serialized) != expected_size:
+            raise ROMFormatError(
+                "serialized ROM is {} bytes; expected {}".format(len(serialized), expected_size)
+            )
+
+        return cls(
+            geometry=geometry,
+            body=serialized[_ROM_HEADER.size :],
+            stored_size=stored_size,
+            raw_size=raw_size,
+            digest=digest,
+            compressed=bool(flags & _ROM_FLAG_COMPRESSED),
+        )
+
+    @classmethod
+    def read(cls, path: PathLike) -> "ChrysalisROM":
+        return cls.deserialize(Path(path).read_bytes())
+
+    def serialize(self) -> bytes:
+        flags = _ROM_FLAG_COMPRESSED if self.compressed else 0
+        header = _ROM_HEADER.pack(
+            _ROM_MAGIC,
+            _ROM_VERSION,
+            flags,
+            0,
+            self.geometry.engines,
+            self.geometry.x,
+            self.geometry.y,
+            self.geometry.z,
+            self.geometry.cell_bytes,
+            self.stored_size,
+            self.raw_size,
+            self.digest,
+        )
+        return header + self._body
+
+    def write(self, path: PathLike) -> None:
+        """Atomically persist the complete fixed-capacity ROM image."""
+
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        handle = tempfile.NamedTemporaryFile(
+            mode="wb",
+            prefix=destination.name + ".",
+            suffix=".tmp",
+            dir=str(destination.parent),
+            delete=False,
+        )
+        temporary_name = handle.name
+        try:
+            with handle:
+                handle.write(self.serialize())
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_name, str(destination))
+        except Exception:
+            try:
+                os.unlink(temporary_name)
+            except OSError:
+                pass
+            raise
+
+    def payload(self, verify: bool = True) -> bytes:
+        stored = self._body[: self.stored_size]
+        if self.compressed:
+            try:
+                raw = zlib.decompress(stored)
+            except zlib.error as exc:
+                raise ROMIntegrityError("compressed payload is corrupt") from exc
+        else:
+            raw = stored
+
+        if verify:
+            if any(self._body[self.stored_size :]):
+                raise ROMIntegrityError("ROM padding is non-zero")
+            if len(raw) != self.raw_size:
+                raise ROMIntegrityError(
+                    "decoded payload is {} bytes; expected {}".format(len(raw), self.raw_size)
+                )
+            actual = hashlib.sha256(raw).digest()
+            if actual != self.digest:
+                raise ROMIntegrityError("payload SHA-256 mismatch")
+        return raw
+
+    def verify(self) -> bool:
+        self.payload(verify=True)
+        return True
+
+    def cell(self, engine: int, x: int, y: int, z: int) -> bytes:
+        index = self.geometry.cell_index(engine, x, y, z)
+        start = index * self.geometry.cell_bytes
+        end = start + self.geometry.cell_bytes
+        return self._body[start:end]
+
+    def address_for_stored_offset(self, offset: int) -> Tuple[int, int, int, int, int]:
+        if offset < 0 or offset >= self.stored_size:
+            raise IndexError("stored payload offset outside 0..{}".format(self.stored_size - 1))
+        cell_index, within_cell = divmod(offset, self.geometry.cell_bytes)
+        engine, remainder = divmod(cell_index, self.geometry.cells_per_engine)
+        x, remainder = divmod(remainder, self.geometry.y * self.geometry.z)
+        y, z = divmod(remainder, self.geometry.z)
+        return engine, x, y, z, within_cell
+
+    def statistics(self) -> Dict[str, object]:
+        return {
+            "format": "JXROM3D",
+            "version": _ROM_VERSION,
+            "engines": self.geometry.engines,
+            "grid_shape": [self.geometry.x, self.geometry.y, self.geometry.z],
+            "cell_bytes": self.geometry.cell_bytes,
+            "cell_count": self.geometry.cell_count,
+            "capacity_bytes": self.geometry.capacity_bytes,
+            "stored_bytes": self.stored_size,
+            "raw_bytes": self.raw_size,
+            "compressed": self.compressed,
+            "utilization": (
+                float(self.stored_size) / float(self.geometry.capacity_bytes)
+                if self.geometry.capacity_bytes
+                else 0.0
+            ),
+            "sha256": self.digest.hex(),
+        }
+
+
+def _validate_grid_shape(grid_shape: Tuple[int, int, int]) -> Tuple[int, int, int]:
+    if len(grid_shape) != 3:
+        raise ValueError("grid shape must contain exactly X, Y, and Z")
+    values = tuple(grid_shape)
+    for value in values:
+        if not isinstance(value, int) or isinstance(value, bool) or value < 1 or value > 0xFFFF:
+            raise ValueError("grid dimensions must be integers in the range 1..65535")
+    return values[0], values[1], values[2]
+
+
+def pack_bytecode(words: Iterable[int]) -> bytes:
+    materialized = list(words)
+    if len(materialized) > 0xFFFFFFFF:
+        raise ValueError("bytecode image contains too many words")
+
+    encoded = bytearray(_BYTECODE_HEADER.pack(_BYTECODE_MAGIC, _BYTECODE_VERSION, len(materialized)))
+    for index, word in enumerate(materialized):
+        if not isinstance(word, int) or isinstance(word, bool):
+            raise TypeError("bytecode word {} is not an integer".format(index))
+        if word < 0 or word > _MAX_WORD:
+            raise ValueError("bytecode word {} does not fit in 64 bits".format(index))
+        encoded.extend(_WORD.pack(word))
+    return bytes(encoded)
+
+
+def unpack_bytecode(image: bytes) -> List[int]:
+    data = bytes(image)
+    if len(data) < _BYTECODE_HEADER.size:
+        raise ROMFormatError("bytecode image is shorter than its header")
+
+    magic, version, count = _BYTECODE_HEADER.unpack_from(data)
+    if magic != _BYTECODE_MAGIC:
+        raise ROMFormatError("invalid Jarvis-X bytecode image magic")
+    if version != _BYTECODE_VERSION:
+        raise ROMFormatError("unsupported Jarvis-X bytecode image version {}".format(version))
+
+    expected = _BYTECODE_HEADER.size + (count * _WORD.size)
+    if len(data) != expected:
+        raise ROMFormatError(
+            "bytecode image is {} bytes; expected {} for {} words".format(
+                len(data), expected, count
+            )
+        )
+    return [
+        _WORD.unpack_from(data, _BYTECODE_HEADER.size + index * _WORD.size)[0]
+        for index in range(count)
+    ]
+
+
+def assemble_source(source: str) -> List[int]:
+    return Assembler().assemble(Parser().parse(source))
+
+
+def rom_from_source(
+    source: str,
+    engines: int = 1,
+    grid_shape: Tuple[int, int, int] = (4, 4, 4),
+    cell_bytes: Optional[int] = None,
+    compress: bool = False,
+) -> ChrysalisROM:
+    image = pack_bytecode(assemble_source(source))
+    return ChrysalisROM.from_payload(
+        image,
+        engines=engines,
+        grid_shape=grid_shape,
+        cell_bytes=cell_bytes,
+        compress=compress,
+    )
+
+
+def words_from_rom(rom: ChrysalisROM) -> List[int]:
+    return unpack_bytecode(rom.payload(verify=True))
+
+
+def run_rom(rom: ChrysalisROM) -> CodexVM:
+    words = words_from_rom(rom)
+    if not words:
+        raise ROMFormatError("cannot execute an empty bytecode image")
+    vm = CodexVM()
+    vm.load(words)
+    vm.run()
+    return vm
+
+
+def mutate_immediate(rom: ChrysalisROM, word_index: int, delta: int) -> ChrysalisROM:
+    """Create a verified candidate ROM by changing one SET immediate only.
+
+    The opcode, destination register, source registers, grid dimensions, and
+    cell capacity remain unchanged. This is a bounded structural mutation, not
+    an arbitrary bit flip.
+    """
+
+    words = words_from_rom(rom)
+    if word_index < 0 or word_index >= len(words):
+        raise IndexError("word index outside 0..{}".format(len(words) - 1))
+    if not isinstance(delta, int) or isinstance(delta, bool):
+        raise TypeError("delta must be an integer")
+
+    word = words[word_index]
+    opcode = (word >> 56) & 0xFF
+    if opcode != OPCODES["SET"]:
+        raise ValueError("bounded mutation only supports SET instructions")
+
+    current = (word >> 8) & 0xFFFF
+    candidate = current + delta
+    if candidate < 0 or candidate > 0xFFFF:
+        raise ValueError("mutated immediate must remain in the range 0..65535")
+
+    words[word_index] = (word & ~_IMMEDIATE_MASK) | (candidate << 8)
+    image = pack_bytecode(words)
+    geometry = rom.geometry
+    return ChrysalisROM.from_payload(
+        image,
+        engines=geometry.engines,
+        grid_shape=(geometry.x, geometry.y, geometry.z),
+        cell_bytes=geometry.cell_bytes,
+        compress=rom.compressed,
+    )

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,38 +1,178 @@
+import argparse
+import json
 import sys
-from .parser import Parser
-from .assembler import Assembler
-from .core import CodexVM
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
 from .api import start_api
-from .web import start_web
+from .assembler import Assembler
+from .chrysalis_rom import (
+    ChrysalisROM,
+    ROMError,
+    mutate_immediate,
+    rom_from_source,
+    run_rom,
+    words_from_rom,
+)
+from .core import CodexVM
 from .node import CodexNode
+from .parser import Parser
+from .web import start_web
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
-        return
 
-    cmd = sys.argv[1]
+def _grid_shape(value: str) -> Tuple[int, int, int]:
+    normalized = value.lower().replace(",", "x")
+    parts = normalized.split("x")
+    if len(parts) != 3:
+        raise argparse.ArgumentTypeError("grid must be formatted as XxYxZ")
+    try:
+        shape = tuple(int(part) for part in parts)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("grid dimensions must be integers") from exc
+    if any(dimension < 1 or dimension > 0xFFFF for dimension in shape):
+        raise argparse.ArgumentTypeError("grid dimensions must be in the range 1..65535")
+    return shape[0], shape[1], shape[2]
 
-    if cmd == "run":
-        file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm = CodexVM()
-        vm.load(bytecode)
-        vm.run()
-        print("Registers:", vm.regs.snapshot())
 
-    elif cmd == "api":
-        start_api()
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx",
+        description="Jarvis-X assembly VM and deterministic Chrysalis 3D byte-ROM runtime.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
 
-    elif cmd == "web":
-        start_web()
+    run_command = commands.add_parser("run", help="assemble and run a Jarvis-X source file")
+    run_command.add_argument("file", type=Path)
 
-    elif cmd == "node":
-        node = CodexNode()
-        node.start()
+    commands.add_parser("api", help="start the API service")
+    commands.add_parser("web", help="start the web service")
+    commands.add_parser("node", help="start a Jarvis-X node")
+
+    rom_command = commands.add_parser("rom", help="operate the Chrysalis 3D byte-ROM")
+    rom_commands = rom_command.add_subparsers(dest="rom_command", required=True)
+
+    encode = rom_commands.add_parser("encode", help="assemble source into a ROM image")
+    encode.add_argument("source", type=Path)
+    encode.add_argument("output", type=Path)
+    encode.add_argument("--engines", type=int, default=1)
+    encode.add_argument("--grid", type=_grid_shape, default=(4, 4, 4), metavar="XxYxZ")
+    encode.add_argument("--cell-bytes", type=int)
+    encode.add_argument("--compress", action="store_true")
+
+    inspect = rom_commands.add_parser("inspect", help="verify and describe a ROM image")
+    inspect.add_argument("rom", type=Path)
+
+    verify = rom_commands.add_parser("verify", help="verify ROM and bytecode integrity")
+    verify.add_argument("rom", type=Path)
+
+    extract = rom_commands.add_parser("extract", help="extract the packed bytecode image")
+    extract.add_argument("rom", type=Path)
+    extract.add_argument("output", type=Path)
+
+    execute = rom_commands.add_parser("run", help="verify and execute a ROM image")
+    execute.add_argument("rom", type=Path)
+
+    mutate = rom_commands.add_parser(
+        "mutate",
+        help="create a bounded candidate by changing one SET immediate",
+    )
+    mutate.add_argument("rom", type=Path)
+    mutate.add_argument("output", type=Path)
+    mutate.add_argument("--word-index", type=int, required=True)
+    mutate.add_argument("--delta", type=int, required=True)
+
+    return parser
+
+
+def _run_source(path: Path) -> CodexVM:
+    source = path.read_text(encoding="utf-8")
+    ast = Parser().parse(source)
+    bytecode = Assembler().assemble(ast)
+    vm = CodexVM()
+    vm.load(bytecode)
+    vm.run()
+    return vm
+
+
+def _print_rom_stats(rom: ChrysalisROM, word_count: Optional[int] = None) -> None:
+    stats = rom.statistics()
+    if word_count is not None:
+        stats["bytecode_words"] = word_count
+    print(json.dumps(stats, indent=2, sort_keys=True))
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "run":
+            vm = _run_source(args.file)
+            print("Registers:", vm.regs.snapshot())
+            return 0
+
+        if args.command == "api":
+            start_api()
+            return 0
+
+        if args.command == "web":
+            start_web()
+            return 0
+
+        if args.command == "node":
+            CodexNode().start()
+            return 0
+
+        if args.rom_command == "encode":
+            source = args.source.read_text(encoding="utf-8")
+            rom = rom_from_source(
+                source,
+                engines=args.engines,
+                grid_shape=args.grid,
+                cell_bytes=args.cell_bytes,
+                compress=args.compress,
+            )
+            rom.write(args.output)
+            _print_rom_stats(rom, word_count=len(words_from_rom(rom)))
+            return 0
+
+        rom = ChrysalisROM.read(args.rom)
+
+        if args.rom_command == "inspect":
+            words = words_from_rom(rom)
+            _print_rom_stats(rom, word_count=len(words))
+            return 0
+
+        if args.rom_command == "verify":
+            words = words_from_rom(rom)
+            print("verified: {} bytecode words".format(len(words)))
+            return 0
+
+        if args.rom_command == "extract":
+            payload = rom.payload(verify=True)
+            args.output.parent.mkdir(parents=True, exist_ok=True)
+            args.output.write_bytes(payload)
+            print("extracted {} bytes to {}".format(len(payload), args.output))
+            return 0
+
+        if args.rom_command == "run":
+            vm = run_rom(rom)
+            print("Registers:", vm.regs.snapshot())
+            return 0
+
+        if args.rom_command == "mutate":
+            candidate = mutate_immediate(
+                rom,
+                word_index=args.word_index,
+                delta=args.delta,
+            )
+            candidate.write(args.output)
+            _print_rom_stats(candidate, word_count=len(words_from_rom(candidate)))
+            return 0
+
+        raise RuntimeError("unreachable command state")
+    except (OSError, ROMError, ValueError, IndexError, TypeError) as exc:
+        print("jarvisx: {}".format(exc), file=sys.stderr)
+        return 2
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/tests/test_chrysalis_rom.py
+++ b/tests/test_chrysalis_rom.py
@@ -1,0 +1,97 @@
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from jarvisx.assembler import OPCODES
+from jarvisx.chrysalis_rom import (
+    ChrysalisROM,
+    ROMCapacityError,
+    ROMFormatError,
+    ROMIntegrityError,
+    assemble_source,
+    mutate_immediate,
+    pack_bytecode,
+    rom_from_source,
+    unpack_bytecode,
+    words_from_rom,
+)
+
+
+def test_payload_round_trip_and_addressing(tmp_path: Path):
+    payload = bytes(range(256)) * 3
+    rom = ChrysalisROM.from_payload(
+        payload,
+        engines=2,
+        grid_shape=(2, 3, 4),
+        cell_bytes=16,
+        compress=False,
+    )
+
+    assert rom.payload() == payload
+    assert rom.verify()
+    assert len(rom.cell(0, 0, 0, 0)) == 16
+    assert rom.address_for_stored_offset(0) == (0, 0, 0, 0, 0)
+    assert rom.address_for_stored_offset(16) == (0, 0, 0, 1, 0)
+
+    path = tmp_path / "image.jrom"
+    rom.write(path)
+    restored = ChrysalisROM.read(path)
+    assert restored.payload() == payload
+    assert restored.statistics()["sha256"] == hashlib.sha256(payload).hexdigest()
+
+
+def test_bytecode_round_trip_is_big_endian_and_exact():
+    words = [0, 1, 0x0102030405060708, (1 << 64) - 1]
+    image = pack_bytecode(words)
+    assert image[:4] == b"JXBC"
+    assert image[-8:] == b"\xff" * 8
+    assert unpack_bytecode(image) == words
+
+
+def test_source_to_rom_round_trip():
+    source = "SET A 7\nSET B 5\nADD C A B\nHALT"
+    expected = assemble_source(source)
+    rom = rom_from_source(source, engines=1, grid_shape=(2, 2, 2))
+    assert words_from_rom(rom) == expected
+
+
+def test_bounded_mutation_changes_only_set_immediate():
+    rom = rom_from_source("SET A 7\nHALT", grid_shape=(1, 1, 2), cell_bytes=16)
+    original = words_from_rom(rom)
+    candidate = mutate_immediate(rom, word_index=0, delta=5)
+    mutated = words_from_rom(candidate)
+
+    assert ((mutated[0] >> 56) & 0xFF) == OPCODES["SET"]
+    assert ((mutated[0] >> 40) & 0xFF) == ((original[0] >> 40) & 0xFF)
+    assert ((mutated[0] >> 8) & 0xFFFF) == 12
+    assert mutated[1] == original[1]
+    assert candidate.verify()
+
+
+def test_mutation_rejects_non_set_instruction():
+    rom = rom_from_source("HALT", grid_shape=(1, 1, 1), cell_bytes=32)
+    with pytest.raises(ValueError, match="SET"):
+        mutate_immediate(rom, word_index=0, delta=1)
+
+
+def test_capacity_is_enforced():
+    with pytest.raises(ROMCapacityError):
+        ChrysalisROM.from_payload(
+            b"too large", engines=1, grid_shape=(1, 1, 1), cell_bytes=2
+        )
+
+
+def test_payload_tampering_is_detected():
+    rom = ChrysalisROM.from_payload(b"integrity", grid_shape=(1, 1, 1), cell_bytes=16)
+    serialized = bytearray(rom.serialize())
+    serialized[-16] ^= 0x01
+    tampered = ChrysalisROM.deserialize(bytes(serialized))
+    with pytest.raises(ROMIntegrityError, match="SHA-256"):
+        tampered.payload()
+
+
+def test_malformed_bytecode_length_is_rejected():
+    image = pack_bytecode([1, 2])
+    with pytest.raises(ROMFormatError, match="expected"):
+        unpack_bytecode(image[:-1])


### PR DESCRIPTION
## What changed

- Added a deterministic `JXROM3D` runtime for Jarvis-X bytecode.
- Added exact big-endian packing and unpacking of the native 64-bit instruction words in a versioned `JXBC` envelope.
- Added engine-by-`X × Y × Z` fixed-cell addressing, capacity enforcement, optional compression, SHA-256 integrity checks, zero-padding validation, and atomic persistence.
- Added bounded mutation of a single `SET` immediate while preserving opcode and register fields.
- Added CLI operations for encode, inspect, verify, extract, run, and mutate.
- Added a complete format and operating-contract document plus README examples.
- Added eight tests covering byte and bytecode round trips, addressing, tamper detection, capacity errors, malformed images, and bounded mutation.
- Corrected the invalid pytest-cov report name from `term-local` to `term-missing` so the configured test command can start.

## Why

The prior concept used random, untrained latent vectors and could not reconstruct ordered source or executable bytecode. This change implements the operational core against the repository's actual 64-bit Jarvis-X ISA: exact bytes in, exact bytes out, verification before execution, and mutation constrained to a declared instruction field.

## Developer impact

New commands:

```bash
jarvisx rom encode program.jx program.jrom --grid 4x4x4
jarvisx rom inspect program.jrom
jarvisx rom verify program.jrom
jarvisx rom run program.jrom
jarvisx rom extract program.jrom program.jxbc
jarvisx rom mutate program.jrom candidate.jrom --word-index 0 --delta 5
```

## Validation

- `8 passed` for the new ROM test module in an isolated Python package harness.
- CLI smoke test passed for encode, verify, and inspect.
- `py_compile` passed for the new ROM module and updated CLI.

A full repository checkout was not available in the execution environment, so GitHub Actions remains the authoritative whole-repository integration check.