### PR TITLE
Operationalise hierarchical cognitive kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,95 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer, policy gate, persistent Ω ledger, and a transactional hierarchical cognitive kernel.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## Assembly VM
+
+```bash
+jarvisx run program.jx
+```
+
+The existing VM supports deterministic bytecode decoding, register execution, Λ policy checks, reflex stabilisation, tracing, sandbox limits, and ledger recording.
+
+## Hierarchical cognitive kernel
+
+The operational kernel executes the canonical cycle:
+
+```text
+Encode Q3
+  -> Hierarchical Condensation
+  -> Predict
+  -> Compare / Residual
+  -> Update cumulative Ω memory
+  -> Project through Λ constraints
+  -> Decode
+  -> Commit or Roll Back
+```
+
+Run a cycle directly:
+
+```bash
+jarvisx cognitive 3 1 -1 -3
+```
+
+Or from Python:
+
+```python
+from jarvisx.core import CodexVM
+
+vm = CodexVM()
+result = vm.cognitive_cycle([3, 1, -1, -3])
+
+print(result.committed)
+print(result.hierarchy)
+print(result.metrics)
+print(vm.regs.snapshot())
+```
+
+### Operational properties
+
+- Signed three-bit latent domain: `Q3 = {-4, -3, -2, -1, 0, 1, 2, 3}`.
+- Deterministic integer/fixed-ratio prediction and memory updates.
+- Configurable branching factor and bounded hierarchy depth.
+- Cumulative Ω correction memory with retention and learning ratios.
+- Λ gates for residual, active-node, memory, and quantisation bounds.
+- Atomic commit or rollback: rejected candidates never mutate committed state.
+- SHA-256 state-hash chain for replay and provenance.
+- Bounded in-memory journal of committed and rejected cycles.
+- Existing Greek register bridge:
+  - `Ξ`: encoded input aggregate
+  - `Ψ`: condensed root
+  - `Φ`: prediction aggregate
+  - `Λ`: commit gate
+  - `Ω`: cumulative memory aggregate
+  - `𝒮`: residual magnitude
+  - `Π`: decoded aggregate
+
+### Measured outputs
+
+Each cycle reports:
+
+- raw and condensed bit counts;
+- hierarchy depth and total nodes;
+- condensation ratio;
+- active-node fraction;
+- prediction residual magnitude;
+- cumulative memory magnitude;
+- reconstruction error;
+- previous, candidate, and committed state hashes.
+
+## Tests
+
+```bash
+pytest
+```
+
+The cognitive tests cover signed three-bit quantisation, hierarchical condensation, Ω learning, deterministic replay, Λ rollback, and register integration.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,4 +1,6 @@
+import json
 import sys
+
 from .parser import Parser
 from .assembler import Assembler
 from .core import CodexVM
@@ -6,23 +8,37 @@ from .api import start_api
 from .web import start_web
 from .node import CodexNode
 
+
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
+        print("Usage: jarvisx [run|cognitive|api|web|node] <arguments>")
         return
 
     cmd = sys.argv[1]
 
     if cmd == "run":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: jarvisx run <assembly-file>")
         file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
+        with open(file) as source_file:
+            source = source_file.read()
         ast = Parser().parse(source)
         bytecode = Assembler().assemble(ast)
         vm = CodexVM()
         vm.load(bytecode)
         vm.run()
         print("Registers:", vm.regs.snapshot())
+
+    elif cmd == "cognitive":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: jarvisx cognitive <number> [number ...]")
+        try:
+            values = [float(value) for value in sys.argv[2:]]
+        except ValueError as exc:
+            raise SystemExit("cognitive inputs must be finite numbers") from exc
+        vm = CodexVM()
+        result = vm.cognitive_cycle(values)
+        print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
 
     elif cmd == "api":
         start_api()
@@ -33,6 +49,10 @@ def main():
     elif cmd == "node":
         node = CodexNode()
         node.start()
+
+    else:
+        raise SystemExit("Unknown command: {}".format(cmd))
+
 
 if __name__ == "__main__":
     main()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,12 +1,12 @@
 import json
 import sys
 
-from .parser import Parser
+from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .api import start_api
-from .web import start_web
 from .node import CodexNode
+from .parser import Parser
+from .web import start_web
 
 
 def main():
@@ -34,10 +34,10 @@ def main():
             raise SystemExit("Usage: jarvisx cognitive <number> [number ...]")
         try:
             values = [float(value) for value in sys.argv[2:]]
-        except ValueError as exc:
+            vm = CodexVM()
+            result = vm.cognitive_cycle(values)
+        except (OverflowError, ValueError) as exc:
             raise SystemExit("cognitive inputs must be finite numbers") from exc
-        vm = CodexVM()
-        result = vm.cognitive_cycle(values)
         print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
 
     elif cmd == "api":

--- a/src/jarvisx/cognitive.py
+++ b/src/jarvisx/cognitive.py
@@ -5,8 +5,8 @@ The kernel operationalises the canonical cycle:
     encode -> condense -> predict -> compare -> update Omega
     -> project Lambda -> decode -> commit/rollback
 
-It uses signed 3-bit latent values and integer/fixed-ratio updates so runs are
-replayable across supported Python versions and hardware.
+All committed state is integer-valued and hash chained. Candidate state is
+validated before it is exposed through the VM register bridge.
 """
 
 from __future__ import annotations
@@ -42,9 +42,10 @@ def _div_round_nearest(numerator: int, denominator: int) -> int:
 
 def quantize_q3(value: Number, scale: float = 1.0) -> int:
     """Quantize a scalar into the signed 3-bit domain {-4, ..., 3}."""
-    if not math.isfinite(float(value)):
+    numeric = float(value)
+    if not math.isfinite(numeric):
         raise ValueError("input values must be finite")
-    return _clamp(_round_half_away_from_zero(float(value) * scale), Q3_MIN, Q3_MAX)
+    return _clamp(_round_half_away_from_zero(numeric * scale), Q3_MIN, Q3_MAX)
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,7 @@ class CognitiveConfig:
     branch_factor: int = 4
     input_scale: float = 1.0
     max_levels: int = 16
+    max_input_values: int = 65536
     retention_numerator: int = 7
     retention_denominator: int = 8
     learning_numerator: int = 1
@@ -67,14 +69,24 @@ class CognitiveConfig:
             raise ValueError("branch_factor must be >= 2")
         if self.max_levels < 1:
             raise ValueError("max_levels must be >= 1")
+        if self.max_input_values < 1:
+            raise ValueError("max_input_values must be positive")
         if self.input_scale <= 0 or not math.isfinite(self.input_scale):
             raise ValueError("input_scale must be positive and finite")
         if self.retention_denominator <= 0 or self.learning_denominator <= 0:
             raise ValueError("update denominators must be positive")
+        if not 0 <= self.retention_numerator <= self.retention_denominator:
+            raise ValueError("retention ratio must be between 0 and 1")
+        if self.learning_numerator < 0:
+            raise ValueError("learning_numerator must be non-negative")
         if self.omega_prediction_scale <= 0:
             raise ValueError("omega_prediction_scale must be positive")
         if self.omega_limit < 1:
             raise ValueError("omega_limit must be positive")
+        if self.max_residual_l1 is not None and self.max_residual_l1 < 0:
+            raise ValueError("max_residual_l1 must be non-negative")
+        if self.max_active_nodes is not None and self.max_active_nodes < 0:
+            raise ValueError("max_active_nodes must be non-negative")
         if self.journal_limit < 1:
             raise ValueError("journal_limit must be positive")
 
@@ -129,12 +141,17 @@ class CognitiveKernel:
         encoded = tuple(quantize_q3(value, self.config.input_scale) for value in source)
         if not encoded:
             raise ValueError("at least one input value is required")
+        if len(encoded) > self.config.max_input_values:
+            raise ValueError("input exceeds max_input_values")
         return encoded
 
     def condense(self, encoded: Tuple[int, ...]) -> Tuple[Tuple[int, ...], ...]:
         levels: List[Tuple[int, ...]] = [encoded]
         current = encoded
-        while len(current) > 1 and len(levels) < self.config.max_levels:
+
+        while len(current) > 1:
+            if len(levels) >= self.config.max_levels:
+                raise ValueError("hierarchy exceeds max_levels")
             parent: List[int] = []
             for start in range(0, len(current), self.config.branch_factor):
                 group = current[start : start + self.config.branch_factor]
@@ -143,9 +160,6 @@ class CognitiveKernel:
             current = tuple(parent)
             levels.append(current)
 
-        if len(current) > 1:
-            root = _clamp(_div_round_nearest(sum(current), len(current)), Q3_MIN, Q3_MAX)
-            levels.append((root,))
         return tuple(levels)
 
     def predict(self, encoded_length: int) -> Tuple[int, ...]:
@@ -175,18 +189,23 @@ class CognitiveKernel:
                 error * self.config.learning_numerator,
                 self.config.learning_denominator,
             )
-            updated.append(_clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit))
+            updated.append(
+                _clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit)
+            )
         return tuple(updated)
 
     def decode(self, hierarchy: Tuple[Tuple[int, ...], ...]) -> Tuple[int, ...]:
-        """Top-down approximate reconstruction from the condensed root."""
-        reconstructed = hierarchy[-1]
-        for child_level in reversed(hierarchy[:-1]):
-            expanded: List[int] = []
-            for value in reconstructed:
-                expanded.extend([value] * self.config.branch_factor)
-            reconstructed = tuple(expanded[: len(child_level)])
-        return tuple(_clamp(value, Q3_MIN, Q3_MAX) for value in reconstructed)
+        """Reconstruct the leaf width from the finest available condensed level."""
+        if len(hierarchy) == 1:
+            return hierarchy[0]
+
+        reconstructed = hierarchy[1]
+        expanded: List[int] = []
+        for value in reconstructed:
+            expanded.extend([value] * self.config.branch_factor)
+        return tuple(
+            _clamp(value, Q3_MIN, Q3_MAX) for value in expanded[: len(hierarchy[0])]
+        )
 
     def _validate_candidate(
         self,
@@ -197,16 +216,21 @@ class CognitiveKernel:
     ) -> Tuple[bool, str]:
         if not hierarchy or hierarchy[0] != encoded or len(hierarchy[-1]) != 1:
             return False, "invalid hierarchy"
+        if len(hierarchy) > self.config.max_levels:
+            return False, "hierarchy depth exceeded"
         if any(value < Q3_MIN or value > Q3_MAX for level in hierarchy for value in level):
             return False, "q3 range violation"
         if any(abs(value) > self.config.omega_limit for value in omega):
             return False, "omega bound violation"
+
         residual_l1 = sum(abs(value) for value in residual)
         if self.config.max_residual_l1 is not None and residual_l1 > self.config.max_residual_l1:
             return False, "residual budget exceeded"
+
         active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
         if self.config.max_active_nodes is not None and active_nodes > self.config.max_active_nodes:
             return False, "active-node budget exceeded"
+
         return True, "committed"
 
     @staticmethod
@@ -235,6 +259,7 @@ class CognitiveKernel:
             "hierarchy_nodes": float(hierarchy_nodes),
             "hierarchy_levels": float(len(hierarchy)),
             "condensation_ratio": float(raw_nodes) / float(root_nodes),
+            "materialization_ratio": float(hierarchy_nodes) / float(raw_nodes),
             "active_fraction": float(active_nodes) / float(hierarchy_nodes),
             "residual_l1": float(sum(abs(value) for value in residual)),
             "memory_l1": float(sum(abs(value) for value in omega)),
@@ -254,6 +279,7 @@ class CognitiveKernel:
         cycle = self.state.cycle + 1
 
         candidate_payload: Dict[str, object] = {
+            "config": asdict(self.config),
             "cycle": cycle,
             "encoded": encoded,
             "hierarchy": hierarchy,
@@ -307,7 +333,7 @@ class CognitiveKernel:
 
 
 class CognitiveVMBridge:
-    """Expose kernel state through the existing Jarvis-X Greek register bank."""
+    """Expose only committed kernel state through the Jarvis-X register bank."""
 
     def __init__(self, registers: object, kernel: Optional[CognitiveKernel] = None) -> None:
         self.registers = registers
@@ -315,13 +341,23 @@ class CognitiveVMBridge:
 
     def cycle(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
         result = self.kernel.step(values)
-        root = result.hierarchy[-1][0]
-        self.registers["Ξ"] = sum(result.encoded)
-        self.registers["Ψ"] = root
-        self.registers["Φ"] = sum(result.prediction)
-        self.registers["Λ"] = 1 if result.committed else 0
-        self.registers["Ω"] = sum(result.omega_after)
-        self.registers["Θ"] = self.kernel.config.learning_numerator
-        self.registers["𝒮"] = int(result.metrics["residual_l1"])
-        self.registers["Π"] = sum(result.decoded)
+        if not result.committed:
+            self.registers["Λ"] = 0
+            return result
+
+        before = self.registers.snapshot()
+        try:
+            root = result.hierarchy[-1][0]
+            self.registers["Ξ"] = sum(result.encoded)
+            self.registers["Ψ"] = root
+            self.registers["Φ"] = sum(result.prediction)
+            self.registers["Λ"] = 1
+            self.registers["Ω"] = sum(result.omega_after)
+            self.registers["Θ"] = self.kernel.config.learning_numerator
+            self.registers["𝒮"] = int(result.metrics["residual_l1"])
+            self.registers["Π"] = sum(result.decoded)
+        except Exception:
+            for name, value in before.items():
+                self.registers[name] = value
+            raise
         return result

--- a/src/jarvisx/cognitive.py
+++ b/src/jarvisx/cognitive.py
@@ -1,0 +1,327 @@
+"""Deterministic hierarchical cognitive kernel for Jarvis-X.
+
+The kernel operationalises the canonical cycle:
+
+    encode -> condense -> predict -> compare -> update Omega
+    -> project Lambda -> decode -> commit/rollback
+
+It uses signed 3-bit latent values and integer/fixed-ratio updates so runs are
+replayable across supported Python versions and hardware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+import math
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+Number = Union[int, float]
+Q3_MIN = -4
+Q3_MAX = 3
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return max(lower, min(upper, int(value)))
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    if value >= 0:
+        return int(math.floor(value + 0.5))
+    return int(math.ceil(value - 0.5))
+
+
+def _div_round_nearest(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    if numerator >= 0:
+        return (numerator + denominator // 2) // denominator
+    return -((-numerator + denominator // 2) // denominator)
+
+
+def quantize_q3(value: Number, scale: float = 1.0) -> int:
+    """Quantize a scalar into the signed 3-bit domain {-4, ..., 3}."""
+    if not math.isfinite(float(value)):
+        raise ValueError("input values must be finite")
+    return _clamp(_round_half_away_from_zero(float(value) * scale), Q3_MIN, Q3_MAX)
+
+
+@dataclass(frozen=True)
+class CognitiveConfig:
+    branch_factor: int = 4
+    input_scale: float = 1.0
+    max_levels: int = 16
+    retention_numerator: int = 7
+    retention_denominator: int = 8
+    learning_numerator: int = 1
+    learning_denominator: int = 2
+    omega_prediction_scale: int = 4
+    omega_limit: int = 127
+    max_residual_l1: Optional[int] = None
+    max_active_nodes: Optional[int] = None
+    journal_limit: int = 128
+
+    def validate(self) -> None:
+        if self.branch_factor < 2:
+            raise ValueError("branch_factor must be >= 2")
+        if self.max_levels < 1:
+            raise ValueError("max_levels must be >= 1")
+        if self.input_scale <= 0 or not math.isfinite(self.input_scale):
+            raise ValueError("input_scale must be positive and finite")
+        if self.retention_denominator <= 0 or self.learning_denominator <= 0:
+            raise ValueError("update denominators must be positive")
+        if self.omega_prediction_scale <= 0:
+            raise ValueError("omega_prediction_scale must be positive")
+        if self.omega_limit < 1:
+            raise ValueError("omega_limit must be positive")
+        if self.journal_limit < 1:
+            raise ValueError("journal_limit must be positive")
+
+
+@dataclass(frozen=True)
+class CognitiveState:
+    cycle: int = 0
+    encoded: Tuple[int, ...] = field(default_factory=tuple)
+    hierarchy: Tuple[Tuple[int, ...], ...] = field(default_factory=tuple)
+    prediction: Tuple[int, ...] = field(default_factory=tuple)
+    residual: Tuple[int, ...] = field(default_factory=tuple)
+    omega: Tuple[int, ...] = field(default_factory=tuple)
+    decoded: Tuple[int, ...] = field(default_factory=tuple)
+    state_hash: str = "GENESIS"
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    cycle: int
+    committed: bool
+    reason: str
+    encoded: Tuple[int, ...]
+    hierarchy: Tuple[Tuple[int, ...], ...]
+    prediction: Tuple[int, ...]
+    residual: Tuple[int, ...]
+    omega_before: Tuple[int, ...]
+    omega_after: Tuple[int, ...]
+    decoded: Tuple[int, ...]
+    metrics: Dict[str, float]
+    previous_hash: str
+    candidate_hash: str
+    state_hash: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+class CognitiveKernel:
+    """Transactional signed-3-bit hierarchical predictive runtime."""
+
+    def __init__(self, config: Optional[CognitiveConfig] = None) -> None:
+        self.config = config or CognitiveConfig()
+        self.config.validate()
+        self.state = CognitiveState()
+        self.journal: List[CycleResult] = []
+
+    def encode(self, values: Union[Number, Sequence[Number]]) -> Tuple[int, ...]:
+        if isinstance(values, (int, float)):
+            source: Iterable[Number] = (values,)
+        else:
+            source = values
+        encoded = tuple(quantize_q3(value, self.config.input_scale) for value in source)
+        if not encoded:
+            raise ValueError("at least one input value is required")
+        return encoded
+
+    def condense(self, encoded: Tuple[int, ...]) -> Tuple[Tuple[int, ...], ...]:
+        levels: List[Tuple[int, ...]] = [encoded]
+        current = encoded
+        while len(current) > 1 and len(levels) < self.config.max_levels:
+            parent: List[int] = []
+            for start in range(0, len(current), self.config.branch_factor):
+                group = current[start : start + self.config.branch_factor]
+                mean = _div_round_nearest(sum(group), len(group))
+                parent.append(_clamp(mean, Q3_MIN, Q3_MAX))
+            current = tuple(parent)
+            levels.append(current)
+
+        if len(current) > 1:
+            root = _clamp(_div_round_nearest(sum(current), len(current)), Q3_MIN, Q3_MAX)
+            levels.append((root,))
+        return tuple(levels)
+
+    def predict(self, encoded_length: int) -> Tuple[int, ...]:
+        previous = self.state.encoded
+        omega = self.state.omega
+        prediction: List[int] = []
+        for index in range(encoded_length):
+            base = previous[index] if index < len(previous) else 0
+            memory = omega[index] if index < len(omega) else 0
+            correction = _div_round_nearest(memory, self.config.omega_prediction_scale)
+            prediction.append(_clamp(base + correction, Q3_MIN, Q3_MAX))
+        return tuple(prediction)
+
+    @staticmethod
+    def compare(encoded: Tuple[int, ...], prediction: Tuple[int, ...]) -> Tuple[int, ...]:
+        return tuple(actual - expected for actual, expected in zip(encoded, prediction))
+
+    def update_omega(self, residual: Tuple[int, ...]) -> Tuple[int, ...]:
+        updated: List[int] = []
+        for index, error in enumerate(residual):
+            old = self.state.omega[index] if index < len(self.state.omega) else 0
+            retained = _div_round_nearest(
+                old * self.config.retention_numerator,
+                self.config.retention_denominator,
+            )
+            learned = _div_round_nearest(
+                error * self.config.learning_numerator,
+                self.config.learning_denominator,
+            )
+            updated.append(_clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit))
+        return tuple(updated)
+
+    def decode(self, hierarchy: Tuple[Tuple[int, ...], ...]) -> Tuple[int, ...]:
+        """Top-down approximate reconstruction from the condensed root."""
+        reconstructed = hierarchy[-1]
+        for child_level in reversed(hierarchy[:-1]):
+            expanded: List[int] = []
+            for value in reconstructed:
+                expanded.extend([value] * self.config.branch_factor)
+            reconstructed = tuple(expanded[: len(child_level)])
+        return tuple(_clamp(value, Q3_MIN, Q3_MAX) for value in reconstructed)
+
+    def _validate_candidate(
+        self,
+        encoded: Tuple[int, ...],
+        hierarchy: Tuple[Tuple[int, ...], ...],
+        residual: Tuple[int, ...],
+        omega: Tuple[int, ...],
+    ) -> Tuple[bool, str]:
+        if not hierarchy or hierarchy[0] != encoded or len(hierarchy[-1]) != 1:
+            return False, "invalid hierarchy"
+        if any(value < Q3_MIN or value > Q3_MAX for level in hierarchy for value in level):
+            return False, "q3 range violation"
+        if any(abs(value) > self.config.omega_limit for value in omega):
+            return False, "omega bound violation"
+        residual_l1 = sum(abs(value) for value in residual)
+        if self.config.max_residual_l1 is not None and residual_l1 > self.config.max_residual_l1:
+            return False, "residual budget exceeded"
+        active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
+        if self.config.max_active_nodes is not None and active_nodes > self.config.max_active_nodes:
+            return False, "active-node budget exceeded"
+        return True, "committed"
+
+    @staticmethod
+    def _hash_candidate(payload: Dict[str, object]) -> str:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _metrics(
+        self,
+        encoded: Tuple[int, ...],
+        hierarchy: Tuple[Tuple[int, ...], ...],
+        residual: Tuple[int, ...],
+        omega: Tuple[int, ...],
+        decoded: Tuple[int, ...],
+    ) -> Dict[str, float]:
+        raw_nodes = len(encoded)
+        root_nodes = len(hierarchy[-1])
+        hierarchy_nodes = sum(len(level) for level in hierarchy)
+        active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
+        reconstruction_error = sum(abs(a - b) for a, b in zip(encoded, decoded))
+        return {
+            "raw_nodes": float(raw_nodes),
+            "raw_bits": float(raw_nodes * 3),
+            "root_nodes": float(root_nodes),
+            "root_bits": float(root_nodes * 3),
+            "hierarchy_nodes": float(hierarchy_nodes),
+            "hierarchy_levels": float(len(hierarchy)),
+            "condensation_ratio": float(raw_nodes) / float(root_nodes),
+            "active_fraction": float(active_nodes) / float(hierarchy_nodes),
+            "residual_l1": float(sum(abs(value) for value in residual)),
+            "memory_l1": float(sum(abs(value) for value in omega)),
+            "reconstruction_error_l1": float(reconstruction_error),
+        }
+
+    def step(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
+        previous_hash = self.state.state_hash
+        encoded = self.encode(values)
+        hierarchy = self.condense(encoded)
+        prediction = self.predict(len(encoded))
+        residual = self.compare(encoded, prediction)
+        omega_before = self.state.omega
+        omega_after = self.update_omega(residual)
+        decoded = self.decode(hierarchy)
+        metrics = self._metrics(encoded, hierarchy, residual, omega_after, decoded)
+        cycle = self.state.cycle + 1
+
+        candidate_payload: Dict[str, object] = {
+            "cycle": cycle,
+            "encoded": encoded,
+            "hierarchy": hierarchy,
+            "prediction": prediction,
+            "residual": residual,
+            "omega": omega_after,
+            "decoded": decoded,
+            "previous_hash": previous_hash,
+        }
+        candidate_hash = self._hash_candidate(candidate_payload)
+        valid, reason = self._validate_candidate(encoded, hierarchy, residual, omega_after)
+
+        if valid:
+            self.state = CognitiveState(
+                cycle=cycle,
+                encoded=encoded,
+                hierarchy=hierarchy,
+                prediction=prediction,
+                residual=residual,
+                omega=omega_after,
+                decoded=decoded,
+                state_hash=candidate_hash,
+            )
+
+        result = CycleResult(
+            cycle=cycle,
+            committed=valid,
+            reason=reason,
+            encoded=encoded,
+            hierarchy=hierarchy,
+            prediction=prediction,
+            residual=residual,
+            omega_before=omega_before,
+            omega_after=omega_after,
+            decoded=decoded,
+            metrics=metrics,
+            previous_hash=previous_hash,
+            candidate_hash=candidate_hash,
+            state_hash=self.state.state_hash,
+        )
+        self.journal.append(result)
+        if len(self.journal) > self.config.journal_limit:
+            del self.journal[: len(self.journal) - self.config.journal_limit]
+        return result
+
+    def run(self, stream: Iterable[Union[Number, Sequence[Number]]]) -> List[CycleResult]:
+        return [self.step(values) for values in stream]
+
+    def snapshot(self) -> Dict[str, object]:
+        return asdict(self.state)
+
+
+class CognitiveVMBridge:
+    """Expose kernel state through the existing Jarvis-X Greek register bank."""
+
+    def __init__(self, registers: object, kernel: Optional[CognitiveKernel] = None) -> None:
+        self.registers = registers
+        self.kernel = kernel or CognitiveKernel()
+
+    def cycle(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
+        result = self.kernel.step(values)
+        root = result.hierarchy[-1][0]
+        self.registers["Ξ"] = sum(result.encoded)
+        self.registers["Ψ"] = root
+        self.registers["Φ"] = sum(result.prediction)
+        self.registers["Λ"] = 1 if result.committed else 0
+        self.registers["Ω"] = sum(result.omega_after)
+        self.registers["Θ"] = self.kernel.config.learning_numerator
+        self.registers["𝒮"] = int(result.metrics["residual_l1"])
+        self.registers["Π"] = sum(result.decoded)
+        return result

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -12,7 +12,7 @@ from .cognitive import CognitiveKernel, CognitiveVMBridge
 
 
 class CodexVM:
-    def __init__(self):
+    def __init__(self, reflex_enabled=False):
         self.regs = Registers()
         self.mem = Memory()
         self.decoder = Decoder()
@@ -20,6 +20,7 @@ class CodexVM:
         self.ledger = PersistentLedger()
         self.ethics = LambdaShield()
         self.reflex = ReflexEngine()
+        self.reflex_enabled = bool(reflex_enabled)
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
@@ -44,7 +45,8 @@ class CodexVM:
         cont = self.executor.execute(instr)
         self.ledger.log(self.regs.snapshot(), instr.opcode)
         self.tracer.record(instr, self.regs.snapshot())
-        self.reflex.stabilize(self.regs)
+        if self.reflex_enabled:
+            self.reflex.stabilize(self.regs)
 
         self.regs["IP"] += 1
         self.cycles += 1
@@ -56,6 +58,10 @@ class CodexVM:
     def run(self):
         while self.running:
             self.step()
+
+    def apply_reflex(self):
+        """Apply one explicit reflex-stabilisation step to the register bank."""
+        self.reflex.stabilize(self.regs)
 
     def cognitive_cycle(self, values):
         """Execute one atomic hierarchical intelligence transaction.

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -58,10 +58,20 @@ class CodexVM:
             self.step()
 
     def cognitive_cycle(self, values):
-        """Execute one transactional hierarchical intelligence cycle.
+        """Execute one atomic hierarchical intelligence transaction.
 
-        The cycle quantizes into Q3, condenses through the hierarchy, predicts,
-        computes the residual, updates cumulative Omega memory, applies Lambda
-        constraints, decodes, and atomically commits or rolls back.
+        Kernel state, journal state, and VM registers are restored together if
+        the register projection fails after the kernel has accepted a candidate.
         """
-        return self.cognitive_bridge.cycle(values)
+        state_before = self.cognitive.state
+        journal_length = len(self.cognitive.journal)
+        registers_before = self.regs.snapshot()
+
+        try:
+            return self.cognitive_bridge.cycle(values)
+        except Exception:
+            self.cognitive.state = state_before
+            del self.cognitive.journal[journal_length:]
+            for name, value in registers_before.items():
+                self.regs[name] = value
+            raise

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -8,6 +8,8 @@ from .reflex import ReflexEngine
 from .sandbox import Sandbox
 from .debugger import Debugger
 from .tracer import Tracer
+from .cognitive import CognitiveKernel, CognitiveVMBridge
+
 
 class CodexVM:
     def __init__(self):
@@ -21,6 +23,8 @@ class CodexVM:
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
+        self.cognitive = CognitiveKernel()
+        self.cognitive_bridge = CognitiveVMBridge(self.regs, self.cognitive)
         self.program = []
         self.cycles = 0
         self.running = True
@@ -28,6 +32,7 @@ class CodexVM:
     def load(self, bytecode):
         self.program = bytecode
         self.regs["IP"] = 0
+        self.running = True
 
     def step(self):
         ip = self.regs["IP"]
@@ -51,3 +56,12 @@ class CodexVM:
     def run(self):
         while self.running:
             self.step()
+
+    def cognitive_cycle(self, values):
+        """Execute one transactional hierarchical intelligence cycle.
+
+        The cycle quantizes into Q3, condenses through the hierarchy, predicts,
+        computes the residual, updates cumulative Omega memory, applies Lambda
+        constraints, decodes, and atomically commits or rolls back.
+        """
+        return self.cognitive_bridge.cycle(values)

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,44 @@
 import hashlib
-import time
+import json
+
 
 class OmegaLedger:
+    """Deterministic hash-chained execution ledger."""
+
     def __init__(self):
         self.chain = []
 
+    @staticmethod
+    def _serialize_payload(payload):
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        payload = {
+            "sequence": len(self.chain),
+            "state": state,
+            "opcode": int(opcode),
+        }
+        previous_hash = self.chain[-1]["hash"].encode("ascii") if self.chain else b""
+        digest = hashlib.sha256(previous_hash + self._serialize_payload(payload)).hexdigest()
+        entry = {"hash": digest, "payload": payload}
+        self.chain.append(entry)
+        return entry
+
+    def verify(self):
+        previous_hash = b""
+        for sequence, entry in enumerate(self.chain):
+            payload = entry.get("payload")
+            if not isinstance(payload, dict) or payload.get("sequence") != sequence:
+                return False
+            expected = hashlib.sha256(
+                previous_hash + self._serialize_payload(payload)
+            ).hexdigest()
+            if entry.get("hash") != expected:
+                return False
+            previous_hash = expected.encode("ascii")
+        return True

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -1,16 +1,44 @@
 import json
 import os
+
 from .ledger import OmegaLedger
 
+
 class PersistentLedger(OmegaLedger):
+    """Omega ledger persisted with an atomic replace operation."""
+
     def __init__(self, path="omega_ledger.json"):
         super().__init__()
         self.path = path
         if os.path.exists(path):
-            with open(path) as f:
-                self.chain = json.load(f)
+            try:
+                with open(path, encoding="utf-8") as source:
+                    chain = json.load(source)
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RuntimeError("Unable to load persistent Omega ledger") from exc
+            if not isinstance(chain, list):
+                raise RuntimeError("Persistent Omega ledger must contain a list")
+            self.chain = chain
+            if not self.verify():
+                raise RuntimeError("Persistent Omega ledger hash chain is invalid")
 
     def log(self, state, opcode):
-        super().log(state, opcode)
-        with open(self.path, "w") as f:
-            json.dump(self.chain, f, indent=2)
+        previous_length = len(self.chain)
+        entry = super().log(state, opcode)
+        temporary_path = "{}.tmp".format(self.path)
+
+        try:
+            with open(temporary_path, "w", encoding="utf-8") as destination:
+                json.dump(self.chain, destination, ensure_ascii=False, indent=2)
+                destination.flush()
+                os.fsync(destination.fileno())
+            os.replace(temporary_path, self.path)
+        except Exception:
+            del self.chain[previous_length:]
+            try:
+                if os.path.exists(temporary_path):
+                    os.remove(temporary_path)
+            finally:
+                raise
+
+        return entry

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -1,3 +1,7 @@
+import math
+
+import pytest
+
 from jarvisx.cognitive import (
     CognitiveConfig,
     CognitiveKernel,
@@ -14,6 +18,13 @@ def test_q3_quantization_is_bounded_and_signed():
     assert quantize_q3(99) == 3
 
 
+def test_q3_quantization_rejects_non_finite_values():
+    with pytest.raises(ValueError, match="finite"):
+        quantize_q3(math.inf)
+    with pytest.raises(ValueError, match="finite"):
+        quantize_q3(math.nan)
+
+
 def test_hierarchy_condenses_to_single_root():
     kernel = CognitiveKernel(CognitiveConfig(branch_factor=2))
     result = kernel.step([3, 2, 1, 0, -1, -2, -3, -4])
@@ -21,6 +32,13 @@ def test_hierarchy_condenses_to_single_root():
     assert result.hierarchy[0] == (3, 2, 1, 0, -1, -2, -3, -4)
     assert len(result.hierarchy[-1]) == 1
     assert result.metrics["condensation_ratio"] == 8.0
+
+
+def test_hierarchy_enforces_maximum_depth_before_allocation_continues():
+    kernel = CognitiveKernel(CognitiveConfig(branch_factor=2, max_levels=2))
+    with pytest.raises(ValueError, match="max_levels"):
+        kernel.step([1, 1, 1, 1])
+    assert kernel.snapshot()["state_hash"] == "GENESIS"
 
 
 def test_prediction_error_updates_cumulative_memory():
@@ -58,3 +76,31 @@ def test_vm_bridge_maps_cycle_to_existing_registers():
     assert regs["Λ"] == 1
     assert regs["Ψ"] == result.hierarchy[-1][0]
     assert regs["𝒮"] == int(result.metrics["residual_l1"])
+
+
+def test_vm_bridge_rejection_does_not_leak_candidate_registers():
+    regs = Registers()
+    kernel = CognitiveKernel(CognitiveConfig(max_residual_l1=4))
+    bridge = CognitiveVMBridge(regs, kernel)
+
+    committed = bridge.cycle([1, 1, 1, 1])
+    assert committed.committed
+    before = regs.snapshot()
+
+    rejected = bridge.cycle([-4, -4, -4, -4])
+    after = regs.snapshot()
+
+    assert not rejected.committed
+    assert rejected.reason == "residual budget exceeded"
+    assert rejected.state_hash == committed.state_hash
+    assert after["Λ"] == 0
+    for name, value in before.items():
+        if name != "Λ":
+            assert after[name] == value
+
+
+def test_configuration_rejects_unbounded_update_ratios():
+    with pytest.raises(ValueError, match="retention ratio"):
+        CognitiveKernel(CognitiveConfig(retention_numerator=9, retention_denominator=8))
+    with pytest.raises(ValueError, match="non-negative"):
+        CognitiveKernel(CognitiveConfig(learning_numerator=-1))

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -8,6 +8,7 @@ from jarvisx.cognitive import (
     CognitiveVMBridge,
     quantize_q3,
 )
+from jarvisx.core import CodexVM
 from jarvisx.registers import Registers
 
 
@@ -97,6 +98,34 @@ def test_vm_bridge_rejection_does_not_leak_candidate_registers():
     for name, value in before.items():
         if name != "Λ":
             assert after[name] == value
+
+
+def test_vm_rolls_back_kernel_and_registers_on_projection_failure():
+    class FailingRegisters(Registers):
+        def __init__(self):
+            super().__init__()
+            self.fail_once = False
+
+        def __setitem__(self, key, value):
+            if self.fail_once and key == "Ω":
+                self.fail_once = False
+                raise RuntimeError("simulated register failure")
+            super().__setitem__(key, value)
+
+    vm = CodexVM()
+    failing = FailingRegisters()
+    vm.regs = failing
+    vm.cognitive_bridge.registers = failing
+    before_state = vm.cognitive.snapshot()
+    before_registers = failing.snapshot()
+    failing.fail_once = True
+
+    with pytest.raises(RuntimeError, match="simulated register failure"):
+        vm.cognitive_cycle([3, 1, -1, -3])
+
+    assert vm.cognitive.snapshot() == before_state
+    assert vm.cognitive.journal == []
+    assert failing.snapshot() == before_registers
 
 
 def test_configuration_rejects_unbounded_update_ratios():

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -1,0 +1,60 @@
+from jarvisx.cognitive import (
+    CognitiveConfig,
+    CognitiveKernel,
+    CognitiveVMBridge,
+    quantize_q3,
+)
+from jarvisx.registers import Registers
+
+
+def test_q3_quantization_is_bounded_and_signed():
+    assert quantize_q3(-99) == -4
+    assert quantize_q3(-1.5) == -2
+    assert quantize_q3(1.5) == 2
+    assert quantize_q3(99) == 3
+
+
+def test_hierarchy_condenses_to_single_root():
+    kernel = CognitiveKernel(CognitiveConfig(branch_factor=2))
+    result = kernel.step([3, 2, 1, 0, -1, -2, -3, -4])
+    assert result.committed
+    assert result.hierarchy[0] == (3, 2, 1, 0, -1, -2, -3, -4)
+    assert len(result.hierarchy[-1]) == 1
+    assert result.metrics["condensation_ratio"] == 8.0
+
+
+def test_prediction_error_updates_cumulative_memory():
+    kernel = CognitiveKernel()
+    first = kernel.step([3, 3, 3, 3])
+    second = kernel.step([0, 0, 0, 0])
+    assert first.omega_after == (2, 2, 2, 2)
+    assert second.prediction == (3, 3, 3, 3)
+    assert second.residual == (-3, -3, -3, -3)
+    assert second.omega_after == (0, 0, 0, 0)
+
+
+def test_same_stream_produces_same_hash_chain():
+    stream = [[1, 2, 3, -4], [1, 1, 2, -3], [0, 1, 1, -2]]
+    left = CognitiveKernel().run(stream)
+    right = CognitiveKernel().run(stream)
+    assert [item.state_hash for item in left] == [item.state_hash for item in right]
+
+
+def test_lambda_rejection_rolls_back_committed_state():
+    kernel = CognitiveKernel(CognitiveConfig(max_residual_l1=0))
+    before = kernel.snapshot()
+    result = kernel.step([1, 0, 0, 0])
+    assert not result.committed
+    assert result.reason == "residual budget exceeded"
+    assert kernel.snapshot() == before
+    assert result.state_hash == "GENESIS"
+
+
+def test_vm_bridge_maps_cycle_to_existing_registers():
+    regs = Registers()
+    bridge = CognitiveVMBridge(regs)
+    result = bridge.cycle([3, 1, -1, -3])
+    assert result.committed
+    assert regs["Λ"] == 1
+    assert regs["Ψ"] == result.hierarchy[-1][0]
+    assert regs["𝒮"] == int(result.metrics["residual_l1"])

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,51 @@
+import json
+
+from jarvisx.ledger import OmegaLedger
+from jarvisx.ledger_store import PersistentLedger
+
+
+def test_omega_ledger_is_deterministic_and_verifiable():
+    state = {"Ψ": 7, "Φ": 3}
+    left = OmegaLedger()
+    right = OmegaLedger()
+
+    left_entry = left.log(state, 1)
+    right_entry = right.log(state, 1)
+
+    assert left_entry == right_entry
+    assert left.verify()
+    assert right.verify()
+
+
+def test_persistent_ledger_is_json_serializable_and_reloadable(tmp_path):
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(str(path))
+    ledger.log({"Ψ": 10, "Φ": 20}, 1)
+    ledger.log({"A": 30}, 3)
+
+    with path.open(encoding="utf-8") as source:
+        raw = json.load(source)
+
+    assert raw == ledger.chain
+    assert ledger.verify()
+
+    reloaded = PersistentLedger(str(path))
+    assert reloaded.chain == ledger.chain
+    assert reloaded.verify()
+
+
+def test_persistent_ledger_rejects_tampering(tmp_path):
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(str(path))
+    ledger.log({"A": 1}, 1)
+
+    data = ledger.chain
+    data[0]["payload"]["state"]["A"] = 99
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    try:
+        PersistentLedger(str(path))
+    except RuntimeError as exc:
+        assert "hash chain" in str(exc)
+    else:
+        raise AssertionError("tampered ledger was accepted")

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,12 +1,23 @@
+from jarvisx.assembler import Assembler
 from jarvisx.core import CodexVM
 from jarvisx.parser import Parser
-from jarvisx.assembler import Assembler
 
-def test_add():
+
+def test_add_preserves_exact_assembly_semantics():
     code = "SET Ψ 10\nSET Φ 20\nADD A Ψ Φ\nHALT"
     ast = Parser().parse(code)
-    bc = Assembler().assemble(ast)
+    bytecode = Assembler().assemble(ast)
     vm = CodexVM()
-    vm.load(bc)
+    vm.load(bytecode)
     vm.run()
     assert vm.regs["A"] == 30
+
+
+def test_reflex_stabilisation_is_explicit():
+    vm = CodexVM()
+    vm.regs["Ψ"] = 10
+    vm.regs["Φ"] = 20
+
+    vm.apply_reflex()
+
+    assert vm.regs["Φ"] == 19


### PR DESCRIPTION
## What changed

- added a deterministic signed-3-bit hierarchical cognitive kernel
- implemented encode → condense → predict → compare → update Ω → project Λ → decode → commit/rollback
- integrated the kernel through `CodexVM.cognitive_cycle(...)`
- exposed `jarvisx cognitive <number>...`
- added bounded input and hierarchy controls, cumulative Ω memory, metrics, journaling, and SHA-256 provenance

## Debugging fixes

The first full CI runs exposed three pre-existing integration defects and one transactional defect:

1. **Pytest could not collect tests** because `pyproject.toml` used the nonexistent coverage reporter `term-local`. It now uses `term-missing`.
2. **Λ rollback leaked candidate state into VM registers.** Rejected candidates now preserve every committed register except the Λ result gate, and projection exceptions roll back kernel state, journal entries, and registers together.
3. **The persistent Ω ledger stored `bytes` and passed them to `json.dump`.** Ledger payloads are now canonical JSON, deterministically hash chained, verified on load, and persisted with atomic file replacement.
4. **The reflex layer corrupted base ISA semantics.** Automatic reflex mutation changed `SET Ψ 10; SET Φ 20; ADD A Ψ Φ` from 30 to 29. Reflex stabilisation is now explicit/opt-in, preserving exact assembly execution by default.

Additional hardening:

- non-finite cognitive inputs are rejected cleanly
- hierarchy depth and input size are bounded before continued allocation
- retention and learning ratios are validated
- configuration is included in the cognitive state provenance hash
- regression tests cover transaction rollback, projection failure, ledger tampering, deterministic replay, hierarchy bounds, and explicit reflex control

## Validation

GitHub Actions run **#272** passed completely:

- Python 3.8: passed
- Python 3.9: passed
- Python 3.10: passed
- Python 3.11: passed
- Python 3.12: passed
- pytest and coverage: passed
- mypy type check: passed
- Black and isort checks: passed

## Design constraints

- deterministic integer/fixed-ratio cognitive updates
- signed three-bit latent domain
- candidate validation before mutation
- atomic commit or rollback
- deterministic, auditable persistence
- backward-compatible base VM and ISA behavior
