### PR TITLE
Permeate D-MUAD v2 constitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,31 @@
 Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
+## Architecture constitutions
+
+- [Dr Moagi Unified Auto-Encoding Dynamics (D-MUAD v2.0-C)](docs/DR_MOAGI_UNIFIED_AUTO_ENCODING_DYNAMICS.md)
+- The executable D-MUAD contract is implemented in `src/jarvisx/d_muad.py`.
+
+D-MUAD formalizes a compressive, recurrent, physics-regularized, dual-branch
+geometric autoencoding architecture. It exposes exact padding and tensor-shape
+rules, arithmetic budget functions, the corrected five-term loss, Adam
+recurrence, and explicit injectivity, determinism, and differentiability
+boundaries.
+
+```python
+from jarvisx.d_muad import derive_contract
+
+contract = derive_contract((1, 4, 9, 17, 25))
+assert contract.padded == (1, 4, 16, 24, 32)
+assert contract.compressive
+assert not contract.exact_global_inverse_possible
+```
+
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```

--- a/docs/DR_MOAGI_UNIFIED_AUTO_ENCODING_DYNAMICS.md
+++ b/docs/DR_MOAGI_UNIFIED_AUTO_ENCODING_DYNAMICS.md
@@ -1,0 +1,447 @@
+# Dr Moagi Unified Auto-Encoding Dynamics (D-MUAD)
+
+## Status
+
+**D-MUAD v2.0-C** is the canonical mathematical constitution for a compressive,
+recurrent, physics-regularized, dual-branch geometric autoencoding system.
+
+The system is a closed computational recurrence, not a closed-form global
+solution. Its neural training core is differentiable almost everywhere; its
+hard egress operations are discrete.
+
+---
+
+## 1. Constitutional classification
+
+D-MUAD implements
+
+\[
+\mathcal X
+\xrightarrow{\Pi}
+\mathcal X_p
+\xrightarrow{\mathcal E_{emb}}
+\mathcal X_e
+\xrightarrow{\mathcal E_{3D}}
+\mathbf v_q
+\xrightarrow{\mathcal L_{phy}}
+(\mathbf h_q,\mathbf c_q)
+\xrightarrow{\mathcal P}
+\mathbf Z_q
+\xrightarrow{\mathcal D_{vol},\mathcal R_{NeRF}}
+(\mathcal G_{rgb},\mathcal G_{sdf},\mathcal G_\rho,\widehat{\mathbf C}).
+\]
+
+The canonical claim set is:
+
+- **representation:** compressive and distributionally reconstructive;
+- **inverse:** approximate decoder, not a global exact inverse;
+- **differentiability:** training core differentiable almost everywhere;
+- **determinism:** conditional on fixed parameters, recurrent state, kernels,
+  statistics, seeds, hardware behavior, and reduction order;
+- **optimization:** closed Adam recurrence, not a closed-form optimum;
+- **arithmetic budget:** derived from concrete tensor dimensions and kernel
+  implementation.
+
+---
+
+## 2. Spacetime domain and padding
+
+Let
+
+\[
+\mathcal X\in\mathbb R^{B\times4\times T\times H\times W}.
+\]
+
+Define
+
+\[
+T_p=8\left\lceil\frac{T}{8}\right\rceil,\qquad
+H_p=8\left\lceil\frac{H}{8}\right\rceil,\qquad
+W_p=8\left\lceil\frac{W}{8}\right\rceil.
+\]
+
+The padded tensor is
+
+\[
+\mathcal X_p=\Pi_W\circ\Pi_H\circ\Pi_T(\mathcal X)
+\in\mathbb R^{B\times4\times T_p\times H_p\times W_p}.
+\]
+
+A validity mask must accompany the tensor:
+
+\[
+M[b,t,i,j]=
+\begin{cases}
+1,&t<T,\ i<H,\ j<W,\\
+0,&\text{otherwise}.
+\end{cases}
+\]
+
+Losses are normalized over valid elements, not padded zeros.
+
+---
+
+## 3. Dr Moagi Transform I: separable spatiotemporal embedding
+
+For output channel \(c\in\{0,\dots,63\}\),
+
+\[
+\mathcal X_e[b,c,t,i,j]
+=
+\beta_c+
+\sum_{k=0}^{3}
+\sum_{w=-1}^{1}
+\sum_{u=-1}^{1}
+\sum_{v=-1}^{1}
+K_t[c,w]K_s[c,k,u,v]
+\mathcal X_p[b,k,t+w,i+u,j+v].
+\]
+
+The boundary convention must be explicit: zero, reflection, replication, or
+circular padding. The canonical output is
+
+\[
+\mathcal X_e\in\mathbb R^{B\times64\times T_p\times H_p\times W_p}.
+\]
+
+---
+
+## 4. Dr Moagi Transform II: hierarchical 3D encoding
+
+Using same-padded 3D convolutions,
+
+\[
+\begin{aligned}
+\mathcal H_1 &= \operatorname{ReLU}(\operatorname{BN}(W_1*\mathcal X_e+b_1)),\\
+\mathcal H_2 &= \operatorname{ReLU}(\operatorname{BN}(W_2*\mathcal H_1+b_2)),\\
+\mathcal H_3 &= \operatorname{ReLU}(\operatorname{BN}(W_3*\mathcal H_2+b_3)).
+\end{aligned}
+\]
+
+The canonical shapes are
+
+\[
+\begin{aligned}
+\mathcal H_1&:[B,256,T_p/2,H_p/2,W_p/2],\\
+\mathcal H_2&:[B,512,T_p/4,H_p/4,W_p/4],\\
+\mathcal H_3&:[B,1024,T_p/4,H_p/4,W_p/4].
+\end{aligned}
+\]
+
+Global average pooling gives
+
+\[
+\mathbf v_q[b,c]
+=
+\frac{1}{(T_p/4)(H_p/4)(W_p/4)}
+\sum_{t,i,j}\mathcal H_3[b,c,t,i,j].
+\]
+
+The index \(q\) denotes the recurrent observation cycle. It is distinct from
+frame time \(t\).
+
+---
+
+## 5. Dr Moagi Transform III: recurrent latent physics
+
+For observation cycle \(q\),
+
+\[
+\begin{aligned}
+\mathbf i_q&=\sigma(W_{ii}\mathbf v_q+b_{ii}+W_{hi}\mathbf h_{q-1}+b_{hi}),\\
+\mathbf f_q&=\sigma(W_{if}\mathbf v_q+b_{if}+W_{hf}\mathbf h_{q-1}+b_{hf}),\\
+\mathbf g_q&=\tanh(W_{ig}\mathbf v_q+b_{ig}+W_{hg}\mathbf h_{q-1}+b_{hg}),\\
+\mathbf o_q&=\sigma(W_{io}\mathbf v_q+b_{io}+W_{ho}\mathbf h_{q-1}+b_{ho}),\\
+\mathbf c_q&=\mathbf f_q\odot\mathbf c_{q-1}+\mathbf i_q\odot\mathbf g_q,\\
+\mathbf h_q&=\mathbf o_q\odot\tanh(\mathbf c_q).
+\end{aligned}
+\]
+
+The latent code is
+
+\[
+\boxed{
+\mathbf Z_q=W_{proj}[\mathbf h_{q-1};\mathbf h_q]+b_{proj}
+}
+\qquad
+\mathbf Z_q\in\mathbb R^{B\times1024}.
+\]
+
+---
+
+## 6. Injectivity boundary
+
+The padded input contains
+
+\[
+4T_pH_pW_p
+\]
+
+values per sample, while the latent contains \(1024\). Strided convolutions,
+ReLU, global pooling, and the finite bottleneck are many-to-one. Therefore
+
+\[
+\boxed{
+\mathcal E_{D\text{-}MUAD}\text{ is not globally injective.}
+}
+\]
+
+The reconstruction contract is
+
+\[
+\boxed{
+\mathcal D_\Theta(\mathcal E_\Theta(\mathcal X))\approx\mathcal X
+}
+\]
+
+over the modeled data distribution.
+
+---
+
+## 7. Dr Moagi Transform IV: volumetric decoder
+
+The original dense expansion to
+
+\[
+[B,1024,T_p/4,H_p/4,W_p/4]
+\]
+
+requires
+
+\[
+1024^2(T_p/4)(H_p/4)(W_p/4)
+=
+16\,384T_pH_pW_p
+\]
+
+weights, excluding bias. This term is resolution dependent and must be counted
+explicitly.
+
+A scalable implementation should use a fixed learned seed followed by
+convolutional upsampling and final interpolation. The semantic decoder heads
+must remain distinct:
+
+\[
+\begin{aligned}
+\mathcal G_{rgb}&=\sigma(L_{rgb}),\\
+\mathcal G_{sdf}&=L_{sdf},\\
+\mathcal G_{\rho}&=\operatorname{softplus}(L_\rho).
+\end{aligned}
+\]
+
+The output therefore has five semantic channels or three separate heads:
+RGB, signed distance, and nonnegative density.
+
+---
+
+## 8. Dr Moagi Transform V: NeRF branch
+
+For camera ray
+
+\[
+\mathbf r(s)=\mathbf o+s\mathbf d
+\]
+
+and samples \(s_k\), the radiance network maps
+
+\[
+(\mathbf Z_q,\gamma(\mathbf r(s_k)),\gamma(\mathbf d))
+\mapsto
+(\rho_k,\mathbf c_k).
+\]
+
+Use
+
+\[
+\rho_k=\operatorname{softplus}(W_\rho f_k+b_\rho),
+\qquad
+\mathbf c_k=\sigma(W_cf_k+b_c).
+\]
+
+Then
+
+\[
+\alpha_k=1-e^{-\rho_k\delta_k},
+\qquad
+T_k=\prod_{m<k}(1-\alpha_m),
+\]
+
+and
+
+\[
+\boxed{
+\widehat{\mathbf C}(i,j)=\sum_kT_k\alpha_k\mathbf c_k.
+}
+\]
+
+The branch requires a rendering loss or its parameters receive no gradient from
+the volumetric losses.
+
+---
+
+## 9. Unified corrected loss
+
+Normalize RGB to \([0,1]\). Define
+
+\[
+\mathcal L_{sdf}
+=
+\frac{\sum M(\mathcal G_{sdf}-\mathcal SDF_{gt})^2}{\sum M},
+\]
+
+\[
+\mathcal L_{app}
+=
+\frac{\sum M\|\mathcal G_{rgb}-\mathcal X_{rgb}^{norm}\|_2^2}{3\sum M},
+\]
+
+\[
+\mathcal L_{phy}
+=
+\frac{1}{1024B}\sum_b\|\mathbf h_q^{(b)}-\mathbf h_{q-1}^{(b)}\|_2^2,
+\]
+
+\[
+\mathcal L_{eik}
+=
+\frac{1}{|\mathcal R|}
+\sum_{\mathbf r\in\mathcal R}
+(\|\nabla\mathcal G_{sdf}(\mathbf r)\|_2-1)^2,
+\]
+
+and
+
+\[
+\mathcal L_{render}
+=
+\frac{\sum M\|\widehat{\mathbf C}-\mathbf C_{gt}\|_2^2}{3\sum M}.
+\]
+
+The canonical aggregate is
+
+\[
+\boxed{
+\mathcal L_{total}
+=
+\mathcal L_{sdf}
++0.5\mathcal L_{app}
++0.1\mathcal L_{phy}
++0.1\mathcal L_{eik}
++\mathcal L_{render}.
+}
+\]
+
+---
+
+## 10. Adam recurrence
+
+For each parameter \(w\),
+
+\[
+\begin{aligned}
+m_q&=\beta_1m_{q-1}+(1-\beta_1)g_q,\\
+v_q&=\beta_2v_{q-1}+(1-\beta_2)g_q^2,\\
+\widehat m_q&=m_q/(1-\beta_1^q),\\
+\widehat v_q&=v_q/(1-\beta_2^q),\\
+w_{q+1}&=w_q-\eta\frac{\widehat m_q}{\sqrt{\widehat v_q}+\epsilon}.
+\end{aligned}
+\]
+
+This is a closed numerical recurrence. It does not guarantee a global optimum.
+
+---
+
+## 11. Arithmetic closure
+
+For a dense 3D convolution,
+
+\[
+\operatorname{MAC}
+=
+BD_oH_oW_oC_oC_iK_tK_hK_w.
+\]
+
+For a dense layer,
+
+\[
+\operatorname{MAC}=Bn_{in}n_{out}.
+\]
+
+For NeRF,
+
+\[
+\operatorname{MAC}_{NeRF}
+\propto
+BTHWN_s\operatorname{MAC}_{MLP}.
+\]
+
+A universal fixed MAC count is invalid without fixed batch size, padded domain,
+ray count, sample count, MLP widths, decoder implementation, and convolution
+semantics. Backpropagation is implementation dependent and is not exactly twice
+the forward MAC count as a universal law.
+
+---
+
+## 12. Differentiability and egress boundary
+
+The training graph is differentiable almost everywhere. The following are hard,
+discrete operations:
+
+- occupancy thresholding;
+- set construction;
+- clipping and rounding;
+- uint8 conversion;
+- conventional marching cubes;
+- mesh topology changes.
+
+Use
+
+\[
+\mathcal Y_{rgb}=\operatorname{round}(255\mathcal G_{rgb})
+\]
+
+only at egress. Extract the mesh from the SDF zero level set:
+
+\[
+\mathcal Y_{mesh}=\operatorname{MarchingCubes}(\mathcal G_{sdf},0).
+\]
+
+---
+
+## 13. Canonical closed recurrence
+
+\[
+\boxed{
+\begin{aligned}
+\mathcal X_p&=\Pi(\mathcal X),\\
+\mathcal X_e&=\mathcal E_{emb}(\mathcal X_p),\\
+\mathcal H&=\mathcal E_{3D}(\mathcal X_e),\\
+\mathbf v_q&=\operatorname{GAP}(\mathcal H_q),\\
+(\mathbf h_q,\mathbf c_q)&=\mathcal L_{phy}(\mathbf v_q,\mathbf h_{q-1},\mathbf c_{q-1}),\\
+\mathbf Z_q&=W_{proj}[\mathbf h_{q-1};\mathbf h_q]+b_{proj},\\
+(\mathcal G_{rgb},\mathcal G_{sdf},\mathcal G_\rho)&=\mathcal D_{vol}(\mathbf Z_q),\\
+\widehat{\mathbf C}&=\mathcal R_{NeRF}(\mathbf Z_q,\mathcal C),\\
+\Theta_{q+1}&=\operatorname{Adam}(\Theta_q,\nabla_\Theta\mathcal L_{total}).
+\end{aligned}
+}
+\]
+
+---
+
+## 14. Executable contract
+
+`src/jarvisx/d_muad.py` makes the following properties executable without a
+machine-learning dependency:
+
+- minimal padding to a multiple of eight;
+- complete tensor-shape derivation;
+- explicit non-injectivity classification;
+- dense decoder parameter accounting;
+- shape-dependent convolution MAC counts;
+- corrected five-term loss aggregation;
+- scalar Adam state recurrence;
+- constitutional claim boundaries.
+
+The executable contract is a validator and arithmetic constitution. A future
+PyTorch, JAX, or TensorFlow backend must conform to it rather than silently
+changing tensor semantics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]
@@ -74,14 +74,14 @@ omit = [
 [tool.black]
 line-length = 100
 target-version = ['py38']
-include = '\\.pyi?$'
+include = '\.pyi?$'
 extend-exclude = '''
 /(
-    \\.git
-  | \\.hg
-  | \\.mypy_cache
-  | \\.tox
-  | \\.venv
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
   | _build
   | buck-out
   | build

--- a/src/jarvisx/d_muad.py
+++ b/src/jarvisx/d_muad.py
@@ -1,0 +1,297 @@
+"""Executable contracts for the Dr Moagi Unified Auto-Encoding Dynamics.
+
+D-MUAD v2.0-C is a compressive, recurrent, physics-regularized, dual-branch
+geometric autoencoding architecture.  This module does not implement a neural
+network framework.  It makes the architecture's shape rules, arithmetic
+budgets, loss aggregation, optimizer recurrence, and semantic boundaries
+executable and testable with the Python standard library.
+"""
+
+from dataclasses import dataclass
+import math
+from typing import Dict, Tuple
+
+
+Shape5D = Tuple[int, int, int, int, int]
+Shape2D = Tuple[int, int]
+
+
+def padded_extent(size: int, multiple: int = 8) -> int:
+    """Return the smallest positive multiple greater than or equal to size."""
+    if not isinstance(size, int):
+        raise TypeError("Extent must be an integer")
+    if not isinstance(multiple, int):
+        raise TypeError("Padding multiple must be an integer")
+    if size <= 0:
+        raise ValueError("Extent must be positive")
+    if multiple <= 0:
+        raise ValueError("Padding multiple must be positive")
+    return ((size + multiple - 1) // multiple) * multiple
+
+
+@dataclass(frozen=True)
+class DMUADConfig:
+    """Canonical architectural constants for D-MUAD v2.0-C."""
+
+    input_channels: int = 4
+    embedding_channels: int = 64
+    encoder_channels: Tuple[int, int, int] = (256, 512, 1024)
+    latent_dim: int = 1024
+    decoder_channels: Tuple[int, int, int] = (512, 128, 5)
+    recurrent_hidden_dim: int = 1024
+    positional_encoding_dim: int = 63
+    nerf_hidden_dim: int = 256
+    nerf_samples_per_ray: int = 64
+    padding_multiple: int = 8
+
+    def __post_init__(self) -> None:
+        positive = (
+            self.input_channels,
+            self.embedding_channels,
+            self.latent_dim,
+            self.recurrent_hidden_dim,
+            self.positional_encoding_dim,
+            self.nerf_hidden_dim,
+            self.nerf_samples_per_ray,
+            self.padding_multiple,
+        )
+        if any(value <= 0 for value in positive):
+            raise ValueError("All D-MUAD dimensions must be positive")
+        if any(value <= 0 for value in self.encoder_channels):
+            raise ValueError("Encoder channels must be positive")
+        if any(value <= 0 for value in self.decoder_channels):
+            raise ValueError("Decoder channels must be positive")
+
+
+@dataclass(frozen=True)
+class DMUADContract:
+    """Derived tensor contract for one D-MUAD input batch."""
+
+    raw: Shape5D
+    padded: Shape5D
+    embedded: Shape5D
+    h1: Shape5D
+    h2: Shape5D
+    h3: Shape5D
+    pooled: Shape2D
+    latent: Shape2D
+    volumetric_base: Shape5D
+    up1: Shape5D
+    up2: Shape5D
+    volumetric_output: Shape5D
+    padding: Tuple[int, int, int]
+    raw_elements_per_sample: int
+    latent_elements_per_sample: int
+    dense_bottleneck_weights: int
+
+    @property
+    def compressive(self) -> bool:
+        return self.raw_elements_per_sample > self.latent_elements_per_sample
+
+    @property
+    def exact_global_inverse_possible(self) -> bool:
+        """The canonical encoder is not globally invertible.
+
+        Strided convolutions, ReLU, global pooling, and a finite latent bottleneck
+        are many-to-one even for small inputs.  This property remains explicit so
+        callers cannot mistake reconstruction for a bijective codec.
+        """
+        return False
+
+
+def derive_contract(raw: Shape5D, config: DMUADConfig = DMUADConfig()) -> DMUADContract:
+    """Derive all canonical tensor shapes from a raw B,C,T,H,W shape."""
+    if len(raw) != 5:
+        raise ValueError("D-MUAD input shape must be B,C,T,H,W")
+    if any(not isinstance(value, int) for value in raw):
+        raise TypeError("All shape components must be integers")
+    if any(value <= 0 for value in raw):
+        raise ValueError("All shape components must be positive")
+
+    batch, channels, time, height, width = raw
+    if channels != config.input_channels:
+        raise ValueError(
+            "D-MUAD requires {0} input channels; received {1}".format(
+                config.input_channels, channels
+            )
+        )
+
+    time_p = padded_extent(time, config.padding_multiple)
+    height_p = padded_extent(height, config.padding_multiple)
+    width_p = padded_extent(width, config.padding_multiple)
+    padded = (batch, channels, time_p, height_p, width_p)
+    embedded = (batch, config.embedding_channels, time_p, height_p, width_p)
+
+    c1, c2, c3 = config.encoder_channels
+    h1 = (batch, c1, time_p // 2, height_p // 2, width_p // 2)
+    h2 = (batch, c2, time_p // 4, height_p // 4, width_p // 4)
+    h3 = (batch, c3, time_p // 4, height_p // 4, width_p // 4)
+    pooled = (batch, c3)
+    latent = (batch, config.latent_dim)
+
+    volumetric_base = h3
+    d1, d2, d_out = config.decoder_channels
+    up1 = (batch, d1, time_p // 2, height_p // 2, width_p // 2)
+    up2 = (batch, d2, time_p, height_p, width_p)
+    volumetric_output = (batch, d_out, time_p, height_p, width_p)
+
+    base_values_per_sample = c3 * (time_p // 4) * (height_p // 4) * (width_p // 4)
+    dense_bottleneck_weights = config.latent_dim * base_values_per_sample
+    raw_elements_per_sample = channels * time_p * height_p * width_p
+
+    return DMUADContract(
+        raw=raw,
+        padded=padded,
+        embedded=embedded,
+        h1=h1,
+        h2=h2,
+        h3=h3,
+        pooled=pooled,
+        latent=latent,
+        volumetric_base=volumetric_base,
+        up1=up1,
+        up2=up2,
+        volumetric_output=volumetric_output,
+        padding=(time_p - time, height_p - height, width_p - width),
+        raw_elements_per_sample=raw_elements_per_sample,
+        latent_elements_per_sample=config.latent_dim,
+        dense_bottleneck_weights=dense_bottleneck_weights,
+    )
+
+
+def conv3d_macs(
+    output: Shape5D,
+    input_channels: int,
+    kernel: Tuple[int, int, int],
+) -> int:
+    """Multiply-accumulate count for a dense 3D convolution."""
+    batch, output_channels, time, height, width = output
+    kt, kh, kw = kernel
+    values = (
+        batch,
+        output_channels,
+        time,
+        height,
+        width,
+        input_channels,
+        kt,
+        kh,
+        kw,
+    )
+    if any(value <= 0 for value in values):
+        raise ValueError("Convolution dimensions must be positive")
+    return (
+        batch
+        * output_channels
+        * time
+        * height
+        * width
+        * input_channels
+        * kt
+        * kh
+        * kw
+    )
+
+
+def separable_embedding_macs(contract: DMUADContract) -> int:
+    """MACs for a 3x3 spatial stage followed by a length-3 temporal stage."""
+    batch, embedded_channels, time, height, width = contract.embedded
+    input_channels = contract.padded[1]
+    spatial = batch * time * height * width * embedded_channels * input_channels * 9
+    temporal = batch * time * height * width * embedded_channels * 3
+    return spatial + temporal
+
+
+def encoder_macs(contract: DMUADContract) -> int:
+    """MAC count for the three canonical encoder convolutions."""
+    return (
+        conv3d_macs(contract.h1, contract.embedded[1], (3, 3, 3))
+        + conv3d_macs(contract.h2, contract.h1[1], (3, 3, 3))
+        + conv3d_macs(contract.h3, contract.h2[1], (3, 3, 3))
+    )
+
+
+@dataclass(frozen=True)
+class LossWeights:
+    sdf: float = 1.0
+    appearance: float = 0.5
+    physics: float = 0.1
+    eikonal: float = 0.1
+    rendering: float = 1.0
+
+    def __post_init__(self) -> None:
+        if any(value < 0.0 or not math.isfinite(value) for value in self.as_tuple()):
+            raise ValueError("Loss weights must be finite and non-negative")
+
+    def as_tuple(self) -> Tuple[float, float, float, float, float]:
+        return (
+            self.sdf,
+            self.appearance,
+            self.physics,
+            self.eikonal,
+            self.rendering,
+        )
+
+
+def aggregate_loss(
+    sdf: float,
+    appearance: float,
+    physics: float,
+    eikonal: float,
+    rendering: float,
+    weights: LossWeights = LossWeights(),
+) -> float:
+    """Aggregate the corrected D-MUAD loss functional in fp64 host arithmetic."""
+    components = (sdf, appearance, physics, eikonal, rendering)
+    if any(value < 0.0 or not math.isfinite(value) for value in components):
+        raise ValueError("Loss components must be finite and non-negative")
+    return sum(weight * value for weight, value in zip(weights.as_tuple(), components))
+
+
+@dataclass(frozen=True)
+class AdamScalarState:
+    """One scalar parameter and its Adam moments."""
+
+    parameter: float
+    first_moment: float = 0.0
+    second_moment: float = 0.0
+    step: int = 0
+
+
+def adam_scalar_step(
+    state: AdamScalarState,
+    gradient: float,
+    learning_rate: float = 1e-4,
+    beta1: float = 0.9,
+    beta2: float = 0.999,
+    epsilon: float = 1e-8,
+) -> AdamScalarState:
+    """Execute one exact scalar Adam recurrence."""
+    scalars = (state.parameter, gradient, learning_rate, beta1, beta2, epsilon)
+    if any(not math.isfinite(value) for value in scalars):
+        raise ValueError("Adam inputs must be finite")
+    if learning_rate <= 0.0 or epsilon <= 0.0:
+        raise ValueError("Learning rate and epsilon must be positive")
+    if not 0.0 <= beta1 < 1.0 or not 0.0 <= beta2 < 1.0:
+        raise ValueError("Adam beta values must lie in [0, 1)")
+
+    step = state.step + 1
+    first = beta1 * state.first_moment + (1.0 - beta1) * gradient
+    second = beta2 * state.second_moment + (1.0 - beta2) * gradient * gradient
+    first_hat = first / (1.0 - beta1**step)
+    second_hat = second / (1.0 - beta2**step)
+    parameter = state.parameter - learning_rate * first_hat / (math.sqrt(second_hat) + epsilon)
+    return AdamScalarState(parameter, first, second, step)
+
+
+def constitutional_boundaries() -> Dict[str, str]:
+    """Return the claims that are valid for D-MUAD v2.0-C."""
+    return {
+        "representation": "compressive and distributionally reconstructive",
+        "inverse": "approximate decoder, not a global exact inverse",
+        "differentiability": "training core is differentiable almost everywhere",
+        "egress": "thresholding, uint8 conversion, and marching cubes are discrete",
+        "determinism": "conditional on fixed state, parameters, kernels, and reduction order",
+        "optimization": "closed recurrence, not a closed-form global optimum",
+        "arithmetic_budget": "input-shape and implementation dependent",
+    }

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,27 @@
 import hashlib
 import time
 
+
 class OmegaLedger:
     def __init__(self):
         self.chain = []
 
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        """Append a JSON-safe, hash-linked audit record.
+
+        The hash is computed from the exact UTF-8 payload bytes, while the
+        persisted payload is retained as text. This preserves the original
+        audit semantics without placing raw ``bytes`` objects in the ledger
+        chain, which would make the chain impossible to serialize as JSON.
+        """
+        payload = f"{time.time()}|{state}|{opcode}"
+        payload_bytes = payload.encode("utf-8")
+        prev = self.chain[-1]["hash"].encode("ascii") if self.chain else b""
+        digest = hashlib.sha256(prev + payload_bytes).hexdigest()
+        self.chain.append(
+            {
+                "hash": digest,
+                "payload": payload,
+                "payload_encoding": "utf-8",
+            }
+        )

--- a/src/jarvisx/reflex.py
+++ b/src/jarvisx/reflex.py
@@ -1,6 +1,21 @@
 class ReflexEngine:
-    def stabilize(self, regs):
+    """Evaluate or apply bounded Psi/Phi stabilization.
+
+    Reflex evaluation is separated from mutation so deterministic instruction
+    results are not changed implicitly. Active stabilization remains available
+    through the explicit ``apply=True`` mode.
+    """
+
+    def __init__(self):
+        self.last_delta = 0
+
+    def stabilize(self, regs, apply=False):
         psi = regs["Ψ"]
         phi = regs["Φ"]
         delta = int(0.1 * (psi - phi))
-        regs["Φ"] += delta
+        self.last_delta = delta
+
+        if apply:
+            regs["Φ"] += delta
+
+        return delta

--- a/tests/test_d_muad.py
+++ b/tests/test_d_muad.py
@@ -1,0 +1,119 @@
+import math
+
+import pytest
+
+from jarvisx.d_muad import (
+    AdamScalarState,
+    DMUADConfig,
+    LossWeights,
+    adam_scalar_step,
+    aggregate_loss,
+    constitutional_boundaries,
+    conv3d_macs,
+    derive_contract,
+    encoder_macs,
+    padded_extent,
+    separable_embedding_macs,
+)
+
+
+def test_padding_is_minimal_and_divisible_by_eight():
+    assert padded_extent(1) == 8
+    assert padded_extent(8) == 8
+    assert padded_extent(9) == 16
+    assert padded_extent(33) == 40
+
+
+def test_contract_derives_canonical_shapes():
+    contract = derive_contract((2, 4, 9, 17, 25))
+
+    assert contract.padded == (2, 4, 16, 24, 32)
+    assert contract.padding == (7, 7, 7)
+    assert contract.embedded == (2, 64, 16, 24, 32)
+    assert contract.h1 == (2, 256, 8, 12, 16)
+    assert contract.h2 == (2, 512, 4, 6, 8)
+    assert contract.h3 == (2, 1024, 4, 6, 8)
+    assert contract.latent == (2, 1024)
+    assert contract.volumetric_output == (2, 5, 16, 24, 32)
+
+
+def test_contract_explicitly_rejects_global_invertibility_claim():
+    contract = derive_contract((1, 4, 8, 8, 8))
+
+    assert contract.compressive
+    assert not contract.exact_global_inverse_possible
+    assert contract.raw_elements_per_sample == 2048
+    assert contract.latent_elements_per_sample == 1024
+
+
+def test_dense_bottleneck_cardinality_is_resolution_dependent():
+    contract = derive_contract((1, 4, 32, 32, 32))
+
+    expected_base_values = 1024 * 8 * 8 * 8
+    assert contract.dense_bottleneck_weights == 1024 * expected_base_values
+    assert contract.dense_bottleneck_weights == 536_870_912
+
+
+def test_wrong_channel_count_is_rejected():
+    with pytest.raises(ValueError, match="requires 4 input channels"):
+        derive_contract((1, 3, 8, 8, 8))
+
+
+def test_arithmetic_budget_functions_are_positive_and_shape_dependent():
+    small = derive_contract((1, 4, 8, 8, 8))
+    large = derive_contract((1, 4, 16, 16, 16))
+
+    assert separable_embedding_macs(small) > 0
+    assert encoder_macs(small) > 0
+    assert separable_embedding_macs(large) > separable_embedding_macs(small)
+    assert encoder_macs(large) > encoder_macs(small)
+
+
+def test_conv3d_mac_formula():
+    output = (2, 16, 4, 5, 6)
+    assert conv3d_macs(output, 8, (3, 3, 3)) == 2 * 16 * 4 * 5 * 6 * 8 * 27
+
+
+def test_corrected_loss_includes_rendering_and_eikonal_terms():
+    loss = aggregate_loss(
+        sdf=2.0,
+        appearance=4.0,
+        physics=5.0,
+        eikonal=3.0,
+        rendering=6.0,
+    )
+
+    assert loss == pytest.approx(2.0 + 0.5 * 4.0 + 0.1 * 5.0 + 0.1 * 3.0 + 6.0)
+
+
+def test_loss_rejects_non_finite_or_negative_values():
+    with pytest.raises(ValueError):
+        aggregate_loss(math.inf, 0.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError):
+        aggregate_loss(-1.0, 0.0, 0.0, 0.0, 0.0)
+    with pytest.raises(ValueError):
+        LossWeights(rendering=-1.0)
+
+
+def test_adam_first_step_matches_bias_corrected_recurrence():
+    state = AdamScalarState(parameter=1.0)
+    updated = adam_scalar_step(state, gradient=2.0, learning_rate=1e-4)
+
+    expected = 1.0 - 1e-4 * 2.0 / (math.sqrt(4.0) + 1e-8)
+    assert updated.parameter == pytest.approx(expected)
+    assert updated.first_moment == pytest.approx(0.2)
+    assert updated.second_moment == pytest.approx(0.004)
+    assert updated.step == 1
+
+
+def test_constitutional_boundaries_are_explicit():
+    boundaries = constitutional_boundaries()
+
+    assert "not a global exact inverse" in boundaries["inverse"]
+    assert "almost everywhere" in boundaries["differentiability"]
+    assert "shape" in boundaries["arithmetic_budget"]
+
+
+def test_configuration_rejects_non_positive_dimensions():
+    with pytest.raises(ValueError):
+        DMUADConfig(latent_dim=0)


### PR DESCRIPTION
## What changed

- formalizes the Dr Moagi Unified Auto-Encoding Dynamics as D-MUAD v2.0-C
- adds an executable, dependency-free architecture contract
- derives minimal 8-aligned padding and all canonical tensor shapes
- encodes the non-injectivity boundary explicitly
- computes resolution-dependent dense bottleneck cardinality
- adds separable embedding and encoder MAC formulas
- implements the corrected five-term loss functional
- implements the scalar Adam recurrence
- records determinism, differentiability, optimization, and egress boundaries
- adds focused tests and README discoverability

## Canonical classification

D-MUAD is defined as a compressive, recurrent, physics-regularized, dual-branch geometric autoencoding architecture. It is not represented as a lossless bijective codec or a closed-form optimizer.

## Governing recurrence

```text
reality -> padding -> spatiotemporal embedding -> 3D encoding
        -> recurrent latent physics -> volumetric + NeRF decoding
        -> unified loss -> Adam correction -> next cycle
```

## Repository prerequisites

This branch carries the repository-wide prerequisites that block all new suites on current `main`: the valid `term-missing` pytest coverage reporter, JSON-safe ledger payloads, and explicit reflex mutation. Equivalent repairs are already independently validated in PR #18 and will reconcile cleanly when that PR merges.

## Validation

The test suite covers padding, tensor contracts, non-injectivity, dense decoder scaling, MAC formulas, corrected loss aggregation, Adam bias correction, and constitutional claim boundaries.