### PR TITLE
Permeate billion-instance engine architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
+## Architecture
+
+- [Billion-Instance Self-Optimizing Engine](docs/architecture/billion_instance_engine.md) — canonical specification for the streamed 3D virtual work domain, batched Tensor Core execution, hierarchical gradient accumulation, transactional kernel autotuning, and authenticated configuration commits.
+
 ## Install
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```

--- a/docs/architecture/billion_instance_engine.md
+++ b/docs/architecture/billion_instance_engine.md
@@ -1,0 +1,573 @@
+# Jarvis X Billion-Instance Engine
+
+## Status
+
+Canonical operational specification for a self-reflexive, profile-guided GPU execution engine over a logical domain of one billion coordinates.
+
+This document distinguishes the **virtual work geometry** from physical GPU residency and defines an implementable execution model for Hopper-class accelerators.
+
+---
+
+## 1. System identity
+
+The engine is:
+
+```text
+3D virtual work domain
++ streamed microbatch execution
++ batched Tensor Core GEMMs
++ hierarchical gradient accumulation
++ transactional kernel autotuning
++ authenticated configuration commits
+```
+
+A logical domain of size
+
+```text
+1000 × 1000 × 1000 = 1,000,000,000 coordinates
+```
+
+is valid as an index space. It is not physically instantiated as one billion simultaneously resident CUDA thread blocks.
+
+The canonical state is
+
+```text
+Σₙ = (Θₙ, Cₙ, Ωₙ, Qₙ, Gₙ, Hₙ, Λₙ)
+```
+
+where:
+
+- `Θₙ` — model parameters.
+- `Cₙ` — active kernel configuration.
+- `Ωₙ` — retained performance-correction memory.
+- `Qₙ` — measured hardware telemetry.
+- `Gₙ` — accumulated model gradient.
+- `Hₙ` — authenticated runtime journal state.
+- `Λₙ` — numerical, hardware, safety, and resource constraints.
+
+---
+
+## 2. Logical geometry and causal order
+
+Let a logical coordinate be
+
+```text
+u = (i, t, ℓ)
+```
+
+with:
+
+- `i` — data/sample coordinate.
+- `t` — temporal step.
+- `ℓ` — model-layer coordinate.
+
+Only `i` is freely data-parallel. Time and layer depth are causally ordered:
+
+```text
+h[i, t, 0] = x[i, t]
+h[i, t, ℓ + 1] = f_ℓ(h[i, t, ℓ]; Θ[ℓ, t])
+h[i, t + 1, 0] = T(h[i, t, L])
+```
+
+CUDA block indices may encode these coordinates for addressing, but block indices do not impose execution order. Dependencies across `t` or `ℓ` must be represented through:
+
+- sequential loops,
+- staged kernels,
+- CUDA Graph dependencies,
+- cooperative synchronization where legal,
+- or explicit pipeline state.
+
+---
+
+## 3. Data scale
+
+For one billion samples of 784 FP32 values:
+
+```text
+Nvalues = 10⁹ × 784 = 7.84 × 10¹¹
+Bytes   = 7.84 × 10¹¹ × 4 = 3.136 TB
+```
+
+The complete dataset cannot reside in HBM or L2. It must be streamed in microbatches.
+
+Define microbatch `r` with size `B`:
+
+```text
+Bᵣ = {X[rB], …, X[(r + 1)B − 1]}
+```
+
+`B` is selected so the following live set fits in device memory:
+
+```text
+input
++ activations
++ backward intermediates
++ parameters
++ optimizer state
++ gradient accumulation
++ library workspace
+```
+
+Storage ingress terminates in GPU memory. L2 is a cache for reused device-resident data, not a permanent NVMe-backed store.
+
+---
+
+## 4. Model equations
+
+For a shared autoencoder:
+
+```text
+Xᵣ ∈ ℝ^(B×784)
+W₁ ∈ ℝ^(784×128)
+W₂ ∈ ℝ^(128×784)
+```
+
+Forward pass:
+
+```text
+A₁ = XᵣW₁ + b₁
+Zᵣ = ReLU(A₁)
+A₂ = ZᵣW₂ + b₂
+X̂ᵣ = sigmoid(A₂)
+```
+
+Loss:
+
+```text
+Lᵣ = (1 / (B·784)) ||Xᵣ − X̂ᵣ||²_F
+```
+
+Backward pass:
+
+```text
+δ₂ = (2 / (B·784)) (X̂ᵣ − Xᵣ) ⊙ sigmoid′(A₂)
+∇W₂ᵣ = Zᵣᵀδ₂
+δ₁ = (δ₂W₂ᵀ) ⊙ ReLU′(A₁)
+∇W₁ᵣ = Xᵣᵀδ₁
+```
+
+Epoch accumulation:
+
+```text
+Gepoch = Σᵣ |Bᵣ| Gᵣ / N
+```
+
+The parameter dimension is preserved during reduction. The engine must never materialize one complete parameter-gradient tensor per sample.
+
+---
+
+## 5. Arithmetic scale
+
+Approximate work per sample:
+
+```text
+forward  ≈ 4.04 × 10⁵ FLOPs
+backward ≈ 6.02 × 10⁵ FLOPs
+total    ≈ 1.007 × 10⁶ FLOPs
+```
+
+For one billion samples:
+
+```text
+Fepoch ≈ 1.007 × 10¹⁵ FLOPs
+```
+
+This is approximately one petaFLOP of arithmetic per epoch.
+
+A timing claim must be checked against both:
+
+```text
+Tcompute ≥ Fepoch / sustained_compute_rate
+Tmemory  ≥ compulsory_bytes / sustained_memory_rate
+```
+
+The realized epoch time is bounded by the slower path plus synchronization, storage ingestion, launch, and reduction overheads.
+
+---
+
+## 6. Correct GPU execution model
+
+### 6.1 Resident machine
+
+Use a bounded number of resident execution tiles that repeatedly traverse the virtual domain.
+
+A persistent kernel may use a grid-stride work queue:
+
+```cpp
+for (uint64_t i = global_block_id;
+     i < logical_coordinate_count;
+     i += total_blocks) {
+    process_microtile(i);
+}
+```
+
+The persistent grid should cover the available SMs while respecting register and shared-memory limits.
+
+### 6.2 CTA geometry
+
+For Hopper Tensor Core execution, prefer 128- or 256-thread CTAs where appropriate:
+
+- producer warps stage data,
+- consumer warpgroups issue WGMMA operations,
+- TMA moves tiles between global and shared memory,
+- shared-memory buffers are double- or triple-buffered,
+- activation and loss operations are fused into epilogues when numerically valid.
+
+A one-warp block is valid for selected kernels but cannot reach 100% warp occupancy on hardware that is also limited by resident block count.
+
+### 6.3 Memory addressing
+
+Thread layout and data layout are independent. Coalescing requires consecutive lanes to issue aligned, nearby addresses.
+
+For a `4×4×2` logical thread shape, CUDA linear lane order is:
+
+```text
+lane = x + 4y + 16z
+```
+
+A contiguous access should use:
+
+```text
+address = base + lane
+```
+
+A conceptual 3D diagonal does not guarantee physical coalescing.
+
+---
+
+## 7. Gradient mechanics
+
+The full shared-model FP32 gradient contains:
+
+```text
+2 × 784 × 128 = 200,704 values
+200,704 × 4 = 802,816 bytes
+```
+
+This is the gradient size for the accumulated model update, not for each sample.
+
+Valid gradient strategies:
+
+1. Batch reduction directly inside GEMMs.
+2. Microbatch gradient accumulation into one device-resident buffer.
+3. Multi-GPU all-reduce of one accumulated gradient per rank.
+4. Optional reduce-scatter for sharded optimizer states.
+
+Invalid strategy:
+
+```text
+write a complete 802-KB gradient for every sample
+```
+
+because it would generate roughly 803 TB of gradient traffic for one billion samples.
+
+---
+
+## 8. Distributed execution
+
+For `P` devices, each rank processes a local microbatch stream:
+
+```text
+Gglobal = (1 / P) Σₚ Gₚ
+```
+
+NCCL belongs at the inter-rank boundary. It does not reduce ordinary thread blocks within one device.
+
+The distributed transaction is:
+
+```text
+local forward/backward
+→ local gradient accumulation
+→ NCCL all-reduce or reduce-scatter
+→ optimizer update
+→ state verification
+```
+
+---
+
+## 9. Self-reflexive hardware state
+
+The tuner observes a telemetry vector:
+
+```text
+Qₙ = [
+  kernel_latency,
+  step_latency,
+  SM_active,
+  tensor_pipe_active,
+  DRAM_throughput,
+  L2_hit_rate,
+  long_scoreboard_stalls,
+  barrier_stalls,
+  occupancy,
+  registers_per_thread,
+  shared_memory_per_CTA,
+  average_power,
+  latency_variance
+]
+```
+
+The configuration state is discrete:
+
+```text
+Cₙ = (
+  tile_M,
+  tile_N,
+  tile_K,
+  CTA_threads,
+  warps,
+  pipeline_stages,
+  split_K,
+  persistent_blocks,
+  fusion_factor,
+  cache_policy,
+  cluster_shape
+)
+```
+
+These variables are compiler and launch choices. They do not expose direct physical derivatives from the running kernel.
+
+---
+
+## 10. Dr Moagi tuning law
+
+Use the Dr Moagi state-transition structure as a candidate generator:
+
+```text
+C̃ₙ₊₁ = Cₙ + Pφ(Qₙ, Ωₙ) − Eₙ + Ωₙ
+Cₙ₊₁ = ΠΛHW(C̃ₙ₊₁)
+```
+
+where `ΠΛHW` projects proposals onto legal hardware states:
+
+```text
+valid tile shapes
+register limits
+shared-memory limits
+minimum grid coverage
+supported instruction forms
+bounded numerical error
+power budget
+compilation budget
+rollback availability
+```
+
+Because configurations are discrete, selection is shadow-tested:
+
+```text
+Candidatesₙ = Propose(Qₙ, Ωₙ)
+J(c) = median_latency(c)
+     + λσ·latency_variance(c)
+     + λP·power(c)
+     + λE·numerical_error(c)
+     + λC·compile_cost(c)
+```
+
+Commit law:
+
+```text
+c* = argmin J(c)
+
+Cₙ₊₁ = c*  if Correct(c*)
+                and Safe(c*)
+                and J(c*) < J(Cₙ) − δ
+       = Cₙ otherwise
+```
+
+Performance-memory update:
+
+```text
+Ωₙ₊₁ = γΩₙ + η(J(Cₙ) − Ĵ(Cₙ))
+```
+
+---
+
+## 11. Transaction boundaries
+
+A running CUDA launch cannot rewrite its own `gridDim` or `blockDim` for already scheduled work.
+
+The self-modification cycle is therefore:
+
+```text
+profile active kernel
+→ generate candidate configuration
+→ compile or select candidate binary
+→ run correctness test
+→ run isolated benchmark
+→ compare objective
+→ atomically switch next launch
+→ retain rollback target
+→ append authenticated journal entry
+```
+
+No candidate may actuate production state before validation.
+
+---
+
+## 12. Authenticated configuration journal
+
+Let:
+
+```text
+h₀ = SHA256(binary || compiler || initial_config || model_schema)
+```
+
+For each committed configuration:
+
+```text
+hₙ₊₁ = SHA256(
+  hₙ ||
+  digest(Cₙ₊₁) ||
+  digest(Qₙ) ||
+  digest(validation_results) ||
+  nonceₙ
+)
+```
+
+When a hardware-rooted key is available:
+
+```text
+aₙ₊₁ = HMAC(Kroot, hₙ₊₁)
+```
+
+Failure policy:
+
+```text
+reject candidate
++ retain active kernel
++ preserve evidence
++ rollback if active state is compromised
+```
+
+---
+
+## 13. Graph geometry of inward loss
+
+Data, time, and layer are different semantic axes. Their curvature is defined through a graph, not assumed Euclidean derivatives.
+
+Let:
+
+```text
+G = (V, E, W)
+u = (i, t, ℓ)
+```
+
+The graph Laplacian is:
+
+```text
+(LGℓ)u = Σv∈N(u) wuv(ℓu − ℓv)
+```
+
+The inward meta-loss is:
+
+```text
+Lmeta = ||LGℓ||²₂
+```
+
+Edges explicitly encode:
+
+- sample similarity,
+- temporal adjacency,
+- layer connectivity.
+
+This gives the virtual 3D manifold a defined metric and makes its curvature operationally measurable.
+
+---
+
+## 14. Canonical execution transaction
+
+```text
+1. Read the next storage shard into pinned host or device staging memory.
+2. Form a device-resident microbatch.
+3. Execute batched encoder GEMM.
+4. Apply fused activation.
+5. Execute batched decoder GEMM.
+6. Apply fused output activation and loss.
+7. Execute backward GEMMs.
+8. Accumulate one shared gradient.
+9. Reduce gradients across devices when distributed.
+10. Apply the optimizer transaction.
+11. Capture telemetry for the active kernel configuration.
+12. Propose legal candidate configurations.
+13. Compile/select and shadow-test candidates.
+14. Commit only a correct, safe, measured improvement.
+15. Journal the committed state and retain rollback.
+16. Continue streaming across the billion-coordinate virtual domain.
+```
+
+---
+
+## 15. Invariants
+
+### Numerical equivalence
+
+```text
+||Ycandidate − Yreference|| ≤ ε
+```
+
+### Gradient equivalence
+
+```text
+||Gcandidate − Greference|| ≤ εG
+```
+
+### Resource legality
+
+```text
+Cₙ ∈ ΛHW
+```
+
+### No per-sample gradient materialization
+
+```text
+gradient_storage = O(|Θ|), not O(N·|Θ|)
+```
+
+### Transactional improvement
+
+```text
+J(Cₙ₊₁) ≤ J(Cₙ) − δ
+```
+
+only when a candidate is committed.
+
+### Rollback
+
+```text
+failure(Cₙ₊₁) ⇒ restore(Cₙ)
+```
+
+### Closure
+
+```text
+C* = ΠΛHW(C* + Pφ(Q*, Ω*) − E* + Ω*)
+```
+
+and numerically:
+
+```text
+||Cₙ₊₁ − Cₙ|| ≤ εclosure
+```
+
+---
+
+## 16. Final classification
+
+The one-billion-instance system is not one billion physical processors. It is:
+
+```text
+a bounded, resident Hopper execution fabric
+that repeatedly traverses a billion-coordinate virtual manifold,
+streams data through batch-level matrix operations,
+accumulates one shared gradient,
+measures its own hardware behavior,
+and transactionally replaces its next-launch kernel configuration
+when a shadow-tested candidate is demonstrably superior.
+```
+
+The decisive invariant is:
+
+```text
+virtual scale is carried by trajectory and streaming,
+not by simultaneous physical allocation.
+```


### PR DESCRIPTION
## What changed

- Added a canonical architecture specification for the self-reflexive one-billion-coordinate engine.
- Distinguished virtual 3D work geometry from physical CUDA residency.
- Defined streamed microbatch execution, batched Tensor Core GEMMs, shared gradient accumulation, distributed reduction, and profile-guided transactional autotuning.
- Added numerical, resource, rollback, and authenticated-journal invariants.
- Linked the specification from the repository README.

## Why

The original conceptual model treated one billion logical coordinates as though they were simultaneously resident physical processors and materialized a full gradient per coordinate. This specification preserves the intended 3D inward geometry while replacing those contradictions with an executable Hopper-class architecture.

## Operational impact

The resulting design scales through streaming and trajectory rather than simultaneous allocation. It avoids per-sample gradient tensors, makes causal time/layer ordering explicit, constrains kernel self-modification to shadow-tested next-launch transactions, and keeps every configuration change auditable and reversible.

## Validation

Documentation-only change. Equations, storage sizes, gradient dimensions, causal dependencies, and runtime transaction boundaries were checked for internal consistency. No runtime code was modified.