### PR TITLE
Add inward 3D geometric multiparallel RVIS loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer, policy gate, persistent Ω ledger, and a transactional hierarchical cognitive kernel.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer, policy gate, persistent Ω ledger, transactional hierarchical cognitive kernel, and a 3D geometric reasoning-visualisation runtime.
 
 ## Install
 
@@ -17,7 +17,7 @@ pip install .
 jarvisx run program.jx
 ```
 
-The existing VM supports deterministic bytecode decoding, register execution, Λ policy checks, reflex stabilisation, tracing, sandbox limits, and ledger recording.
+The existing VM supports deterministic bytecode decoding, register execution, Λ policy checks, explicit reflex stabilisation, tracing, sandbox limits, and ledger recording.
 
 ## Hierarchical cognitive kernel
 
@@ -75,16 +75,49 @@ print(vm.regs.snapshot())
 
 ### Measured outputs
 
-Each cycle reports:
+Each cycle reports raw and condensed bit counts, hierarchy depth, condensation ratio, active-node fraction, residual magnitude, cumulative memory, reconstruction error, and provenance hashes.
 
-- raw and condensed bit counts;
-- hierarchy depth and total nodes;
-- condensation ratio;
-- active-node fraction;
-- prediction residual magnitude;
-- cumulative memory magnitude;
-- reconstruction error;
-- previous, candidate, and committed state hashes.
+## 3D geometric multiparallel feedback loop
+
+The reasoning-visualisation shell can turn its committed public output inward:
+
+```text
+Public shell values
+  -> signed-3-bit 3D voxel lattice
+  -> identity / diffusion / memory / hybrid lanes in parallel
+  -> 2x2x2 multiresolution condensation
+  -> top-down geometric decoding
+  -> reconstruction scoring
+  -> Λ projection
+  -> atomic commit or rollback
+  -> committed output becomes the next input
+```
+
+Run four inward cycles:
+
+```bash
+jarvisx geometry3d --cycles 4 3 1 -1 -3
+```
+
+The command emits browser-safe JSON containing each cycle, the geometric hierarchy, all four lane candidates, reconstruction and memory metrics, Λ decisions, public shell events, the final state, and the projected register bank.
+
+Python API:
+
+```python
+from jarvisx.core import CodexVM
+
+vm = CodexVM()
+cycles = vm.geometric_feedback([3, 1, -1, -3], cycles=4)
+
+for cycle in cycles:
+    print(cycle.selected_lane)
+    print(cycle.output)
+    print(cycle.events)
+```
+
+Open `geometric-rvis-shell.html` directly in a browser. It provides a rotatable and zoomable 3D lattice, encoded/evolved/decoded stage switching, cycle replay, lane telemetry, Λ status, and the public event timeline. Paste or load JSON produced by the CLI to replay a real execution.
+
+The full design is documented in `docs/JX_RVIS_3D_GEOMETRIC_LOOP.md`.
 
 ## Tests
 
@@ -92,4 +125,4 @@ Each cycle reports:
 pytest
 ```
 
-The cognitive tests cover signed three-bit quantisation, hierarchical condensation, Ω learning, deterministic replay, Λ rollback, and register integration.
+The suites cover signed-three-bit quantisation, hierarchical condensation, Ω learning, deterministic replay, Λ rollback, exact ISA behavior, ledger integrity, 3D address bijection, multiparallel lane determinism, inward feedback, browser event generation, and register integration.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,95 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer, policy gate, persistent Ω ledger, and a transactional hierarchical cognitive kernel.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## Assembly VM
+
+```bash
+jarvisx run program.jx
+```
+
+The existing VM supports deterministic bytecode decoding, register execution, Λ policy checks, reflex stabilisation, tracing, sandbox limits, and ledger recording.
+
+## Hierarchical cognitive kernel
+
+The operational kernel executes the canonical cycle:
+
+```text
+Encode Q3
+  -> Hierarchical Condensation
+  -> Predict
+  -> Compare / Residual
+  -> Update cumulative Ω memory
+  -> Project through Λ constraints
+  -> Decode
+  -> Commit or Roll Back
+```
+
+Run a cycle directly:
+
+```bash
+jarvisx cognitive 3 1 -1 -3
+```
+
+Or from Python:
+
+```python
+from jarvisx.core import CodexVM
+
+vm = CodexVM()
+result = vm.cognitive_cycle([3, 1, -1, -3])
+
+print(result.committed)
+print(result.hierarchy)
+print(result.metrics)
+print(vm.regs.snapshot())
+```
+
+### Operational properties
+
+- Signed three-bit latent domain: `Q3 = {-4, -3, -2, -1, 0, 1, 2, 3}`.
+- Deterministic integer/fixed-ratio prediction and memory updates.
+- Configurable branching factor and bounded hierarchy depth.
+- Cumulative Ω correction memory with retention and learning ratios.
+- Λ gates for residual, active-node, memory, and quantisation bounds.
+- Atomic commit or rollback: rejected candidates never mutate committed state.
+- SHA-256 state-hash chain for replay and provenance.
+- Bounded in-memory journal of committed and rejected cycles.
+- Existing Greek register bridge:
+  - `Ξ`: encoded input aggregate
+  - `Ψ`: condensed root
+  - `Φ`: prediction aggregate
+  - `Λ`: commit gate
+  - `Ω`: cumulative memory aggregate
+  - `𝒮`: residual magnitude
+  - `Π`: decoded aggregate
+
+### Measured outputs
+
+Each cycle reports:
+
+- raw and condensed bit counts;
+- hierarchy depth and total nodes;
+- condensation ratio;
+- active-node fraction;
+- prediction residual magnitude;
+- cumulative memory magnitude;
+- reconstruction error;
+- previous, candidate, and committed state hashes.
+
+## Tests
+
+```bash
+pytest
+```
+
+The cognitive tests cover signed three-bit quantisation, hierarchical condensation, Ω learning, deterministic replay, Λ rollback, and register integration.

--- a/docs/JX_RVIS_3D_GEOMETRIC_LOOP.md
+++ b/docs/JX_RVIS_3D_GEOMETRIC_LOOP.md
@@ -1,0 +1,138 @@
+# JX-RVIS 3D Geometric Auto-Encoding/Decoding Multiparallel Loop
+
+## Operational identity
+
+The shell is turned inward by feeding every committed decoded output into the next geometric cycle:
+
+\[
+X_{t+1}=Y_t,
+\qquad
+Z_t=E_G(X_t),
+\qquad
+Y_t=D_G\!\left(\operatorname{Select}_{\Lambda}\{\mathcal L_k(Z_t,\Omega_t)\}_{k=1}^{K}\right).
+\]
+
+Each cycle is transactional:
+
+```text
+Observe public shell values
+  -> Q3 geometric encoding
+  -> 3D coordinate mapping
+  -> multiparallel candidate lanes
+  -> multiresolution 2x2x2 condensation
+  -> top-down decoding
+  -> reconstruction scoring
+  -> Lambda projection
+  -> commit or rollback
+  -> feed committed output inward
+```
+
+The implementation visualises explicit public state and shell events. It does not expose private hidden chain-of-thought.
+
+## Geometric latent state
+
+\[
+Z_G=(V,E,C,A,M,\Omega,\Lambda)
+\]
+
+- `V`: voxel samples;
+- `E`: implicit six-neighbour relations;
+- `C`: multiresolution 2x2x2 cells;
+- `A`: signed-three-bit activations;
+- `M`: lattice metric and dimensions;
+- `Ω`: cumulative reconstruction correction;
+- `Λ`: admissibility constraints.
+
+Linear and geometric addresses are bijective:
+
+\[
+\gamma^{-1}(x,y,z)=x+W(y+Hz).
+\]
+
+## Multiparallel lanes
+
+Every lane reads the same committed checkpoint and produces an isolated candidate:
+
+| Lane | Evolution |
+|---|---|
+| `identity` | preserves the encoded voxel value |
+| `diffusion` | blends each voxel with its six-neighbour mean |
+| `memory` | applies cumulative Ω correction |
+| `hybrid` | combines local state, neighbourhood and Ω |
+
+The lanes are executed concurrently as pure functions. Results are gathered in a fixed order, so selection and replay remain deterministic.
+
+The selected branch is:
+
+\[
+k^*=\arg\min_{k\in\mathcal K_{\mathrm{admissible}}}
+\|X_t-D_G(Z_t^{(k)})\|_1.
+\]
+
+## Lambda projection
+
+A lane is admissible only when:
+
+\[
+E^{(k)}_{\mathrm{reconstruction}}\leq E_{\max}
+\]
+
+and:
+
+\[
+N^{(k)}_{\mathrm{active}}\leq N_{\max}.
+\]
+
+When no lane passes, the complete committed geometric state remains unchanged.
+
+## Cumulative memory
+
+\[
+\Omega_{t+1}
+=
+\operatorname{clip}
+\left(
+\rho\Omega_t+
+\eta(X_t-Y_t),
+-\Omega_{\max},
+\Omega_{\max}
+\right).
+\]
+
+Ω improves candidate generation but never bypasses Λ verification.
+
+## Python API
+
+```python
+from jarvisx.geometric_rvis import GeometricFeedbackRuntime
+
+runtime = GeometricFeedbackRuntime()
+cycles = runtime.run_feedback([3, 1, -1, -3], cycles=4)
+
+for cycle in cycles:
+    print(cycle.selected_lane)
+    print(cycle.metrics)
+    print(cycle.events)
+```
+
+## CLI
+
+```bash
+jarvisx geometry3d --cycles 4 3 1 -1 -3
+```
+
+The command returns JSON containing every cycle, parallel lane result, 3D hierarchy, Λ decision, public visualization event, and final committed state.
+
+## Browser shell
+
+Open `geometric-rvis-shell.html`, then either run its built-in demonstration or paste/load JSON produced by `jarvisx geometry3d`.
+
+The browser shell provides a rotatable 3D point-lattice projection, encoded/evolved/decoded stage selection, cycle replay, lane telemetry, commit status, and event timeline controls.
+
+## Governing invariant
+
+\[
+\boxed{
+\text{Parallel lanes may propose geometric evolution; only Λ may commit it.}
+}
+\]

--- a/geometric-rvis-shell.html
+++ b/geometric-rvis-shell.html
@@ -69,6 +69,13 @@ input[type=range] { width: 100%; padding: 0; }
 </div>
 <script>
 (() => {
+  'use strict';
+
+  const MAX_CYCLES = 1024;
+  const MAX_EVENTS_PER_CYCLE = 2000;
+  const MAX_VOXELS = 4096;
+  const MAX_JSON_BYTES = 5 * 1024 * 1024;
+
   const canvas = document.querySelector('#view');
   const ctx = canvas.getContext('2d');
   const cycleSlider = document.querySelector('#cycle');
@@ -77,8 +84,19 @@ input[type=range] { width: 100%; padding: 0; }
   const metrics = document.querySelector('#metrics');
   const timeline = document.querySelector('#timeline');
   const status = document.querySelector('#status');
+  const playButton = document.querySelector('#play');
   let cycles = [], angleX = -0.45, angleY = 0.65, zoom = 64, playing = false, timer = null;
   let dragging = false, lastX = 0, lastY = 0;
+
+  function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>"']/g, character => ({
+      '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+    })[character]);
+  }
+
+  function isRecord(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+  }
 
   function resize() {
     const dpr = Math.min(devicePixelRatio || 1, 2);
@@ -90,23 +108,46 @@ input[type=range] { width: 100%; padding: 0; }
   addEventListener('resize', resize);
 
   function normalize(data) {
-    if (Array.isArray(data)) return data;
-    if (Array.isArray(data.cycles)) return data.cycles;
-    if (data.cycle !== undefined) return [data];
-    throw new Error('JSON must be a cycle, an array of cycles, or {cycles:[...]}');
+    let result;
+    if (Array.isArray(data)) result = data;
+    else if (isRecord(data) && Array.isArray(data.cycles)) result = data.cycles;
+    else if (isRecord(data) && data.cycle !== undefined) result = [data];
+    else throw new Error('JSON must be a cycle, an array of cycles, or {cycles:[...]}');
+
+    if (result.length > MAX_CYCLES) throw new Error(`Trace exceeds ${MAX_CYCLES} cycles`);
+    if (result.some(cycle => !isRecord(cycle))) throw new Error('Every cycle must be a JSON object');
+    return result;
+  }
+
+  function validateShape(raw) {
+    if (!Array.isArray(raw) || raw.length !== 3) throw new Error('Cycle shape must contain three axes');
+    const shape = raw.map(Number);
+    if (shape.some(axis => !Number.isInteger(axis) || axis < 1 || axis > 64)) {
+      throw new Error('Cycle shape axes must be integers from 1 to 64');
+    }
+    if (shape[0] * shape[1] * shape[2] > MAX_VOXELS) {
+      throw new Error(`Cycle shape exceeds ${MAX_VOXELS} voxels`);
+    }
+    return shape;
   }
 
   function shapeOf(cycle) {
-    const level = cycle.hierarchy && cycle.hierarchy[0];
-    if (level && level.shape) return level.shape;
-    const event = (cycle.events || []).find(e => e.shape);
-    return event ? event.shape : [4,4,4];
+    const level = Array.isArray(cycle.hierarchy) && cycle.hierarchy[0];
+    if (isRecord(level) && level.shape) return validateShape(level.shape);
+    const event = Array.isArray(cycle.events) ? cycle.events.find(item => isRecord(item) && item.shape) : null;
+    return validateShape(event ? event.shape : [4,4,4]);
+  }
+
+  function q3(value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) return 0;
+    return Math.max(-4, Math.min(3, numeric));
   }
 
   function valuesOf(cycle) {
-    const values = cycle[stageSelect.value] || [];
+    const values = Array.isArray(cycle[stageSelect.value]) ? cycle[stageSelect.value] : [];
     const [w,h,d] = shapeOf(cycle);
-    return Array.from({length:w*h*d}, (_,i) => Number(values[i] || 0));
+    return Array.from({length:w*h*d}, (_,i) => q3(values[i] ?? 0));
   }
 
   function project(x,y,z,w,h,d) {
@@ -137,24 +178,51 @@ input[type=range] { width: 100%; padding: 0; }
   function renderInfo(cycle,index) {
     cycleLabel.textContent=String(index+1);
     const committed=Boolean(cycle.committed);
-    status.innerHTML=`Cycle ${cycle.cycle ?? index+1} · <span class="${committed?'good':'bad'}">${committed?'COMMITTED':'ROLLED BACK'}</span> · lane ${cycle.selected_lane ?? 'none'} · ${stageSelect.value}`;
-    const m=cycle.metrics||{};
+    status.innerHTML=`Cycle ${escapeHtml(cycle.cycle ?? index+1)} · <span class="${committed?'good':'bad'}">${committed?'COMMITTED':'ROLLED BACK'}</span> · lane ${escapeHtml(cycle.selected_lane ?? 'none')} · ${escapeHtml(stageSelect.value)}`;
+    const m=isRecord(cycle.metrics)?cycle.metrics:{};
     const rows={
       'Input values':m.input_values,'Lattice voxels':m.lattice_voxels,'Hierarchy levels':m.hierarchy_levels,
       'Parallel lanes':m.parallel_lanes,'Admissible lanes':m.admissible_lanes,'Best reconstruction L1':m.best_reconstruction_l1,
-      'Active voxels':m.active_voxels,'Memory L1':m.memory_l1,'State hash':(cycle.state_hash||'').slice(0,12)
+      'Active voxels':m.active_voxels,'Memory L1':m.memory_l1,'State hash':String(cycle.state_hash||'').slice(0,12)
     };
-    metrics.innerHTML=Object.entries(rows).map(([k,v])=>`<span>${k}</span><span>${v ?? '—'}</span>`).join('');
-    timeline.innerHTML=(cycle.events||[]).map(e=>`<div class="event"><strong>${e.phase}</strong>${e.lane?` · ${e.lane}`:''}<br>${e.summary||''}</div>`).join('');
+    metrics.innerHTML=Object.entries(rows).map(([key,value])=>`<span>${escapeHtml(key)}</span><span>${escapeHtml(value ?? '—')}</span>`).join('');
+    const events=Array.isArray(cycle.events)?cycle.events.slice(0,MAX_EVENTS_PER_CYCLE):[];
+    timeline.innerHTML=events.map(event=>{
+      const safe=isRecord(event)?event:{};
+      return `<div class="event"><strong>${escapeHtml(safe.phase||'EVENT')}</strong>${safe.lane?` · ${escapeHtml(safe.lane)}`:''}<br>${escapeHtml(safe.summary||'')}</div>`;
+    }).join('');
   }
 
   function draw() {
-    if(!cycles.length){ ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight); return; }
-    const index=Number(cycleSlider.value), cycle=cycles[index]; drawGrid(cycle); renderInfo(cycle,index);
+    if(!cycles.length){ ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight); status.textContent='No geometric cycle loaded.'; return; }
+    const index=Number(cycleSlider.value), cycle=cycles[index];
+    try {
+      drawGrid(cycle);
+      renderInfo(cycle,index);
+    } catch (error) {
+      ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight);
+      status.textContent=`Invalid trace: ${error.message}`;
+    }
+  }
+
+  function stopPlayback() {
+    playing=false;
+    clearInterval(timer);
+    timer=null;
+    playButton.textContent='Play';
   }
 
   function setCycles(next) {
-    cycles=normalize(next); cycleSlider.max=String(Math.max(0,cycles.length-1)); cycleSlider.value='0'; draw();
+    stopPlayback();
+    cycles=normalize(next);
+    cycleSlider.max=String(Math.max(0,cycles.length-1));
+    cycleSlider.value='0';
+    draw();
+  }
+
+  function parseJsonText(text) {
+    if (new Blob([text]).size > MAX_JSON_BYTES) throw new Error('JSON input exceeds 5 MiB');
+    return JSON.parse(text);
   }
 
   function demoData() {
@@ -172,7 +240,7 @@ input[type=range] { width: 100%; padding: 0; }
         {phase:'COMMIT',lane:selected,summary:'Committed branch and fed output inward.'}
       ], state_hash:'demo'+cycle
     });
-    const pad=a=>a.concat(Array(64-a.length).fill(0));
+    const pad=array=>array.concat(Array(64-array.length).fill(0));
     return {cycles:[
       mk(1,'identity',18,pad([3,1,-1,-3,2,0,-2,-4]),pad([1,1,1,1,0,0,0,0])),
       mk(2,'memory',8,pad([1,1,1,1,0,0,0,0]),pad([1,1,1,1,1,1,1,1])),
@@ -181,17 +249,68 @@ input[type=range] { width: 100%; padding: 0; }
   }
 
   document.querySelector('#demo').onclick=()=>setCycles(demoData());
-  document.querySelector('#load').onclick=()=>{ try{setCycles(JSON.parse(document.querySelector('#json').value));}catch(e){alert(e.message);} };
-  document.querySelector('#file').onchange=async e=>{ const f=e.target.files[0]; if(f) setCycles(JSON.parse(await f.text())); };
-  cycleSlider.oninput=draw; stageSelect.onchange=draw;
-  document.querySelector('#step').onclick=()=>{ if(cycles.length){ cycleSlider.value=String((Number(cycleSlider.value)+1)%cycles.length); draw(); } };
-  document.querySelector('#reset').onclick=()=>{ playing=false; clearInterval(timer); cycleSlider.value='0'; angleX=-.45; angleY=.65; zoom=64; draw(); };
-  document.querySelector('#play').onclick=()=>{ playing=!playing; clearInterval(timer); document.querySelector('#play').textContent=playing?'Pause':'Play'; if(playing) timer=setInterval(()=>document.querySelector('#step').click(),900); };
-  canvas.onpointerdown=e=>{dragging=true;lastX=e.clientX;lastY=e.clientY;canvas.setPointerCapture(e.pointerId);};
-  canvas.onpointermove=e=>{if(dragging){angleY+=(e.clientX-lastX)*.008;angleX+=(e.clientY-lastY)*.008;lastX=e.clientX;lastY=e.clientY;draw();}};
+  document.querySelector('#load').onclick=()=>{
+    try{setCycles(parseJsonText(document.querySelector('#json').value));}
+    catch(error){alert(error.message);}
+  };
+  document.querySelector('#file').onchange=async event=>{
+    try {
+      const file=event.target.files[0];
+      if(!file) return;
+      if(file.size>MAX_JSON_BYTES) throw new Error('JSON file exceeds 5 MiB');
+      setCycles(parseJsonText(await file.text()));
+    } catch(error) {
+      alert(error.message);
+      event.target.value='';
+    }
+  };
+  cycleSlider.oninput=draw;
+  stageSelect.onchange=draw;
+  document.querySelector('#step').onclick=()=>{
+    if(cycles.length){
+      cycleSlider.value=String((Number(cycleSlider.value)+1)%cycles.length);
+      draw();
+    }
+  };
+  document.querySelector('#reset').onclick=()=>{
+    stopPlayback();
+    cycleSlider.value='0';
+    angleX=-.45;
+    angleY=.65;
+    zoom=64;
+    draw();
+  };
+  playButton.onclick=()=>{
+    playing=!playing;
+    clearInterval(timer);
+    playButton.textContent=playing?'Pause':'Play';
+    if(playing) timer=setInterval(()=>document.querySelector('#step').click(),900);
+  };
+  canvas.onpointerdown=event=>{
+    dragging=true;
+    lastX=event.clientX;
+    lastY=event.clientY;
+    canvas.setPointerCapture(event.pointerId);
+  };
+  canvas.onpointermove=event=>{
+    if(dragging){
+      angleY+=(event.clientX-lastX)*.008;
+      angleX+=(event.clientY-lastY)*.008;
+      lastX=event.clientX;
+      lastY=event.clientY;
+      draw();
+    }
+  };
   canvas.onpointerup=()=>dragging=false;
-  canvas.onwheel=e=>{e.preventDefault();zoom=Math.max(20,Math.min(150,zoom-e.deltaY*.05));draw();};
-  resize(); setCycles(demoData());
+  canvas.onpointercancel=()=>dragging=false;
+  canvas.onwheel=event=>{
+    event.preventDefault();
+    zoom=Math.max(20,Math.min(150,zoom-event.deltaY*.05));
+    draw();
+  };
+
+  resize();
+  setCycles(demoData());
 })();
 </script>
 </body>

--- a/geometric-rvis-shell.html
+++ b/geometric-rvis-shell.html
@@ -1,0 +1,198 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Jarvis X — 3D Geometric RVIS Shell</title>
+<style>
+:root { color-scheme: dark; font-family: Inter, ui-sans-serif, system-ui, sans-serif; }
+* { box-sizing: border-box; }
+body { margin: 0; background: #05060a; color: #eef2ff; overflow: hidden; }
+#app { display: grid; grid-template-columns: minmax(0,1fr) 330px; height: 100vh; }
+main { position: relative; min-width: 0; }
+canvas { width: 100%; height: 100%; display: block; cursor: grab; }
+canvas:active { cursor: grabbing; }
+aside { border-left: 1px solid #252a3a; background: rgba(10,12,20,.96); padding: 16px; overflow: auto; }
+h1 { font-size: 17px; margin: 0 0 6px; }
+p { color: #aeb7d1; line-height: 1.4; font-size: 13px; }
+.card { border: 1px solid #2b3144; background: #111522; border-radius: 12px; padding: 12px; margin: 12px 0; }
+.row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+button, select, input, textarea { background: #171c2c; color: #f4f6ff; border: 1px solid #343c55; border-radius: 8px; padding: 8px; }
+button { cursor: pointer; }
+button:hover { background: #202840; }
+textarea { width: 100%; min-height: 110px; resize: vertical; font: 11px/1.35 ui-monospace, SFMono-Regular, monospace; }
+label { font-size: 12px; color: #c8d0e8; }
+input[type=range] { width: 100%; padding: 0; }
+.metric { display: grid; grid-template-columns: 1fr auto; gap: 7px; font-size: 12px; }
+.metric span:nth-child(odd) { color: #aeb7d1; }
+#status { position: absolute; top: 16px; left: 16px; padding: 10px 12px; border-radius: 10px; background: rgba(8,10,17,.76); border: 1px solid #2c344c; backdrop-filter: blur(8px); font-size: 12px; pointer-events: none; }
+#timeline { max-height: 220px; overflow: auto; }
+.event { padding: 7px 0; border-bottom: 1px solid #242a3b; font-size: 11px; color: #bbc4dc; }
+.event strong { color: #f3f5ff; }
+.good { color: #7fffb5; } .bad { color: #ff8998; }
+@media (max-width: 800px) { #app { grid-template-columns: 1fr; grid-template-rows: 58vh 42vh; } aside { border-left: 0; border-top: 1px solid #252a3a; } }
+</style>
+</head>
+<body>
+<div id="app">
+<main>
+  <canvas id="view"></canvas>
+  <div id="status">No geometric cycle loaded.</div>
+</main>
+<aside>
+  <h1>JX-RVIS Ω³ Geometric Loop</h1>
+  <p>Public shell state → Q3 lattice → parallel candidate lanes → Λ projection → commit/rollback → inward feedback.</p>
+  <div class="card">
+    <div class="row">
+      <button id="demo">Demo</button>
+      <button id="play">Play</button>
+      <button id="step">Step</button>
+      <button id="reset">Reset</button>
+    </div>
+    <p><label>Cycle <span id="cycleLabel">0</span></label></p>
+    <input id="cycle" type="range" min="0" max="0" value="0" />
+    <p><label>Stage</label></p>
+    <select id="stage">
+      <option value="encoded">Encoded</option>
+      <option value="evolved">Evolved</option>
+      <option value="decoded">Decoded</option>
+    </select>
+  </div>
+  <div class="card"><div id="metrics" class="metric"></div></div>
+  <div class="card">
+    <label>Load CLI JSON</label>
+    <textarea id="json" placeholder='Paste output from: jarvisx geometry3d --cycles 4 3 1 -1 -3'></textarea>
+    <div class="row"><button id="load">Load JSON</button><input id="file" type="file" accept="application/json,.json" /></div>
+  </div>
+  <div class="card"><strong>Event timeline</strong><div id="timeline"></div></div>
+</aside>
+</div>
+<script>
+(() => {
+  const canvas = document.querySelector('#view');
+  const ctx = canvas.getContext('2d');
+  const cycleSlider = document.querySelector('#cycle');
+  const cycleLabel = document.querySelector('#cycleLabel');
+  const stageSelect = document.querySelector('#stage');
+  const metrics = document.querySelector('#metrics');
+  const timeline = document.querySelector('#timeline');
+  const status = document.querySelector('#status');
+  let cycles = [], angleX = -0.45, angleY = 0.65, zoom = 64, playing = false, timer = null;
+  let dragging = false, lastX = 0, lastY = 0;
+
+  function resize() {
+    const dpr = Math.min(devicePixelRatio || 1, 2);
+    canvas.width = Math.floor(canvas.clientWidth * dpr);
+    canvas.height = Math.floor(canvas.clientHeight * dpr);
+    ctx.setTransform(dpr,0,0,dpr,0,0);
+    draw();
+  }
+  addEventListener('resize', resize);
+
+  function normalize(data) {
+    if (Array.isArray(data)) return data;
+    if (Array.isArray(data.cycles)) return data.cycles;
+    if (data.cycle !== undefined) return [data];
+    throw new Error('JSON must be a cycle, an array of cycles, or {cycles:[...]}');
+  }
+
+  function shapeOf(cycle) {
+    const level = cycle.hierarchy && cycle.hierarchy[0];
+    if (level && level.shape) return level.shape;
+    const event = (cycle.events || []).find(e => e.shape);
+    return event ? event.shape : [4,4,4];
+  }
+
+  function valuesOf(cycle) {
+    const values = cycle[stageSelect.value] || [];
+    const [w,h,d] = shapeOf(cycle);
+    return Array.from({length:w*h*d}, (_,i) => Number(values[i] || 0));
+  }
+
+  function project(x,y,z,w,h,d) {
+    x -= (w-1)/2; y -= (h-1)/2; z -= (d-1)/2;
+    const cy=Math.cos(angleY), sy=Math.sin(angleY), cx=Math.cos(angleX), sx=Math.sin(angleX);
+    const rx=x*cy-z*sy, rz=x*sy+z*cy;
+    const ry=y*cx-rz*sx, rz2=y*sx+rz*cx;
+    const perspective = 1/(1+Math.max(-0.75,rz2*0.065));
+    return [canvas.clientWidth/2+rx*zoom*perspective, canvas.clientHeight/2+ry*zoom*perspective, rz2, perspective];
+  }
+
+  function drawGrid(cycle) {
+    const [w,h,d] = shapeOf(cycle), vals = valuesOf(cycle), points=[];
+    for(let z=0;z<d;z++) for(let y=0;y<h;y++) for(let x=0;x<w;x++) {
+      const i=x+w*(y+h*z), p=project(x,y,z,w,h,d); points.push({x:p[0],y:p[1],z:p[2],s:p[3],v:vals[i]});
+    }
+    points.sort((a,b)=>a.z-b.z);
+    ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight);
+    for(const p of points){
+      const r=(3.2+Math.abs(p.v)*1.7)*p.s;
+      const hue=p.v>0?155:p.v<0?350:220, light=46+Math.abs(p.v)*6;
+      ctx.beginPath(); ctx.arc(p.x,p.y,r,0,Math.PI*2);
+      ctx.fillStyle=`hsla(${hue},90%,${light}%,${p.v===0?.18:.88})`; ctx.fill();
+      if(p.v!==0){ ctx.strokeStyle=`hsla(${hue},100%,75%,.65)`; ctx.stroke(); }
+    }
+  }
+
+  function renderInfo(cycle,index) {
+    cycleLabel.textContent=String(index+1);
+    const committed=Boolean(cycle.committed);
+    status.innerHTML=`Cycle ${cycle.cycle ?? index+1} · <span class="${committed?'good':'bad'}">${committed?'COMMITTED':'ROLLED BACK'}</span> · lane ${cycle.selected_lane ?? 'none'} · ${stageSelect.value}`;
+    const m=cycle.metrics||{};
+    const rows={
+      'Input values':m.input_values,'Lattice voxels':m.lattice_voxels,'Hierarchy levels':m.hierarchy_levels,
+      'Parallel lanes':m.parallel_lanes,'Admissible lanes':m.admissible_lanes,'Best reconstruction L1':m.best_reconstruction_l1,
+      'Active voxels':m.active_voxels,'Memory L1':m.memory_l1,'State hash':(cycle.state_hash||'').slice(0,12)
+    };
+    metrics.innerHTML=Object.entries(rows).map(([k,v])=>`<span>${k}</span><span>${v ?? '—'}</span>`).join('');
+    timeline.innerHTML=(cycle.events||[]).map(e=>`<div class="event"><strong>${e.phase}</strong>${e.lane?` · ${e.lane}`:''}<br>${e.summary||''}</div>`).join('');
+  }
+
+  function draw() {
+    if(!cycles.length){ ctx.clearRect(0,0,canvas.clientWidth,canvas.clientHeight); return; }
+    const index=Number(cycleSlider.value), cycle=cycles[index]; drawGrid(cycle); renderInfo(cycle,index);
+  }
+
+  function setCycles(next) {
+    cycles=normalize(next); cycleSlider.max=String(Math.max(0,cycles.length-1)); cycleSlider.value='0'; draw();
+  }
+
+  function demoData() {
+    const mk=(cycle,selected,error,encoded,decoded)=>({
+      cycle, committed:true, selected_lane:selected, encoded, evolved:encoded.map((v,i)=>Math.max(-4,Math.min(3,Math.round((3*v+(encoded[(i+1)%encoded.length]||0))/4)))), decoded,
+      hierarchy:[{shape:[4,4,4],values:encoded},{shape:[2,2,2],values:[1,0,0,-1,0,0,0,0]},{shape:[1,1,1],values:[0]}],
+      metrics:{input_values:8,lattice_voxels:64,hierarchy_levels:3,parallel_lanes:4,admissible_lanes:4,best_reconstruction_l1:error,active_voxels:decoded.filter(Boolean).length,memory_l1:cycle*3},
+      events:[
+        {phase:'GEOM_ENCODE',summary:'Mapped public shell values into a Q3 3D lattice.'},
+        {phase:'MULTIPARALLEL_LANE',lane:'identity',summary:'Evaluated baseline geometric candidate.'},
+        {phase:'MULTIPARALLEL_LANE',lane:'diffusion',summary:'Evaluated neighbourhood-diffused candidate.'},
+        {phase:'MULTIPARALLEL_LANE',lane:'memory',summary:'Evaluated Ω-corrected candidate.'},
+        {phase:'MULTIPARALLEL_LANE',lane:'hybrid',summary:'Evaluated fused geometric candidate.'},
+        {phase:'LAMBDA_PROJECT',lane:selected,summary:'Selected minimum-error admissible lane.'},
+        {phase:'COMMIT',lane:selected,summary:'Committed branch and fed output inward.'}
+      ], state_hash:'demo'+cycle
+    });
+    const pad=a=>a.concat(Array(64-a.length).fill(0));
+    return {cycles:[
+      mk(1,'identity',18,pad([3,1,-1,-3,2,0,-2,-4]),pad([1,1,1,1,0,0,0,0])),
+      mk(2,'memory',8,pad([1,1,1,1,0,0,0,0]),pad([1,1,1,1,1,1,1,1])),
+      mk(3,'hybrid',0,pad([1,1,1,1,1,1,1,1]),pad([1,1,1,1,1,1,1,1]))
+    ]};
+  }
+
+  document.querySelector('#demo').onclick=()=>setCycles(demoData());
+  document.querySelector('#load').onclick=()=>{ try{setCycles(JSON.parse(document.querySelector('#json').value));}catch(e){alert(e.message);} };
+  document.querySelector('#file').onchange=async e=>{ const f=e.target.files[0]; if(f) setCycles(JSON.parse(await f.text())); };
+  cycleSlider.oninput=draw; stageSelect.onchange=draw;
+  document.querySelector('#step').onclick=()=>{ if(cycles.length){ cycleSlider.value=String((Number(cycleSlider.value)+1)%cycles.length); draw(); } };
+  document.querySelector('#reset').onclick=()=>{ playing=false; clearInterval(timer); cycleSlider.value='0'; angleX=-.45; angleY=.65; zoom=64; draw(); };
+  document.querySelector('#play').onclick=()=>{ playing=!playing; clearInterval(timer); document.querySelector('#play').textContent=playing?'Pause':'Play'; if(playing) timer=setInterval(()=>document.querySelector('#step').click(),900); };
+  canvas.onpointerdown=e=>{dragging=true;lastX=e.clientX;lastY=e.clientY;canvas.setPointerCapture(e.pointerId);};
+  canvas.onpointermove=e=>{if(dragging){angleY+=(e.clientX-lastX)*.008;angleX+=(e.clientY-lastY)*.008;lastX=e.clientX;lastY=e.clientY;draw();}};
+  canvas.onpointerup=()=>dragging=false;
+  canvas.onwheel=e=>{e.preventDefault();zoom=Math.max(20,Math.min(150,zoom-e.deltaY*.05));draw();};
+  resize(); setCycles(demoData());
+})();
+</script>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -73,8 +73,11 @@ def main():
 
     elif cmd == "geometry3d":
         cycles, values = _parse_geometry_arguments(sys.argv[2:])
-        vm = CodexVM()
-        results = vm.geometric_feedback(values, cycles)
+        try:
+            vm = CodexVM()
+            results = vm.geometric_feedback(values, cycles)
+        except (OverflowError, ValueError) as exc:
+            raise SystemExit("geometry3d inputs must be finite and fit the lattice") from exc
         payload = {
             "cycles": [result.to_dict() for result in results],
             "final_state": vm.geometric.snapshot(),

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,18 +1,18 @@
 import json
+import math
 import sys
 
-from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .node import CodexNode
 from .parser import Parser
 from .serialization import json_safe
-from .web import start_web
 
 
 def _parse_geometry_arguments(arguments):
     cycles = 4
     values = list(arguments)
+    if values.count("--cycles") > 1:
+        raise SystemExit("--cycles may be specified only once")
     if "--cycles" in values:
         index = values.index("--cycles")
         try:
@@ -25,9 +25,12 @@ def _parse_geometry_arguments(arguments):
     if not values:
         raise SystemExit("Usage: jarvisx geometry3d [--cycles N] <number> [number ...]")
     try:
-        return cycles, [float(value) for value in values]
+        parsed = [float(value) for value in values]
     except (OverflowError, ValueError) as exc:
         raise SystemExit("geometry3d inputs must be finite numbers") from exc
+    if any(not math.isfinite(value) for value in parsed):
+        raise SystemExit("geometry3d inputs must be finite numbers")
+    return cycles, parsed
 
 
 def main():
@@ -55,6 +58,8 @@ def main():
             raise SystemExit("Usage: jarvisx cognitive <number> [number ...]")
         try:
             values = [float(value) for value in sys.argv[2:]]
+            if any(not math.isfinite(value) for value in values):
+                raise ValueError("non-finite cognitive input")
             vm = CodexVM()
             result = vm.cognitive_cycle(values)
         except (OverflowError, ValueError) as exc:
@@ -76,12 +81,18 @@ def main():
         print(json.dumps(json_safe(payload), ensure_ascii=False, indent=2, allow_nan=False))
 
     elif cmd == "api":
+        from .api import start_api
+
         start_api()
 
     elif cmd == "web":
+        from .web import start_web
+
         start_web()
 
     elif cmd == "node":
+        from .node import CodexNode
+
         node = CodexNode()
         node.start()
 

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,5 +1,4 @@
 import json
-import math
 import sys
 
 from .api import start_api
@@ -7,6 +6,7 @@ from .assembler import Assembler
 from .core import CodexVM
 from .node import CodexNode
 from .parser import Parser
+from .serialization import json_safe
 from .web import start_web
 
 
@@ -28,16 +28,6 @@ def _parse_geometry_arguments(arguments):
         return cycles, [float(value) for value in values]
     except (OverflowError, ValueError) as exc:
         raise SystemExit("geometry3d inputs must be finite numbers") from exc
-
-
-def _json_safe(value):
-    if isinstance(value, float) and not math.isfinite(value):
-        return None
-    if isinstance(value, dict):
-        return {key: _json_safe(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_json_safe(item) for item in value]
-    return value
 
 
 def main():
@@ -83,7 +73,7 @@ def main():
             "final_state": vm.geometric.snapshot(),
             "registers": vm.regs.snapshot(),
         }
-        print(json.dumps(_json_safe(payload), ensure_ascii=False, indent=2, allow_nan=False))
+        print(json.dumps(json_safe(payload), ensure_ascii=False, indent=2, allow_nan=False))
 
     elif cmd == "api":
         start_api()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,4 +1,6 @@
+import json
 import sys
+
 from .parser import Parser
 from .assembler import Assembler
 from .core import CodexVM
@@ -6,23 +8,37 @@ from .api import start_api
 from .web import start_web
 from .node import CodexNode
 
+
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
+        print("Usage: jarvisx [run|cognitive|api|web|node] <arguments>")
         return
 
     cmd = sys.argv[1]
 
     if cmd == "run":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: jarvisx run <assembly-file>")
         file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
+        with open(file) as source_file:
+            source = source_file.read()
         ast = Parser().parse(source)
         bytecode = Assembler().assemble(ast)
         vm = CodexVM()
         vm.load(bytecode)
         vm.run()
         print("Registers:", vm.regs.snapshot())
+
+    elif cmd == "cognitive":
+        if len(sys.argv) < 3:
+            raise SystemExit("Usage: jarvisx cognitive <number> [number ...]")
+        try:
+            values = [float(value) for value in sys.argv[2:]]
+        except ValueError as exc:
+            raise SystemExit("cognitive inputs must be finite numbers") from exc
+        vm = CodexVM()
+        result = vm.cognitive_cycle(values)
+        print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
 
     elif cmd == "api":
         start_api()
@@ -33,6 +49,10 @@ def main():
     elif cmd == "node":
         node = CodexNode()
         node.start()
+
+    else:
+        raise SystemExit("Unknown command: {}".format(cmd))
+
 
 if __name__ == "__main__":
     main()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,12 +1,12 @@
 import json
 import sys
 
-from .parser import Parser
+from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .api import start_api
-from .web import start_web
 from .node import CodexNode
+from .parser import Parser
+from .web import start_web
 
 
 def main():
@@ -34,10 +34,10 @@ def main():
             raise SystemExit("Usage: jarvisx cognitive <number> [number ...]")
         try:
             values = [float(value) for value in sys.argv[2:]]
-        except ValueError as exc:
+            vm = CodexVM()
+            result = vm.cognitive_cycle(values)
+        except (OverflowError, ValueError) as exc:
             raise SystemExit("cognitive inputs must be finite numbers") from exc
-        vm = CodexVM()
-        result = vm.cognitive_cycle(values)
         print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
 
     elif cmd == "api":

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -9,9 +9,29 @@ from .parser import Parser
 from .web import start_web
 
 
+def _parse_geometry_arguments(arguments):
+    cycles = 4
+    values = list(arguments)
+    if "--cycles" in values:
+        index = values.index("--cycles")
+        try:
+            cycles = int(values[index + 1])
+        except (IndexError, ValueError) as exc:
+            raise SystemExit("--cycles requires a positive integer") from exc
+        del values[index : index + 2]
+    if cycles < 1:
+        raise SystemExit("--cycles requires a positive integer")
+    if not values:
+        raise SystemExit("Usage: jarvisx geometry3d [--cycles N] <number> [number ...]")
+    try:
+        return cycles, [float(value) for value in values]
+    except (OverflowError, ValueError) as exc:
+        raise SystemExit("geometry3d inputs must be finite numbers") from exc
+
+
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|cognitive|api|web|node] <arguments>")
+        print("Usage: jarvisx [run|cognitive|geometry3d|api|web|node] <arguments>")
         return
 
     cmd = sys.argv[1]
@@ -39,6 +59,17 @@ def main():
         except (OverflowError, ValueError) as exc:
             raise SystemExit("cognitive inputs must be finite numbers") from exc
         print(json.dumps(result.to_dict(), ensure_ascii=False, indent=2))
+
+    elif cmd == "geometry3d":
+        cycles, values = _parse_geometry_arguments(sys.argv[2:])
+        vm = CodexVM()
+        results = vm.geometric_feedback(values, cycles)
+        payload = {
+            "cycles": [result.to_dict() for result in results],
+            "final_state": vm.geometric.snapshot(),
+            "registers": vm.regs.snapshot(),
+        }
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
 
     elif cmd == "api":
         start_api()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,4 +1,5 @@
 import json
+import math
 import sys
 
 from .api import start_api
@@ -27,6 +28,16 @@ def _parse_geometry_arguments(arguments):
         return cycles, [float(value) for value in values]
     except (OverflowError, ValueError) as exc:
         raise SystemExit("geometry3d inputs must be finite numbers") from exc
+
+
+def _json_safe(value):
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
 
 
 def main():
@@ -69,7 +80,7 @@ def main():
             "final_state": vm.geometric.snapshot(),
             "registers": vm.regs.snapshot(),
         }
-        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        print(json.dumps(_json_safe(payload), ensure_ascii=False, indent=2, allow_nan=False))
 
     elif cmd == "api":
         start_api()

--- a/src/jarvisx/cognitive.py
+++ b/src/jarvisx/cognitive.py
@@ -5,8 +5,8 @@ The kernel operationalises the canonical cycle:
     encode -> condense -> predict -> compare -> update Omega
     -> project Lambda -> decode -> commit/rollback
 
-It uses signed 3-bit latent values and integer/fixed-ratio updates so runs are
-replayable across supported Python versions and hardware.
+All committed state is integer-valued and hash chained. Candidate state is
+validated before it is exposed through the VM register bridge.
 """
 
 from __future__ import annotations
@@ -42,9 +42,10 @@ def _div_round_nearest(numerator: int, denominator: int) -> int:
 
 def quantize_q3(value: Number, scale: float = 1.0) -> int:
     """Quantize a scalar into the signed 3-bit domain {-4, ..., 3}."""
-    if not math.isfinite(float(value)):
+    numeric = float(value)
+    if not math.isfinite(numeric):
         raise ValueError("input values must be finite")
-    return _clamp(_round_half_away_from_zero(float(value) * scale), Q3_MIN, Q3_MAX)
+    return _clamp(_round_half_away_from_zero(numeric * scale), Q3_MIN, Q3_MAX)
 
 
 @dataclass(frozen=True)
@@ -52,6 +53,7 @@ class CognitiveConfig:
     branch_factor: int = 4
     input_scale: float = 1.0
     max_levels: int = 16
+    max_input_values: int = 65536
     retention_numerator: int = 7
     retention_denominator: int = 8
     learning_numerator: int = 1
@@ -67,14 +69,24 @@ class CognitiveConfig:
             raise ValueError("branch_factor must be >= 2")
         if self.max_levels < 1:
             raise ValueError("max_levels must be >= 1")
+        if self.max_input_values < 1:
+            raise ValueError("max_input_values must be positive")
         if self.input_scale <= 0 or not math.isfinite(self.input_scale):
             raise ValueError("input_scale must be positive and finite")
         if self.retention_denominator <= 0 or self.learning_denominator <= 0:
             raise ValueError("update denominators must be positive")
+        if not 0 <= self.retention_numerator <= self.retention_denominator:
+            raise ValueError("retention ratio must be between 0 and 1")
+        if self.learning_numerator < 0:
+            raise ValueError("learning_numerator must be non-negative")
         if self.omega_prediction_scale <= 0:
             raise ValueError("omega_prediction_scale must be positive")
         if self.omega_limit < 1:
             raise ValueError("omega_limit must be positive")
+        if self.max_residual_l1 is not None and self.max_residual_l1 < 0:
+            raise ValueError("max_residual_l1 must be non-negative")
+        if self.max_active_nodes is not None and self.max_active_nodes < 0:
+            raise ValueError("max_active_nodes must be non-negative")
         if self.journal_limit < 1:
             raise ValueError("journal_limit must be positive")
 
@@ -129,12 +141,17 @@ class CognitiveKernel:
         encoded = tuple(quantize_q3(value, self.config.input_scale) for value in source)
         if not encoded:
             raise ValueError("at least one input value is required")
+        if len(encoded) > self.config.max_input_values:
+            raise ValueError("input exceeds max_input_values")
         return encoded
 
     def condense(self, encoded: Tuple[int, ...]) -> Tuple[Tuple[int, ...], ...]:
         levels: List[Tuple[int, ...]] = [encoded]
         current = encoded
-        while len(current) > 1 and len(levels) < self.config.max_levels:
+
+        while len(current) > 1:
+            if len(levels) >= self.config.max_levels:
+                raise ValueError("hierarchy exceeds max_levels")
             parent: List[int] = []
             for start in range(0, len(current), self.config.branch_factor):
                 group = current[start : start + self.config.branch_factor]
@@ -143,9 +160,6 @@ class CognitiveKernel:
             current = tuple(parent)
             levels.append(current)
 
-        if len(current) > 1:
-            root = _clamp(_div_round_nearest(sum(current), len(current)), Q3_MIN, Q3_MAX)
-            levels.append((root,))
         return tuple(levels)
 
     def predict(self, encoded_length: int) -> Tuple[int, ...]:
@@ -175,18 +189,23 @@ class CognitiveKernel:
                 error * self.config.learning_numerator,
                 self.config.learning_denominator,
             )
-            updated.append(_clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit))
+            updated.append(
+                _clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit)
+            )
         return tuple(updated)
 
     def decode(self, hierarchy: Tuple[Tuple[int, ...], ...]) -> Tuple[int, ...]:
-        """Top-down approximate reconstruction from the condensed root."""
-        reconstructed = hierarchy[-1]
-        for child_level in reversed(hierarchy[:-1]):
-            expanded: List[int] = []
-            for value in reconstructed:
-                expanded.extend([value] * self.config.branch_factor)
-            reconstructed = tuple(expanded[: len(child_level)])
-        return tuple(_clamp(value, Q3_MIN, Q3_MAX) for value in reconstructed)
+        """Reconstruct the leaf width from the finest available condensed level."""
+        if len(hierarchy) == 1:
+            return hierarchy[0]
+
+        reconstructed = hierarchy[1]
+        expanded: List[int] = []
+        for value in reconstructed:
+            expanded.extend([value] * self.config.branch_factor)
+        return tuple(
+            _clamp(value, Q3_MIN, Q3_MAX) for value in expanded[: len(hierarchy[0])]
+        )
 
     def _validate_candidate(
         self,
@@ -197,16 +216,21 @@ class CognitiveKernel:
     ) -> Tuple[bool, str]:
         if not hierarchy or hierarchy[0] != encoded or len(hierarchy[-1]) != 1:
             return False, "invalid hierarchy"
+        if len(hierarchy) > self.config.max_levels:
+            return False, "hierarchy depth exceeded"
         if any(value < Q3_MIN or value > Q3_MAX for level in hierarchy for value in level):
             return False, "q3 range violation"
         if any(abs(value) > self.config.omega_limit for value in omega):
             return False, "omega bound violation"
+
         residual_l1 = sum(abs(value) for value in residual)
         if self.config.max_residual_l1 is not None and residual_l1 > self.config.max_residual_l1:
             return False, "residual budget exceeded"
+
         active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
         if self.config.max_active_nodes is not None and active_nodes > self.config.max_active_nodes:
             return False, "active-node budget exceeded"
+
         return True, "committed"
 
     @staticmethod
@@ -235,6 +259,7 @@ class CognitiveKernel:
             "hierarchy_nodes": float(hierarchy_nodes),
             "hierarchy_levels": float(len(hierarchy)),
             "condensation_ratio": float(raw_nodes) / float(root_nodes),
+            "materialization_ratio": float(hierarchy_nodes) / float(raw_nodes),
             "active_fraction": float(active_nodes) / float(hierarchy_nodes),
             "residual_l1": float(sum(abs(value) for value in residual)),
             "memory_l1": float(sum(abs(value) for value in omega)),
@@ -254,6 +279,7 @@ class CognitiveKernel:
         cycle = self.state.cycle + 1
 
         candidate_payload: Dict[str, object] = {
+            "config": asdict(self.config),
             "cycle": cycle,
             "encoded": encoded,
             "hierarchy": hierarchy,
@@ -307,7 +333,7 @@ class CognitiveKernel:
 
 
 class CognitiveVMBridge:
-    """Expose kernel state through the existing Jarvis-X Greek register bank."""
+    """Expose only committed kernel state through the Jarvis-X register bank."""
 
     def __init__(self, registers: object, kernel: Optional[CognitiveKernel] = None) -> None:
         self.registers = registers
@@ -315,13 +341,23 @@ class CognitiveVMBridge:
 
     def cycle(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
         result = self.kernel.step(values)
-        root = result.hierarchy[-1][0]
-        self.registers["Ξ"] = sum(result.encoded)
-        self.registers["Ψ"] = root
-        self.registers["Φ"] = sum(result.prediction)
-        self.registers["Λ"] = 1 if result.committed else 0
-        self.registers["Ω"] = sum(result.omega_after)
-        self.registers["Θ"] = self.kernel.config.learning_numerator
-        self.registers["𝒮"] = int(result.metrics["residual_l1"])
-        self.registers["Π"] = sum(result.decoded)
+        if not result.committed:
+            self.registers["Λ"] = 0
+            return result
+
+        before = self.registers.snapshot()
+        try:
+            root = result.hierarchy[-1][0]
+            self.registers["Ξ"] = sum(result.encoded)
+            self.registers["Ψ"] = root
+            self.registers["Φ"] = sum(result.prediction)
+            self.registers["Λ"] = 1
+            self.registers["Ω"] = sum(result.omega_after)
+            self.registers["Θ"] = self.kernel.config.learning_numerator
+            self.registers["𝒮"] = int(result.metrics["residual_l1"])
+            self.registers["Π"] = sum(result.decoded)
+        except Exception:
+            for name, value in before.items():
+                self.registers[name] = value
+            raise
         return result

--- a/src/jarvisx/cognitive.py
+++ b/src/jarvisx/cognitive.py
@@ -1,0 +1,327 @@
+"""Deterministic hierarchical cognitive kernel for Jarvis-X.
+
+The kernel operationalises the canonical cycle:
+
+    encode -> condense -> predict -> compare -> update Omega
+    -> project Lambda -> decode -> commit/rollback
+
+It uses signed 3-bit latent values and integer/fixed-ratio updates so runs are
+replayable across supported Python versions and hardware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+import math
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+Number = Union[int, float]
+Q3_MIN = -4
+Q3_MAX = 3
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return max(lower, min(upper, int(value)))
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    if value >= 0:
+        return int(math.floor(value + 0.5))
+    return int(math.ceil(value - 0.5))
+
+
+def _div_round_nearest(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    if numerator >= 0:
+        return (numerator + denominator // 2) // denominator
+    return -((-numerator + denominator // 2) // denominator)
+
+
+def quantize_q3(value: Number, scale: float = 1.0) -> int:
+    """Quantize a scalar into the signed 3-bit domain {-4, ..., 3}."""
+    if not math.isfinite(float(value)):
+        raise ValueError("input values must be finite")
+    return _clamp(_round_half_away_from_zero(float(value) * scale), Q3_MIN, Q3_MAX)
+
+
+@dataclass(frozen=True)
+class CognitiveConfig:
+    branch_factor: int = 4
+    input_scale: float = 1.0
+    max_levels: int = 16
+    retention_numerator: int = 7
+    retention_denominator: int = 8
+    learning_numerator: int = 1
+    learning_denominator: int = 2
+    omega_prediction_scale: int = 4
+    omega_limit: int = 127
+    max_residual_l1: Optional[int] = None
+    max_active_nodes: Optional[int] = None
+    journal_limit: int = 128
+
+    def validate(self) -> None:
+        if self.branch_factor < 2:
+            raise ValueError("branch_factor must be >= 2")
+        if self.max_levels < 1:
+            raise ValueError("max_levels must be >= 1")
+        if self.input_scale <= 0 or not math.isfinite(self.input_scale):
+            raise ValueError("input_scale must be positive and finite")
+        if self.retention_denominator <= 0 or self.learning_denominator <= 0:
+            raise ValueError("update denominators must be positive")
+        if self.omega_prediction_scale <= 0:
+            raise ValueError("omega_prediction_scale must be positive")
+        if self.omega_limit < 1:
+            raise ValueError("omega_limit must be positive")
+        if self.journal_limit < 1:
+            raise ValueError("journal_limit must be positive")
+
+
+@dataclass(frozen=True)
+class CognitiveState:
+    cycle: int = 0
+    encoded: Tuple[int, ...] = field(default_factory=tuple)
+    hierarchy: Tuple[Tuple[int, ...], ...] = field(default_factory=tuple)
+    prediction: Tuple[int, ...] = field(default_factory=tuple)
+    residual: Tuple[int, ...] = field(default_factory=tuple)
+    omega: Tuple[int, ...] = field(default_factory=tuple)
+    decoded: Tuple[int, ...] = field(default_factory=tuple)
+    state_hash: str = "GENESIS"
+
+
+@dataclass(frozen=True)
+class CycleResult:
+    cycle: int
+    committed: bool
+    reason: str
+    encoded: Tuple[int, ...]
+    hierarchy: Tuple[Tuple[int, ...], ...]
+    prediction: Tuple[int, ...]
+    residual: Tuple[int, ...]
+    omega_before: Tuple[int, ...]
+    omega_after: Tuple[int, ...]
+    decoded: Tuple[int, ...]
+    metrics: Dict[str, float]
+    previous_hash: str
+    candidate_hash: str
+    state_hash: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+class CognitiveKernel:
+    """Transactional signed-3-bit hierarchical predictive runtime."""
+
+    def __init__(self, config: Optional[CognitiveConfig] = None) -> None:
+        self.config = config or CognitiveConfig()
+        self.config.validate()
+        self.state = CognitiveState()
+        self.journal: List[CycleResult] = []
+
+    def encode(self, values: Union[Number, Sequence[Number]]) -> Tuple[int, ...]:
+        if isinstance(values, (int, float)):
+            source: Iterable[Number] = (values,)
+        else:
+            source = values
+        encoded = tuple(quantize_q3(value, self.config.input_scale) for value in source)
+        if not encoded:
+            raise ValueError("at least one input value is required")
+        return encoded
+
+    def condense(self, encoded: Tuple[int, ...]) -> Tuple[Tuple[int, ...], ...]:
+        levels: List[Tuple[int, ...]] = [encoded]
+        current = encoded
+        while len(current) > 1 and len(levels) < self.config.max_levels:
+            parent: List[int] = []
+            for start in range(0, len(current), self.config.branch_factor):
+                group = current[start : start + self.config.branch_factor]
+                mean = _div_round_nearest(sum(group), len(group))
+                parent.append(_clamp(mean, Q3_MIN, Q3_MAX))
+            current = tuple(parent)
+            levels.append(current)
+
+        if len(current) > 1:
+            root = _clamp(_div_round_nearest(sum(current), len(current)), Q3_MIN, Q3_MAX)
+            levels.append((root,))
+        return tuple(levels)
+
+    def predict(self, encoded_length: int) -> Tuple[int, ...]:
+        previous = self.state.encoded
+        omega = self.state.omega
+        prediction: List[int] = []
+        for index in range(encoded_length):
+            base = previous[index] if index < len(previous) else 0
+            memory = omega[index] if index < len(omega) else 0
+            correction = _div_round_nearest(memory, self.config.omega_prediction_scale)
+            prediction.append(_clamp(base + correction, Q3_MIN, Q3_MAX))
+        return tuple(prediction)
+
+    @staticmethod
+    def compare(encoded: Tuple[int, ...], prediction: Tuple[int, ...]) -> Tuple[int, ...]:
+        return tuple(actual - expected for actual, expected in zip(encoded, prediction))
+
+    def update_omega(self, residual: Tuple[int, ...]) -> Tuple[int, ...]:
+        updated: List[int] = []
+        for index, error in enumerate(residual):
+            old = self.state.omega[index] if index < len(self.state.omega) else 0
+            retained = _div_round_nearest(
+                old * self.config.retention_numerator,
+                self.config.retention_denominator,
+            )
+            learned = _div_round_nearest(
+                error * self.config.learning_numerator,
+                self.config.learning_denominator,
+            )
+            updated.append(_clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit))
+        return tuple(updated)
+
+    def decode(self, hierarchy: Tuple[Tuple[int, ...], ...]) -> Tuple[int, ...]:
+        """Top-down approximate reconstruction from the condensed root."""
+        reconstructed = hierarchy[-1]
+        for child_level in reversed(hierarchy[:-1]):
+            expanded: List[int] = []
+            for value in reconstructed:
+                expanded.extend([value] * self.config.branch_factor)
+            reconstructed = tuple(expanded[: len(child_level)])
+        return tuple(_clamp(value, Q3_MIN, Q3_MAX) for value in reconstructed)
+
+    def _validate_candidate(
+        self,
+        encoded: Tuple[int, ...],
+        hierarchy: Tuple[Tuple[int, ...], ...],
+        residual: Tuple[int, ...],
+        omega: Tuple[int, ...],
+    ) -> Tuple[bool, str]:
+        if not hierarchy or hierarchy[0] != encoded or len(hierarchy[-1]) != 1:
+            return False, "invalid hierarchy"
+        if any(value < Q3_MIN or value > Q3_MAX for level in hierarchy for value in level):
+            return False, "q3 range violation"
+        if any(abs(value) > self.config.omega_limit for value in omega):
+            return False, "omega bound violation"
+        residual_l1 = sum(abs(value) for value in residual)
+        if self.config.max_residual_l1 is not None and residual_l1 > self.config.max_residual_l1:
+            return False, "residual budget exceeded"
+        active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
+        if self.config.max_active_nodes is not None and active_nodes > self.config.max_active_nodes:
+            return False, "active-node budget exceeded"
+        return True, "committed"
+
+    @staticmethod
+    def _hash_candidate(payload: Dict[str, object]) -> str:
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+    def _metrics(
+        self,
+        encoded: Tuple[int, ...],
+        hierarchy: Tuple[Tuple[int, ...], ...],
+        residual: Tuple[int, ...],
+        omega: Tuple[int, ...],
+        decoded: Tuple[int, ...],
+    ) -> Dict[str, float]:
+        raw_nodes = len(encoded)
+        root_nodes = len(hierarchy[-1])
+        hierarchy_nodes = sum(len(level) for level in hierarchy)
+        active_nodes = sum(1 for level in hierarchy for value in level if value != 0)
+        reconstruction_error = sum(abs(a - b) for a, b in zip(encoded, decoded))
+        return {
+            "raw_nodes": float(raw_nodes),
+            "raw_bits": float(raw_nodes * 3),
+            "root_nodes": float(root_nodes),
+            "root_bits": float(root_nodes * 3),
+            "hierarchy_nodes": float(hierarchy_nodes),
+            "hierarchy_levels": float(len(hierarchy)),
+            "condensation_ratio": float(raw_nodes) / float(root_nodes),
+            "active_fraction": float(active_nodes) / float(hierarchy_nodes),
+            "residual_l1": float(sum(abs(value) for value in residual)),
+            "memory_l1": float(sum(abs(value) for value in omega)),
+            "reconstruction_error_l1": float(reconstruction_error),
+        }
+
+    def step(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
+        previous_hash = self.state.state_hash
+        encoded = self.encode(values)
+        hierarchy = self.condense(encoded)
+        prediction = self.predict(len(encoded))
+        residual = self.compare(encoded, prediction)
+        omega_before = self.state.omega
+        omega_after = self.update_omega(residual)
+        decoded = self.decode(hierarchy)
+        metrics = self._metrics(encoded, hierarchy, residual, omega_after, decoded)
+        cycle = self.state.cycle + 1
+
+        candidate_payload: Dict[str, object] = {
+            "cycle": cycle,
+            "encoded": encoded,
+            "hierarchy": hierarchy,
+            "prediction": prediction,
+            "residual": residual,
+            "omega": omega_after,
+            "decoded": decoded,
+            "previous_hash": previous_hash,
+        }
+        candidate_hash = self._hash_candidate(candidate_payload)
+        valid, reason = self._validate_candidate(encoded, hierarchy, residual, omega_after)
+
+        if valid:
+            self.state = CognitiveState(
+                cycle=cycle,
+                encoded=encoded,
+                hierarchy=hierarchy,
+                prediction=prediction,
+                residual=residual,
+                omega=omega_after,
+                decoded=decoded,
+                state_hash=candidate_hash,
+            )
+
+        result = CycleResult(
+            cycle=cycle,
+            committed=valid,
+            reason=reason,
+            encoded=encoded,
+            hierarchy=hierarchy,
+            prediction=prediction,
+            residual=residual,
+            omega_before=omega_before,
+            omega_after=omega_after,
+            decoded=decoded,
+            metrics=metrics,
+            previous_hash=previous_hash,
+            candidate_hash=candidate_hash,
+            state_hash=self.state.state_hash,
+        )
+        self.journal.append(result)
+        if len(self.journal) > self.config.journal_limit:
+            del self.journal[: len(self.journal) - self.config.journal_limit]
+        return result
+
+    def run(self, stream: Iterable[Union[Number, Sequence[Number]]]) -> List[CycleResult]:
+        return [self.step(values) for values in stream]
+
+    def snapshot(self) -> Dict[str, object]:
+        return asdict(self.state)
+
+
+class CognitiveVMBridge:
+    """Expose kernel state through the existing Jarvis-X Greek register bank."""
+
+    def __init__(self, registers: object, kernel: Optional[CognitiveKernel] = None) -> None:
+        self.registers = registers
+        self.kernel = kernel or CognitiveKernel()
+
+    def cycle(self, values: Union[Number, Sequence[Number]]) -> CycleResult:
+        result = self.kernel.step(values)
+        root = result.hierarchy[-1][0]
+        self.registers["Ξ"] = sum(result.encoded)
+        self.registers["Ψ"] = root
+        self.registers["Φ"] = sum(result.prediction)
+        self.registers["Λ"] = 1 if result.committed else 0
+        self.registers["Ω"] = sum(result.omega_after)
+        self.registers["Θ"] = self.kernel.config.learning_numerator
+        self.registers["𝒮"] = int(result.metrics["residual_l1"])
+        self.registers["Π"] = sum(result.decoded)
+        return result

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -12,7 +12,7 @@ from .cognitive import CognitiveKernel, CognitiveVMBridge
 
 
 class CodexVM:
-    def __init__(self):
+    def __init__(self, reflex_enabled=False):
         self.regs = Registers()
         self.mem = Memory()
         self.decoder = Decoder()
@@ -20,6 +20,7 @@ class CodexVM:
         self.ledger = PersistentLedger()
         self.ethics = LambdaShield()
         self.reflex = ReflexEngine()
+        self.reflex_enabled = bool(reflex_enabled)
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
@@ -44,7 +45,8 @@ class CodexVM:
         cont = self.executor.execute(instr)
         self.ledger.log(self.regs.snapshot(), instr.opcode)
         self.tracer.record(instr, self.regs.snapshot())
-        self.reflex.stabilize(self.regs)
+        if self.reflex_enabled:
+            self.reflex.stabilize(self.regs)
 
         self.regs["IP"] += 1
         self.cycles += 1
@@ -56,6 +58,10 @@ class CodexVM:
     def run(self):
         while self.running:
             self.step()
+
+    def apply_reflex(self):
+        """Apply one explicit reflex-stabilisation step to the register bank."""
+        self.reflex.stabilize(self.regs)
 
     def cognitive_cycle(self, values):
         """Execute one atomic hierarchical intelligence transaction.

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -58,10 +58,20 @@ class CodexVM:
             self.step()
 
     def cognitive_cycle(self, values):
-        """Execute one transactional hierarchical intelligence cycle.
+        """Execute one atomic hierarchical intelligence transaction.
 
-        The cycle quantizes into Q3, condenses through the hierarchy, predicts,
-        computes the residual, updates cumulative Omega memory, applies Lambda
-        constraints, decodes, and atomically commits or rolls back.
+        Kernel state, journal state, and VM registers are restored together if
+        the register projection fails after the kernel has accepted a candidate.
         """
-        return self.cognitive_bridge.cycle(values)
+        state_before = self.cognitive.state
+        journal_length = len(self.cognitive.journal)
+        registers_before = self.regs.snapshot()
+
+        try:
+            return self.cognitive_bridge.cycle(values)
+        except Exception:
+            self.cognitive.state = state_before
+            del self.cognitive.journal[journal_length:]
+            for name, value in registers_before.items():
+                self.regs[name] = value
+            raise

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -9,6 +9,7 @@ from .sandbox import Sandbox
 from .debugger import Debugger
 from .tracer import Tracer
 from .cognitive import CognitiveKernel, CognitiveVMBridge
+from .geometric_rvis import GeometricFeedbackRuntime
 
 
 class CodexVM:
@@ -26,6 +27,7 @@ class CodexVM:
         self.tracer = Tracer()
         self.cognitive = CognitiveKernel()
         self.cognitive_bridge = CognitiveVMBridge(self.regs, self.cognitive)
+        self.geometric = GeometricFeedbackRuntime()
         self.program = []
         self.cycles = 0
         self.running = True
@@ -78,6 +80,43 @@ class CodexVM:
         except Exception:
             self.cognitive.state = state_before
             del self.cognitive.journal[journal_length:]
+            for name, value in registers_before.items():
+                self.regs[name] = value
+            raise
+
+    def geometric_feedback(self, values, cycles=None):
+        """Run the inward 3D geometric feedback loop atomically.
+
+        Every committed decoded output becomes the next cycle's input. The
+        final accepted geometric state is projected into the existing Greek
+        register bank. Exceptions restore geometric state, journal, and
+        registers together.
+        """
+        state_before = self.geometric.state
+        journal_length = len(self.geometric.journal)
+        registers_before = self.regs.snapshot()
+
+        try:
+            results = self.geometric.run_feedback(values, cycles)
+            if not results:
+                return results
+            final = results[-1]
+            if not final.committed:
+                self.regs["Λ"] = 0
+                return results
+
+            root = final.hierarchy[-1].values[0]
+            self.regs["Ξ"] = sum(final.encoded)
+            self.regs["Ψ"] = root
+            self.regs["Φ"] = sum(final.evolved)
+            self.regs["Λ"] = 1
+            self.regs["Ω"] = sum(final.omega_after)
+            self.regs["𝒮"] = int(final.metrics["best_reconstruction_l1"])
+            self.regs["Π"] = sum(final.output)
+            return results
+        except Exception:
+            self.geometric.state = state_before
+            del self.geometric.journal[journal_length:]
             for name, value in registers_before.items():
                 self.regs[name] = value
             raise

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -88,7 +88,7 @@ class CodexVM:
         """Run the inward 3D geometric feedback loop atomically.
 
         Every committed decoded output becomes the next cycle's input. The
-        final accepted geometric state is projected into the existing Greek
+        last accepted geometric state is projected into the existing Greek
         register bank. Exceptions restore geometric state, journal, and
         registers together.
         """
@@ -98,18 +98,17 @@ class CodexVM:
 
         try:
             results = self.geometric.run_feedback(values, cycles)
-            if not results:
-                return results
-            final = results[-1]
-            if not final.committed:
+            committed = [result for result in results if result.committed]
+            if not committed:
                 self.regs["Λ"] = 0
                 return results
 
+            final = committed[-1]
             root = final.hierarchy[-1].values[0]
             self.regs["Ξ"] = sum(final.encoded)
             self.regs["Ψ"] = root
             self.regs["Φ"] = sum(final.evolved)
-            self.regs["Λ"] = 1
+            self.regs["Λ"] = 1 if results[-1].committed else 0
             self.regs["Ω"] = sum(final.omega_after)
             self.regs["𝒮"] = int(final.metrics["best_reconstruction_l1"])
             self.regs["Π"] = sum(final.output)

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -8,6 +8,8 @@ from .reflex import ReflexEngine
 from .sandbox import Sandbox
 from .debugger import Debugger
 from .tracer import Tracer
+from .cognitive import CognitiveKernel, CognitiveVMBridge
+
 
 class CodexVM:
     def __init__(self):
@@ -21,6 +23,8 @@ class CodexVM:
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
+        self.cognitive = CognitiveKernel()
+        self.cognitive_bridge = CognitiveVMBridge(self.regs, self.cognitive)
         self.program = []
         self.cycles = 0
         self.running = True
@@ -28,6 +32,7 @@ class CodexVM:
     def load(self, bytecode):
         self.program = bytecode
         self.regs["IP"] = 0
+        self.running = True
 
     def step(self):
         ip = self.regs["IP"]
@@ -51,3 +56,12 @@ class CodexVM:
     def run(self):
         while self.running:
             self.step()
+
+    def cognitive_cycle(self, values):
+        """Execute one transactional hierarchical intelligence cycle.
+
+        The cycle quantizes into Q3, condenses through the hierarchy, predicts,
+        computes the residual, updates cumulative Omega memory, applies Lambda
+        constraints, decodes, and atomically commits or rolls back.
+        """
+        return self.cognitive_bridge.cycle(values)

--- a/src/jarvisx/geometric_rvis.py
+++ b/src/jarvisx/geometric_rvis.py
@@ -14,6 +14,7 @@ from dataclasses import asdict, dataclass, field
 import hashlib
 import json
 import math
+from threading import RLock
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 Number = Union[int, float]
@@ -40,6 +41,13 @@ def _div_round_nearest(numerator: int, denominator: int) -> int:
     return -((-numerator + denominator // 2) // denominator)
 
 
+def _validate_shape(shape: Coordinate) -> None:
+    if len(shape) != 3:
+        raise ValueError("shape must contain exactly three axes")
+    if any(isinstance(axis, bool) or not isinstance(axis, int) or axis <= 0 for axis in shape):
+        raise ValueError("shape axes must be positive integers")
+
+
 def quantize_q3(value: Number, scale: float = 1.0) -> int:
     """Quantize a finite scalar into the signed three-bit domain."""
     scalar = float(value)
@@ -52,8 +60,13 @@ def quantize_q3(value: Number, scale: float = 1.0) -> int:
 
 def coordinate_to_index(coord: Coordinate, shape: Coordinate) -> int:
     """Map (x, y, z) to a row-major linear address."""
+    _validate_shape(shape)
+    if len(coord) != 3:
+        raise ValueError("coordinate must contain exactly three axes")
     x, y, z = coord
     width, height, depth = shape
+    if any(isinstance(axis, bool) or not isinstance(axis, int) for axis in coord):
+        raise ValueError("coordinate axes must be integers")
     if not (0 <= x < width and 0 <= y < height and 0 <= z < depth):
         raise ValueError("coordinate outside lattice bounds")
     return x + width * (y + height * z)
@@ -61,6 +74,9 @@ def coordinate_to_index(coord: Coordinate, shape: Coordinate) -> int:
 
 def index_to_coordinate(index: int, shape: Coordinate) -> Coordinate:
     """Inverse of :func:`coordinate_to_index`."""
+    _validate_shape(shape)
+    if isinstance(index, bool) or not isinstance(index, int):
+        raise ValueError("index must be an integer")
     width, height, depth = shape
     volume = width * height * depth
     if index < 0 or index >= volume:
@@ -83,6 +99,7 @@ class GeometricConfig:
     max_input_values: Optional[int] = None
     parallel_workers: int = 4
     feedback_cycles: int = 4
+    max_feedback_cycles: int = 1024
     retention_numerator: int = 7
     retention_denominator: int = 8
     learning_numerator: int = 1
@@ -93,6 +110,7 @@ class GeometricConfig:
     journal_limit: int = 128
 
     def validate(self) -> None:
+        _validate_shape(self.shape)
         if any(not _is_power_of_two(axis) for axis in self.shape):
             raise ValueError("shape axes must be positive powers of two")
         if not math.isfinite(self.input_scale) or self.input_scale <= 0:
@@ -101,6 +119,10 @@ class GeometricConfig:
             raise ValueError("parallel_workers must be positive")
         if self.feedback_cycles < 1:
             raise ValueError("feedback_cycles must be positive")
+        if self.max_feedback_cycles < 1:
+            raise ValueError("max_feedback_cycles must be positive")
+        if self.feedback_cycles > self.max_feedback_cycles:
+            raise ValueError("feedback_cycles exceeds max_feedback_cycles")
         if self.retention_denominator <= 0 or self.learning_denominator <= 0:
             raise ValueError("update denominators must be positive")
         if not 0 <= self.retention_numerator <= self.retention_denominator:
@@ -111,9 +133,13 @@ class GeometricConfig:
             raise ValueError("omega_limit must be positive")
         if self.journal_limit < 1:
             raise ValueError("journal_limit must be positive")
-        volume = self.shape[0] * self.shape[1] * self.shape[2]
+        volume = self.volume
         if self.max_input_values is not None and not 1 <= self.max_input_values <= volume:
             raise ValueError("max_input_values must fit inside the lattice")
+        if self.max_reconstruction_l1 is not None and self.max_reconstruction_l1 < 0:
+            raise ValueError("max_reconstruction_l1 must be non-negative")
+        if self.max_active_voxels is not None and not 0 <= self.max_active_voxels <= volume:
+            raise ValueError("max_active_voxels must fit inside the lattice")
 
     @property
     def volume(self) -> int:
@@ -169,7 +195,7 @@ class GeometricCycleResult:
     omega_before: Tuple[int, ...]
     omega_after: Tuple[int, ...]
     lanes: Tuple[LaneResult, ...]
-    metrics: Dict[str, float]
+    metrics: Dict[str, object]
     events: Tuple[Dict[str, object], ...]
     previous_hash: str
     candidate_hash: str
@@ -189,6 +215,7 @@ class GeometricFeedbackRuntime:
         self.config.validate()
         self.state = GeometricState()
         self.journal: List[GeometricCycleResult] = []
+        self._lock = RLock()
 
     def encode(self, values: Union[Number, Sequence[Number]]) -> Tuple[Tuple[int, ...], int]:
         if isinstance(values, (int, float)):
@@ -204,36 +231,87 @@ class GeometricFeedbackRuntime:
         encoded.extend([0] * (self.config.volume - len(encoded)))
         return tuple(encoded), len(materialized)
 
-    def _pool_level(self, level: GeometricLevel) -> GeometricLevel:
+    @staticmethod
+    def _child_axes(parent_axis: int, child_size: int) -> Tuple[int, ...]:
+        if child_size == 1:
+            return (0,)
+        base = 2 * parent_axis
+        return (base, base + 1)
+
+    def _pool_level(
+        self,
+        level: GeometricLevel,
+        weights: Tuple[int, ...],
+    ) -> Tuple[GeometricLevel, Tuple[int, ...]]:
         width, height, depth = level.shape
-        parent_shape = (width // 2, height // 2, depth // 2)
-        parent: List[int] = []
+        parent_shape = tuple(max(1, axis // 2) for axis in level.shape)
+        parent_values: List[int] = []
+        parent_weights: List[int] = []
+
         for pz in range(parent_shape[2]):
             for py in range(parent_shape[1]):
                 for px in range(parent_shape[0]):
-                    group: List[int] = []
-                    for dz in (0, 1):
-                        for dy in (0, 1):
-                            for dx in (0, 1):
-                                child = (2 * px + dx, 2 * py + dy, 2 * pz + dz)
-                                group.append(level.values[coordinate_to_index(child, level.shape)])
-                    parent.append(_clamp(_div_round_nearest(sum(group), 8), Q3_MIN, Q3_MAX))
-        return GeometricLevel(parent_shape, tuple(parent))
+                    weighted_sum = 0
+                    total_weight = 0
+                    for z in self._child_axes(pz, depth):
+                        for y in self._child_axes(py, height):
+                            for x in self._child_axes(px, width):
+                                index = coordinate_to_index((x, y, z), level.shape)
+                                weight = weights[index]
+                                weighted_sum += level.values[index] * weight
+                                total_weight += weight
 
-    def condense(self, values: Tuple[int, ...]) -> Tuple[GeometricLevel, ...]:
+                    if total_weight:
+                        value = _clamp(
+                            _div_round_nearest(weighted_sum, total_weight),
+                            Q3_MIN,
+                            Q3_MAX,
+                        )
+                    else:
+                        value = 0
+                    parent_values.append(value)
+                    parent_weights.append(total_weight)
+
+        return (
+            GeometricLevel(parent_shape, tuple(parent_values)),
+            tuple(parent_weights),
+        )
+
+    def condense(
+        self,
+        values: Tuple[int, ...],
+        active_length: Optional[int] = None,
+    ) -> Tuple[GeometricLevel, ...]:
+        if len(values) != self.config.volume:
+            raise ValueError("geometric level does not match configured lattice volume")
+        if active_length is None:
+            active_length = len(values)
+        if not 1 <= active_length <= len(values):
+            raise ValueError("active_length must fit inside the geometric level")
+
         levels: List[GeometricLevel] = [GeometricLevel(self.config.shape, values)]
+        weights = tuple(1 if index < active_length else 0 for index in range(len(values)))
         while levels[-1].shape != (1, 1, 1):
-            levels.append(self._pool_level(levels[-1]))
+            parent, weights = self._pool_level(levels[-1], weights)
+            levels.append(parent)
         return tuple(levels)
 
     def decode(self, hierarchy: Tuple[GeometricLevel, ...]) -> Tuple[int, ...]:
+        if not hierarchy:
+            raise ValueError("hierarchy must contain at least one geometric level")
         reconstructed = hierarchy[-1]
+        if reconstructed.shape != (1, 1, 1):
+            raise ValueError("hierarchy must terminate in a single root voxel")
         for target in reversed(hierarchy[:-1]):
             values: List[int] = []
             for z in range(target.shape[2]):
                 for y in range(target.shape[1]):
                     for x in range(target.shape[0]):
-                        parent = (x // 2, y // 2, z // 2)
+                        parent = (
+                            x // 2 if target.shape[0] > reconstructed.shape[0] else x,
+                            y // 2 if target.shape[1] > reconstructed.shape[1] else y,
+                            z // 2 if target.shape[2] > reconstructed.shape[2] else z,
+                        )
                         values.append(
                             reconstructed.values[coordinate_to_index(parent, reconstructed.shape)]
                         )
@@ -259,12 +337,17 @@ class GeometricFeedbackRuntime:
             return values[coordinate_to_index(coord, self.config.shape)]
         return _div_round_nearest(sum(neighbors), len(neighbors))
 
-    def _evolve_lane(self, name: str, encoded: Tuple[int, ...]) -> Tuple[int, ...]:
+    def _evolve_lane(
+        self,
+        name: str,
+        encoded: Tuple[int, ...],
+        omega: Tuple[int, ...],
+    ) -> Tuple[int, ...]:
         evolved: List[int] = []
         for index, value in enumerate(encoded):
             coord = index_to_coordinate(index, self.config.shape)
             neighbor = self._neighbor_mean(encoded, coord)
-            memory = self.state.omega[index] if index < len(self.state.omega) else 0
+            memory = omega[index] if index < len(omega) else 0
             correction = _div_round_nearest(memory, 4)
             if name == "identity":
                 candidate = value
@@ -279,12 +362,19 @@ class GeometricFeedbackRuntime:
             evolved.append(_clamp(candidate, Q3_MIN, Q3_MAX))
         return tuple(evolved)
 
+    @staticmethod
+    def _mask_padding(values: Tuple[int, ...], input_length: int) -> Tuple[int, ...]:
+        return values[:input_length] + (0,) * (len(values) - input_length)
+
     def _validate_lane(
         self,
         decoded: Tuple[int, ...],
         encoded: Tuple[int, ...],
+        input_length: int,
     ) -> Tuple[bool, str, int, int]:
-        reconstruction_l1 = sum(abs(a - b) for a, b in zip(encoded, decoded))
+        reconstruction_l1 = sum(
+            abs(encoded[index] - decoded[index]) for index in range(input_length)
+        )
         active_voxels = sum(1 for value in decoded if value != 0)
         if (
             self.config.max_reconstruction_l1 is not None
@@ -295,18 +385,46 @@ class GeometricFeedbackRuntime:
             return False, "active-voxel budget exceeded", reconstruction_l1, active_voxels
         return True, "admissible", reconstruction_l1, active_voxels
 
-    def _run_lane(self, name: str, encoded: Tuple[int, ...]) -> LaneResult:
-        evolved = self._evolve_lane(name, encoded)
-        hierarchy = self.condense(evolved)
-        decoded = self.decode(hierarchy)
-        valid, reason, error, active = self._validate_lane(decoded, encoded)
+    def _run_lane(
+        self,
+        name: str,
+        encoded: Tuple[int, ...],
+        input_length: int,
+        omega: Tuple[int, ...],
+    ) -> LaneResult:
+        evolved = self._evolve_lane(name, encoded, omega)
+        hierarchy = self.condense(evolved, input_length)
+        decoded = self._mask_padding(self.decode(hierarchy), input_length)
+        valid, reason, error, active = self._validate_lane(
+            decoded,
+            encoded,
+            input_length,
+        )
         return LaneResult(name, evolved, hierarchy, decoded, error, active, valid, reason)
 
-    def run_parallel_lanes(self, encoded: Tuple[int, ...]) -> Tuple[LaneResult, ...]:
+    def run_parallel_lanes(
+        self,
+        encoded: Tuple[int, ...],
+        input_length: Optional[int] = None,
+        omega: Optional[Tuple[int, ...]] = None,
+    ) -> Tuple[LaneResult, ...]:
+        if len(encoded) != self.config.volume:
+            raise ValueError("encoded lattice does not match configured volume")
+        active_length = len(encoded) if input_length is None else input_length
+        if not 1 <= active_length <= len(encoded):
+            raise ValueError("input_length must fit inside the encoded lattice")
+        memory = self.state.omega if omega is None else omega
         workers = min(self.config.parallel_workers, len(self.LANE_ORDER))
         with ThreadPoolExecutor(max_workers=workers) as executor:
             futures = {
-                name: executor.submit(self._run_lane, name, encoded) for name in self.LANE_ORDER
+                name: executor.submit(
+                    self._run_lane,
+                    name,
+                    encoded,
+                    active_length,
+                    memory,
+                )
+                for name in self.LANE_ORDER
             }
             results = {name: future.result() for name, future in futures.items()}
         return tuple(results[name] for name in self.LANE_ORDER)
@@ -397,120 +515,127 @@ class GeometricFeedbackRuntime:
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
     def step(self, values: Union[Number, Sequence[Number]]) -> GeometricCycleResult:
-        previous_hash = self.state.state_hash
-        omega_before = self.state.omega
-        encoded, input_length = self.encode(values)
-        lanes = self.run_parallel_lanes(encoded)
-        admissible = tuple(lane for lane in lanes if lane.valid)
-        selected = (
-            min(
-                admissible,
-                key=lambda lane: (
-                    lane.reconstruction_l1,
-                    self.LANE_ORDER.index(lane.name),
-                ),
+        with self._lock:
+            previous_hash = self.state.state_hash
+            omega_before = self.state.omega
+            encoded, input_length = self.encode(values)
+            lanes = self.run_parallel_lanes(encoded, input_length, omega_before)
+            admissible = tuple(lane for lane in lanes if lane.valid)
+            selected = (
+                min(
+                    admissible,
+                    key=lambda lane: (
+                        lane.reconstruction_l1,
+                        self.LANE_ORDER.index(lane.name),
+                    ),
+                )
+                if admissible
+                else None
             )
-            if admissible
-            else None
-        )
-        committed = selected is not None
-        reason = (
-            "selected minimum-error admissible lane"
-            if committed
-            else "no lane passed Lambda projection"
-        )
-        cycle = self.state.cycle + 1
+            committed = selected is not None
+            reason = (
+                "selected minimum-error admissible lane"
+                if committed
+                else "no lane passed Lambda projection"
+            )
+            cycle = self.state.cycle + 1
 
-        if selected is None:
-            evolved: Tuple[int, ...] = tuple()
-            hierarchy: Tuple[GeometricLevel, ...] = tuple()
-            decoded: Tuple[int, ...] = tuple()
-            omega_after = self.state.omega
-        else:
-            evolved = selected.evolved
-            hierarchy = selected.hierarchy
-            decoded = selected.decoded
-            omega_after = self._update_omega(encoded, decoded)
+            if selected is None:
+                evolved: Tuple[int, ...] = tuple()
+                hierarchy: Tuple[GeometricLevel, ...] = tuple()
+                decoded: Tuple[int, ...] = tuple()
+                omega_after = self.state.omega
+            else:
+                evolved = selected.evolved
+                hierarchy = selected.hierarchy
+                decoded = selected.decoded
+                omega_after = self._update_omega(encoded, decoded)
 
-        candidate_payload: Dict[str, object] = {
-            "config": asdict(self.config),
-            "cycle": cycle,
-            "input_length": input_length,
-            "encoded": encoded,
-            "selected_lane": selected.name if selected else None,
-            "evolved": evolved,
-            "hierarchy": [asdict(level) for level in hierarchy],
-            "decoded": decoded,
-            "omega": omega_after,
-            "previous_hash": previous_hash,
-        }
-        candidate_hash = self._hash_candidate(candidate_payload)
-        if committed and selected is not None:
-            self.state = GeometricState(
+            candidate_payload: Dict[str, object] = {
+                "config": asdict(self.config),
+                "cycle": cycle,
+                "input_length": input_length,
+                "encoded": encoded,
+                "selected_lane": selected.name if selected else None,
+                "evolved": evolved,
+                "hierarchy": [asdict(level) for level in hierarchy],
+                "decoded": decoded,
+                "omega": omega_after,
+                "previous_hash": previous_hash,
+            }
+            candidate_hash = self._hash_candidate(candidate_payload)
+            if committed and selected is not None:
+                self.state = GeometricState(
+                    cycle=cycle,
+                    input_length=input_length,
+                    encoded=encoded,
+                    evolved=evolved,
+                    hierarchy=hierarchy,
+                    decoded=decoded,
+                    omega=omega_after,
+                    selected_lane=selected.name,
+                    state_hash=candidate_hash,
+                )
+
+            events = self._events(cycle, input_length, lanes, selected, committed, reason)
+            metrics: Dict[str, object] = {
+                "input_values": float(input_length),
+                "lattice_voxels": float(self.config.volume),
+                "hierarchy_levels": float(len(hierarchy)),
+                "parallel_lanes": float(len(lanes)),
+                "admissible_lanes": float(len(admissible)),
+                "best_reconstruction_l1": (
+                    float(selected.reconstruction_l1) if selected is not None else None
+                ),
+                "active_voxels": float(selected.active_voxels) if selected else 0.0,
+                "memory_l1": float(sum(abs(value) for value in omega_after)),
+            }
+            result = GeometricCycleResult(
                 cycle=cycle,
-                input_length=input_length,
+                committed=committed,
+                reason=reason,
+                selected_lane=selected.name if selected else None,
                 encoded=encoded,
                 evolved=evolved,
                 hierarchy=hierarchy,
                 decoded=decoded,
-                omega=omega_after,
-                selected_lane=selected.name,
-                state_hash=candidate_hash,
+                output=decoded[:input_length],
+                omega_before=omega_before,
+                omega_after=omega_after,
+                lanes=lanes,
+                metrics=metrics,
+                events=events,
+                previous_hash=previous_hash,
+                candidate_hash=candidate_hash,
+                state_hash=self.state.state_hash,
             )
-
-        events = self._events(cycle, input_length, lanes, selected, committed, reason)
-        best_error = float(selected.reconstruction_l1) if selected else math.inf
-        metrics = {
-            "input_values": float(input_length),
-            "lattice_voxels": float(self.config.volume),
-            "hierarchy_levels": float(len(hierarchy)),
-            "parallel_lanes": float(len(lanes)),
-            "admissible_lanes": float(len(admissible)),
-            "best_reconstruction_l1": best_error,
-            "active_voxels": float(selected.active_voxels) if selected else 0.0,
-            "memory_l1": float(sum(abs(value) for value in omega_after)),
-        }
-        result = GeometricCycleResult(
-            cycle=cycle,
-            committed=committed,
-            reason=reason,
-            selected_lane=selected.name if selected else None,
-            encoded=encoded,
-            evolved=evolved,
-            hierarchy=hierarchy,
-            decoded=decoded,
-            output=decoded[:input_length],
-            omega_before=omega_before,
-            omega_after=omega_after,
-            lanes=lanes,
-            metrics=metrics,
-            events=events,
-            previous_hash=previous_hash,
-            candidate_hash=candidate_hash,
-            state_hash=self.state.state_hash,
-        )
-        self.journal.append(result)
-        if len(self.journal) > self.config.journal_limit:
-            del self.journal[: len(self.journal) - self.config.journal_limit]
-        return result
+            self.journal.append(result)
+            if len(self.journal) > self.config.journal_limit:
+                del self.journal[: len(self.journal) - self.config.journal_limit]
+            return result
 
     def run_feedback(
         self,
         values: Union[Number, Sequence[Number]],
         cycles: Optional[int] = None,
     ) -> List[GeometricCycleResult]:
-        count = cycles or self.config.feedback_cycles
-        if count < 1:
-            raise ValueError("feedback cycles must be positive")
-        current: Union[Number, Sequence[Number]] = values
-        results: List[GeometricCycleResult] = []
-        for _ in range(count):
-            result = self.step(current)
-            results.append(result)
-            if not result.committed:
-                break
-            current = result.output
-        return results
+        count = self.config.feedback_cycles if cycles is None else cycles
+        if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+            raise ValueError("feedback cycles must be a positive integer")
+        if count > self.config.max_feedback_cycles:
+            raise ValueError("feedback cycles exceed configured maximum")
+
+        with self._lock:
+            current: Union[Number, Sequence[Number]] = values
+            results: List[GeometricCycleResult] = []
+            for _ in range(count):
+                result = self.step(current)
+                results.append(result)
+                if not result.committed:
+                    break
+                current = result.output
+            return results
 
     def snapshot(self) -> Dict[str, object]:
-        return asdict(self.state)
+        with self._lock:
+            return asdict(self.state)

--- a/src/jarvisx/geometric_rvis.py
+++ b/src/jarvisx/geometric_rvis.py
@@ -1,0 +1,516 @@
+"""Transactional 3D geometric auto-encoding/decoding feedback runtime.
+
+The runtime converts public shell values into a signed-3-bit voxel lattice,
+builds a multiresolution geometric pyramid, evaluates independent candidate
+lanes in parallel, validates the candidates through Lambda constraints, and
+commits or rolls back atomically. Committed decoded output may be fed into the
+next cycle to form an inward recursive loop.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+import hashlib
+import json
+import math
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+Number = Union[int, float]
+Coordinate = Tuple[int, int, int]
+Q3_MIN = -4
+Q3_MAX = 3
+
+
+def _clamp(value: int, lower: int, upper: int) -> int:
+    return max(lower, min(upper, int(value)))
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    if value >= 0:
+        return int(math.floor(value + 0.5))
+    return int(math.ceil(value - 0.5))
+
+
+def _div_round_nearest(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    if numerator >= 0:
+        return (numerator + denominator // 2) // denominator
+    return -((-numerator + denominator // 2) // denominator)
+
+
+def quantize_q3(value: Number, scale: float = 1.0) -> int:
+    """Quantize a finite scalar into the signed three-bit domain."""
+    scalar = float(value)
+    if not math.isfinite(scalar):
+        raise ValueError("geometric input values must be finite")
+    if not math.isfinite(scale) or scale <= 0:
+        raise ValueError("scale must be positive and finite")
+    return _clamp(_round_half_away_from_zero(scalar * scale), Q3_MIN, Q3_MAX)
+
+
+def coordinate_to_index(coord: Coordinate, shape: Coordinate) -> int:
+    """Map (x, y, z) to a row-major linear address."""
+    x, y, z = coord
+    width, height, depth = shape
+    if not (0 <= x < width and 0 <= y < height and 0 <= z < depth):
+        raise ValueError("coordinate outside lattice bounds")
+    return x + width * (y + height * z)
+
+
+def index_to_coordinate(index: int, shape: Coordinate) -> Coordinate:
+    """Inverse of :func:`coordinate_to_index`."""
+    width, height, depth = shape
+    volume = width * height * depth
+    if index < 0 or index >= volume:
+        raise ValueError("index outside lattice bounds")
+    x = index % width
+    yz = index // width
+    y = yz % height
+    z = yz // height
+    return x, y, z
+
+
+def _is_power_of_two(value: int) -> bool:
+    return value > 0 and (value & (value - 1)) == 0
+
+
+@dataclass(frozen=True)
+class GeometricConfig:
+    shape: Coordinate = (4, 4, 4)
+    input_scale: float = 1.0
+    max_input_values: Optional[int] = None
+    parallel_workers: int = 4
+    feedback_cycles: int = 4
+    retention_numerator: int = 7
+    retention_denominator: int = 8
+    learning_numerator: int = 1
+    learning_denominator: int = 2
+    omega_limit: int = 127
+    max_reconstruction_l1: Optional[int] = None
+    max_active_voxels: Optional[int] = None
+    journal_limit: int = 128
+
+    def validate(self) -> None:
+        if any(not _is_power_of_two(axis) for axis in self.shape):
+            raise ValueError("shape axes must be positive powers of two")
+        if not math.isfinite(self.input_scale) or self.input_scale <= 0:
+            raise ValueError("input_scale must be positive and finite")
+        if self.parallel_workers < 1:
+            raise ValueError("parallel_workers must be positive")
+        if self.feedback_cycles < 1:
+            raise ValueError("feedback_cycles must be positive")
+        if self.retention_denominator <= 0 or self.learning_denominator <= 0:
+            raise ValueError("update denominators must be positive")
+        if not 0 <= self.retention_numerator <= self.retention_denominator:
+            raise ValueError("retention ratio must be in [0, 1]")
+        if self.learning_numerator < 0:
+            raise ValueError("learning numerator must be non-negative")
+        if self.omega_limit < 1:
+            raise ValueError("omega_limit must be positive")
+        if self.journal_limit < 1:
+            raise ValueError("journal_limit must be positive")
+        volume = self.shape[0] * self.shape[1] * self.shape[2]
+        if self.max_input_values is not None and not 1 <= self.max_input_values <= volume:
+            raise ValueError("max_input_values must fit inside the lattice")
+
+    @property
+    def volume(self) -> int:
+        return self.shape[0] * self.shape[1] * self.shape[2]
+
+    @property
+    def input_limit(self) -> int:
+        return self.max_input_values or self.volume
+
+
+@dataclass(frozen=True)
+class GeometricLevel:
+    shape: Coordinate
+    values: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class LaneResult:
+    name: str
+    evolved: Tuple[int, ...]
+    hierarchy: Tuple[GeometricLevel, ...]
+    decoded: Tuple[int, ...]
+    reconstruction_l1: int
+    active_voxels: int
+    valid: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class GeometricState:
+    cycle: int = 0
+    input_length: int = 0
+    encoded: Tuple[int, ...] = field(default_factory=tuple)
+    evolved: Tuple[int, ...] = field(default_factory=tuple)
+    hierarchy: Tuple[GeometricLevel, ...] = field(default_factory=tuple)
+    decoded: Tuple[int, ...] = field(default_factory=tuple)
+    omega: Tuple[int, ...] = field(default_factory=tuple)
+    selected_lane: str = "GENESIS"
+    state_hash: str = "GENESIS"
+
+
+@dataclass(frozen=True)
+class GeometricCycleResult:
+    cycle: int
+    committed: bool
+    reason: str
+    selected_lane: Optional[str]
+    encoded: Tuple[int, ...]
+    evolved: Tuple[int, ...]
+    hierarchy: Tuple[GeometricLevel, ...]
+    decoded: Tuple[int, ...]
+    output: Tuple[int, ...]
+    omega_before: Tuple[int, ...]
+    omega_after: Tuple[int, ...]
+    lanes: Tuple[LaneResult, ...]
+    metrics: Dict[str, float]
+    events: Tuple[Dict[str, object], ...]
+    previous_hash: str
+    candidate_hash: str
+    state_hash: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+class GeometricFeedbackRuntime:
+    """3D geometric transactional runtime with deterministic parallel lanes."""
+
+    LANE_ORDER = ("identity", "diffusion", "memory", "hybrid")
+
+    def __init__(self, config: Optional[GeometricConfig] = None) -> None:
+        self.config = config or GeometricConfig()
+        self.config.validate()
+        self.state = GeometricState()
+        self.journal: List[GeometricCycleResult] = []
+
+    def encode(self, values: Union[Number, Sequence[Number]]) -> Tuple[Tuple[int, ...], int]:
+        if isinstance(values, (int, float)):
+            source: Iterable[Number] = (values,)
+        else:
+            source = values
+        materialized = tuple(source)
+        if not materialized:
+            raise ValueError("at least one geometric input value is required")
+        if len(materialized) > self.config.input_limit:
+            raise ValueError("input exceeds configured geometric lattice capacity")
+        encoded = [quantize_q3(value, self.config.input_scale) for value in materialized]
+        encoded.extend([0] * (self.config.volume - len(encoded)))
+        return tuple(encoded), len(materialized)
+
+    def _pool_level(self, level: GeometricLevel) -> GeometricLevel:
+        width, height, depth = level.shape
+        parent_shape = (width // 2, height // 2, depth // 2)
+        parent: List[int] = []
+        for pz in range(parent_shape[2]):
+            for py in range(parent_shape[1]):
+                for px in range(parent_shape[0]):
+                    group: List[int] = []
+                    for dz in (0, 1):
+                        for dy in (0, 1):
+                            for dx in (0, 1):
+                                child = (2 * px + dx, 2 * py + dy, 2 * pz + dz)
+                                group.append(level.values[coordinate_to_index(child, level.shape)])
+                    parent.append(_clamp(_div_round_nearest(sum(group), 8), Q3_MIN, Q3_MAX))
+        return GeometricLevel(parent_shape, tuple(parent))
+
+    def condense(self, values: Tuple[int, ...]) -> Tuple[GeometricLevel, ...]:
+        levels: List[GeometricLevel] = [GeometricLevel(self.config.shape, values)]
+        while levels[-1].shape != (1, 1, 1):
+            levels.append(self._pool_level(levels[-1]))
+        return tuple(levels)
+
+    def decode(self, hierarchy: Tuple[GeometricLevel, ...]) -> Tuple[int, ...]:
+        reconstructed = hierarchy[-1]
+        for target in reversed(hierarchy[:-1]):
+            values: List[int] = []
+            for z in range(target.shape[2]):
+                for y in range(target.shape[1]):
+                    for x in range(target.shape[0]):
+                        parent = (x // 2, y // 2, z // 2)
+                        values.append(
+                            reconstructed.values[coordinate_to_index(parent, reconstructed.shape)]
+                        )
+            reconstructed = GeometricLevel(target.shape, tuple(values))
+        return reconstructed.values
+
+    def _neighbor_mean(self, values: Tuple[int, ...], coord: Coordinate) -> int:
+        x, y, z = coord
+        width, height, depth = self.config.shape
+        neighbors: List[int] = []
+        for dx, dy, dz in (
+            (1, 0, 0),
+            (-1, 0, 0),
+            (0, 1, 0),
+            (0, -1, 0),
+            (0, 0, 1),
+            (0, 0, -1),
+        ):
+            nx, ny, nz = x + dx, y + dy, z + dz
+            if 0 <= nx < width and 0 <= ny < height and 0 <= nz < depth:
+                neighbors.append(values[coordinate_to_index((nx, ny, nz), self.config.shape)])
+        if not neighbors:
+            return values[coordinate_to_index(coord, self.config.shape)]
+        return _div_round_nearest(sum(neighbors), len(neighbors))
+
+    def _evolve_lane(self, name: str, encoded: Tuple[int, ...]) -> Tuple[int, ...]:
+        evolved: List[int] = []
+        for index, value in enumerate(encoded):
+            coord = index_to_coordinate(index, self.config.shape)
+            neighbor = self._neighbor_mean(encoded, coord)
+            memory = self.state.omega[index] if index < len(self.state.omega) else 0
+            correction = _div_round_nearest(memory, 4)
+            if name == "identity":
+                candidate = value
+            elif name == "diffusion":
+                candidate = _div_round_nearest(3 * value + neighbor, 4)
+            elif name == "memory":
+                candidate = value + correction
+            elif name == "hybrid":
+                candidate = _div_round_nearest(3 * value + neighbor + correction, 5)
+            else:
+                raise ValueError("unknown geometric lane")
+            evolved.append(_clamp(candidate, Q3_MIN, Q3_MAX))
+        return tuple(evolved)
+
+    def _validate_lane(
+        self,
+        decoded: Tuple[int, ...],
+        encoded: Tuple[int, ...],
+    ) -> Tuple[bool, str, int, int]:
+        reconstruction_l1 = sum(abs(a - b) for a, b in zip(encoded, decoded))
+        active_voxels = sum(1 for value in decoded if value != 0)
+        if (
+            self.config.max_reconstruction_l1 is not None
+            and reconstruction_l1 > self.config.max_reconstruction_l1
+        ):
+            return False, "reconstruction budget exceeded", reconstruction_l1, active_voxels
+        if self.config.max_active_voxels is not None and active_voxels > self.config.max_active_voxels:
+            return False, "active-voxel budget exceeded", reconstruction_l1, active_voxels
+        return True, "admissible", reconstruction_l1, active_voxels
+
+    def _run_lane(self, name: str, encoded: Tuple[int, ...]) -> LaneResult:
+        evolved = self._evolve_lane(name, encoded)
+        hierarchy = self.condense(evolved)
+        decoded = self.decode(hierarchy)
+        valid, reason, error, active = self._validate_lane(decoded, encoded)
+        return LaneResult(name, evolved, hierarchy, decoded, error, active, valid, reason)
+
+    def run_parallel_lanes(self, encoded: Tuple[int, ...]) -> Tuple[LaneResult, ...]:
+        workers = min(self.config.parallel_workers, len(self.LANE_ORDER))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                name: executor.submit(self._run_lane, name, encoded) for name in self.LANE_ORDER
+            }
+            results = {name: future.result() for name, future in futures.items()}
+        return tuple(results[name] for name in self.LANE_ORDER)
+
+    def _update_omega(
+        self,
+        encoded: Tuple[int, ...],
+        decoded: Tuple[int, ...],
+    ) -> Tuple[int, ...]:
+        updated: List[int] = []
+        for index, (actual, reconstructed) in enumerate(zip(encoded, decoded)):
+            old = self.state.omega[index] if index < len(self.state.omega) else 0
+            residual = actual - reconstructed
+            retained = _div_round_nearest(
+                old * self.config.retention_numerator,
+                self.config.retention_denominator,
+            )
+            learned = _div_round_nearest(
+                residual * self.config.learning_numerator,
+                self.config.learning_denominator,
+            )
+            updated.append(
+                _clamp(retained + learned, -self.config.omega_limit, self.config.omega_limit)
+            )
+        return tuple(updated)
+
+    def _events(
+        self,
+        cycle: int,
+        input_length: int,
+        lanes: Tuple[LaneResult, ...],
+        selected: Optional[LaneResult],
+        committed: bool,
+        reason: str,
+    ) -> Tuple[Dict[str, object], ...]:
+        events: List[Dict[str, object]] = [
+            {
+                "seq": 0,
+                "cycle": cycle,
+                "phase": "GEOM_ENCODE",
+                "summary": "Mapped public shell values into a bounded signed-3-bit 3D lattice.",
+                "shape": self.config.shape,
+                "input_length": input_length,
+                "committed": False,
+            }
+        ]
+        for lane in lanes:
+            events.append(
+                {
+                    "seq": len(events),
+                    "cycle": cycle,
+                    "phase": "MULTIPARALLEL_LANE",
+                    "lane": lane.name,
+                    "summary": "Encoded, evolved, condensed, and decoded one independent geometric candidate.",
+                    "reconstruction_l1": lane.reconstruction_l1,
+                    "valid": lane.valid,
+                    "reason": lane.reason,
+                    "committed": False,
+                }
+            )
+        events.append(
+            {
+                "seq": len(events),
+                "cycle": cycle,
+                "phase": "LAMBDA_PROJECT",
+                "lane": selected.name if selected else None,
+                "summary": reason,
+                "passed": committed,
+                "committed": False,
+            }
+        )
+        events.append(
+            {
+                "seq": len(events),
+                "cycle": cycle,
+                "phase": "COMMIT" if committed else "ROLLBACK",
+                "lane": selected.name if selected else None,
+                "summary": "Committed the best admissible geometric branch."
+                if committed
+                else "Restored the previously committed geometric state.",
+                "committed": committed,
+            }
+        )
+        return tuple(events)
+
+    def _hash_candidate(self, payload: Dict[str, object]) -> str:
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def step(self, values: Union[Number, Sequence[Number]]) -> GeometricCycleResult:
+        previous_hash = self.state.state_hash
+        omega_before = self.state.omega
+        encoded, input_length = self.encode(values)
+        lanes = self.run_parallel_lanes(encoded)
+        admissible = tuple(lane for lane in lanes if lane.valid)
+        selected = (
+            min(
+                admissible,
+                key=lambda lane: (
+                    lane.reconstruction_l1,
+                    self.LANE_ORDER.index(lane.name),
+                ),
+            )
+            if admissible
+            else None
+        )
+        committed = selected is not None
+        reason = (
+            "selected minimum-error admissible lane"
+            if committed
+            else "no lane passed Lambda projection"
+        )
+        cycle = self.state.cycle + 1
+
+        if selected is None:
+            evolved: Tuple[int, ...] = tuple()
+            hierarchy: Tuple[GeometricLevel, ...] = tuple()
+            decoded: Tuple[int, ...] = tuple()
+            omega_after = self.state.omega
+        else:
+            evolved = selected.evolved
+            hierarchy = selected.hierarchy
+            decoded = selected.decoded
+            omega_after = self._update_omega(encoded, decoded)
+
+        candidate_payload: Dict[str, object] = {
+            "config": asdict(self.config),
+            "cycle": cycle,
+            "input_length": input_length,
+            "encoded": encoded,
+            "selected_lane": selected.name if selected else None,
+            "evolved": evolved,
+            "hierarchy": [asdict(level) for level in hierarchy],
+            "decoded": decoded,
+            "omega": omega_after,
+            "previous_hash": previous_hash,
+        }
+        candidate_hash = self._hash_candidate(candidate_payload)
+        if committed and selected is not None:
+            self.state = GeometricState(
+                cycle=cycle,
+                input_length=input_length,
+                encoded=encoded,
+                evolved=evolved,
+                hierarchy=hierarchy,
+                decoded=decoded,
+                omega=omega_after,
+                selected_lane=selected.name,
+                state_hash=candidate_hash,
+            )
+
+        events = self._events(cycle, input_length, lanes, selected, committed, reason)
+        best_error = float(selected.reconstruction_l1) if selected else math.inf
+        metrics = {
+            "input_values": float(input_length),
+            "lattice_voxels": float(self.config.volume),
+            "hierarchy_levels": float(len(hierarchy)),
+            "parallel_lanes": float(len(lanes)),
+            "admissible_lanes": float(len(admissible)),
+            "best_reconstruction_l1": best_error,
+            "active_voxels": float(selected.active_voxels) if selected else 0.0,
+            "memory_l1": float(sum(abs(value) for value in omega_after)),
+        }
+        result = GeometricCycleResult(
+            cycle=cycle,
+            committed=committed,
+            reason=reason,
+            selected_lane=selected.name if selected else None,
+            encoded=encoded,
+            evolved=evolved,
+            hierarchy=hierarchy,
+            decoded=decoded,
+            output=decoded[:input_length],
+            omega_before=omega_before,
+            omega_after=omega_after,
+            lanes=lanes,
+            metrics=metrics,
+            events=events,
+            previous_hash=previous_hash,
+            candidate_hash=candidate_hash,
+            state_hash=self.state.state_hash,
+        )
+        self.journal.append(result)
+        if len(self.journal) > self.config.journal_limit:
+            del self.journal[: len(self.journal) - self.config.journal_limit]
+        return result
+
+    def run_feedback(
+        self,
+        values: Union[Number, Sequence[Number]],
+        cycles: Optional[int] = None,
+    ) -> List[GeometricCycleResult]:
+        count = cycles or self.config.feedback_cycles
+        if count < 1:
+            raise ValueError("feedback cycles must be positive")
+        current: Union[Number, Sequence[Number]] = values
+        results: List[GeometricCycleResult] = []
+        for _ in range(count):
+            result = self.step(current)
+            results.append(result)
+            if not result.committed:
+                break
+            current = result.output
+        return results
+
+    def snapshot(self) -> Dict[str, object]:
+        return asdict(self.state)

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,44 @@
 import hashlib
-import time
+import json
+
 
 class OmegaLedger:
+    """Deterministic hash-chained execution ledger."""
+
     def __init__(self):
         self.chain = []
 
+    @staticmethod
+    def _serialize_payload(payload):
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        payload = {
+            "sequence": len(self.chain),
+            "state": state,
+            "opcode": int(opcode),
+        }
+        previous_hash = self.chain[-1]["hash"].encode("ascii") if self.chain else b""
+        digest = hashlib.sha256(previous_hash + self._serialize_payload(payload)).hexdigest()
+        entry = {"hash": digest, "payload": payload}
+        self.chain.append(entry)
+        return entry
+
+    def verify(self):
+        previous_hash = b""
+        for sequence, entry in enumerate(self.chain):
+            payload = entry.get("payload")
+            if not isinstance(payload, dict) or payload.get("sequence") != sequence:
+                return False
+            expected = hashlib.sha256(
+                previous_hash + self._serialize_payload(payload)
+            ).hexdigest()
+            if entry.get("hash") != expected:
+                return False
+            previous_hash = expected.encode("ascii")
+        return True

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -1,16 +1,44 @@
 import json
 import os
+
 from .ledger import OmegaLedger
 
+
 class PersistentLedger(OmegaLedger):
+    """Omega ledger persisted with an atomic replace operation."""
+
     def __init__(self, path="omega_ledger.json"):
         super().__init__()
         self.path = path
         if os.path.exists(path):
-            with open(path) as f:
-                self.chain = json.load(f)
+            try:
+                with open(path, encoding="utf-8") as source:
+                    chain = json.load(source)
+            except (OSError, json.JSONDecodeError) as exc:
+                raise RuntimeError("Unable to load persistent Omega ledger") from exc
+            if not isinstance(chain, list):
+                raise RuntimeError("Persistent Omega ledger must contain a list")
+            self.chain = chain
+            if not self.verify():
+                raise RuntimeError("Persistent Omega ledger hash chain is invalid")
 
     def log(self, state, opcode):
-        super().log(state, opcode)
-        with open(self.path, "w") as f:
-            json.dump(self.chain, f, indent=2)
+        previous_length = len(self.chain)
+        entry = super().log(state, opcode)
+        temporary_path = "{}.tmp".format(self.path)
+
+        try:
+            with open(temporary_path, "w", encoding="utf-8") as destination:
+                json.dump(self.chain, destination, ensure_ascii=False, indent=2)
+                destination.flush()
+                os.fsync(destination.fileno())
+            os.replace(temporary_path, self.path)
+        except Exception:
+            del self.chain[previous_length:]
+            try:
+                if os.path.exists(temporary_path):
+                    os.remove(temporary_path)
+            finally:
+                raise
+
+        return entry

--- a/src/jarvisx/serialization.py
+++ b/src/jarvisx/serialization.py
@@ -1,0 +1,14 @@
+"""Serialization helpers for deterministic browser-safe runtime output."""
+
+import math
+
+
+def json_safe(value):
+    """Recursively replace non-finite floats with JSON null-compatible values."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_safe(item) for item in value]
+    return value

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -1,3 +1,7 @@
+import math
+
+import pytest
+
 from jarvisx.cognitive import (
     CognitiveConfig,
     CognitiveKernel,
@@ -14,6 +18,13 @@ def test_q3_quantization_is_bounded_and_signed():
     assert quantize_q3(99) == 3
 
 
+def test_q3_quantization_rejects_non_finite_values():
+    with pytest.raises(ValueError, match="finite"):
+        quantize_q3(math.inf)
+    with pytest.raises(ValueError, match="finite"):
+        quantize_q3(math.nan)
+
+
 def test_hierarchy_condenses_to_single_root():
     kernel = CognitiveKernel(CognitiveConfig(branch_factor=2))
     result = kernel.step([3, 2, 1, 0, -1, -2, -3, -4])
@@ -21,6 +32,13 @@ def test_hierarchy_condenses_to_single_root():
     assert result.hierarchy[0] == (3, 2, 1, 0, -1, -2, -3, -4)
     assert len(result.hierarchy[-1]) == 1
     assert result.metrics["condensation_ratio"] == 8.0
+
+
+def test_hierarchy_enforces_maximum_depth_before_allocation_continues():
+    kernel = CognitiveKernel(CognitiveConfig(branch_factor=2, max_levels=2))
+    with pytest.raises(ValueError, match="max_levels"):
+        kernel.step([1, 1, 1, 1])
+    assert kernel.snapshot()["state_hash"] == "GENESIS"
 
 
 def test_prediction_error_updates_cumulative_memory():
@@ -58,3 +76,31 @@ def test_vm_bridge_maps_cycle_to_existing_registers():
     assert regs["Λ"] == 1
     assert regs["Ψ"] == result.hierarchy[-1][0]
     assert regs["𝒮"] == int(result.metrics["residual_l1"])
+
+
+def test_vm_bridge_rejection_does_not_leak_candidate_registers():
+    regs = Registers()
+    kernel = CognitiveKernel(CognitiveConfig(max_residual_l1=4))
+    bridge = CognitiveVMBridge(regs, kernel)
+
+    committed = bridge.cycle([1, 1, 1, 1])
+    assert committed.committed
+    before = regs.snapshot()
+
+    rejected = bridge.cycle([-4, -4, -4, -4])
+    after = regs.snapshot()
+
+    assert not rejected.committed
+    assert rejected.reason == "residual budget exceeded"
+    assert rejected.state_hash == committed.state_hash
+    assert after["Λ"] == 0
+    for name, value in before.items():
+        if name != "Λ":
+            assert after[name] == value
+
+
+def test_configuration_rejects_unbounded_update_ratios():
+    with pytest.raises(ValueError, match="retention ratio"):
+        CognitiveKernel(CognitiveConfig(retention_numerator=9, retention_denominator=8))
+    with pytest.raises(ValueError, match="non-negative"):
+        CognitiveKernel(CognitiveConfig(learning_numerator=-1))

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -8,6 +8,7 @@ from jarvisx.cognitive import (
     CognitiveVMBridge,
     quantize_q3,
 )
+from jarvisx.core import CodexVM
 from jarvisx.registers import Registers
 
 
@@ -97,6 +98,34 @@ def test_vm_bridge_rejection_does_not_leak_candidate_registers():
     for name, value in before.items():
         if name != "Λ":
             assert after[name] == value
+
+
+def test_vm_rolls_back_kernel_and_registers_on_projection_failure():
+    class FailingRegisters(Registers):
+        def __init__(self):
+            super().__init__()
+            self.fail_once = False
+
+        def __setitem__(self, key, value):
+            if self.fail_once and key == "Ω":
+                self.fail_once = False
+                raise RuntimeError("simulated register failure")
+            super().__setitem__(key, value)
+
+    vm = CodexVM()
+    failing = FailingRegisters()
+    vm.regs = failing
+    vm.cognitive_bridge.registers = failing
+    before_state = vm.cognitive.snapshot()
+    before_registers = failing.snapshot()
+    failing.fail_once = True
+
+    with pytest.raises(RuntimeError, match="simulated register failure"):
+        vm.cognitive_cycle([3, 1, -1, -3])
+
+    assert vm.cognitive.snapshot() == before_state
+    assert vm.cognitive.journal == []
+    assert failing.snapshot() == before_registers
 
 
 def test_configuration_rejects_unbounded_update_ratios():

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -1,0 +1,60 @@
+from jarvisx.cognitive import (
+    CognitiveConfig,
+    CognitiveKernel,
+    CognitiveVMBridge,
+    quantize_q3,
+)
+from jarvisx.registers import Registers
+
+
+def test_q3_quantization_is_bounded_and_signed():
+    assert quantize_q3(-99) == -4
+    assert quantize_q3(-1.5) == -2
+    assert quantize_q3(1.5) == 2
+    assert quantize_q3(99) == 3
+
+
+def test_hierarchy_condenses_to_single_root():
+    kernel = CognitiveKernel(CognitiveConfig(branch_factor=2))
+    result = kernel.step([3, 2, 1, 0, -1, -2, -3, -4])
+    assert result.committed
+    assert result.hierarchy[0] == (3, 2, 1, 0, -1, -2, -3, -4)
+    assert len(result.hierarchy[-1]) == 1
+    assert result.metrics["condensation_ratio"] == 8.0
+
+
+def test_prediction_error_updates_cumulative_memory():
+    kernel = CognitiveKernel()
+    first = kernel.step([3, 3, 3, 3])
+    second = kernel.step([0, 0, 0, 0])
+    assert first.omega_after == (2, 2, 2, 2)
+    assert second.prediction == (3, 3, 3, 3)
+    assert second.residual == (-3, -3, -3, -3)
+    assert second.omega_after == (0, 0, 0, 0)
+
+
+def test_same_stream_produces_same_hash_chain():
+    stream = [[1, 2, 3, -4], [1, 1, 2, -3], [0, 1, 1, -2]]
+    left = CognitiveKernel().run(stream)
+    right = CognitiveKernel().run(stream)
+    assert [item.state_hash for item in left] == [item.state_hash for item in right]
+
+
+def test_lambda_rejection_rolls_back_committed_state():
+    kernel = CognitiveKernel(CognitiveConfig(max_residual_l1=0))
+    before = kernel.snapshot()
+    result = kernel.step([1, 0, 0, 0])
+    assert not result.committed
+    assert result.reason == "residual budget exceeded"
+    assert kernel.snapshot() == before
+    assert result.state_hash == "GENESIS"
+
+
+def test_vm_bridge_maps_cycle_to_existing_registers():
+    regs = Registers()
+    bridge = CognitiveVMBridge(regs)
+    result = bridge.cycle([3, 1, -1, -3])
+    assert result.committed
+    assert regs["Λ"] == 1
+    assert regs["Ψ"] == result.hierarchy[-1][0]
+    assert regs["𝒮"] == int(result.metrics["residual_l1"])

--- a/tests/test_geometric_rvis.py
+++ b/tests/test_geometric_rvis.py
@@ -1,7 +1,9 @@
+import json
 import math
 
 import pytest
 
+from jarvisx.cli import _json_safe
 from jarvisx.core import CodexVM
 from jarvisx.geometric_rvis import (
     GeometricConfig,
@@ -90,3 +92,12 @@ def test_codex_vm_projects_geometric_commit_into_registers():
     assert vm.regs["Ψ"] == final.hierarchy[-1].values[0]
     assert vm.regs["𝒮"] == int(final.metrics["best_reconstruction_l1"])
     assert vm.regs["Π"] == sum(final.output)
+
+
+def test_rejected_cycle_serializes_as_strict_browser_json():
+    runtime = GeometricFeedbackRuntime(GeometricConfig(max_reconstruction_l1=0))
+    rejected = runtime.step([3, -4, 3, -4])
+    payload = _json_safe(rejected.to_dict())
+    encoded = json.dumps(payload, allow_nan=False)
+    assert "Infinity" not in encoded
+    assert payload["metrics"]["best_reconstruction_l1"] is None

--- a/tests/test_geometric_rvis.py
+++ b/tests/test_geometric_rvis.py
@@ -1,0 +1,80 @@
+import math
+
+import pytest
+
+from jarvisx.geometric_rvis import (
+    GeometricConfig,
+    GeometricFeedbackRuntime,
+    coordinate_to_index,
+    index_to_coordinate,
+    quantize_q3,
+)
+
+
+def test_coordinate_mapping_is_bijective():
+    shape = (4, 4, 4)
+    for index in range(64):
+        coord = index_to_coordinate(index, shape)
+        assert coordinate_to_index(coord, shape) == index
+
+
+def test_quantization_rejects_non_finite_input():
+    with pytest.raises(ValueError, match="finite"):
+        quantize_q3(math.inf)
+
+
+def test_geometric_pyramid_condenses_to_one_voxel():
+    runtime = GeometricFeedbackRuntime()
+    encoded, _ = runtime.encode([3, 2, 1, 0, -1, -2, -3, -4])
+    hierarchy = runtime.condense(encoded)
+    assert hierarchy[0].shape == (4, 4, 4)
+    assert hierarchy[-1].shape == (1, 1, 1)
+    assert len(hierarchy[-1].values) == 1
+
+
+def test_parallel_lanes_are_deterministic():
+    values = [3, 1, -1, -3, 2, 0, -2, -4]
+    left = GeometricFeedbackRuntime().step(values)
+    right = GeometricFeedbackRuntime().step(values)
+    assert left.committed and right.committed
+    assert left.selected_lane == right.selected_lane
+    assert left.candidate_hash == right.candidate_hash
+    assert [lane.reconstruction_l1 for lane in left.lanes] == [
+        lane.reconstruction_l1 for lane in right.lanes
+    ]
+
+
+def test_feedback_turns_committed_output_into_next_input():
+    runtime = GeometricFeedbackRuntime(GeometricConfig(feedback_cycles=3))
+    results = runtime.run_feedback([3, 1, -1, -3])
+    assert len(results) == 3
+    assert all(result.committed for result in results)
+    assert results[1].encoded[:4] == results[0].output
+    assert results[-1].state_hash == runtime.state.state_hash
+
+
+def test_lambda_rejection_preserves_committed_state():
+    config = GeometricConfig(max_reconstruction_l1=0)
+    runtime = GeometricFeedbackRuntime(config)
+    before = runtime.snapshot()
+    result = runtime.step([3, -4, 3, -4])
+    assert not result.committed
+    assert runtime.snapshot() == before
+    assert result.state_hash == "GENESIS"
+
+
+def test_shell_events_expose_3d_pipeline_without_uncommitted_render():
+    result = GeometricFeedbackRuntime().step([1, 2, 3, -4])
+    phases = [event["phase"] for event in result.events]
+    assert phases[0] == "GEOM_ENCODE"
+    assert phases.count("MULTIPARALLEL_LANE") == 4
+    assert phases[-1] == "COMMIT"
+    assert result.events[-1]["committed"] is True
+
+
+def test_cycle_reports_memory_before_and_after_without_aliasing():
+    runtime = GeometricFeedbackRuntime()
+    first = runtime.step([3, 1, -1, -3])
+    second = runtime.step(first.output)
+    assert first.omega_before == ()
+    assert second.omega_before == first.omega_after

--- a/tests/test_geometric_rvis.py
+++ b/tests/test_geometric_rvis.py
@@ -1,5 +1,9 @@
+import importlib
 import json
 import math
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import sys
 
 import pytest
 
@@ -21,6 +25,13 @@ def test_coordinate_mapping_is_bijective():
         assert coordinate_to_index(coord, shape) == index
 
 
+def test_coordinate_mapping_rejects_invalid_shapes_and_indices():
+    with pytest.raises(ValueError, match="positive integers"):
+        coordinate_to_index((0, 0, 0), (4, 0, 4))
+    with pytest.raises(ValueError, match="integer"):
+        index_to_coordinate(True, (4, 4, 4))
+
+
 def test_quantization_rejects_non_finite_input():
     with pytest.raises(ValueError, match="finite"):
         quantize_q3(math.inf)
@@ -35,6 +46,28 @@ def test_geometric_pyramid_condenses_to_one_voxel():
     assert len(hierarchy[-1].values) == 1
 
 
+def test_non_cubic_power_of_two_lattice_reaches_a_valid_root():
+    runtime = GeometricFeedbackRuntime(GeometricConfig(shape=(8, 4, 2)))
+    encoded, input_length = runtime.encode([3, 2, 1, 0])
+    hierarchy = runtime.condense(encoded, input_length)
+    assert [level.shape for level in hierarchy] == [
+        (8, 4, 2),
+        (4, 2, 1),
+        (2, 1, 1),
+        (1, 1, 1),
+    ]
+    assert len(runtime.decode(hierarchy)) == runtime.config.volume
+
+
+def test_sparse_padding_does_not_dominate_geometric_condensation():
+    result = GeometricFeedbackRuntime().step([3, 3, 3, 3])
+    assert result.committed
+    assert result.selected_lane == "identity"
+    assert result.output == (3, 3, 3, 3)
+    assert result.metrics["best_reconstruction_l1"] == 0.0
+    assert result.metrics["active_voxels"] == 4.0
+
+
 def test_parallel_lanes_are_deterministic():
     values = [3, 1, -1, -3, 2, 0, -2, -4]
     left = GeometricFeedbackRuntime().step(values)
@@ -47,6 +80,20 @@ def test_parallel_lanes_are_deterministic():
     ]
 
 
+def test_concurrent_steps_are_serialized_into_unique_committed_cycles():
+    runtime = GeometricFeedbackRuntime()
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        results = list(
+            executor.map(
+                runtime.step,
+                ([1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [-1, -1, -1, -1]),
+            )
+        )
+    assert runtime.state.cycle == 4
+    assert sorted(result.cycle for result in results) == [1, 2, 3, 4]
+    assert len(runtime.journal) == 4
+
+
 def test_feedback_turns_committed_output_into_next_input():
     runtime = GeometricFeedbackRuntime(GeometricConfig(feedback_cycles=3))
     results = runtime.run_feedback([3, 1, -1, -3])
@@ -54,6 +101,14 @@ def test_feedback_turns_committed_output_into_next_input():
     assert all(result.committed for result in results)
     assert results[1].encoded[:4] == results[0].output
     assert results[-1].state_hash == runtime.state.state_hash
+
+
+def test_feedback_rejects_zero_and_excessive_cycle_counts():
+    runtime = GeometricFeedbackRuntime(GeometricConfig(max_feedback_cycles=4))
+    with pytest.raises(ValueError, match="positive integer"):
+        runtime.run_feedback([1], cycles=0)
+    with pytest.raises(ValueError, match="maximum"):
+        runtime.run_feedback([1], cycles=5)
 
 
 def test_lambda_rejection_preserves_committed_state():
@@ -64,6 +119,13 @@ def test_lambda_rejection_preserves_committed_state():
     assert not result.committed
     assert runtime.snapshot() == before
     assert result.state_hash == "GENESIS"
+
+
+def test_invalid_lambda_budgets_are_rejected_at_configuration_time():
+    with pytest.raises(ValueError, match="non-negative"):
+        GeometricFeedbackRuntime(GeometricConfig(max_reconstruction_l1=-1))
+    with pytest.raises(ValueError, match="fit inside"):
+        GeometricFeedbackRuntime(GeometricConfig(max_active_voxels=65))
 
 
 def test_shell_events_expose_3d_pipeline_without_uncommitted_render():
@@ -101,3 +163,21 @@ def test_rejected_cycle_serializes_as_strict_browser_json():
     encoded = json.dumps(payload, allow_nan=False)
     assert "Infinity" not in encoded
     assert payload["metrics"]["best_reconstruction_l1"] is None
+
+
+def test_cli_import_does_not_load_optional_service_modules():
+    for module_name in ("jarvisx.api", "jarvisx.web", "jarvisx.node"):
+        sys.modules.pop(module_name, None)
+    cli = importlib.import_module("jarvisx.cli")
+    importlib.reload(cli)
+    assert "jarvisx.api" not in sys.modules
+    assert "jarvisx.web" not in sys.modules
+    assert "jarvisx.node" not in sys.modules
+
+
+def test_browser_shell_escapes_trace_text_and_bounds_loaded_geometry():
+    shell = (Path(__file__).parents[1] / "geometric-rvis-shell.html").read_text()
+    assert "function escapeHtml" in shell
+    assert "escapeHtml(safe.summary" in shell
+    assert "MAX_VOXELS" in shell
+    assert "MAX_JSON_BYTES" in shell

--- a/tests/test_geometric_rvis.py
+++ b/tests/test_geometric_rvis.py
@@ -3,7 +3,6 @@ import math
 
 import pytest
 
-from jarvisx.cli import _json_safe
 from jarvisx.core import CodexVM
 from jarvisx.geometric_rvis import (
     GeometricConfig,
@@ -12,6 +11,7 @@ from jarvisx.geometric_rvis import (
     index_to_coordinate,
     quantize_q3,
 )
+from jarvisx.serialization import json_safe
 
 
 def test_coordinate_mapping_is_bijective():
@@ -97,7 +97,7 @@ def test_codex_vm_projects_geometric_commit_into_registers():
 def test_rejected_cycle_serializes_as_strict_browser_json():
     runtime = GeometricFeedbackRuntime(GeometricConfig(max_reconstruction_l1=0))
     rejected = runtime.step([3, -4, 3, -4])
-    payload = _json_safe(rejected.to_dict())
+    payload = json_safe(rejected.to_dict())
     encoded = json.dumps(payload, allow_nan=False)
     assert "Infinity" not in encoded
     assert payload["metrics"]["best_reconstruction_l1"] is None

--- a/tests/test_geometric_rvis.py
+++ b/tests/test_geometric_rvis.py
@@ -2,6 +2,7 @@ import math
 
 import pytest
 
+from jarvisx.core import CodexVM
 from jarvisx.geometric_rvis import (
     GeometricConfig,
     GeometricFeedbackRuntime,
@@ -78,3 +79,14 @@ def test_cycle_reports_memory_before_and_after_without_aliasing():
     second = runtime.step(first.output)
     assert first.omega_before == ()
     assert second.omega_before == first.omega_after
+
+
+def test_codex_vm_projects_geometric_commit_into_registers():
+    vm = CodexVM()
+    results = vm.geometric_feedback([3, 1, -1, -3], cycles=2)
+    final = results[-1]
+    assert final.committed
+    assert vm.regs["Λ"] == 1
+    assert vm.regs["Ψ"] == final.hierarchy[-1].values[0]
+    assert vm.regs["𝒮"] == int(final.metrics["best_reconstruction_l1"])
+    assert vm.regs["Π"] == sum(final.output)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,51 @@
+import json
+
+from jarvisx.ledger import OmegaLedger
+from jarvisx.ledger_store import PersistentLedger
+
+
+def test_omega_ledger_is_deterministic_and_verifiable():
+    state = {"Ψ": 7, "Φ": 3}
+    left = OmegaLedger()
+    right = OmegaLedger()
+
+    left_entry = left.log(state, 1)
+    right_entry = right.log(state, 1)
+
+    assert left_entry == right_entry
+    assert left.verify()
+    assert right.verify()
+
+
+def test_persistent_ledger_is_json_serializable_and_reloadable(tmp_path):
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(str(path))
+    ledger.log({"Ψ": 10, "Φ": 20}, 1)
+    ledger.log({"A": 30}, 3)
+
+    with path.open(encoding="utf-8") as source:
+        raw = json.load(source)
+
+    assert raw == ledger.chain
+    assert ledger.verify()
+
+    reloaded = PersistentLedger(str(path))
+    assert reloaded.chain == ledger.chain
+    assert reloaded.verify()
+
+
+def test_persistent_ledger_rejects_tampering(tmp_path):
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(str(path))
+    ledger.log({"A": 1}, 1)
+
+    data = ledger.chain
+    data[0]["payload"]["state"]["A"] = 99
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    try:
+        PersistentLedger(str(path))
+    except RuntimeError as exc:
+        assert "hash chain" in str(exc)
+    else:
+        raise AssertionError("tampered ledger was accepted")

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,12 +1,23 @@
+from jarvisx.assembler import Assembler
 from jarvisx.core import CodexVM
 from jarvisx.parser import Parser
-from jarvisx.assembler import Assembler
 
-def test_add():
+
+def test_add_preserves_exact_assembly_semantics():
     code = "SET Ψ 10\nSET Φ 20\nADD A Ψ Φ\nHALT"
     ast = Parser().parse(code)
-    bc = Assembler().assemble(ast)
+    bytecode = Assembler().assemble(ast)
     vm = CodexVM()
-    vm.load(bc)
+    vm.load(bytecode)
     vm.run()
     assert vm.regs["A"] == 30
+
+
+def test_reflex_stabilisation_is_explicit():
+    vm = CodexVM()
+    vm.regs["Ψ"] = 10
+    vm.regs["Φ"] = 20
+
+    vm.apply_reflex()
+
+    assert vm.regs["Φ"] == 19


### PR DESCRIPTION
## What changed

- added a transactional 3D geometric auto-encoding/decoding runtime
- mapped public shell values into a bounded signed-three-bit voxel lattice
- added bijective linear ↔ `(x, y, z)` addressing
- added multiresolution geometric condensation and top-down decoding
- added four isolated candidate lanes executed in parallel: identity, diffusion, Ω-memory, and hybrid
- selected the minimum-error admissible lane through Λ projection
- fed each committed decoded output into the next inward feedback cycle
- projected the last committed geometric state into the existing Ξ, Ψ, Φ, Λ, Ω, 𝒮, and Π registers
- exposed `jarvisx geometry3d --cycles N <values...>` with strict browser-safe JSON output
- added a dependency-free interactive HTML shell with 3D rotation, zoom, cycle replay, stage selection, telemetry, and event timeline

## Operational loop

```text
public shell state
  -> Q3 3D encoding
  -> multiparallel candidate evolution
  -> weighted geometric condensation
  -> geometric decoding
  -> reconstruction scoring
  -> Λ projection
  -> commit or rollback
  -> decoded output becomes next input
```

## Debugging corrections

The runtime audit found and fixed four substantive defects:

1. **Anisotropic lattice collapse** — shapes such as `(8, 4, 2)` could halve an axis from `1` to `0`, preventing a valid `(1, 1, 1)` root. Pooling and decoding now preserve completed axes while the remaining axes continue to condense.
2. **Padding dominated semantic reconstruction** — zero-filled lattice capacity was included in condensation and reconstruction scoring, causing short inputs to collapse toward zero. Condensation now carries occupancy weights, reconstruction is scored only over materialized input, and decoded padding is masked back to zero.
3. **Parallel lanes read mutable runtime state** — candidate workers read `self.state.omega` directly and concurrent `step()` calls were not serialized. Every lane now receives an immutable Ω snapshot, while `step()`, `run_feedback()`, and `snapshot()` are protected by a re-entrant transaction lock.
4. **Untrusted shell JSON crossed unsafe boundaries** — trace text was interpolated into `innerHTML`, and hostile shapes/events/files were unbounded. The shell now escapes every trace-derived field, clamps non-finite voxel values, validates 3D shapes, and enforces voxel, cycle, event, and 5 MiB JSON limits.

Additional fixes:

- `cycles=0` no longer silently falls back to the configured default
- feedback cycles have a configurable maximum
- invalid negative Λ budgets are rejected during configuration
- coordinate/index helpers reject malformed dimensions and boolean indices
- rejected cycles use JSON-native `null` rather than an internal infinity metric
- optional API/web/node services are lazily imported, so `geometry3d`, `cognitive`, and assembly commands do not require undeclared Flask or service dependencies
- duplicate `--cycles` arguments and non-finite CLI values are rejected cleanly

## Determinism and safety

- parallel lanes are pure with respect to one committed checkpoint
- results are collected and tie-broken in fixed lane order
- no candidate mutates committed state before Λ approval
- failed cycles preserve the previous state
- a late rejected cycle preserves and projects the last committed geometric state
- exceptions restore geometric state, journal entries, and registers together
- visualization events contain explicit public shell state, not private hidden chain-of-thought

## Validation

Focused geometric suite: **18 regression tests**.

GitHub Actions run **#282** passed completely:

- Python 3.8: passed
- Python 3.9: passed
- Python 3.10: passed
- Python 3.11: passed
- Python 3.12: passed
- pytest and coverage: passed
- mypy: passed
- Black and isort: passed

The new coverage includes anisotropic root formation, sparse-input weighting, concurrent transaction serialization, feedback-cycle bounds, configuration validation, optional-service import isolation, hostile trace escaping, shape/file/event budgets, strict JSON, Λ rollback, deterministic parallel selection, Ω memory reporting, and CodexVM register projection.

## Dependency

This draft builds on PR #21 (`agent/operational-cognitive-kernel`). It targets `main` so the repository's GitHub Actions matrix runs. Until PR #21 merges, the displayed diff includes that prerequisite; after #21 lands, this PR's effective scope reduces to the geometric RVIS layer.