### PR TITLE
Operationalize the Jarvis X reference stack and AEDSIE engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,15 @@ The reference runtime implements corrected Q8.8 arithmetic, the 128-bit SVI,
 and cadence-based fusion. See
 [`docs/JARVIS_X_800_INSTANCE_RUNTIME.md`](docs/JARVIS_X_800_INSTANCE_RUNTIME.md)
 for the exact operational contract and limitations.
+
+## Run the bounded Self-Evolving ROM
+
+```bash
+jarvisx ser 8
+```
+
+The SER runtime profiles adjacent bytecode, proposes `LDC` and `DSM` macro-op
+fusions, replays baseline and candidate programs from the same deterministic
+snapshot, and publishes a parent-linked ROM version only when machine-state
+semantics are exactly preserved and execution cost is reduced. See
+[`docs/DR_MOAGI_SELF_EVOLVING_ROM.md`](docs/DR_MOAGI_SELF_EVOLVING_ROM.md).

--- a/README.md
+++ b/README.md
@@ -41,3 +41,23 @@ fusions, replays baseline and candidate programs from the same deterministic
 snapshot, and publishes a parent-linked ROM version only when machine-state
 semantics are exactly preserved and execution cost is reduced. See
 [`docs/DR_MOAGI_SELF_EVOLVING_ROM.md`](docs/DR_MOAGI_SELF_EVOLVING_ROM.md).
+
+## Run the AEDSIE-Sigma virtual engine
+
+```bash
+jarvisx aedsie 4
+```
+
+Disable the bounded inward mechanics proposal:
+
+```bash
+jarvisx aedsie 4 --no-inward
+```
+
+The AEDSIE reference engine auto-executes deterministic synthetic RF ingestion,
+DDC and channelisation, 3D tensorisation, the Dr Moagi differential operator,
+residual encoding and decoding, Omega correction, positive metric evolution,
+nine-expert routing, angle estimation, SHA3 provenance, and transactional
+commit. See
+[`docs/AEDSIE_SIGMA_VIRTUAL_ENGINE.md`](docs/AEDSIE_SIGMA_VIRTUAL_ENGINE.md)
+for the mathematical contract and scope boundary.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,28 @@ Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## Run the 800-instance reference swarm
+
+```bash
+jarvisx swarm 1
+```
+
+Run ten cycles without inward ROM mutation:
+
+```bash
+jarvisx swarm 10 --no-mutate
+```
+
+The reference runtime implements corrected Q8.8 arithmetic, the 128-bit SVI,
+4 KiB ROM geometry, protected shadow mutation, the 800 -> 80 -> 8 hierarchy,
+and cadence-based fusion. See
+[`docs/JARVIS_X_800_INSTANCE_RUNTIME.md`](docs/JARVIS_X_800_INSTANCE_RUNTIME.md)
+for the exact operational contract and limitations.

--- a/docs/AEDSIE_SIGMA_VIRTUAL_ENGINE.md
+++ b/docs/AEDSIE_SIGMA_VIRTUAL_ENGINE.md
@@ -1,0 +1,353 @@
+# AEDSIE-Sigma End-to-End Virtual Engine
+
+## Status
+
+Executable deterministic reference model for the Auto-Encoding and Decoding
+Electromagnetic Signalling Intelligence Engine.  The implementation turns the
+corrected mathematical architecture into one auto-executing virtual pipeline.
+
+It is a CPU reference engine for semantics, testing, provenance, and bounded
+self-optimisation.  It is not a measured 1 GSPS radio, FPGA bitstream, lossless
+universal codec, or deployment benchmark.
+
+## Run
+
+```bash
+jarvisx aedsie 4
+```
+
+Disable the inward mechanics proposal:
+
+```bash
+jarvisx aedsie 4 --no-inward
+```
+
+The command emits JSON containing the final state metrics, expert routing,
+angle estimate, mechanics decision, SHA3 state seal, ledger head, and complete
+program trace.
+
+## Virtual geometry
+
+The default signal field is:
+
+```text
+4 antennas x 8 frequency bins x 4 temporal slices x 3 vector channels
+```
+
+The vector channels are:
+
+```text
+(real I, imaginary Q, magnitude)
+```
+
+The default latent state has 16 dimensions.  All dimensions are deliberately
+small enough for deterministic CI execution while preserving the mathematical
+contract needed by larger CPU, GPU, or FPGA backends.
+
+## Auto-executing program
+
+Every committed cycle executes:
+
+```text
+ACQUIRE_RF
+  -> DDC_CHANNELIZE
+  -> TENSORIZE_3D
+  -> DR_MOAGI_OPERATOR
+  -> ENCODE_RESIDUAL
+  -> DECODE_RESIDUAL
+  -> COMPARE
+  -> UPDATE_OMEGA
+  -> INWARD_SHADOW
+  -> PROJECT_MANIFOLD
+  -> ROUTE_EXPERTS
+  -> ESTIMATE_AOA
+  -> SEAL_SHA3
+  -> COMMIT
+```
+
+The program is closed over an explicit state:
+
+\[
+\Sigma_t=(X_t,\phi_t,Z_t,\widehat\phi_t,E_t,\Omega_t,g_t,
+          \mathcal M_t,J_t).
+\]
+
+## Deterministic RF source
+
+The reference source synthesises two complex emitters with antenna-dependent
+phase slopes and deterministic low-amplitude interference.  No wall-clock
+value, system entropy, or unseeded random number enters the execution path.
+
+For antenna \(a\) and sample \(n\):
+
+\[
+x_{a,n}=e^{j2\pi(f_1n+p_1a)}+
+0.55e^{j2\pi(f_2n+p_2a+q t)}+\epsilon_{a,n}.
+\]
+
+This source is a repeatable test vector, not a substitute for an ADC interface.
+
+## Channelisation
+
+The engine performs deterministic digital downconversion, Hann windowing, and
+a direct discrete Fourier transform:
+
+\[
+X_a[k]=\frac1N\sum_{n=0}^{N-1}
+ x_a[n]w[n]e^{-j2\pi(f_c+k/N)n}.
+\]
+
+A production backend may replace the direct transform with FFT hardware while
+preserving the numerical and state-transition tests.
+
+## Dr Moagi differential operator
+
+The finite-difference feature operator is:
+
+\[
+\mathcal M_{3d}(\phi)=\operatorname{swish}\left(
+\alpha\nabla^2\phi+
+\beta\nabla\times\phi+
+\gamma\nabla(\nabla\cdot\phi)+
+\delta(K_{local}\phi-\phi)
+\right).
+\]
+
+Periodic boundaries make the reference stencil fully specified.  The operator
+is a learned-style differential feature transform; it is not labelled an exact
+Helmholtz-Hodge decomposition.
+
+## Residual autoencoder
+
+The encoder preserves a per-channel global baseband skip:
+
+\[
+b_c=\frac1{|V|}\sum_{v\in V}\phi_{v,c},
+\qquad r=\operatorname{vec}(\phi-b).
+\]
+
+A finite orthonormal cosine basis \(Q\) produces:
+
+\[
+Z=Qr.
+\]
+
+The tied decoder is the exact adjoint of that projection:
+
+\[
+\widehat\phi=b+Q^T Z.
+\]
+
+Therefore:
+
+\[
+\widehat\phi=b+Q^TQr,
+\]
+
+which is a projection onto the declared latent subspace, not a claim that
+\(Q^TQ=I\) over the complete field space.
+
+The reconstruction residual is:
+
+\[
+E_t=\widehat\phi_t-\phi_t.
+\]
+
+## Field and Omega update
+
+The persistent correction state evolves as:
+
+\[
+\Omega_{t+1}=\rho_\Omega\Omega_t+\eta_\Omega E_t.
+\]
+
+The bounded explicit field proposal is:
+
+\[
+\widetilde\phi_{t+1}=\phi_t+\Delta t\left[
+\mathcal M_{3d}(\phi_t)+\lambda E_t+\Omega_{t+1}
+\right].
+\]
+
+The implementation admits mechanics only when the conservative load proxy
+satisfies:
+
+\[
+\Delta t(6|\alpha|+|\lambda|)\leq0.90.
+\]
+
+This is a reference policy bound for the six-neighbour explicit stencil, not a
+universal nonlinear PDE stability theorem.
+
+## Positive manifold metric
+
+The virtual Riemannian metric is represented by a positive diagonal tensor:
+
+\[
+g_{i,t+1}=\max\left(\varepsilon,
+(1-\eta_g)g_{i,t}+\eta_g(1+|Z_{i,t}|)
+\right).
+\]
+
+This guarantees:
+
+\[
+g_t\succ0.
+\]
+
+The reference implementation does not claim Lorentzian geometry or geodesic
+closure merely because recurrent state is used.
+
+## Expert routing
+
+Nine deterministic expert projections share one class-logit space.  Routing is:
+
+\[
+\omega_i=
+\frac{\exp(\operatorname{cos}(Z,e_i)/\tau)}
+{\sum_j\exp(\operatorname{cos}(Z,e_j)/\tau)},
+\qquad \tau=0.80.
+\]
+
+The fused logits are:
+
+\[
+\ell_c=\sum_i\omega_i\langle W_{i,c},Z\rangle.
+\]
+
+A final softmax produces the virtual classification and confidence.  The
+experts are deterministic reference operators, not empirical SOTA claims.
+
+## Angle-of-arrival projection
+
+The strongest frequency bin is selected from aggregate antenna magnitude.  The
+mean adjacent-antenna phase difference \(\Delta\varphi\) is projected under a
+half-wavelength spacing model:
+
+\[
+\widehat\theta=\arcsin\left(
+\operatorname{clip}(\Delta\varphi/\pi,-1,1)
+\right).
+\]
+
+This is a deterministic narrowband reference estimator.  Real arrays require
+calibration, ambiguity handling, geometry metadata, and measured uncertainty.
+
+## Bounded inward turn
+
+The mechanics state is:
+
+\[
+\mathcal M_t=(\alpha,\beta,\gamma,\delta,\lambda,\Delta t,v_t).
+\]
+
+Each cycle generates at most one declared candidate.  Baseline and candidate
+execute from the same field, reconstruction, and Omega snapshot:
+
+\[
+S_{base}=F_{\mathcal M_t}(S_t),
+\qquad
+S_{shadow}=F_{\mathcal M'_t}(S_t).
+\]
+
+The measured objective is:
+
+\[
+C(S)=
+\operatorname{MSE}(S,\phi_{obs})+
+0.2\operatorname{MSE}(S,\widehat\phi)+
+0.001\|S\|_2^2.
+\]
+
+A candidate is committed only when:
+
+\[
+C(S_{shadow})<C(S_{base}),
+\]
+
+its state is finite, its mechanics pass the stability gate, and:
+
+\[
+\text{analysis share}=\frac{1}{1+1}=0.5
+\leq B_{analysis}.
+\]
+
+Rejected candidates cannot mutate committed state.  Every accepted mechanics
+version receives a parent-linked SHA3 manifest.
+
+## SHA3 provenance
+
+The authoritative state is canonically quantised before hashing.  The state
+seal contains:
+
+```text
+logical cycle
+canonical field
+latent vector
+positive metric
+mechanics version
+prediction
+angle estimate
+```
+
+The ledger transition is:
+
+\[
+J_{t+1}=\operatorname{SHA3-256}
+\left(J_t\parallel\operatorname{Canon}(\Sigma_{t+1})\right).
+\]
+
+No wall-clock value or external randomness enters the hash.  The chain is
+tamper-evident relative to its trusted head; it is not described as physically
+immutable without external anchoring.
+
+## Output contract
+
+One cycle returns:
+
+```text
+cycle
+reconstruction_mse
+field_energy
+latent_energy
+predicted_class
+confidence
+aoa_degrees
+routing_weights
+metric_min / metric_max
+mechanics
+inward decision
+state_hash
+ledger_head
+program_trace
+```
+
+## Verified invariants
+
+The test suite checks:
+
+1. identical initial state and inputs produce identical state and ledger hashes;
+2. every declared program stage executes exactly once per committed cycle;
+3. routing weights sum to one;
+4. metric values remain strictly positive;
+5. ledger heads change once per commit and remain parent-linked;
+6. an accepted inward candidate has lower measured cost than the baseline;
+7. disabling inward execution leaves mechanics unchanged;
+8. autoencoder output is finite and shape preserving;
+9. invalid FFT and unstable mechanics configurations are rejected.
+
+## Extension boundary
+
+The reference interfaces can be replaced independently:
+
+```text
+SyntheticRFSource -> ADC / recorded IQ source
+Direct DFT        -> FFT / FPGA channelizer
+Python stencil    -> SIMD / CUDA / FPGA kernel
+Cosine projection -> trained or invertible encoder
+Reference experts -> calibrated task models
+Local ledger      -> signed durable transparency log
+```
+
+Each replacement must preserve the transaction, deterministic replay, policy,
+and provenance contracts before promotion.

--- a/docs/DR_MOAGI_SELF_EVOLVING_ROM.md
+++ b/docs/DR_MOAGI_SELF_EVOLVING_ROM.md
@@ -1,0 +1,172 @@
+# Dr Moagi Bounded Self-Evolving ROM
+
+## Status
+
+Executable reference implementation of a semantics-preserving ROM optimizer.
+
+The runtime turns inward by analysing its own instruction stream, but it does
+not permit arbitrary source rewriting or unverified firmware replacement.
+Every accepted patch is drawn from a declared rule set, evaluated in a shadow
+core from the same deterministic snapshot, and published as a new immutable ROM
+version only when the final machine state is exactly equal and the instruction
+cost is lower.
+
+## Run
+
+```bash
+jarvisx ser 8
+```
+
+The command emits JSON containing:
+
+- each optimization epoch;
+- the accepted macro-op rule;
+- baseline and shadow cycle counts;
+- semantic-equivalence results;
+- analysis-cycle share;
+- the final ROM and hexdump;
+- the parent-linked ROM version journal;
+- the final deterministic state hash.
+
+## 64-bit instruction format
+
+```text
+[ opcode:8 | rs:8 | rt:8 | ru:8 | immediate:16 | address:16 ]
+```
+
+Supported operations:
+
+```text
+NOP LOAD3D STORE3D ENC DEC MAC3D BUNDLE META LDC DSM HALT
+```
+
+`LDC` and `DSM` are macro-ops:
+
+```text
+LDC = LOAD3D + ENC
+DSM = DEC + STORE3D
+```
+
+## Correct fusion conditions
+
+A `LOAD3D` and `ENC` pair may be fused only when they are adjacent and the
+encoder reads the same register written by the load:
+
+```text
+LOAD3D rs=a, addr=p
+ENC    rs=a, rt=b
+```
+
+The replacement is:
+
+```text
+LDC rs=a, rt=b, addr=p
+```
+
+A `DEC` and `STORE3D` pair may be fused only when they are adjacent and the
+store reads the decoder destination:
+
+```text
+DEC     rs=a, rt=b
+STORE3D rt=b, addr=p
+```
+
+The replacement is:
+
+```text
+DSM rs=a, rt=b, addr=p
+```
+
+The originally proposed example attempted to fuse a `LOAD3D` with an `ENC`
+across an intervening second load. That rewrite is not generally safe and is
+intentionally rejected by this implementation.
+
+## Shadow verification
+
+For baseline ROM `B`, candidate ROM `B'`, and deterministic initial snapshot
+`S0`, the optimizer executes:
+
+```text
+S_base   = EXECUTE(B,  S0)
+S_shadow = EXECUTE(B', S0)
+```
+
+A patch is admissible only when:
+
+```text
+S_shadow == S_base
+```
+
+and:
+
+```text
+cycles(B') < cycles(B)
+length(B') < length(B)
+```
+
+The reference backend uses exact deterministic tuple state, so equality is
+byte-for-byte at the canonical serialized snapshot level.
+
+## Analysis budget
+
+The optimizer models the inward-analysis budget as the shadow-execution share:
+
+```text
+analysis_share = shadow_cycles / (baseline_cycles + shadow_cycles)
+```
+
+The default policy requires:
+
+```text
+analysis_share <= 0.5
+```
+
+Only one candidate is evaluated per epoch, keeping the reference controller
+within the declared 50 percent analysis envelope.
+
+## Versioned Delta-ROM publication
+
+The active ROM is never modified without a version transition. Every committed
+version records:
+
+```text
+version
+parent_hash
+manifest_hash
+instruction_words
+patch_rule
+```
+
+The manifest is SHA-256 over the parent manifest, patch-rule identifier, and
+ordered 64-bit instruction words. This creates a causal ROM provenance chain.
+
+## Fixed point
+
+The engine reaches a fixed point when no declared fusion rule applies. For the
+eight-instruction demo ROM, two verified rewrites reduce the program to six
+instructions:
+
+```text
+8 instructions
+  -> fuse LOAD3D + ENC
+7 instructions
+  -> fuse DEC + STORE3D
+6 instructions
+  -> no admissible rule
+```
+
+This is a fixed point relative to the current rule set and benchmark semantics.
+It is not a proof of global optimality, universal computation in zero cycles, or
+precomputed answers to arbitrary queries. A six-instruction program still
+requires physical execution, memory movement, and finite clock cycles.
+
+## Safety invariants
+
+1. Only declared adjacent macro-op rules may modify the ROM.
+2. Baseline and candidate execute from the same deterministic snapshot.
+3. Candidate state must equal baseline state exactly.
+4. Candidate instruction and dynamic-cycle costs must both decrease.
+5. Analysis share may not exceed the configured bound.
+6. Every accepted ROM version is immutable and parent-linked.
+7. No wall-clock value or external randomness enters the state hash.
+8. A rule-set fixed point is reported honestly as bounded convergence.

--- a/docs/DR_MOAGI_SELF_EVOLVING_ROM.md
+++ b/docs/DR_MOAGI_SELF_EVOLVING_ROM.md
@@ -40,6 +40,9 @@ Supported operations:
 NOP LOAD3D STORE3D ENC DEC MAC3D BUNDLE META LDC DSM HALT
 ```
 
+`NOP` is a true no-operation. Program termination is represented explicitly by
+`HALT`; the optimizer never treats silence as an implicit stop condition.
+
 `LDC` and `DSM` are macro-ops:
 
 ```text

--- a/docs/JARVIS_X_800_INSTANCE_RUNTIME.md
+++ b/docs/JARVIS_X_800_INSTANCE_RUNTIME.md
@@ -1,0 +1,171 @@
+# Jarvis X 800-Instance Runtime
+
+This document describes the executable reference implementation in
+`src/jarvisx/swarm800.py`.
+
+## Scope
+
+The runtime operationalises the corrected control-plane mathematics of the
+800-instance swarm. It is a deterministic Python simulator for:
+
+- signed Q8.8 arithmetic;
+- the corrected 128-bit Spatial Virtual Instruction (SVI);
+- a 4 KiB ROM containing 256 16-byte instructions;
+- the 8 x 8 x 4 PC geometry;
+- exact 128-dimensional instruction encoding and reconstruction;
+- a 23 microsecond logical pipeline model;
+- copy-on-write ROM mutation with protected fields;
+- 800 instances arranged as 80 zones and 8 regions;
+- zone, region, and global fusion cadences;
+- sealed base-ROM manifests and dynamic hash chains;
+- monotonic best-checkpoint loss.
+
+It is not a WebGPU kernel, a real-time scheduler, a federated network, or a
+trained 16,384-to-128 neural autoencoder. Those can be attached behind the
+interfaces once the deterministic reference semantics are accepted.
+
+## Run
+
+```bash
+pip install -e .
+jarvisx swarm 1
+```
+
+Disable inward ROM mutation:
+
+```bash
+jarvisx swarm 10 --no-mutate
+```
+
+The command prints a JSON report containing the hierarchy counts, current
+fusion metrics, accepted mutations, best loss, and sealed manifest hash.
+
+## Canonical hierarchy
+
+```text
+800 instances
+  = 80 zones x 10 instances
+  = 8 regions x 10 zones x 10 instances
+```
+
+Fusion cadence:
+
+| Level | Members | Cadence |
+|---|---:|---:|
+| Instance | 1 | every cycle |
+| Zone | 10 instances | every 10 cycles |
+| Region | 10 zones / 100 instances | every 100 cycles |
+| Global | 8 regions / 800 instances | every 1000 cycles |
+
+## Corrected SVI layout
+
+| Field | Bits |
+|---|---:|
+| OPCODE | 8 |
+| FLAGS | 8 |
+| X | 12 signed |
+| Y | 12 signed |
+| Z | 12 signed |
+| OPERAND | 32 |
+| EDGE_FINGERPRINT | 32 |
+| AGE_TIMER | 12 |
+| **Total** | **128** |
+
+The 32-bit edge field is explicitly a fingerprint, not a collision-free Morton
+code for the complete signed 12-bit coordinate domain.
+
+## ROM geometry
+
+Each SVI occupies 16 bytes. A 4 KiB ROM therefore stores 256 instructions:
+
+```text
+4096 / 16 = 256 = 8 x 8 x 4
+```
+
+The byte-address PC mapping is:
+
+```text
+index = PC / 16
+X = index & 7
+Y = (index >> 3) & 7
+Z = (index >> 6) & 3
+```
+
+The inverse is:
+
+```text
+PC = 16 x (X + 8Y + 64Z)
+```
+
+## Pipeline model
+
+```text
+FETCH 1 us -> ENCODE 5 us -> DECODE 5 us -> EXECUTE 2 us -> BACKPROP 10 us
+```
+
+Logical latency is the sum:
+
+```text
+1 + 5 + 5 + 2 + 10 = 23 us
+```
+
+Steady-state ideal throughput is bounded by the 10 microsecond bottleneck, not
+by the reciprocal of 23 microseconds when stages overlap.
+
+## Inward mutation transaction
+
+Only packed bits 52 through 115 are mutable, covering the operand and edge
+fingerprint. Opcode, flags, coordinates, and age are protected.
+
+For each candidate:
+
+1. choose three distinct mutable bits;
+2. construct a shadow SVI;
+3. validate its field ranges;
+4. compare deterministic shadow fitness;
+5. commit only if fitness improves by more than 0.1 percent;
+6. append the committed cycle to the instance hash chain.
+
+The immutable shared ROM is never rewritten. Every instance maintains a
+copy-on-write patch table.
+
+## Sealed invariants
+
+The implementation enforces:
+
+```text
+8 x 10 x 10 = 800
+PC mod 16 = 0
+0 <= PC < 4096
+-32768 <= Q8.8 register <= 32767
+all SVI fields remain within their bit widths
+all instances share the same base-ROM manifest hash
+best_loss(t+1) <= best_loss(t)
+```
+
+## Validation
+
+The test module `tests/test_swarm800.py` checks:
+
+- Q8.8 conversion, multiplication, division, and divide-by-zero handling;
+- exact 128-bit SVI packing and unpacking;
+- exact 128-dimensional latent reconstruction;
+- complete 4 KiB ROM coordinate round trips;
+- 16-byte PC stride;
+- protected-field mutation safety;
+- the canonical 800 / 80 / 8 hierarchy;
+- zone fusion after ten cycles;
+- monotonic best-checkpoint loss.
+
+Local validation used:
+
+```text
+8 passed
+```
+
+## Extension points
+
+The deterministic `SVICodec` can be replaced by a learned encoder-decoder.
+`SwarmInstance.step` can be backed by GPU kernels. `fuse_telemetry` can be
+replaced by weighted federated aggregation. The present implementation fixes
+the transaction semantics those backends must preserve.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/src/jarvisx/aedsie_engine.py
+++ b/src/jarvisx/aedsie_engine.py
@@ -1,0 +1,710 @@
+"""Deterministic end-to-end AEDSIE-Sigma virtual reference engine.
+
+The implementation operationalises the mathematical pipeline without claiming
+lossless universal reconstruction or measured RF/FPGA performance.  It uses a
+small deterministic signal source, finite-difference 3D operators, an adjoint
+linear residual autoencoder, bounded mechanics optimisation, and a SHA3-256
+provenance chain.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+Vec3 = Tuple[float, float, float]
+Field = Tuple[Vec3, ...]
+Spectrum = Tuple[Tuple[complex, ...], ...]
+
+
+PROGRAM = (
+    "ACQUIRE_RF",
+    "DDC_CHANNELIZE",
+    "TENSORIZE_3D",
+    "DR_MOAGI_OPERATOR",
+    "ENCODE_RESIDUAL",
+    "DECODE_RESIDUAL",
+    "COMPARE",
+    "UPDATE_OMEGA",
+    "INWARD_SHADOW",
+    "PROJECT_MANIFOLD",
+    "ROUTE_EXPERTS",
+    "ESTIMATE_AOA",
+    "SEAL_SHA3",
+    "COMMIT",
+)
+
+
+@dataclass(frozen=True)
+class AEDSIEConfig:
+    antennas: int = 4
+    samples_per_frame: int = 32
+    fft_bins: int = 8
+    time_depth: int = 4
+    latent_dim: int = 16
+    expert_count: int = 9
+    class_count: int = 4
+    carrier_cycles_per_sample: float = 0.125
+    routing_temperature: float = 0.80
+    source_blend: float = 0.35
+    metric_step: float = 0.05
+    omega_decay: float = 0.90
+    omega_gain: float = 0.10
+    analysis_budget: float = 0.50
+
+    def validate(self) -> None:
+        dimensions = (
+            self.antennas,
+            self.samples_per_frame,
+            self.fft_bins,
+            self.time_depth,
+            self.latent_dim,
+            self.expert_count,
+            self.class_count,
+        )
+        if any(value <= 0 for value in dimensions):
+            raise ValueError("all AEDSIE dimensions must be positive")
+        if self.fft_bins > self.samples_per_frame:
+            raise ValueError("fft_bins cannot exceed samples_per_frame")
+        if not 0.0 < self.routing_temperature:
+            raise ValueError("routing temperature must be positive")
+        if not 0.0 <= self.source_blend <= 1.0:
+            raise ValueError("source_blend must be in [0, 1]")
+        if not 0.0 <= self.analysis_budget <= 0.5:
+            raise ValueError("analysis_budget must be in [0, 0.5]")
+
+
+@dataclass(frozen=True)
+class Mechanics:
+    alpha: float = 0.050
+    beta: float = 0.030
+    gamma: float = 0.020
+    delta: float = 0.040
+    coherence: float = 0.250
+    dt: float = 0.100
+    version: int = 0
+
+    def stability_load(self) -> float:
+        # Conservative explicit-step proxy for six-neighbour diffusion plus
+        # the reconstruction reaction.  It is a policy gate, not a theorem for
+        # every nonlinear workload.
+        return self.dt * (6.0 * abs(self.alpha) + abs(self.coherence))
+
+    def admissible(self) -> bool:
+        values = (self.alpha, self.beta, self.gamma, self.delta, self.coherence, self.dt)
+        return all(math.isfinite(v) and v >= 0.0 for v in values) and self.stability_load() <= 0.90
+
+
+@dataclass(frozen=True)
+class InwardDecision:
+    attempted: bool
+    accepted: bool
+    rule: str
+    baseline_cost: float
+    shadow_cost: float
+    analysis_share: float
+    mechanics_version: int
+
+
+@dataclass(frozen=True)
+class CycleReport:
+    cycle: int
+    reconstruction_mse: float
+    field_energy: float
+    latent_energy: float
+    predicted_class: int
+    confidence: float
+    aoa_degrees: float
+    routing_weights: Tuple[float, ...]
+    metric_min: float
+    metric_max: float
+    mechanics: Mechanics
+    inward: InwardDecision
+    state_hash: str
+    ledger_head: str
+    program_trace: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class EngineReport:
+    cycles: int
+    field_shape: Tuple[int, int, int, int]
+    latent_dim: int
+    final_cycle: CycleReport
+    ledger_entries: int
+    ledger_head: str
+    mechanics_history: Tuple[str, ...]
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _swish(value: float) -> float:
+    if value >= 0.0:
+        return value / (1.0 + math.exp(-value))
+    exp_value = math.exp(value)
+    return value * exp_value / (1.0 + exp_value)
+
+
+def _softmax(values: Sequence[float], temperature: float = 1.0) -> Tuple[float, ...]:
+    if not values:
+        raise ValueError("softmax requires at least one value")
+    scaled = [value / temperature for value in values]
+    peak = max(scaled)
+    exps = [math.exp(value - peak) for value in scaled]
+    total = sum(exps)
+    return tuple(value / total for value in exps)
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    if len(a) != len(b):
+        raise ValueError("cosine vectors must have equal length")
+    numerator = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    return numerator / (norm_a * norm_b + 1e-12)
+
+
+def _field_mse(a: Field, b: Field) -> float:
+    if len(a) != len(b):
+        raise ValueError("field sizes differ")
+    return sum((x - y) ** 2 for va, vb in zip(a, b) for x, y in zip(va, vb)) / (3 * len(a))
+
+
+def _field_energy(field: Field) -> float:
+    return sum(value * value for vector in field for value in vector) / (3 * len(field))
+
+
+def _latent_energy(latent: Sequence[float]) -> float:
+    return sum(value * value for value in latent) / max(1, len(latent))
+
+
+def _blend_fields(previous: Optional[Field], observed: Field, source_blend: float) -> Field:
+    if previous is None:
+        return observed
+    keep = 1.0 - source_blend
+    return tuple(
+        tuple(keep * old + source_blend * new for old, new in zip(v_old, v_new))  # type: ignore[misc]
+        for v_old, v_new in zip(previous, observed)
+    )  # type: ignore[return-value]
+
+
+def _quantize(value: float, scale: int = 1_000_000) -> int:
+    if not math.isfinite(value):
+        raise ValueError("non-finite value cannot be sealed")
+    return int(round(value * scale))
+
+
+def _canonical_field(field: Field) -> List[int]:
+    return [_quantize(value) for vector in field for value in vector]
+
+
+class SyntheticRFSource:
+    """Deterministic multi-emitter complex baseband source."""
+
+    def __init__(self, config: AEDSIEConfig):
+        self.config = config
+
+    def frame(self, frame_index: int) -> Tuple[Tuple[complex, ...], ...]:
+        output: List[Tuple[complex, ...]] = []
+        n_samples = self.config.samples_per_frame
+        for antenna in range(self.config.antennas):
+            samples: List[complex] = []
+            for n in range(n_samples):
+                absolute = frame_index * n_samples + n
+                p1 = 2.0 * math.pi * (0.1875 * absolute + 0.115 * antenna)
+                p2 = 2.0 * math.pi * (0.3125 * absolute - 0.071 * antenna + 0.03 * frame_index)
+                deterministic_noise = 0.015 * math.sin(0.73 * absolute + 0.41 * antenna)
+                value = complex(math.cos(p1), math.sin(p1))
+                value += 0.55 * complex(math.cos(p2), math.sin(p2))
+                value += complex(deterministic_noise, -0.5 * deterministic_noise)
+                samples.append(value)
+            output.append(tuple(samples))
+        return tuple(output)
+
+
+class Channelizer:
+    def __init__(self, config: AEDSIEConfig):
+        self.config = config
+
+    def process(self, samples: Tuple[Tuple[complex, ...], ...]) -> Spectrum:
+        result: List[Tuple[complex, ...]] = []
+        size = self.config.samples_per_frame
+        for antenna_samples in samples:
+            if len(antenna_samples) != size:
+                raise ValueError("unexpected RF frame length")
+            downconverted = []
+            for n, sample in enumerate(antenna_samples):
+                carrier_phase = -2.0 * math.pi * self.config.carrier_cycles_per_sample * n
+                carrier = complex(math.cos(carrier_phase), math.sin(carrier_phase))
+                window = 0.5 - 0.5 * math.cos(2.0 * math.pi * n / max(1, size - 1))
+                downconverted.append(sample * carrier * window)
+            bins = []
+            for k in range(self.config.fft_bins):
+                total = 0j
+                for n, sample in enumerate(downconverted):
+                    phase = -2.0 * math.pi * k * n / size
+                    total += sample * complex(math.cos(phase), math.sin(phase))
+                bins.append(total / size)
+            result.append(tuple(bins))
+        return tuple(result)
+
+
+class Tensorizer:
+    def __init__(self, config: AEDSIEConfig):
+        self.config = config
+        self.history: List[Spectrum] = []
+
+    def push(self, spectrum: Spectrum) -> Field:
+        self.history.append(spectrum)
+        self.history = self.history[-self.config.time_depth :]
+        padded = [self.history[0]] * (self.config.time_depth - len(self.history)) + self.history
+        field: List[Vec3] = []
+        for antenna in range(self.config.antennas):
+            for frequency in range(self.config.fft_bins):
+                for time_index in range(self.config.time_depth):
+                    value = padded[time_index][antenna][frequency]
+                    field.append((value.real, value.imag, abs(value)))
+        return tuple(field)
+
+
+class DrMoagi3DOperator:
+    def __init__(self, config: AEDSIEConfig):
+        self.config = config
+        self.nx = config.antennas
+        self.ny = config.fft_bins
+        self.nz = config.time_depth
+
+    def _index(self, x: int, y: int, z: int) -> int:
+        return ((x % self.nx) * self.ny + (y % self.ny)) * self.nz + (z % self.nz)
+
+    def _vector(self, field: Field, x: int, y: int, z: int) -> Vec3:
+        return field[self._index(x, y, z)]
+
+    def _divergence(self, field: Field, x: int, y: int, z: int) -> float:
+        xp, xm = self._vector(field, x + 1, y, z), self._vector(field, x - 1, y, z)
+        yp, ym = self._vector(field, x, y + 1, z), self._vector(field, x, y - 1, z)
+        zp, zm = self._vector(field, x, y, z + 1), self._vector(field, x, y, z - 1)
+        return 0.5 * ((xp[0] - xm[0]) + (yp[1] - ym[1]) + (zp[2] - zm[2]))
+
+    def apply(self, field: Field, mechanics: Mechanics) -> Field:
+        if len(field) != self.nx * self.ny * self.nz:
+            raise ValueError("field shape does not match operator geometry")
+        output: List[Vec3] = []
+        for x in range(self.nx):
+            for y in range(self.ny):
+                for z in range(self.nz):
+                    center = self._vector(field, x, y, z)
+                    xp, xm = self._vector(field, x + 1, y, z), self._vector(field, x - 1, y, z)
+                    yp, ym = self._vector(field, x, y + 1, z), self._vector(field, x, y - 1, z)
+                    zp, zm = self._vector(field, x, y, z + 1), self._vector(field, x, y, z - 1)
+                    neighbours = (xp, xm, yp, ym, zp, zm)
+                    lap = tuple(sum(v[c] for v in neighbours) - 6.0 * center[c] for c in range(3))
+                    curl = (
+                        0.5 * ((yp[2] - ym[2]) - (zp[1] - zm[1])),
+                        0.5 * ((zp[0] - zm[0]) - (xp[2] - xm[2])),
+                        0.5 * ((xp[1] - xm[1]) - (yp[0] - ym[0])),
+                    )
+                    grad_div = (
+                        0.5
+                        * (
+                            self._divergence(field, x + 1, y, z)
+                            - self._divergence(field, x - 1, y, z)
+                        ),
+                        0.5
+                        * (
+                            self._divergence(field, x, y + 1, z)
+                            - self._divergence(field, x, y - 1, z)
+                        ),
+                        0.5
+                        * (
+                            self._divergence(field, x, y, z + 1)
+                            - self._divergence(field, x, y, z - 1)
+                        ),
+                    )
+                    local_mix = tuple(sum(v[c] for v in neighbours) / 6.0 - center[c] for c in range(3))
+                    combined = tuple(
+                        mechanics.alpha * lap[c]
+                        + mechanics.beta * curl[c]
+                        + mechanics.gamma * grad_div[c]
+                        + mechanics.delta * local_mix[c]
+                        for c in range(3)
+                    )
+                    output.append(tuple(_swish(value) for value in combined))  # type: ignore[arg-type]
+        return tuple(output)
+
+
+class ResidualAutoencoder:
+    """Finite orthonormal projection with an explicit per-channel baseband skip."""
+
+    def __init__(self, field_cells: int, latent_dim: int):
+        self.field_cells = field_cells
+        self.width = field_cells * 3
+        self.latent_dim = min(latent_dim, max(1, self.width - 3))
+        scale = math.sqrt(2.0 / self.width)
+        self.basis: Tuple[Tuple[float, ...], ...] = tuple(
+            tuple(scale * math.cos(math.pi * (j + 0.5) * (k + 1) / self.width) for j in range(self.width))
+            for k in range(self.latent_dim)
+        )
+
+    def encode(self, field: Field) -> Tuple[Tuple[float, ...], Vec3]:
+        if len(field) != self.field_cells:
+            raise ValueError("unexpected autoencoder field size")
+        base = tuple(sum(vector[c] for vector in field) / len(field) for c in range(3))
+        residual = [vector[c] - base[c] for vector in field for c in range(3)]
+        latent = tuple(sum(weight * value for weight, value in zip(row, residual)) for row in self.basis)
+        return latent, base  # type: ignore[return-value]
+
+    def decode(self, latent: Sequence[float], base: Vec3) -> Field:
+        if len(latent) != self.latent_dim:
+            raise ValueError("unexpected latent size")
+        reconstructed = [0.0] * self.width
+        for coefficient, row in zip(latent, self.basis):
+            for index, weight in enumerate(row):
+                reconstructed[index] += coefficient * weight
+        field = []
+        for cell in range(self.field_cells):
+            offset = cell * 3
+            field.append(
+                (
+                    base[0] + reconstructed[offset],
+                    base[1] + reconstructed[offset + 1],
+                    base[2] + reconstructed[offset + 2],
+                )
+            )
+        return tuple(field)
+
+
+class ExpertRouter:
+    def __init__(self, config: AEDSIEConfig, latent_dim: int):
+        self.config = config
+        self.latent_dim = latent_dim
+        norm = math.sqrt(max(1, latent_dim))
+        self.embeddings = tuple(
+            tuple(math.cos((expert + 1) * (index + 1) * 0.37) / norm for index in range(latent_dim))
+            for expert in range(config.expert_count)
+        )
+        self.weights = tuple(
+            tuple(
+                tuple(
+                    math.sin((expert + 1) * (class_id + 2) * (index + 1) * 0.11) / norm
+                    for index in range(latent_dim)
+                )
+                for class_id in range(config.class_count)
+            )
+            for expert in range(config.expert_count)
+        )
+
+    def infer(self, latent: Sequence[float]) -> Tuple[int, float, Tuple[float, ...]]:
+        similarities = [_cosine(latent, embedding) for embedding in self.embeddings]
+        routing = _softmax(similarities, self.config.routing_temperature)
+        logits = [0.0] * self.config.class_count
+        for expert, route_weight in enumerate(routing):
+            for class_id in range(self.config.class_count):
+                expert_logit = sum(
+                    weight * value for weight, value in zip(self.weights[expert][class_id], latent)
+                )
+                logits[class_id] += route_weight * expert_logit
+        probabilities = _softmax(logits)
+        predicted = max(range(len(probabilities)), key=probabilities.__getitem__)
+        return predicted, probabilities[predicted], routing
+
+
+class OmegaLedger:
+    def __init__(self):
+        self.head = "0" * 64
+        self.records: List[str] = []
+
+    def append(self, payload: Dict[str, object]) -> str:
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        self.head = hashlib.sha3_256(bytes.fromhex(self.head) + canonical).hexdigest()
+        self.records.append(self.head)
+        return self.head
+
+
+class AEDSIEVirtualEngine:
+    def __init__(
+        self,
+        config: Optional[AEDSIEConfig] = None,
+        mechanics: Optional[Mechanics] = None,
+    ):
+        self.config = config or AEDSIEConfig()
+        self.config.validate()
+        self.mechanics = mechanics or Mechanics()
+        if not self.mechanics.admissible():
+            raise ValueError("initial mechanics are not admissible")
+        self.source = SyntheticRFSource(self.config)
+        self.channelizer = Channelizer(self.config)
+        self.tensorizer = Tensorizer(self.config)
+        cells = self.config.antennas * self.config.fft_bins * self.config.time_depth
+        self.operator = DrMoagi3DOperator(self.config)
+        self.autoencoder = ResidualAutoencoder(cells, self.config.latent_dim)
+        self.router = ExpertRouter(self.config, self.autoencoder.latent_dim)
+        self.ledger = OmegaLedger()
+        self.field: Optional[Field] = None
+        self.omega: Field = tuple((0.0, 0.0, 0.0) for _ in range(cells))
+        self.metric: Tuple[float, ...] = tuple(1.0 for _ in range(self.autoencoder.latent_dim))
+        self.cycle_index = 0
+        self.mechanics_history: List[str] = [self._mechanics_hash(self.mechanics, "BOOT")]
+
+    @staticmethod
+    def _mechanics_hash(mechanics: Mechanics, parent: str) -> str:
+        payload = json.dumps(
+            {"mechanics": asdict(mechanics), "parent": parent}, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        return hashlib.sha3_256(payload).hexdigest()
+
+    def _transition(
+        self,
+        field: Field,
+        reconstructed: Field,
+        omega: Field,
+        mechanics: Mechanics,
+    ) -> Tuple[Field, Field]:
+        if not mechanics.admissible():
+            raise ValueError("inadmissible mechanics")
+        differential = self.operator.apply(field, mechanics)
+        next_omega = []
+        next_field = []
+        for current, target, memory, motion in zip(field, reconstructed, omega, differential):
+            error = tuple(target[c] - current[c] for c in range(3))
+            updated_memory = tuple(
+                self.config.omega_decay * memory[c] + self.config.omega_gain * error[c]
+                for c in range(3)
+            )
+            proposal = tuple(
+                current[c]
+                + mechanics.dt
+                * (motion[c] + mechanics.coherence * error[c] + updated_memory[c])
+                for c in range(3)
+            )
+            next_omega.append(updated_memory)
+            next_field.append(proposal)
+        return tuple(next_field), tuple(next_omega)
+
+    @staticmethod
+    def _cost(candidate: Field, observed: Field, reconstructed: Field) -> float:
+        return (
+            _field_mse(candidate, observed)
+            + 0.20 * _field_mse(candidate, reconstructed)
+            + 0.001 * _field_energy(candidate)
+        )
+
+    def _candidate(self, reconstruction_mse: float) -> Tuple[str, Mechanics]:
+        current = self.mechanics
+        if reconstruction_mse > 1e-4:
+            return (
+                "INCREASE_COHERENCE",
+                Mechanics(
+                    current.alpha,
+                    current.beta,
+                    current.gamma,
+                    current.delta,
+                    min(0.80, current.coherence * 1.10),
+                    current.dt,
+                    current.version + 1,
+                ),
+            )
+        return (
+            "REDUCE_DIFFUSION",
+            Mechanics(
+                max(0.005, current.alpha * 0.90),
+                current.beta,
+                current.gamma,
+                current.delta,
+                current.coherence,
+                current.dt,
+                current.version + 1,
+            ),
+        )
+
+    def _inward_turn(
+        self,
+        field: Field,
+        observed: Field,
+        reconstructed: Field,
+        baseline_field: Field,
+        baseline_omega: Field,
+        reconstruction_mse: float,
+        enabled: bool,
+    ) -> Tuple[Field, Field, InwardDecision]:
+        baseline_cost = self._cost(baseline_field, observed, reconstructed)
+        if not enabled:
+            decision = InwardDecision(
+                False,
+                False,
+                "DISABLED",
+                baseline_cost,
+                baseline_cost,
+                0.0,
+                self.mechanics.version,
+            )
+            return baseline_field, baseline_omega, decision
+        rule, candidate = self._candidate(reconstruction_mse)
+        if not candidate.admissible():
+            decision = InwardDecision(
+                True,
+                False,
+                rule,
+                baseline_cost,
+                float("inf"),
+                0.5,
+                self.mechanics.version,
+            )
+            return baseline_field, baseline_omega, decision
+        shadow_field, shadow_omega = self._transition(field, reconstructed, self.omega, candidate)
+        shadow_cost = self._cost(shadow_field, observed, reconstructed)
+        analysis_share = 0.5
+        accepted = (
+            analysis_share <= self.config.analysis_budget
+            and shadow_cost + 1e-12 < baseline_cost
+            and all(math.isfinite(value) for vector in shadow_field for value in vector)
+        )
+        if accepted:
+            parent = self.mechanics_history[-1]
+            self.mechanics = candidate
+            self.mechanics_history.append(self._mechanics_hash(candidate, parent + rule))
+            selected_field, selected_omega = shadow_field, shadow_omega
+        else:
+            selected_field, selected_omega = baseline_field, baseline_omega
+        decision = InwardDecision(
+            True,
+            accepted,
+            rule,
+            baseline_cost,
+            shadow_cost,
+            analysis_share,
+            self.mechanics.version,
+        )
+        return selected_field, selected_omega, decision
+
+    def _update_metric(self, latent: Sequence[float]) -> None:
+        step = self.config.metric_step
+        self.metric = tuple(
+            max(1e-6, (1.0 - step) * current + step * (1.0 + abs(value)))
+            for current, value in zip(self.metric, latent)
+        )
+
+    @staticmethod
+    def _estimate_aoa(spectrum: Spectrum) -> float:
+        if len(spectrum) < 2 or not spectrum[0]:
+            return 0.0
+        strongest = max(
+            range(len(spectrum[0])),
+            key=lambda index: sum(abs(antenna[index]) for antenna in spectrum),
+        )
+        differences = []
+        for left, right in zip(spectrum, spectrum[1:]):
+            product = right[strongest] * left[strongest].conjugate()
+            differences.append(math.atan2(product.imag, product.real))
+        mean_phase = sum(differences) / max(1, len(differences))
+        return math.degrees(math.asin(_clamp(mean_phase / math.pi, -1.0, 1.0)))
+
+    def step(self, inward: bool = True) -> CycleReport:
+        trace: List[str] = []
+        samples = self.source.frame(self.cycle_index)
+        trace.append("ACQUIRE_RF")
+        spectrum = self.channelizer.process(samples)
+        trace.append("DDC_CHANNELIZE")
+        observed = self.tensorizer.push(spectrum)
+        trace.append("TENSORIZE_3D")
+        field = _blend_fields(self.field, observed, self.config.source_blend)
+        trace.append("DR_MOAGI_OPERATOR")
+        latent, base = self.autoencoder.encode(field)
+        trace.append("ENCODE_RESIDUAL")
+        reconstructed = self.autoencoder.decode(latent, base)
+        trace.append("DECODE_RESIDUAL")
+        reconstruction_mse = _field_mse(field, reconstructed)
+        trace.append("COMPARE")
+        baseline_field, baseline_omega = self._transition(
+            field, reconstructed, self.omega, self.mechanics
+        )
+        trace.append("UPDATE_OMEGA")
+        selected_field, selected_omega, decision = self._inward_turn(
+            field,
+            observed,
+            reconstructed,
+            baseline_field,
+            baseline_omega,
+            reconstruction_mse,
+            inward,
+        )
+        trace.append("INWARD_SHADOW")
+        self.field = selected_field
+        self.omega = selected_omega
+        self._update_metric(latent)
+        trace.append("PROJECT_MANIFOLD")
+        predicted, confidence, routing = self.router.infer(latent)
+        trace.append("ROUTE_EXPERTS")
+        aoa = self._estimate_aoa(spectrum)
+        trace.append("ESTIMATE_AOA")
+        state_payload = {
+            "cycle": self.cycle_index + 1,
+            "field": _canonical_field(self.field),
+            "latent": [_quantize(value) for value in latent],
+            "metric": [_quantize(value) for value in self.metric],
+            "mechanics": asdict(self.mechanics),
+            "prediction": predicted,
+            "aoa": _quantize(aoa),
+        }
+        state_bytes = json.dumps(state_payload, sort_keys=True, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        state_hash = hashlib.sha3_256(state_bytes).hexdigest()
+        ledger_head = self.ledger.append(
+            {
+                "cycle": self.cycle_index + 1,
+                "state_hash": state_hash,
+                "mechanics_hash": self.mechanics_history[-1],
+                "program": PROGRAM,
+            }
+        )
+        trace.append("SEAL_SHA3")
+        self.cycle_index += 1
+        trace.append("COMMIT")
+        return CycleReport(
+            self.cycle_index,
+            reconstruction_mse,
+            _field_energy(self.field),
+            _latent_energy(latent),
+            predicted,
+            confidence,
+            aoa,
+            routing,
+            min(self.metric),
+            max(self.metric),
+            self.mechanics,
+            decision,
+            state_hash,
+            ledger_head,
+            tuple(trace),
+        )
+
+    def run(self, cycles: int = 4, inward: bool = True) -> EngineReport:
+        if cycles < 1:
+            raise ValueError("cycles must be positive")
+        final = None
+        for _ in range(cycles):
+            final = self.step(inward=inward)
+        assert final is not None
+        return EngineReport(
+            cycles,
+            (self.config.antennas, self.config.fft_bins, self.config.time_depth, 3),
+            self.autoencoder.latent_dim,
+            final,
+            len(self.ledger.records),
+            self.ledger.head,
+            tuple(self.mechanics_history),
+        )
+
+
+def run_aedsie(cycles: int = 4, inward: bool = True) -> Dict[str, object]:
+    """Run the complete deterministic reference pipeline and return JSON-safe data."""
+
+    return AEDSIEVirtualEngine().run(cycles=cycles, inward=inward).to_dict()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -7,12 +7,13 @@ from .core import CodexVM
 from .api import start_api
 from .web import start_web
 from .node import CodexNode
+from .self_evolving_rom import run_self_evolving_rom
 from .swarm800 import run_swarm
 
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node|swarm] <file|cycles>")
+        print("Usage: jarvisx [run|api|web|node|swarm|ser] <file|cycles|epochs>")
         return
 
     cmd = sys.argv[1]
@@ -44,6 +45,11 @@ def main():
         cycles = int(sys.argv[2]) if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else 1
         mutate = "--no-mutate" not in sys.argv[2:]
         report = run_swarm(cycles=cycles, mutate=mutate)
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    elif cmd == "ser":
+        epochs = int(sys.argv[2]) if len(sys.argv) >= 3 else 8
+        report = run_self_evolving_rom(max_epochs=epochs)
         print(json.dumps(report, indent=2, sort_keys=True))
 
     else:

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,19 +1,25 @@
+import json
 import sys
+
 from .parser import Parser
 from .assembler import Assembler
 from .core import CodexVM
 from .api import start_api
 from .web import start_web
 from .node import CodexNode
+from .swarm800 import run_swarm
+
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
+        print("Usage: jarvisx [run|api|web|node|swarm] <file|cycles>")
         return
 
     cmd = sys.argv[1]
 
     if cmd == "run":
+        if len(sys.argv) < 3:
+            raise SystemExit("jarvisx run requires an input file")
         file = sys.argv[2]
         with open(file) as f:
             source = f.read()
@@ -33,6 +39,16 @@ def main():
     elif cmd == "node":
         node = CodexNode()
         node.start()
+
+    elif cmd == "swarm":
+        cycles = int(sys.argv[2]) if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else 1
+        mutate = "--no-mutate" not in sys.argv[2:]
+        report = run_swarm(cycles=cycles, mutate=mutate)
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    else:
+        raise SystemExit("unknown command: %s" % cmd)
+
 
 if __name__ == "__main__":
     main()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,19 +1,20 @@
 import json
 import sys
 
-from .parser import Parser
+from .aedsie_engine import run_aedsie
+from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .api import start_api
-from .web import start_web
 from .node import CodexNode
+from .parser import Parser
 from .self_evolving_rom import run_self_evolving_rom
 from .swarm800 import run_swarm
+from .web import start_web
 
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node|swarm|ser] <file|cycles|epochs>")
+        print("Usage: jarvisx [run|api|web|node|swarm|ser|aedsie] <file|cycles|epochs>")
         return
 
     cmd = sys.argv[1]
@@ -50,6 +51,12 @@ def main():
     elif cmd == "ser":
         epochs = int(sys.argv[2]) if len(sys.argv) >= 3 else 8
         report = run_self_evolving_rom(max_epochs=epochs)
+        print(json.dumps(report, indent=2, sort_keys=True))
+
+    elif cmd == "aedsie":
+        cycles = int(sys.argv[2]) if len(sys.argv) >= 3 and not sys.argv[2].startswith("--") else 4
+        inward = "--no-inward" not in sys.argv[2:]
+        report = run_aedsie(cycles=cycles, inward=inward)
         print(json.dumps(report, indent=2, sort_keys=True))
 
     else:

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -9,6 +9,7 @@ from .sandbox import Sandbox
 from .debugger import Debugger
 from .tracer import Tracer
 
+
 class CodexVM:
     def __init__(self):
         self.regs = Registers()
@@ -28,6 +29,7 @@ class CodexVM:
     def load(self, bytecode):
         self.program = bytecode
         self.regs["IP"] = 0
+        self.running = True
 
     def step(self):
         ip = self.regs["IP"]
@@ -39,7 +41,6 @@ class CodexVM:
         cont = self.executor.execute(instr)
         self.ledger.log(self.regs.snapshot(), instr.opcode)
         self.tracer.record(instr, self.regs.snapshot())
-        self.reflex.stabilize(self.regs)
 
         self.regs["IP"] += 1
         self.cycles += 1
@@ -51,3 +52,4 @@ class CodexVM:
     def run(self):
         while self.running:
             self.step()
+        self.reflex.stabilize(self.regs)

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,14 @@
 import hashlib
 import time
 
+
 class OmegaLedger:
     def __init__(self):
         self.chain = []
 
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        payload_text = f"{time.time()}|{state}|{opcode}"
+        payload_bytes = payload_text.encode("utf-8")
+        prev = self.chain[-1]["hash"].encode("utf-8") if self.chain else b""
+        entry_hash = hashlib.sha256(prev + payload_bytes).hexdigest()
+        self.chain.append({"hash": entry_hash, "payload": payload_text})

--- a/src/jarvisx/self_evolving_rom.py
+++ b/src/jarvisx/self_evolving_rom.py
@@ -1,0 +1,414 @@
+"""Bounded, semantics-preserving self-evolving ROM reference runtime.
+
+The optimizer is deliberately narrower than unrestricted self-modification. It
+profiles adjacent instruction pairs, proposes a declared macro-op rewrite, runs
+baseline and candidate programs from the same deterministic snapshot, and
+publishes a new immutable ROM version only when the final machine states are
+identical and the instruction cost is lower.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from collections import Counter
+from dataclasses import asdict, dataclass
+from enum import IntEnum
+from typing import Dict, List, Optional, Sequence, Tuple
+
+WORD_MASK = (1 << 64) - 1
+REGISTER_COUNT = 8
+VECTOR_WIDTH = 8
+
+
+class Opcode(IntEnum):
+    NOP = 0x00
+    LOAD3D = 0x01
+    STORE3D = 0x02
+    ENC = 0x03
+    DEC = 0x04
+    MAC3D = 0x05
+    BUNDLE = 0x06
+    META = 0x07
+    LDC = 0x08
+    DSM = 0x09
+    HALT = 0x0A
+
+
+@dataclass(frozen=True)
+class Instruction:
+    opcode: int
+    rs: int = 0
+    rt: int = 0
+    ru: int = 0
+    imm: int = 0
+    addr: int = 0
+
+    def validate(self) -> None:
+        fields = (self.opcode, self.rs, self.rt, self.ru)
+        if any(not 0 <= value <= 0xFF for value in fields):
+            raise ValueError("opcode and register fields must fit in 8 bits")
+        if any(value >= REGISTER_COUNT for value in (self.rs, self.rt, self.ru)):
+            raise ValueError("register index outside the eight-register file")
+        if not 0 <= self.imm <= 0xFFFF or not 0 <= self.addr <= 0xFFFF:
+            raise ValueError("immediate and address fields must fit in 16 bits")
+        if self.opcode not in {int(op) for op in Opcode}:
+            raise ValueError("unknown opcode")
+
+    def pack(self) -> int:
+        self.validate()
+        return (
+            (self.opcode << 56)
+            | (self.rs << 48)
+            | (self.rt << 40)
+            | (self.ru << 32)
+            | (self.imm << 16)
+            | self.addr
+        ) & WORD_MASK
+
+    @classmethod
+    def unpack(cls, word: int) -> "Instruction":
+        if word < 0 or word > WORD_MASK:
+            raise ValueError("instruction must be an unsigned 64-bit word")
+        instruction = cls(
+            opcode=(word >> 56) & 0xFF,
+            rs=(word >> 48) & 0xFF,
+            rt=(word >> 40) & 0xFF,
+            ru=(word >> 32) & 0xFF,
+            imm=(word >> 16) & 0xFFFF,
+            addr=word & 0xFFFF,
+        )
+        instruction.validate()
+        return instruction
+
+    @property
+    def mnemonic(self) -> str:
+        return Opcode(self.opcode).name
+
+
+Vector = Tuple[float, ...]
+
+
+def _zero_vector() -> Vector:
+    return (0.0,) * VECTOR_WIDTH
+
+
+def _deterministic_vector(address: int) -> Vector:
+    """Generate stable pseudo-data without wall-clock or global randomness."""
+    values = []
+    state = (address ^ 0xA5A5) & 0xFFFFFFFF
+    for lane in range(VECTOR_WIDTH):
+        state = (1664525 * (state + lane) + 1013904223) & 0xFFFFFFFF
+        values.append(((state >> 8) & 0xFFFF) / 32768.0 - 1.0)
+    return tuple(values)
+
+
+@dataclass(frozen=True)
+class MachineSnapshot:
+    registers: Tuple[Vector, ...]
+    memory: Tuple[Tuple[int, Vector], ...]
+    meta_rate: int
+
+    def canonical_bytes(self) -> bytes:
+        payload = {
+            "registers": self.registers,
+            "memory": self.memory,
+            "meta_rate": self.meta_rate,
+        }
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    snapshot: MachineSnapshot
+    trace: Tuple[str, ...]
+    cycles: int
+
+
+class SpatialCore:
+    """Small deterministic execution core used for equivalence checking."""
+
+    def __init__(self, snapshot: Optional[MachineSnapshot] = None):
+        if snapshot is None:
+            self.registers = [_zero_vector() for _ in range(REGISTER_COUNT)]
+            self.memory: Dict[int, Vector] = {}
+            self.meta_rate = 0
+        else:
+            self.registers = [tuple(vector) for vector in snapshot.registers]
+            self.memory = {address: tuple(vector) for address, vector in snapshot.memory}
+            self.meta_rate = snapshot.meta_rate
+
+    def snapshot(self) -> MachineSnapshot:
+        return MachineSnapshot(
+            registers=tuple(tuple(vector) for vector in self.registers),
+            memory=tuple(sorted((address, tuple(vector)) for address, vector in self.memory.items())),
+            meta_rate=self.meta_rate,
+        )
+
+    def _load(self, register: int, address: int) -> None:
+        self.registers[register] = self.memory.get(address, _deterministic_vector(address))
+
+    def _encode(self, source: int, target: int) -> None:
+        mean = sum(self.registers[source]) / VECTOR_WIDTH
+        self.registers[target] = (mean,) * VECTOR_WIDTH
+
+    def _decode(self, source: int, target: int) -> None:
+        # Reference decoder is deterministic and intentionally simple. A learned
+        # backend may replace it while preserving the same transaction contract.
+        self.registers[target] = tuple(self.registers[source])
+
+    def execute(self, instruction: Instruction) -> bool:
+        op = Opcode(instruction.opcode)
+        if op == Opcode.NOP:
+            return True
+        if op == Opcode.HALT:
+            return False
+        if op == Opcode.LOAD3D:
+            self._load(instruction.rs, instruction.addr)
+        elif op == Opcode.STORE3D:
+            self.memory[instruction.addr] = tuple(self.registers[instruction.rt])
+        elif op == Opcode.ENC:
+            self._encode(instruction.rs, instruction.rt)
+        elif op == Opcode.DEC:
+            self._decode(instruction.rs, instruction.rt)
+        elif op == Opcode.MAC3D:
+            self.registers[instruction.ru] = tuple(
+                a * b for a, b in zip(self.registers[instruction.rs], self.registers[instruction.rt])
+            )
+        elif op == Opcode.BUNDLE:
+            self.registers[instruction.ru] = tuple(
+                a + b for a, b in zip(self.registers[instruction.rs], self.registers[instruction.rt])
+            )
+        elif op == Opcode.META:
+            self.meta_rate = instruction.imm
+        elif op == Opcode.LDC:
+            self._load(instruction.rs, instruction.addr)
+            self._encode(instruction.rs, instruction.rt)
+        elif op == Opcode.DSM:
+            self._decode(instruction.rs, instruction.rt)
+            self.memory[instruction.addr] = tuple(self.registers[instruction.rt])
+        else:  # pragma: no cover - Instruction.validate prevents this path.
+            raise ValueError("unsupported opcode")
+        return True
+
+    def run(self, rom: Sequence[Instruction]) -> ExecutionResult:
+        trace: List[str] = []
+        cycles = 0
+        for instruction in rom:
+            trace.append(instruction.mnemonic)
+            cycles += 1
+            if not self.execute(instruction):
+                break
+        return ExecutionResult(self.snapshot(), tuple(trace), cycles)
+
+
+@dataclass(frozen=True)
+class PatchProposal:
+    rule: str
+    index: int
+    replacement: Instruction
+    removed: Instruction
+
+
+@dataclass(frozen=True)
+class RomVersion:
+    version: int
+    parent_hash: str
+    manifest_hash: str
+    instructions: Tuple[int, ...]
+    patch_rule: str
+
+
+@dataclass(frozen=True)
+class EpochReport:
+    epoch: int
+    accepted: bool
+    rule: str
+    before_length: int
+    after_length: int
+    baseline_cycles: int
+    shadow_cycles: int
+    semantic_equal: bool
+    analysis_share: float
+    manifest_hash: str
+
+
+class SelfEvolvingROM:
+    """Versioned ROM optimizer with shadow verification and bounded rules."""
+
+    def __init__(self, rom: Sequence[Instruction], analysis_cycle_fraction: float = 0.5):
+        if not rom or Opcode(rom[-1].opcode) != Opcode.HALT:
+            raise ValueError("ROM must terminate with HALT")
+        if not 0.0 < analysis_cycle_fraction <= 0.5:
+            raise ValueError("analysis cycle fraction must be in (0, 0.5]")
+        self.analysis_cycle_fraction = analysis_cycle_fraction
+        self.rom = tuple(rom)
+        self.epoch = 0
+        self.locked = False
+        self.journal: List[RomVersion] = []
+        self._publish_version(parent_hash="0" * 64, patch_rule="BOOT")
+
+    @staticmethod
+    def demo_rom() -> Tuple[Instruction, ...]:
+        """Eight-instruction demo containing two valid adjacent fusion pairs."""
+        return (
+            Instruction(Opcode.LOAD3D, rs=0, addr=0x1000),
+            Instruction(Opcode.ENC, rs=0, rt=2),
+            Instruction(Opcode.STORE3D, rt=2, addr=0x3000),
+            Instruction(Opcode.DEC, rs=2, rt=3),
+            Instruction(Opcode.STORE3D, rt=3, addr=0x4000),
+            Instruction(Opcode.LOAD3D, rs=1, addr=0x2000),
+            Instruction(Opcode.META, rs=0, imm=0x000A),
+            Instruction(Opcode.HALT),
+        )
+
+    @staticmethod
+    def profile(trace: Sequence[str]) -> Dict[str, int]:
+        return dict(sorted(Counter(trace).items()))
+
+    @staticmethod
+    def _manifest(parent_hash: str, words: Sequence[int], rule: str) -> str:
+        payload = bytearray.fromhex(parent_hash)
+        payload.extend(rule.encode("utf-8"))
+        for word in words:
+            payload.extend(int(word).to_bytes(8, "big"))
+        return hashlib.sha256(bytes(payload)).hexdigest()
+
+    def _publish_version(self, parent_hash: str, patch_rule: str) -> None:
+        words = tuple(instruction.pack() for instruction in self.rom)
+        manifest = self._manifest(parent_hash, words, patch_rule)
+        self.journal.append(
+            RomVersion(
+                version=len(self.journal),
+                parent_hash=parent_hash,
+                manifest_hash=manifest,
+                instructions=words,
+                patch_rule=patch_rule,
+            )
+        )
+
+    def _candidate(self) -> Optional[PatchProposal]:
+        for index in range(len(self.rom) - 1):
+            first, second = self.rom[index], self.rom[index + 1]
+            first_op, second_op = Opcode(first.opcode), Opcode(second.opcode)
+            if first_op == Opcode.LOAD3D and second_op == Opcode.ENC and first.rs == second.rs:
+                return PatchProposal(
+                    rule="FUSE_LOAD3D_ENC_TO_LDC",
+                    index=index,
+                    replacement=Instruction(
+                        Opcode.LDC, rs=first.rs, rt=second.rt, addr=first.addr
+                    ),
+                    removed=second,
+                )
+            if first_op == Opcode.DEC and second_op == Opcode.STORE3D and first.rt == second.rt:
+                return PatchProposal(
+                    rule="FUSE_DEC_STORE3D_TO_DSM",
+                    index=index,
+                    replacement=Instruction(
+                        Opcode.DSM, rs=first.rs, rt=first.rt, addr=second.addr
+                    ),
+                    removed=second,
+                )
+        return None
+
+    def _apply(self, proposal: PatchProposal) -> Tuple[Instruction, ...]:
+        candidate = list(self.rom)
+        candidate[proposal.index] = proposal.replacement
+        del candidate[proposal.index + 1]
+        return tuple(candidate)
+
+    @staticmethod
+    def _run_from(snapshot: MachineSnapshot, rom: Sequence[Instruction]) -> ExecutionResult:
+        return SpatialCore(snapshot).run(rom)
+
+    def inward_turn(self) -> EpochReport:
+        if self.locked:
+            latest = self.journal[-1]
+            return EpochReport(
+                epoch=self.epoch,
+                accepted=False,
+                rule="FIXED_POINT",
+                before_length=len(self.rom),
+                after_length=len(self.rom),
+                baseline_cycles=0,
+                shadow_cycles=0,
+                semantic_equal=True,
+                analysis_share=0.0,
+                manifest_hash=latest.manifest_hash,
+            )
+
+        self.epoch += 1
+        initial = SpatialCore().snapshot()
+        baseline = self._run_from(initial, self.rom)
+        proposal = self._candidate()
+        if proposal is None:
+            self.locked = True
+            latest = self.journal[-1]
+            return EpochReport(
+                epoch=self.epoch,
+                accepted=False,
+                rule="FIXED_POINT",
+                before_length=len(self.rom),
+                after_length=len(self.rom),
+                baseline_cycles=baseline.cycles,
+                shadow_cycles=0,
+                semantic_equal=True,
+                analysis_share=0.0,
+                manifest_hash=latest.manifest_hash,
+            )
+
+        candidate_rom = self._apply(proposal)
+        shadow = self._run_from(initial, candidate_rom)
+        semantic_equal = baseline.snapshot == shadow.snapshot
+        lower_cost = shadow.cycles < baseline.cycles and len(candidate_rom) < len(self.rom)
+        analysis_share = shadow.cycles / float(baseline.cycles + shadow.cycles)
+        within_budget = analysis_share <= self.analysis_cycle_fraction
+        accepted = semantic_equal and lower_cost and within_budget
+
+        if accepted:
+            parent_hash = self.journal[-1].manifest_hash
+            self.rom = candidate_rom
+            self._publish_version(parent_hash=parent_hash, patch_rule=proposal.rule)
+
+        return EpochReport(
+            epoch=self.epoch,
+            accepted=accepted,
+            rule=proposal.rule,
+            before_length=len(self.rom) + (1 if accepted else 0),
+            after_length=len(self.rom),
+            baseline_cycles=baseline.cycles,
+            shadow_cycles=shadow.cycles,
+            semantic_equal=semantic_equal,
+            analysis_share=analysis_share,
+            manifest_hash=self.journal[-1].manifest_hash,
+        )
+
+    def optimize(self, max_epochs: int = 8) -> Dict[str, object]:
+        if max_epochs < 1:
+            raise ValueError("max_epochs must be positive")
+        reports: List[EpochReport] = []
+        for _ in range(max_epochs):
+            report = self.inward_turn()
+            reports.append(report)
+            if self.locked:
+                break
+        final_run = SpatialCore().run(self.rom)
+        return {
+            "epochs": [asdict(report) for report in reports],
+            "locked": self.locked,
+            "rom_length": len(self.rom),
+            "rom": [
+                {
+                    "address": index,
+                    "word": "0x%016X" % instruction.pack(),
+                    "opcode": instruction.mnemonic,
+                }
+                for index, instruction in enumerate(self.rom)
+            ],
+            "trace_profile": self.profile(final_run.trace),
+            "versions": [asdict(version) for version in self.journal],
+            "final_state_hash": hashlib.sha256(final_run.snapshot.canonical_bytes()).hexdigest(),
+        }
+
+
+def run_self_evolving_rom(max_epochs: int = 8) -> Dict[str, object]:
+    return SelfEvolvingROM(SelfEvolvingROM.demo_rom()).optimize(max_epochs=max_epochs)

--- a/src/jarvisx/swarm800.py
+++ b/src/jarvisx/swarm800.py
@@ -1,0 +1,603 @@
+"""Operational reference model for the Jarvis-X 800-instance swarm.
+
+This module turns the corrected arithmetic and hierarchy into a deterministic,
+standard-library-only simulator. It models the control plane, SVI encoding,
+fixed-point arithmetic, safe mutation, fusion cadence, and sealed invariants;
+it does not pretend to be a WebGPU or distributed-training backend.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import struct
+from dataclasses import asdict, dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+Q_FRAC_BITS = 8
+Q_SCALE = 1 << Q_FRAC_BITS
+Q_MIN = -(1 << 15)
+Q_MAX = (1 << 15) - 1
+SVI_BYTES = 16
+ROM_BYTES = 4096
+ROM_INSTRUCTIONS = ROM_BYTES // SVI_BYTES
+AGE_MAX = (1 << 12) - 1
+COORD_MIN = -(1 << 11)
+COORD_MAX = (1 << 11) - 1
+
+INSTANCE_COUNT = 800
+INSTANCES_PER_ZONE = 10
+ZONES_PER_REGION = 10
+REGION_COUNT = 8
+ZONE_COUNT = REGION_COUNT * ZONES_PER_REGION
+
+PIPELINE_US = {
+    "fetch": 1.0,
+    "encode": 5.0,
+    "decode": 5.0,
+    "execute": 2.0,
+    "backprop": 10.0,
+}
+PIPELINE_LATENCY_US = sum(PIPELINE_US.values())
+PIPELINE_BOTTLENECK_US = max(PIPELINE_US.values())
+
+
+class SwarmInvariantError(RuntimeError):
+    """Raised when a sealed runtime invariant is violated."""
+
+
+def _sat16(value: int) -> int:
+    return max(Q_MIN, min(Q_MAX, int(value)))
+
+
+def _trunc_div(numerator: int, denominator: int) -> int:
+    if denominator == 0:
+        raise ZeroDivisionError("Q8.8 division by zero")
+    sign = -1 if (numerator < 0) ^ (denominator < 0) else 1
+    return sign * (abs(numerator) // abs(denominator))
+
+
+def q_from_float(value: float) -> int:
+    """Encode a real value as saturated signed Q8.8."""
+    return _sat16(round(float(value) * Q_SCALE))
+
+
+def q_to_float(value: int) -> float:
+    return int(value) / Q_SCALE
+
+
+def q_add(a: int, b: int) -> int:
+    return _sat16(int(a) + int(b))
+
+
+def q_sub(a: int, b: int) -> int:
+    return _sat16(int(a) - int(b))
+
+
+def q_mul(a: int, b: int) -> int:
+    """Q8.8 multiply with a wide intermediate and nearest rounding."""
+    product = int(a) * int(b)
+    magnitude = (abs(product) + (Q_SCALE // 2)) >> Q_FRAC_BITS
+    return _sat16(-magnitude if product < 0 else magnitude)
+
+
+def q_div(a: int, b: int) -> int:
+    """Q8.8 divide with truncation toward zero."""
+    return _sat16(_trunc_div(int(a) << Q_FRAC_BITS, int(b)))
+
+
+def _encode_signed_12(value: int) -> int:
+    if not COORD_MIN <= value <= COORD_MAX:
+        raise ValueError("12-bit signed coordinate out of range")
+    return value & 0xFFF
+
+
+def _decode_signed_12(value: int) -> int:
+    value &= 0xFFF
+    return value - 0x1000 if value & 0x800 else value
+
+
+@dataclass(frozen=True)
+class SVI:
+    """Corrected 128-bit Spatial Virtual Instruction.
+
+    Layout, least significant bit first:
+      opcode: 8, flags: 8, x/y/z: 12 each, operand: 32,
+      edge_fingerprint: 32, age_timer: 12.
+    """
+
+    opcode: int = 0
+    flags: int = 0
+    x: int = 0
+    y: int = 0
+    z: int = 0
+    operand: int = 0
+    edge_fingerprint: int = 0
+    age_timer: int = 0
+
+    def validate(self) -> None:
+        if not 0 <= self.opcode <= 0xFF:
+            raise ValueError("opcode must fit 8 bits")
+        if not 0 <= self.flags <= 0xFF:
+            raise ValueError("flags must fit 8 bits")
+        for value in (self.x, self.y, self.z):
+            if not COORD_MIN <= value <= COORD_MAX:
+                raise ValueError("coordinate must fit signed 12 bits")
+        if not 0 <= self.operand <= 0xFFFFFFFF:
+            raise ValueError("operand must fit 32 bits")
+        if not 0 <= self.edge_fingerprint <= 0xFFFFFFFF:
+            raise ValueError("edge_fingerprint must fit 32 bits")
+        if not 0 <= self.age_timer <= AGE_MAX:
+            raise ValueError("age_timer must fit 12 bits")
+
+    def pack_int(self) -> int:
+        self.validate()
+        word = self.opcode
+        word |= self.flags << 8
+        word |= _encode_signed_12(self.x) << 16
+        word |= _encode_signed_12(self.y) << 28
+        word |= _encode_signed_12(self.z) << 40
+        word |= self.operand << 52
+        word |= self.edge_fingerprint << 84
+        word |= self.age_timer << 116
+        if word.bit_length() > 128:
+            raise SwarmInvariantError("SVI exceeded 128 bits")
+        return word
+
+    def to_bytes(self) -> bytes:
+        return self.pack_int().to_bytes(SVI_BYTES, "little", signed=False)
+
+    @classmethod
+    def unpack_int(cls, word: int) -> "SVI":
+        if word < 0 or word.bit_length() > 128:
+            raise ValueError("SVI word must be an unsigned 128-bit integer")
+        return cls(
+            opcode=word & 0xFF,
+            flags=(word >> 8) & 0xFF,
+            x=_decode_signed_12((word >> 16) & 0xFFF),
+            y=_decode_signed_12((word >> 28) & 0xFFF),
+            z=_decode_signed_12((word >> 40) & 0xFFF),
+            operand=(word >> 52) & 0xFFFFFFFF,
+            edge_fingerprint=(word >> 84) & 0xFFFFFFFF,
+            age_timer=(word >> 116) & 0xFFF,
+        )
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> "SVI":
+        if len(payload) != SVI_BYTES:
+            raise ValueError("SVI payload must be exactly 16 bytes")
+        return cls.unpack_int(int.from_bytes(payload, "little", signed=False))
+
+    def aged(self) -> "SVI":
+        values = asdict(self)
+        values["age_timer"] = min(AGE_MAX, self.age_timer + 1)
+        return SVI(**values)
+
+
+def pc_to_xyz(pc_byte: int) -> Tuple[int, int, int]:
+    """Map a byte PC in a 4 KiB ROM to the corrected 8x8x4 grid."""
+    if pc_byte % SVI_BYTES != 0:
+        raise ValueError("PC must be 16-byte aligned")
+    index = pc_byte // SVI_BYTES
+    if not 0 <= index < ROM_INSTRUCTIONS:
+        raise ValueError("PC outside 4 KiB ROM")
+    return index & 7, (index >> 3) & 7, (index >> 6) & 3
+
+
+def xyz_to_pc(x: int, y: int, z: int) -> int:
+    if not (0 <= x < 8 and 0 <= y < 8 and 0 <= z < 4):
+        raise ValueError("ROM coordinate outside 8x8x4 geometry")
+    return SVI_BYTES * (x + 8 * y + 64 * z)
+
+
+def next_pc(pc_byte: int, branch: bool = False, instruction_offset: int = 0) -> int:
+    current_index = pc_byte // SVI_BYTES
+    target = current_index + 1 + (instruction_offset if branch else 0)
+    return (target % ROM_INSTRUCTIONS) * SVI_BYTES
+
+
+def edge_fingerprint(x: int, y: int, z: int, operand: int) -> int:
+    """Produce a 32-bit fingerprint; unlike a 36-bit Morton code, collisions are allowed."""
+    payload = struct.pack("<hhhI", x, y, z, operand & 0xFFFFFFFF)
+    return int.from_bytes(hashlib.blake2s(payload, digest_size=4).digest(), "little")
+
+
+class SVICodec:
+    """Exact 128-dimensional Q8.8 bit-latent codec for the reference runtime.
+
+    Every instruction bit is represented as +1 or -1 in Q8.8. This keeps the
+    simulator deterministic and exact while leaving a clean interface for a
+    learned 16,384-to-128 encoder backend.
+    """
+
+    latent_dim = 128
+
+    @staticmethod
+    def encode(instruction: SVI) -> Tuple[int, ...]:
+        word = instruction.pack_int()
+        return tuple(Q_SCALE if (word >> bit) & 1 else -Q_SCALE for bit in range(128))
+
+    @staticmethod
+    def decode(latent: Sequence[int]) -> SVI:
+        if len(latent) != 128:
+            raise ValueError("latent vector must have 128 elements")
+        word = 0
+        for bit, value in enumerate(latent):
+            if int(value) >= 0:
+                word |= 1 << bit
+        return SVI.unpack_int(word)
+
+
+@dataclass(frozen=True)
+class Metrics:
+    byte_fidelity: float
+    spatial_fidelity: float
+    latency_us: float
+    throughput_per_second: float
+    psnr: float
+    latent_energy: float
+    meta_loss: float
+    fitness: float
+
+
+def _psnr(original: bytes, reconstructed: bytes) -> float:
+    if len(original) != len(reconstructed):
+        return 0.0
+    mse = sum((a - b) ** 2 for a, b in zip(original, reconstructed)) / len(original)
+    if mse == 0:
+        return 99.0
+    return 20.0 * math.log10(255.0 / math.sqrt(mse))
+
+
+def evaluate_instruction(original: SVI, reconstructed: SVI, latent: Sequence[int]) -> Metrics:
+    before = original.to_bytes()
+    after = reconstructed.to_bytes()
+    equal_bits = 128 - (original.pack_int() ^ reconstructed.pack_int()).bit_count()
+    byte_fidelity = equal_bits / 128.0
+    spatial_fidelity = (
+        int(original.x == reconstructed.x)
+        + int(original.y == reconstructed.y)
+        + int(original.z == reconstructed.z)
+    ) / 3.0
+    latency = PIPELINE_LATENCY_US
+    throughput = 1_000_000.0 / PIPELINE_BOTTLENECK_US
+    latent_energy = sum(q_to_float(v) ** 2 for v in latent) / max(1, len(latent))
+    meta_loss = (
+        0.7 * (1.0 - byte_fidelity)
+        + 0.2 * (1.0 - spatial_fidelity)
+        + 0.09 * (latency / PIPELINE_LATENCY_US)
+        + 0.01 * latent_energy
+    )
+    fitness = (
+        1.0 / (1.0 + latency / PIPELINE_LATENCY_US)
+        + 0.02 * _psnr(before, after)
+        - 0.1 * latent_energy
+    )
+    return Metrics(
+        byte_fidelity=byte_fidelity,
+        spatial_fidelity=spatial_fidelity,
+        latency_us=latency,
+        throughput_per_second=throughput,
+        psnr=_psnr(before, after),
+        latent_energy=latent_energy,
+        meta_loss=meta_loss,
+        fitness=fitness,
+    )
+
+
+class SharedROM:
+    """Immutable 4 KiB base ROM with per-instance copy-on-write patches."""
+
+    def __init__(self, instructions: Sequence[SVI]):
+        if len(instructions) != ROM_INSTRUCTIONS:
+            raise ValueError("base ROM must contain exactly 256 SVIs")
+        self.instructions = tuple(instructions)
+        self.manifest_hash = hashlib.sha256(
+            b"".join(instruction.to_bytes() for instruction in self.instructions)
+        ).hexdigest()
+
+    @classmethod
+    def deterministic(cls, seed: int = 0xDEADBEEF) -> "SharedROM":
+        rng = random.Random(seed)
+        instructions: List[SVI] = []
+        for index in range(ROM_INSTRUCTIONS):
+            x, y, z = pc_to_xyz(index * SVI_BYTES)
+            operand = rng.getrandbits(32)
+            instructions.append(
+                SVI(
+                    opcode=index & 0xFF,
+                    flags=0,
+                    x=x,
+                    y=y,
+                    z=z,
+                    operand=operand,
+                    edge_fingerprint=edge_fingerprint(x, y, z, operand),
+                    age_timer=0,
+                )
+            )
+        return cls(instructions)
+
+    def fetch(self, pc_byte: int, patches: Dict[int, SVI]) -> SVI:
+        index = pc_byte // SVI_BYTES
+        if not 0 <= index < ROM_INSTRUCTIONS:
+            raise SwarmInvariantError("fetch outside ROM")
+        return patches.get(index, self.instructions[index])
+
+
+@dataclass
+class MutationResult:
+    accepted: bool
+    index: int
+    flipped_bits: Tuple[int, int, int]
+    old_fitness: float
+    new_fitness: float
+
+
+@dataclass
+class InstanceTelemetry:
+    instance_id: int
+    cycle: int
+    meta_loss: float
+    best_loss: float
+    fitness: float
+    latency_us: float
+    accepted_mutations: int
+    pc_byte: int
+    hash_head: str
+
+
+@dataclass
+class SwarmInstance:
+    instance_id: int
+    base_rom: SharedROM
+    seed: int
+    pc_byte: int = 0
+    registers: List[int] = field(default_factory=lambda: [0] * 16)
+    patches: Dict[int, SVI] = field(default_factory=dict)
+    cycle: int = 0
+    accepted_mutations: int = 0
+    best_loss: float = float("inf")
+    hash_head: str = "0" * 64
+
+    def __post_init__(self) -> None:
+        self._rng = random.Random(self.seed)
+
+    def _execute(self, instruction: SVI) -> None:
+        operand = instruction.operand
+        rd = operand & 0xF
+        rs1 = (operand >> 4) & 0xF
+        rs2 = (operand >> 8) & 0xF
+        a = self.registers[rs1]
+        b = self.registers[rs2]
+        operation = instruction.opcode % 10
+        if operation == 0:
+            out = q_add(a, b)
+        elif operation == 1:
+            out = q_sub(a, b)
+        elif operation == 2:
+            out = q_mul(a, b)
+        elif operation == 3:
+            out = q_div(a, b) if b else Q_MAX
+        elif operation == 4:
+            out = _sat16((a & 0xFFFF) & (b & 0xFFFF))
+        elif operation == 5:
+            out = _sat16((a & 0xFFFF) | (b & 0xFFFF))
+        elif operation == 6:
+            out = _sat16((a & 0xFFFF) ^ (b & 0xFFFF))
+        elif operation == 7:
+            out = _sat16(a << (b & 0xF))
+        elif operation == 8:
+            out = _sat16((a & 0xFFFF) >> (b & 0xF))
+        else:
+            out = _sat16(a >> (b & 0xF))
+        self.registers[rd] = out
+
+        branch = bool(instruction.flags & 0x1) and out != 0
+        offset_raw = (operand >> 16) & 0xFFFF
+        offset = offset_raw - 0x10000 if offset_raw & 0x8000 else offset_raw
+        self.pc_byte = next_pc(self.pc_byte, branch=branch, instruction_offset=offset)
+
+    @staticmethod
+    def _shadow_cost(instruction: SVI) -> float:
+        return (
+            instruction.edge_fingerprint.bit_count() / 32.0
+            + instruction.operand.bit_count() / 64.0
+            + instruction.age_timer / AGE_MAX
+        )
+
+    def _attempt_mutation(self, index: int, current: SVI, baseline: Metrics) -> MutationResult:
+        # Only operand and edge-fingerprint bits are mutable: packed bits 52..115.
+        bits = tuple(sorted(self._rng.sample(range(52, 116), 3)))
+        candidate_word = current.pack_int()
+        for bit in bits:
+            candidate_word ^= 1 << bit
+        candidate = SVI.unpack_int(candidate_word)
+        candidate.validate()
+
+        old_fitness = baseline.fitness - 0.01 * self._shadow_cost(current)
+        new_fitness = baseline.fitness - 0.01 * self._shadow_cost(candidate)
+        accepted = new_fitness > old_fitness * 1.001
+        if accepted:
+            self.patches[index] = candidate
+            self.accepted_mutations += 1
+        return MutationResult(accepted, index, bits, old_fitness, new_fitness)
+
+    def step(self, mutate: bool = True) -> InstanceTelemetry:
+        index = self.pc_byte // SVI_BYTES
+        instruction = self.base_rom.fetch(self.pc_byte, self.patches)
+        latent = SVICodec.encode(instruction)
+        reconstructed = SVICodec.decode(latent)
+        metrics = evaluate_instruction(instruction, reconstructed, latent)
+
+        self._execute(reconstructed)
+        aged = reconstructed.aged()
+        self.patches[index] = aged
+        if mutate:
+            self._attempt_mutation(index, aged, metrics)
+
+        self.cycle += 1
+        self.best_loss = min(self.best_loss, metrics.meta_loss)
+        event = {
+            "instance": self.instance_id,
+            "cycle": self.cycle,
+            "pc": self.pc_byte,
+            "loss": round(metrics.meta_loss, 12),
+            "patches": len(self.patches),
+        }
+        self.hash_head = hashlib.sha256(
+            bytes.fromhex(self.hash_head) + json.dumps(event, sort_keys=True).encode("utf-8")
+        ).hexdigest()
+        self.validate()
+        return InstanceTelemetry(
+            instance_id=self.instance_id,
+            cycle=self.cycle,
+            meta_loss=metrics.meta_loss,
+            best_loss=self.best_loss,
+            fitness=metrics.fitness,
+            latency_us=metrics.latency_us,
+            accepted_mutations=self.accepted_mutations,
+            pc_byte=self.pc_byte,
+            hash_head=self.hash_head,
+        )
+
+    def validate(self) -> None:
+        if self.pc_byte % SVI_BYTES != 0 or not 0 <= self.pc_byte < ROM_BYTES:
+            raise SwarmInvariantError("invalid PC")
+        if len(self.registers) != 16 or any(not Q_MIN <= value <= Q_MAX for value in self.registers):
+            raise SwarmInvariantError("invalid Q8.8 register state")
+        for index, instruction in self.patches.items():
+            if not 0 <= index < ROM_INSTRUCTIONS:
+                raise SwarmInvariantError("patch index outside ROM")
+            instruction.validate()
+
+
+@dataclass(frozen=True)
+class FusionState:
+    count: int
+    cycle: int
+    mean_loss: float
+    best_loss: float
+    mean_fitness: float
+    p95_latency_us: float
+    accepted_mutations: int
+
+
+def fuse_telemetry(items: Sequence[InstanceTelemetry]) -> FusionState:
+    if not items:
+        raise ValueError("cannot fuse an empty telemetry set")
+    ordered_latency = sorted(item.latency_us for item in items)
+    p95_index = min(len(ordered_latency) - 1, math.ceil(0.95 * len(ordered_latency)) - 1)
+    return FusionState(
+        count=len(items),
+        cycle=max(item.cycle for item in items),
+        mean_loss=sum(item.meta_loss for item in items) / len(items),
+        best_loss=min(item.best_loss for item in items),
+        mean_fitness=sum(item.fitness for item in items) / len(items),
+        p95_latency_us=ordered_latency[p95_index],
+        accepted_mutations=sum(item.accepted_mutations for item in items),
+    )
+
+
+@dataclass
+class SwarmReport:
+    cycle: int
+    instance_count: int
+    zone_count: int
+    region_count: int
+    current: FusionState
+    zone_fusions: int
+    region_fusions: int
+    global_fusions: int
+    global_best_loss: float
+    manifest_hash: str
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+class Swarm800:
+    """Hierarchical 800-instance reference swarm.
+
+    Fusion cadence:
+      - zone: every 10 cycles
+      - region: every 100 cycles
+      - global checkpoint: every 1000 cycles
+    """
+
+    def __init__(self, seed: int = 0xDEADBEEF):
+        self.seed = seed
+        self.base_rom = SharedROM.deterministic(seed)
+        self.instances = [
+            SwarmInstance(instance_id=i, base_rom=self.base_rom, seed=seed ^ (i * 0x9E3779B1))
+            for i in range(INSTANCE_COUNT)
+        ]
+        self.cycle = 0
+        self.zone_states: Dict[int, FusionState] = {}
+        self.region_states: Dict[int, FusionState] = {}
+        self.global_state: Optional[FusionState] = None
+        self.global_best_loss = float("inf")
+        self._last_telemetry: List[InstanceTelemetry] = []
+        self.validate_topology()
+
+    def validate_topology(self) -> None:
+        if len(self.instances) != INSTANCE_COUNT:
+            raise SwarmInvariantError("canonical swarm must contain exactly 800 instances")
+        if INSTANCE_COUNT != REGION_COUNT * ZONES_PER_REGION * INSTANCES_PER_ZONE:
+            raise SwarmInvariantError("hierarchy product does not equal 800")
+        if any(instance.base_rom.manifest_hash != self.base_rom.manifest_hash for instance in self.instances):
+            raise SwarmInvariantError("sealed ROM manifest differs across instances")
+
+    def _zone_slice(self, zone_id: int) -> slice:
+        start = zone_id * INSTANCES_PER_ZONE
+        return slice(start, start + INSTANCES_PER_ZONE)
+
+    def step(self, mutate: bool = True) -> SwarmReport:
+        telemetry = [instance.step(mutate=mutate) for instance in self.instances]
+        self._last_telemetry = telemetry
+        self.cycle += 1
+        current = fuse_telemetry(telemetry)
+        self.global_best_loss = min(self.global_best_loss, current.best_loss)
+
+        if self.cycle % 10 == 0:
+            for zone_id in range(ZONE_COUNT):
+                self.zone_states[zone_id] = fuse_telemetry(telemetry[self._zone_slice(zone_id)])
+
+        if self.cycle % 100 == 0:
+            region_width = ZONES_PER_REGION * INSTANCES_PER_ZONE
+            for region_id in range(REGION_COUNT):
+                start = region_id * region_width
+                self.region_states[region_id] = fuse_telemetry(telemetry[start : start + region_width])
+
+        if self.cycle % 1000 == 0:
+            self.global_state = current
+
+        self.validate_topology()
+        return SwarmReport(
+            cycle=self.cycle,
+            instance_count=INSTANCE_COUNT,
+            zone_count=ZONE_COUNT,
+            region_count=REGION_COUNT,
+            current=current,
+            zone_fusions=len(self.zone_states),
+            region_fusions=len(self.region_states),
+            global_fusions=1 if self.global_state is not None else 0,
+            global_best_loss=self.global_best_loss,
+            manifest_hash=self.base_rom.manifest_hash,
+        )
+
+    def run(self, cycles: int, mutate: bool = True) -> SwarmReport:
+        if cycles < 1:
+            raise ValueError("cycles must be positive")
+        report: Optional[SwarmReport] = None
+        for _ in range(cycles):
+            report = self.step(mutate=mutate)
+        assert report is not None
+        return report
+
+
+def run_swarm(cycles: int = 1, seed: int = 0xDEADBEEF, mutate: bool = True) -> Dict[str, object]:
+    """Convenience entry point used by the CLI and smoke tests."""
+    swarm = Swarm800(seed=seed)
+    return swarm.run(cycles=cycles, mutate=mutate).to_dict()

--- a/src/jarvisx/swarm800.py
+++ b/src/jarvisx/swarm800.py
@@ -1,11 +1,4 @@
-"""Operational reference model for the Jarvis-X 800-instance swarm.
-
-This module turns the corrected arithmetic and hierarchy into a deterministic,
-standard-library-only simulator. It models the control plane, SVI encoding,
-fixed-point arithmetic, safe mutation, fusion cadence, and sealed invariants;
-it does not pretend to be a WebGPU or distributed-training backend.
-"""
-
+"""Deterministic operational model of the Jarvis-X 800-instance swarm."""
 from __future__ import annotations
 
 import hashlib
@@ -16,98 +9,83 @@ import struct
 from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
-Q_FRAC_BITS = 8
-Q_SCALE = 1 << Q_FRAC_BITS
-Q_MIN = -(1 << 15)
-Q_MAX = (1 << 15) - 1
-SVI_BYTES = 16
-ROM_BYTES = 4096
+Q_SCALE = 256
+Q_MIN, Q_MAX = -32768, 32767
+SVI_BYTES, ROM_BYTES = 16, 4096
 ROM_INSTRUCTIONS = ROM_BYTES // SVI_BYTES
-AGE_MAX = (1 << 12) - 1
-COORD_MIN = -(1 << 11)
-COORD_MAX = (1 << 11) - 1
-
-INSTANCE_COUNT = 800
-INSTANCES_PER_ZONE = 10
-ZONES_PER_REGION = 10
-REGION_COUNT = 8
+AGE_MAX = 4095
+COORD_MIN, COORD_MAX = -2048, 2047
+INSTANCE_COUNT, INSTANCES_PER_ZONE = 800, 10
+ZONES_PER_REGION, REGION_COUNT = 10, 8
 ZONE_COUNT = REGION_COUNT * ZONES_PER_REGION
-
-PIPELINE_US = {
-    "fetch": 1.0,
-    "encode": 5.0,
-    "decode": 5.0,
-    "execute": 2.0,
-    "backprop": 10.0,
-}
+PIPELINE_US = {"fetch": 1.0, "encode": 5.0, "decode": 5.0, "execute": 2.0, "backprop": 10.0}
 PIPELINE_LATENCY_US = sum(PIPELINE_US.values())
 PIPELINE_BOTTLENECK_US = max(PIPELINE_US.values())
 
 
 class SwarmInvariantError(RuntimeError):
-    """Raised when a sealed runtime invariant is violated."""
+    pass
 
 
-def _sat16(value: int) -> int:
-    return max(Q_MIN, min(Q_MAX, int(value)))
+def _sat16(v: int) -> int:
+    return max(Q_MIN, min(Q_MAX, int(v)))
 
 
-def _trunc_div(numerator: int, denominator: int) -> int:
-    if denominator == 0:
+def _signed16(v: int) -> int:
+    v &= 0xFFFF
+    return v - 0x10000 if v & 0x8000 else v
+
+
+def _popcount(v: int) -> int:
+    return bin(abs(int(v))).count("1")
+
+
+def _trunc_div(a: int, b: int) -> int:
+    if b == 0:
         raise ZeroDivisionError("Q8.8 division by zero")
-    sign = -1 if (numerator < 0) ^ (denominator < 0) else 1
-    return sign * (abs(numerator) // abs(denominator))
+    sign = -1 if (a < 0) ^ (b < 0) else 1
+    return sign * (abs(a) // abs(b))
 
 
-def q_from_float(value: float) -> int:
-    """Encode a real value as saturated signed Q8.8."""
-    return _sat16(round(float(value) * Q_SCALE))
+def q_from_float(v: float) -> int:
+    return _sat16(round(float(v) * Q_SCALE))
 
 
-def q_to_float(value: int) -> float:
-    return int(value) / Q_SCALE
+def q_to_float(v: int) -> float:
+    return int(v) / Q_SCALE
 
 
 def q_add(a: int, b: int) -> int:
-    return _sat16(int(a) + int(b))
+    return _sat16(a + b)
 
 
 def q_sub(a: int, b: int) -> int:
-    return _sat16(int(a) - int(b))
+    return _sat16(a - b)
 
 
 def q_mul(a: int, b: int) -> int:
-    """Q8.8 multiply with a wide intermediate and nearest rounding."""
     product = int(a) * int(b)
-    magnitude = (abs(product) + (Q_SCALE // 2)) >> Q_FRAC_BITS
-    return _sat16(-magnitude if product < 0 else magnitude)
+    out = (abs(product) + 128) >> 8
+    return _sat16(-out if product < 0 else out)
 
 
 def q_div(a: int, b: int) -> int:
-    """Q8.8 divide with truncation toward zero."""
-    return _sat16(_trunc_div(int(a) << Q_FRAC_BITS, int(b)))
+    return _sat16(_trunc_div(int(a) << 8, int(b)))
 
 
-def _encode_signed_12(value: int) -> int:
-    if not COORD_MIN <= value <= COORD_MAX:
-        raise ValueError("12-bit signed coordinate out of range")
-    return value & 0xFFF
+def _enc12(v: int) -> int:
+    if not COORD_MIN <= v <= COORD_MAX:
+        raise ValueError("coordinate outside signed 12-bit range")
+    return v & 0xFFF
 
 
-def _decode_signed_12(value: int) -> int:
-    value &= 0xFFF
-    return value - 0x1000 if value & 0x800 else value
+def _dec12(v: int) -> int:
+    v &= 0xFFF
+    return v - 0x1000 if v & 0x800 else v
 
 
 @dataclass(frozen=True)
 class SVI:
-    """Corrected 128-bit Spatial Virtual Instruction.
-
-    Layout, least significant bit first:
-      opcode: 8, flags: 8, x/y/z: 12 each, operand: 32,
-      edge_fingerprint: 32, age_timer: 12.
-    """
-
     opcode: int = 0
     flags: int = 0
     x: int = 0
@@ -118,57 +96,53 @@ class SVI:
     age_timer: int = 0
 
     def validate(self) -> None:
-        if not 0 <= self.opcode <= 0xFF:
-            raise ValueError("opcode must fit 8 bits")
-        if not 0 <= self.flags <= 0xFF:
-            raise ValueError("flags must fit 8 bits")
-        for value in (self.x, self.y, self.z):
-            if not COORD_MIN <= value <= COORD_MAX:
-                raise ValueError("coordinate must fit signed 12 bits")
+        if not 0 <= self.opcode <= 0xFF or not 0 <= self.flags <= 0xFF:
+            raise ValueError("opcode/flags outside 8-bit range")
+        if any(not COORD_MIN <= v <= COORD_MAX for v in (self.x, self.y, self.z)):
+            raise ValueError("coordinate outside signed 12-bit range")
         if not 0 <= self.operand <= 0xFFFFFFFF:
-            raise ValueError("operand must fit 32 bits")
+            raise ValueError("operand outside 32-bit range")
         if not 0 <= self.edge_fingerprint <= 0xFFFFFFFF:
-            raise ValueError("edge_fingerprint must fit 32 bits")
+            raise ValueError("edge fingerprint outside 32-bit range")
         if not 0 <= self.age_timer <= AGE_MAX:
-            raise ValueError("age_timer must fit 12 bits")
+            raise ValueError("age outside 12-bit range")
 
     def pack_int(self) -> int:
         self.validate()
-        word = self.opcode
-        word |= self.flags << 8
-        word |= _encode_signed_12(self.x) << 16
-        word |= _encode_signed_12(self.y) << 28
-        word |= _encode_signed_12(self.z) << 40
+        word = self.opcode | (self.flags << 8)
+        word |= _enc12(self.x) << 16
+        word |= _enc12(self.y) << 28
+        word |= _enc12(self.z) << 40
         word |= self.operand << 52
         word |= self.edge_fingerprint << 84
         word |= self.age_timer << 116
         if word.bit_length() > 128:
-            raise SwarmInvariantError("SVI exceeded 128 bits")
+            raise SwarmInvariantError("SVI exceeds 128 bits")
         return word
 
     def to_bytes(self) -> bytes:
-        return self.pack_int().to_bytes(SVI_BYTES, "little", signed=False)
+        return self.pack_int().to_bytes(16, "little")
 
     @classmethod
     def unpack_int(cls, word: int) -> "SVI":
         if word < 0 or word.bit_length() > 128:
-            raise ValueError("SVI word must be an unsigned 128-bit integer")
+            raise ValueError("word is not unsigned 128-bit")
         return cls(
-            opcode=word & 0xFF,
-            flags=(word >> 8) & 0xFF,
-            x=_decode_signed_12((word >> 16) & 0xFFF),
-            y=_decode_signed_12((word >> 28) & 0xFFF),
-            z=_decode_signed_12((word >> 40) & 0xFFF),
-            operand=(word >> 52) & 0xFFFFFFFF,
-            edge_fingerprint=(word >> 84) & 0xFFFFFFFF,
-            age_timer=(word >> 116) & 0xFFF,
+            word & 0xFF,
+            (word >> 8) & 0xFF,
+            _dec12(word >> 16),
+            _dec12(word >> 28),
+            _dec12(word >> 40),
+            (word >> 52) & 0xFFFFFFFF,
+            (word >> 84) & 0xFFFFFFFF,
+            (word >> 116) & 0xFFF,
         )
 
     @classmethod
-    def from_bytes(cls, payload: bytes) -> "SVI":
-        if len(payload) != SVI_BYTES:
-            raise ValueError("SVI payload must be exactly 16 bytes")
-        return cls.unpack_int(int.from_bytes(payload, "little", signed=False))
+    def from_bytes(cls, data: bytes) -> "SVI":
+        if len(data) != 16:
+            raise ValueError("SVI must be 16 bytes")
+        return cls.unpack_int(int.from_bytes(data, "little"))
 
     def aged(self) -> "SVI":
         values = asdict(self)
@@ -176,57 +150,43 @@ class SVI:
         return SVI(**values)
 
 
-def pc_to_xyz(pc_byte: int) -> Tuple[int, int, int]:
-    """Map a byte PC in a 4 KiB ROM to the corrected 8x8x4 grid."""
-    if pc_byte % SVI_BYTES != 0:
+def pc_to_xyz(pc: int) -> Tuple[int, int, int]:
+    if pc % 16:
         raise ValueError("PC must be 16-byte aligned")
-    index = pc_byte // SVI_BYTES
-    if not 0 <= index < ROM_INSTRUCTIONS:
+    n = pc // 16
+    if not 0 <= n < 256:
         raise ValueError("PC outside 4 KiB ROM")
-    return index & 7, (index >> 3) & 7, (index >> 6) & 3
+    return n & 7, (n >> 3) & 7, (n >> 6) & 3
 
 
 def xyz_to_pc(x: int, y: int, z: int) -> int:
     if not (0 <= x < 8 and 0 <= y < 8 and 0 <= z < 4):
-        raise ValueError("ROM coordinate outside 8x8x4 geometry")
-    return SVI_BYTES * (x + 8 * y + 64 * z)
+        raise ValueError("coordinate outside 8x8x4 ROM")
+    return 16 * (x + 8 * y + 64 * z)
 
 
-def next_pc(pc_byte: int, branch: bool = False, instruction_offset: int = 0) -> int:
-    current_index = pc_byte // SVI_BYTES
-    target = current_index + 1 + (instruction_offset if branch else 0)
-    return (target % ROM_INSTRUCTIONS) * SVI_BYTES
+def next_pc(pc: int, branch: bool = False, instruction_offset: int = 0) -> int:
+    return ((pc // 16 + 1 + (instruction_offset if branch else 0)) % 256) * 16
 
 
 def edge_fingerprint(x: int, y: int, z: int, operand: int) -> int:
-    """Produce a 32-bit fingerprint; unlike a 36-bit Morton code, collisions are allowed."""
-    payload = struct.pack("<hhhI", x, y, z, operand & 0xFFFFFFFF)
-    return int.from_bytes(hashlib.blake2s(payload, digest_size=4).digest(), "little")
+    data = struct.pack("<hhhI", x, y, z, operand & 0xFFFFFFFF)
+    return int.from_bytes(hashlib.blake2s(data, digest_size=4).digest(), "little")
 
 
 class SVICodec:
-    """Exact 128-dimensional Q8.8 bit-latent codec for the reference runtime.
-
-    Every instruction bit is represented as +1 or -1 in Q8.8. This keeps the
-    simulator deterministic and exact while leaving a clean interface for a
-    learned 16,384-to-128 encoder backend.
-    """
-
     latent_dim = 128
 
     @staticmethod
-    def encode(instruction: SVI) -> Tuple[int, ...]:
-        word = instruction.pack_int()
-        return tuple(Q_SCALE if (word >> bit) & 1 else -Q_SCALE for bit in range(128))
+    def encode(i: SVI) -> Tuple[int, ...]:
+        word = i.pack_int()
+        return tuple(Q_SCALE if (word >> b) & 1 else -Q_SCALE for b in range(128))
 
     @staticmethod
-    def decode(latent: Sequence[int]) -> SVI:
-        if len(latent) != 128:
-            raise ValueError("latent vector must have 128 elements")
-        word = 0
-        for bit, value in enumerate(latent):
-            if int(value) >= 0:
-                word |= 1 << bit
+    def decode(z: Sequence[int]) -> SVI:
+        if len(z) != 128:
+            raise ValueError("latent must have 128 values")
+        word = sum((1 << b) for b, v in enumerate(z) if int(v) >= 0)
         return SVI.unpack_int(word)
 
 
@@ -242,88 +202,54 @@ class Metrics:
     fitness: float
 
 
-def _psnr(original: bytes, reconstructed: bytes) -> float:
-    if len(original) != len(reconstructed):
-        return 0.0
-    mse = sum((a - b) ** 2 for a, b in zip(original, reconstructed)) / len(original)
-    if mse == 0:
-        return 99.0
-    return 20.0 * math.log10(255.0 / math.sqrt(mse))
+def _psnr(a: bytes, b: bytes) -> float:
+    mse = sum((x - y) ** 2 for x, y in zip(a, b)) / len(a)
+    return 99.0 if mse == 0 else 20 * math.log10(255 / math.sqrt(mse))
 
 
-def evaluate_instruction(original: SVI, reconstructed: SVI, latent: Sequence[int]) -> Metrics:
-    before = original.to_bytes()
-    after = reconstructed.to_bytes()
-    equal_bits = 128 - (original.pack_int() ^ reconstructed.pack_int()).bit_count()
-    byte_fidelity = equal_bits / 128.0
-    spatial_fidelity = (
-        int(original.x == reconstructed.x)
-        + int(original.y == reconstructed.y)
-        + int(original.z == reconstructed.z)
-    ) / 3.0
-    latency = PIPELINE_LATENCY_US
-    throughput = 1_000_000.0 / PIPELINE_BOTTLENECK_US
-    latent_energy = sum(q_to_float(v) ** 2 for v in latent) / max(1, len(latent))
-    meta_loss = (
-        0.7 * (1.0 - byte_fidelity)
-        + 0.2 * (1.0 - spatial_fidelity)
-        + 0.09 * (latency / PIPELINE_LATENCY_US)
-        + 0.01 * latent_energy
-    )
-    fitness = (
-        1.0 / (1.0 + latency / PIPELINE_LATENCY_US)
-        + 0.02 * _psnr(before, after)
-        - 0.1 * latent_energy
-    )
+def evaluate_instruction(a: SVI, b: SVI, z: Sequence[int]) -> Metrics:
+    fidelity = (128 - _popcount(a.pack_int() ^ b.pack_int())) / 128
+    spatial = sum((a.x == b.x, a.y == b.y, a.z == b.z)) / 3
+    energy = sum(q_to_float(v) ** 2 for v in z) / len(z)
+    psnr = _psnr(a.to_bytes(), b.to_bytes())
+    loss = 0.7 * (1 - fidelity) + 0.2 * (1 - spatial) + 0.09 + 0.01 * energy
+    fitness = 0.5 + 0.02 * psnr - 0.1 * energy
     return Metrics(
-        byte_fidelity=byte_fidelity,
-        spatial_fidelity=spatial_fidelity,
-        latency_us=latency,
-        throughput_per_second=throughput,
-        psnr=_psnr(before, after),
-        latent_energy=latent_energy,
-        meta_loss=meta_loss,
-        fitness=fitness,
+        fidelity,
+        spatial,
+        PIPELINE_LATENCY_US,
+        1_000_000 / PIPELINE_BOTTLENECK_US,
+        psnr,
+        energy,
+        loss,
+        fitness,
     )
 
 
 class SharedROM:
-    """Immutable 4 KiB base ROM with per-instance copy-on-write patches."""
-
     def __init__(self, instructions: Sequence[SVI]):
-        if len(instructions) != ROM_INSTRUCTIONS:
-            raise ValueError("base ROM must contain exactly 256 SVIs")
+        if len(instructions) != 256:
+            raise ValueError("ROM must contain 256 instructions")
         self.instructions = tuple(instructions)
         self.manifest_hash = hashlib.sha256(
-            b"".join(instruction.to_bytes() for instruction in self.instructions)
+            b"".join(i.to_bytes() for i in instructions)
         ).hexdigest()
 
     @classmethod
     def deterministic(cls, seed: int = 0xDEADBEEF) -> "SharedROM":
         rng = random.Random(seed)
-        instructions: List[SVI] = []
-        for index in range(ROM_INSTRUCTIONS):
-            x, y, z = pc_to_xyz(index * SVI_BYTES)
+        rom = []
+        for n in range(256):
+            x, y, z = pc_to_xyz(n * 16)
             operand = rng.getrandbits(32)
-            instructions.append(
-                SVI(
-                    opcode=index & 0xFF,
-                    flags=0,
-                    x=x,
-                    y=y,
-                    z=z,
-                    operand=operand,
-                    edge_fingerprint=edge_fingerprint(x, y, z, operand),
-                    age_timer=0,
-                )
-            )
-        return cls(instructions)
+            rom.append(SVI(n, 0, x, y, z, operand, edge_fingerprint(x, y, z, operand), 0))
+        return cls(rom)
 
-    def fetch(self, pc_byte: int, patches: Dict[int, SVI]) -> SVI:
-        index = pc_byte // SVI_BYTES
-        if not 0 <= index < ROM_INSTRUCTIONS:
+    def fetch(self, pc: int, patches: Dict[int, SVI]) -> SVI:
+        n = pc // 16
+        if not 0 <= n < 256:
             raise SwarmInvariantError("fetch outside ROM")
-        return patches.get(index, self.instructions[index])
+        return patches.get(n, self.instructions[n])
 
 
 @dataclass
@@ -364,112 +290,92 @@ class SwarmInstance:
     def __post_init__(self) -> None:
         self._rng = random.Random(self.seed)
 
-    def _execute(self, instruction: SVI) -> None:
-        operand = instruction.operand
-        rd = operand & 0xF
-        rs1 = (operand >> 4) & 0xF
-        rs2 = (operand >> 8) & 0xF
-        a = self.registers[rs1]
-        b = self.registers[rs2]
-        operation = instruction.opcode % 10
-        if operation == 0:
-            out = q_add(a, b)
-        elif operation == 1:
-            out = q_sub(a, b)
-        elif operation == 2:
-            out = q_mul(a, b)
-        elif operation == 3:
-            out = q_div(a, b) if b else Q_MAX
-        elif operation == 4:
-            out = _sat16((a & 0xFFFF) & (b & 0xFFFF))
-        elif operation == 5:
-            out = _sat16((a & 0xFFFF) | (b & 0xFFFF))
-        elif operation == 6:
-            out = _sat16((a & 0xFFFF) ^ (b & 0xFFFF))
-        elif operation == 7:
-            out = _sat16(a << (b & 0xF))
-        elif operation == 8:
-            out = _sat16((a & 0xFFFF) >> (b & 0xF))
-        else:
-            out = _sat16(a >> (b & 0xF))
+    def _execute(self, i: SVI) -> None:
+        rd = i.operand & 15
+        rs1 = (i.operand >> 4) & 15
+        rs2 = (i.operand >> 8) & 15
+        a, b, op = self.registers[rs1], self.registers[rs2], i.opcode % 10
+        operations = {
+            0: lambda: q_add(a, b),
+            1: lambda: q_sub(a, b),
+            2: lambda: q_mul(a, b),
+            3: lambda: q_div(a, b) if b else Q_MAX,
+            4: lambda: _signed16(a & b),
+            5: lambda: _signed16(a | b),
+            6: lambda: _signed16(a ^ b),
+            7: lambda: _signed16(a << (b & 15)),
+            8: lambda: _signed16((a & 0xFFFF) >> (b & 15)),
+            9: lambda: _sat16(a >> (b & 15)),
+        }
+        out = operations[op]()
         self.registers[rd] = out
-
-        branch = bool(instruction.flags & 0x1) and out != 0
-        offset_raw = (operand >> 16) & 0xFFFF
-        offset = offset_raw - 0x10000 if offset_raw & 0x8000 else offset_raw
-        self.pc_byte = next_pc(self.pc_byte, branch=branch, instruction_offset=offset)
+        raw = (i.operand >> 16) & 0xFFFF
+        offset = raw - 0x10000 if raw & 0x8000 else raw
+        self.pc_byte = next_pc(self.pc_byte, bool(i.flags & 1) and out != 0, offset)
 
     @staticmethod
-    def _shadow_cost(instruction: SVI) -> float:
+    def _shadow_cost(i: SVI) -> float:
         return (
-            instruction.edge_fingerprint.bit_count() / 32.0
-            + instruction.operand.bit_count() / 64.0
-            + instruction.age_timer / AGE_MAX
+            _popcount(i.edge_fingerprint) / 32
+            + _popcount(i.operand) / 64
+            + i.age_timer / AGE_MAX
         )
 
-    def _attempt_mutation(self, index: int, current: SVI, baseline: Metrics) -> MutationResult:
-        # Only operand and edge-fingerprint bits are mutable: packed bits 52..115.
+    def _attempt_mutation(self, n: int, current: SVI, baseline: Metrics) -> MutationResult:
         bits = tuple(sorted(self._rng.sample(range(52, 116), 3)))
-        candidate_word = current.pack_int()
+        word = current.pack_int()
         for bit in bits:
-            candidate_word ^= 1 << bit
-        candidate = SVI.unpack_int(candidate_word)
+            word ^= 1 << bit
+        candidate = SVI.unpack_int(word)
         candidate.validate()
-
-        old_fitness = baseline.fitness - 0.01 * self._shadow_cost(current)
-        new_fitness = baseline.fitness - 0.01 * self._shadow_cost(candidate)
-        accepted = new_fitness > old_fitness * 1.001
+        old = baseline.fitness - 0.05 * self._shadow_cost(current)
+        new = baseline.fitness - 0.05 * self._shadow_cost(candidate)
+        accepted = new > old * 1.001
         if accepted:
-            self.patches[index] = candidate
+            self.patches[n] = candidate
             self.accepted_mutations += 1
-        return MutationResult(accepted, index, bits, old_fitness, new_fitness)
+        return MutationResult(accepted, n, bits, old, new)
 
     def step(self, mutate: bool = True) -> InstanceTelemetry:
-        index = self.pc_byte // SVI_BYTES
+        n = self.pc_byte // 16
         instruction = self.base_rom.fetch(self.pc_byte, self.patches)
         latent = SVICodec.encode(instruction)
         reconstructed = SVICodec.decode(latent)
         metrics = evaluate_instruction(instruction, reconstructed, latent)
-
         self._execute(reconstructed)
         aged = reconstructed.aged()
-        self.patches[index] = aged
+        self.patches[n] = aged
         if mutate:
-            self._attempt_mutation(index, aged, metrics)
-
+            self._attempt_mutation(n, aged, metrics)
         self.cycle += 1
         self.best_loss = min(self.best_loss, metrics.meta_loss)
-        event = {
-            "instance": self.instance_id,
-            "cycle": self.cycle,
-            "pc": self.pc_byte,
-            "loss": round(metrics.meta_loss, 12),
-            "patches": len(self.patches),
-        }
-        self.hash_head = hashlib.sha256(
-            bytes.fromhex(self.hash_head) + json.dumps(event, sort_keys=True).encode("utf-8")
-        ).hexdigest()
+        event = json.dumps(
+            {"i": self.instance_id, "c": self.cycle, "pc": self.pc_byte,
+             "loss": round(metrics.meta_loss, 12)},
+            sort_keys=True,
+        ).encode()
+        self.hash_head = hashlib.sha256(bytes.fromhex(self.hash_head) + event).hexdigest()
         self.validate()
         return InstanceTelemetry(
-            instance_id=self.instance_id,
-            cycle=self.cycle,
-            meta_loss=metrics.meta_loss,
-            best_loss=self.best_loss,
-            fitness=metrics.fitness,
-            latency_us=metrics.latency_us,
-            accepted_mutations=self.accepted_mutations,
-            pc_byte=self.pc_byte,
-            hash_head=self.hash_head,
+            self.instance_id,
+            self.cycle,
+            metrics.meta_loss,
+            self.best_loss,
+            metrics.fitness,
+            metrics.latency_us,
+            self.accepted_mutations,
+            self.pc_byte,
+            self.hash_head,
         )
 
     def validate(self) -> None:
-        if self.pc_byte % SVI_BYTES != 0 or not 0 <= self.pc_byte < ROM_BYTES:
+        if self.pc_byte % 16 or not 0 <= self.pc_byte < 4096:
             raise SwarmInvariantError("invalid PC")
-        if len(self.registers) != 16 or any(not Q_MIN <= value <= Q_MAX for value in self.registers):
-            raise SwarmInvariantError("invalid Q8.8 register state")
-        for index, instruction in self.patches.items():
-            if not 0 <= index < ROM_INSTRUCTIONS:
-                raise SwarmInvariantError("patch index outside ROM")
+        if len(self.registers) != 16 or any(not Q_MIN <= v <= Q_MAX for v in self.registers):
+            raise SwarmInvariantError("invalid register state")
+        for n, instruction in self.patches.items():
+            if not 0 <= n < 256:
+                raise SwarmInvariantError("invalid patch index")
             instruction.validate()
 
 
@@ -486,17 +392,17 @@ class FusionState:
 
 def fuse_telemetry(items: Sequence[InstanceTelemetry]) -> FusionState:
     if not items:
-        raise ValueError("cannot fuse an empty telemetry set")
-    ordered_latency = sorted(item.latency_us for item in items)
-    p95_index = min(len(ordered_latency) - 1, math.ceil(0.95 * len(ordered_latency)) - 1)
+        raise ValueError("cannot fuse empty telemetry")
+    latencies = sorted(i.latency_us for i in items)
+    p95 = latencies[min(len(latencies) - 1, math.ceil(0.95 * len(latencies)) - 1)]
     return FusionState(
-        count=len(items),
-        cycle=max(item.cycle for item in items),
-        mean_loss=sum(item.meta_loss for item in items) / len(items),
-        best_loss=min(item.best_loss for item in items),
-        mean_fitness=sum(item.fitness for item in items) / len(items),
-        p95_latency_us=ordered_latency[p95_index],
-        accepted_mutations=sum(item.accepted_mutations for item in items),
+        len(items),
+        max(i.cycle for i in items),
+        sum(i.meta_loss for i in items) / len(items),
+        min(i.best_loss for i in items),
+        sum(i.fitness for i in items) / len(items),
+        p95,
+        sum(i.accepted_mutations for i in items),
     )
 
 
@@ -518,19 +424,10 @@ class SwarmReport:
 
 
 class Swarm800:
-    """Hierarchical 800-instance reference swarm.
-
-    Fusion cadence:
-      - zone: every 10 cycles
-      - region: every 100 cycles
-      - global checkpoint: every 1000 cycles
-    """
-
     def __init__(self, seed: int = 0xDEADBEEF):
-        self.seed = seed
         self.base_rom = SharedROM.deterministic(seed)
         self.instances = [
-            SwarmInstance(instance_id=i, base_rom=self.base_rom, seed=seed ^ (i * 0x9E3779B1))
+            SwarmInstance(i, self.base_rom, seed ^ (i * 0x9E3779B1))
             for i in range(INSTANCE_COUNT)
         ]
         self.cycle = 0
@@ -538,66 +435,52 @@ class Swarm800:
         self.region_states: Dict[int, FusionState] = {}
         self.global_state: Optional[FusionState] = None
         self.global_best_loss = float("inf")
-        self._last_telemetry: List[InstanceTelemetry] = []
         self.validate_topology()
 
     def validate_topology(self) -> None:
-        if len(self.instances) != INSTANCE_COUNT:
-            raise SwarmInvariantError("canonical swarm must contain exactly 800 instances")
-        if INSTANCE_COUNT != REGION_COUNT * ZONES_PER_REGION * INSTANCES_PER_ZONE:
-            raise SwarmInvariantError("hierarchy product does not equal 800")
-        if any(instance.base_rom.manifest_hash != self.base_rom.manifest_hash for instance in self.instances):
-            raise SwarmInvariantError("sealed ROM manifest differs across instances")
-
-    def _zone_slice(self, zone_id: int) -> slice:
-        start = zone_id * INSTANCES_PER_ZONE
-        return slice(start, start + INSTANCES_PER_ZONE)
+        if len(self.instances) != 800 or 800 != 8 * 10 * 10:
+            raise SwarmInvariantError("invalid 800-instance hierarchy")
+        if any(i.base_rom.manifest_hash != self.base_rom.manifest_hash for i in self.instances):
+            raise SwarmInvariantError("base ROM manifest mismatch")
 
     def step(self, mutate: bool = True) -> SwarmReport:
-        telemetry = [instance.step(mutate=mutate) for instance in self.instances]
-        self._last_telemetry = telemetry
+        telemetry = [i.step(mutate) for i in self.instances]
         self.cycle += 1
         current = fuse_telemetry(telemetry)
         self.global_best_loss = min(self.global_best_loss, current.best_loss)
-
         if self.cycle % 10 == 0:
-            for zone_id in range(ZONE_COUNT):
-                self.zone_states[zone_id] = fuse_telemetry(telemetry[self._zone_slice(zone_id)])
-
+            for zone in range(80):
+                start = zone * 10
+                self.zone_states[zone] = fuse_telemetry(telemetry[start:start + 10])
         if self.cycle % 100 == 0:
-            region_width = ZONES_PER_REGION * INSTANCES_PER_ZONE
-            for region_id in range(REGION_COUNT):
-                start = region_id * region_width
-                self.region_states[region_id] = fuse_telemetry(telemetry[start : start + region_width])
-
+            for region in range(8):
+                start = region * 100
+                self.region_states[region] = fuse_telemetry(telemetry[start:start + 100])
         if self.cycle % 1000 == 0:
             self.global_state = current
-
         self.validate_topology()
         return SwarmReport(
-            cycle=self.cycle,
-            instance_count=INSTANCE_COUNT,
-            zone_count=ZONE_COUNT,
-            region_count=REGION_COUNT,
-            current=current,
-            zone_fusions=len(self.zone_states),
-            region_fusions=len(self.region_states),
-            global_fusions=1 if self.global_state is not None else 0,
-            global_best_loss=self.global_best_loss,
-            manifest_hash=self.base_rom.manifest_hash,
+            self.cycle,
+            800,
+            80,
+            8,
+            current,
+            len(self.zone_states),
+            len(self.region_states),
+            int(self.global_state is not None),
+            self.global_best_loss,
+            self.base_rom.manifest_hash,
         )
 
     def run(self, cycles: int, mutate: bool = True) -> SwarmReport:
         if cycles < 1:
             raise ValueError("cycles must be positive")
-        report: Optional[SwarmReport] = None
+        report = None
         for _ in range(cycles):
-            report = self.step(mutate=mutate)
+            report = self.step(mutate)
         assert report is not None
         return report
 
 
 def run_swarm(cycles: int = 1, seed: int = 0xDEADBEEF, mutate: bool = True) -> Dict[str, object]:
-    """Convenience entry point used by the CLI and smoke tests."""
-    swarm = Swarm800(seed=seed)
-    return swarm.run(cycles=cycles, mutate=mutate).to_dict()
+    return Swarm800(seed).run(cycles, mutate).to_dict()

--- a/tests/test_aedsie_engine.py
+++ b/tests/test_aedsie_engine.py
@@ -1,0 +1,100 @@
+import math
+
+from jarvisx.aedsie_engine import (
+    PROGRAM,
+    AEDSIEConfig,
+    AEDSIEVirtualEngine,
+    Mechanics,
+    ResidualAutoencoder,
+    run_aedsie,
+)
+
+
+def test_end_to_end_engine_is_deterministic():
+    first = run_aedsie(cycles=2, inward=True)
+    second = run_aedsie(cycles=2, inward=True)
+
+    assert first["ledger_head"] == second["ledger_head"]
+    assert first["final_cycle"]["state_hash"] == second["final_cycle"]["state_hash"]
+    assert first["final_cycle"]["predicted_class"] == second["final_cycle"]["predicted_class"]
+
+
+def test_program_executes_every_declared_stage():
+    report = AEDSIEVirtualEngine().step()
+
+    assert report.program_trace == PROGRAM
+    assert report.cycle == 1
+    assert len(report.ledger_head) == 64
+    assert len(report.state_hash) == 64
+
+
+def test_field_latent_metric_and_routing_invariants():
+    engine = AEDSIEVirtualEngine()
+    report = engine.step()
+
+    assert len(engine.field) == 4 * 8 * 4
+    assert len(report.routing_weights) == 9
+    assert math.isclose(sum(report.routing_weights), 1.0, rel_tol=0.0, abs_tol=1e-12)
+    assert report.metric_min > 0.0
+    assert report.metric_max >= report.metric_min
+    assert report.reconstruction_mse >= 0.0
+    assert math.isfinite(report.aoa_degrees)
+
+
+def test_ledger_is_parent_chained_and_advances_once_per_commit():
+    engine = AEDSIEVirtualEngine()
+    first = engine.step()
+    second = engine.step()
+
+    assert first.ledger_head != second.ledger_head
+    assert second.ledger_head == engine.ledger.head
+    assert len(engine.ledger.records) == 2
+
+
+def test_inward_turn_never_commits_a_worse_candidate():
+    engine = AEDSIEVirtualEngine()
+    report = engine.step(inward=True)
+
+    if report.inward.accepted:
+        assert report.inward.shadow_cost < report.inward.baseline_cost
+        assert report.mechanics.version == 1
+    else:
+        assert report.mechanics.version == 0
+    assert report.inward.analysis_share <= engine.config.analysis_budget
+    assert report.mechanics.admissible()
+
+
+def test_disabling_inward_turn_preserves_mechanics():
+    engine = AEDSIEVirtualEngine()
+    report = engine.step(inward=False)
+
+    assert not report.inward.attempted
+    assert not report.inward.accepted
+    assert report.mechanics == Mechanics()
+    assert len(engine.mechanics_history) == 1
+
+
+def test_residual_autoencoder_is_finite_and_shape_preserving():
+    autoencoder = ResidualAutoencoder(field_cells=8, latent_dim=4)
+    field = tuple((float(i), float(i % 3), -float(i) / 2.0) for i in range(8))
+
+    latent, base = autoencoder.encode(field)
+    reconstructed = autoencoder.decode(latent, base)
+
+    assert len(latent) == 4
+    assert len(reconstructed) == len(field)
+    assert all(math.isfinite(value) for vector in reconstructed for value in vector)
+
+
+def test_configuration_and_stability_guards():
+    AEDSIEConfig().validate()
+    assert Mechanics().admissible()
+    assert not Mechanics(alpha=2.0, coherence=2.0, dt=1.0).admissible()
+
+    invalid = AEDSIEConfig(fft_bins=64, samples_per_frame=32)
+    try:
+        invalid.validate()
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("invalid FFT configuration was accepted")

--- a/tests/test_self_evolving_rom.py
+++ b/tests/test_self_evolving_rom.py
@@ -1,0 +1,98 @@
+from jarvisx.self_evolving_rom import (
+    Instruction,
+    Opcode,
+    SelfEvolvingROM,
+    SpatialCore,
+    run_self_evolving_rom,
+)
+
+
+def test_instruction_round_trip_is_exact():
+    instruction = Instruction(Opcode.LDC, rs=1, rt=2, ru=3, imm=0x1234, addr=0xBEEF)
+    assert Instruction.unpack(instruction.pack()) == instruction
+
+
+def test_load_encode_fusion_preserves_machine_state():
+    rom = (
+        Instruction(Opcode.LOAD3D, rs=0, addr=0x1000),
+        Instruction(Opcode.ENC, rs=0, rt=2),
+        Instruction(Opcode.HALT),
+    )
+    engine = SelfEvolvingROM(rom)
+    baseline = SpatialCore().run(rom)
+    report = engine.inward_turn()
+    candidate = SpatialCore().run(engine.rom)
+
+    assert report.accepted
+    assert report.rule == "FUSE_LOAD3D_ENC_TO_LDC"
+    assert report.semantic_equal
+    assert candidate.snapshot == baseline.snapshot
+    assert len(engine.rom) == 2
+    assert Opcode(engine.rom[0].opcode) == Opcode.LDC
+
+
+def test_decode_store_fusion_preserves_machine_state():
+    rom = (
+        Instruction(Opcode.LOAD3D, rs=0, addr=0x1000),
+        Instruction(Opcode.ENC, rs=0, rt=2),
+        Instruction(Opcode.DEC, rs=2, rt=3),
+        Instruction(Opcode.STORE3D, rt=3, addr=0x4000),
+        Instruction(Opcode.HALT),
+    )
+    engine = SelfEvolvingROM(rom)
+    engine.inward_turn()  # First remove LOAD3D + ENC.
+    baseline = SpatialCore().run(engine.rom)
+    report = engine.inward_turn()
+    candidate = SpatialCore().run(engine.rom)
+
+    assert report.accepted
+    assert report.rule == "FUSE_DEC_STORE3D_TO_DSM"
+    assert candidate.snapshot == baseline.snapshot
+    assert any(Opcode(i.opcode) == Opcode.DSM for i in engine.rom)
+
+
+def test_non_adjacent_operations_are_not_illegally_fused():
+    rom = (
+        Instruction(Opcode.LOAD3D, rs=0, addr=0x1000),
+        Instruction(Opcode.LOAD3D, rs=1, addr=0x2000),
+        Instruction(Opcode.ENC, rs=0, rt=2),
+        Instruction(Opcode.HALT),
+    )
+    engine = SelfEvolvingROM(rom)
+    report = engine.inward_turn()
+
+    assert not report.accepted
+    assert report.rule == "FIXED_POINT"
+    assert len(engine.rom) == 4
+
+
+def test_demo_rom_reaches_rule_set_fixed_point_at_six_instructions():
+    result = run_self_evolving_rom(max_epochs=8)
+
+    assert result["locked"] is True
+    assert result["rom_length"] == 6
+    assert [epoch["rule"] for epoch in result["epochs"]] == [
+        "FUSE_LOAD3D_ENC_TO_LDC",
+        "FUSE_DEC_STORE3D_TO_DSM",
+        "FIXED_POINT",
+    ]
+    assert len(result["versions"]) == 3
+    assert all(epoch["semantic_equal"] for epoch in result["epochs"])
+
+
+def test_version_chain_is_parent_linked_and_manifested():
+    result = run_self_evolving_rom(max_epochs=8)
+    versions = result["versions"]
+
+    assert versions[0]["parent_hash"] == "0" * 64
+    assert versions[1]["parent_hash"] == versions[0]["manifest_hash"]
+    assert versions[2]["parent_hash"] == versions[1]["manifest_hash"]
+    assert len({version["manifest_hash"] for version in versions}) == len(versions)
+
+
+def test_analysis_budget_never_exceeds_half_of_measured_cycles():
+    result = run_self_evolving_rom(max_epochs=8)
+    accepted = [epoch for epoch in result["epochs"] if epoch["accepted"]]
+
+    assert accepted
+    assert all(epoch["analysis_share"] <= 0.5 for epoch in accepted)

--- a/tests/test_swarm800.py
+++ b/tests/test_swarm800.py
@@ -1,0 +1,97 @@
+import math
+
+import pytest
+
+from jarvisx.swarm800 import (
+    AGE_MAX,
+    INSTANCE_COUNT,
+    PIPELINE_LATENCY_US,
+    ROM_BYTES,
+    SVI,
+    SVICodec,
+    SharedROM,
+    Swarm800,
+    SwarmInstance,
+    next_pc,
+    pc_to_xyz,
+    q_div,
+    q_from_float,
+    q_mul,
+    q_to_float,
+    xyz_to_pc,
+)
+
+
+def test_q88_round_trip_and_arithmetic():
+    a = q_from_float(1.5)
+    b = q_from_float(-2.0)
+    assert q_to_float(a) == 1.5
+    assert q_to_float(q_mul(a, b)) == -3.0
+    assert q_to_float(q_div(a, q_from_float(0.5))) == 3.0
+    with pytest.raises(ZeroDivisionError):
+        q_div(a, 0)
+
+
+def test_svi_is_exactly_128_bits_and_round_trips():
+    instruction = SVI(
+        opcode=255,
+        flags=3,
+        x=-2048,
+        y=2047,
+        z=-1,
+        operand=0xDEADBEEF,
+        edge_fingerprint=0x12345678,
+        age_timer=AGE_MAX,
+    )
+    payload = instruction.to_bytes()
+    assert len(payload) == 16
+    assert SVI.from_bytes(payload) == instruction
+
+
+def test_exact_128_dimensional_latent_codec():
+    instruction = SVI(opcode=17, x=3, y=2, z=1, operand=42)
+    latent = SVICodec.encode(instruction)
+    assert len(latent) == 128
+    assert SVICodec.decode(latent) == instruction
+
+
+def test_rom_geometry_is_8_by_8_by_4():
+    for pc in range(0, ROM_BYTES, 16):
+        assert xyz_to_pc(*pc_to_xyz(pc)) == pc
+    assert pc_to_xyz(ROM_BYTES - 16) == (7, 7, 3)
+
+
+def test_pc_stride_is_16_bytes():
+    assert next_pc(0) == 16
+    assert next_pc(16, branch=True, instruction_offset=2) == 64
+
+
+def test_instance_safe_mutation_never_changes_protected_fields():
+    rom = SharedROM.deterministic(1)
+    instance = SwarmInstance(0, rom, seed=2)
+    original = rom.fetch(0, {})
+    instance.step(mutate=True)
+    changed = instance.patches[0]
+    assert changed.opcode == original.opcode
+    assert changed.flags == original.flags
+    assert (changed.x, changed.y, changed.z) == (original.x, original.y, original.z)
+    assert changed.age_timer == min(AGE_MAX, original.age_timer + 1)
+
+
+def test_canonical_hierarchy_and_zone_fusion():
+    swarm = Swarm800(seed=3)
+    assert len(swarm.instances) == INSTANCE_COUNT
+    report = swarm.run(cycles=10, mutate=False)
+    assert report.zone_count == 80
+    assert report.region_count == 8
+    assert report.zone_fusions == 80
+    assert report.region_fusions == 0
+    assert report.current.count == 800
+    assert math.isclose(report.current.p95_latency_us, PIPELINE_LATENCY_US)
+
+
+def test_best_checkpoint_loss_is_monotonic():
+    swarm = Swarm800(seed=4)
+    first = swarm.step(mutate=False).global_best_loss
+    second = swarm.step(mutate=False).global_best_loss
+    assert second <= first


### PR DESCRIPTION
## What changed

This draft PR operationalises the current Jarvis X mathematical reference stack against `main`.

### 800-instance spatial runtime

- deterministic `Swarm800` control-plane runtime with 800 instances, 80 zones, and 8 regions
- corrected Q8.8 arithmetic and exact 128-bit SVI packing
- 4 KiB ROM mapped to an 8 x 8 x 4 instruction geometry
- protected copy-on-write mutation, cadence fusion, manifests, and hash chains
- repaired pytest configuration, ledger serialization, and reflex execution ordering

### Bounded Self-Evolving ROM

- deterministic 64-bit SER execution core
- `LDC` (`LOAD3D + ENC`) and `DSM` (`DEC + STORE3D`) macro-ops
- adjacent, dependency-compatible fusion only
- baseline-versus-shadow execution from the same deterministic snapshot
- publication only when final machine state is exactly equal, static and dynamic cost decrease, and analysis share remains at or below 50 percent
- immutable parent-linked ROM versions using SHA-256 manifests

### AEDSIE-Sigma end-to-end virtual engine

- deterministic synthetic multi-emitter RF acquisition
- digital downconversion, Hann windowing, and channelisation
- 4 x 8 x 4 x 3 electromagnetic signal tensor
- finite-difference Dr Moagi 3D operator using Laplacian, curl, gradient-divergence, and local residual terms
- residual autoencoder with explicit baseband skip and tied adjoint cosine projection
- reconstruction residual and persistent Omega correction
- positive diagonal Riemannian metric evolution
- nine deterministic expert projections with temperature-controlled routing
- narrowband angle-of-arrival projection
- SHA3-256 canonical state sealing and parent-linked ledger
- one-candidate bounded inward mechanics optimisation with stability and objective gates
- complete auto-executing stage trace from RF acquisition through transactional commit

## Commands

```bash
jarvisx swarm 1
jarvisx swarm 10 --no-mutate
jarvisx ser 8
jarvisx aedsie 4
jarvisx aedsie 4 --no-inward
```

## Mathematical execution contract

Each AEDSIE cycle executes:

```text
ACQUIRE_RF
  -> DDC_CHANNELIZE
  -> TENSORIZE_3D
  -> DR_MOAGI_OPERATOR
  -> ENCODE_RESIDUAL
  -> DECODE_RESIDUAL
  -> COMPARE
  -> UPDATE_OMEGA
  -> INWARD_SHADOW
  -> PROJECT_MANIFOLD
  -> ROUTE_EXPERTS
  -> ESTIMATE_AOA
  -> SEAL_SHA3
  -> COMMIT
```

A mechanics candidate is accepted only when its shadow objective is lower than the baseline, all state values are finite, the conservative explicit-step stability gate passes, and analysis share does not exceed the configured budget. Rejected candidates cannot mutate committed state.

## Scope boundary

The implementation is a deterministic CPU reference engine for semantics, replay, provenance, and backend conformance. It does not claim measured 1 GSPS hardware operation, exact lossless compression over arbitrary fields, empirical SOTA expert performance, or an FPGA timing/power result.

## Validation

GitHub Actions run 326 completed successfully. The passing matrix covers:

- Python 3.8, 3.9, 3.10, 3.11, and 3.12
- the complete pytest suite and coverage generation
- flake8
- mypy
- Black
- isort
- Codecov upload

Dedicated AEDSIE tests verify deterministic replay, complete stage execution, positive metric invariants, normalized expert routing, ledger chaining, bounded inward acceptance, disabled-inward immutability, shape-preserving finite reconstruction, and configuration/stability rejection.