### PR TITLE
Permeate VM-integrated 3D visual memory and MM3D Omega4 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control
+layer, policy gate, transactional ledger, and an experimental 3D geometric
+visual-memory subsystem.
 
 ## Install
 
@@ -12,28 +13,42 @@ pip install -r requirements.txt
 pip install .
 ```
 
-## 3D visual-memory permeation
+## Unified execution model
 
-Jarvis-X now includes a dependency-free reference implementation of a
-transactional 3D visual-memory ANN. It encodes a scalar voxel volume into a
-compact geometric latent lattice, recalls associative memory, recursively
-projects reconstruction residuals back into the latent field, decodes the
-result, and evaluates a bounded set of mechanics candidates.
+The VM is the authoritative control plane. Bytecode and geometric operations
+both pass through policy, journaling, and trace boundaries.
 
 ```text
-Volume3D
-  -> GeometricCodec.encode
-  -> LatentField
-  -> SpatialMemory.read/write
-  -> recursive residual refinement
-  -> GeometricCodec.decode
-  -> objective and mechanics gate
+Assembly -> Parser -> Assembler -> CodexVM -> Registers / Ledger / Trace
+                                      |
+                                      +-> V3D.PERMEATE
+                                           |
+Volume3D -> GeometricCodec -> LatentField -> SpatialMemory
+                                           |
+                                  spatial residual refinement
+                                           |
+                                     reconstruction
+                                           |
+                                bounded candidate commit
 ```
 
-The optimiser does not rewrite arbitrary source code. Every candidate is a
-validated `GeometricConfig`, every candidate runs from the same memory snapshot,
-and a change is committed only when its measured reconstruction-plus-compute
-objective improves over the baseline.
+## 3D visual-memory permeation
+
+The current 3D module is a deterministic reference state-transition kernel. It
+is ANN-compatible, but it is not yet a trained neural network: encoding,
+decoding, associative recall, and residual projection are explicit mathematical
+operators rather than learned weights.
+
+The runtime:
+
+- encodes scalar voxel data into a compact geometric latent lattice;
+- recalls finite content-addressed memory;
+- decodes a reconstruction;
+- projects each spatial residual region back into its corresponding latent cell;
+- evaluates a bounded set of validated mechanics candidates from identical
+  memory snapshots;
+- commits only a strictly improved reconstruction-plus-compute objective;
+- journals every candidate measurement and the selected VM-authoritative event.
 
 Run the deterministic demonstration:
 
@@ -41,6 +56,35 @@ Run the deterministic demonstration:
 jarvisx visual-memory 12
 ```
 
-The command emits JSON containing the selected mechanics, reconstruction loss,
-estimated operation count, candidate count, and auditable latent-refinement
+The command emits JSON containing selected mechanics, reconstruction loss,
+estimated operation count, all candidate objectives, and numerical refinement
 telemetry.
+
+## Local API and dashboard
+
+Jarvis-X uses its declared FastAPI/Uvicorn stack:
+
+```bash
+jarvisx api   # http://127.0.0.1:8080
+jarvisx web   # http://127.0.0.1:5000
+```
+
+Available API routes include:
+
+```text
+GET  /health
+POST /run
+POST /visual-memory
+```
+
+These development servers bind to loopback by default. Production exposure
+requires an external authentication, authorisation, TLS, rate-limiting, and
+process-isolation boundary.
+
+## Invariants
+
+1. Equal initial state and input must produce equal geometric results.
+2. Candidate mechanics must start from identical memory snapshots.
+3. A candidate cannot commit unless its declared objective improves.
+4. Geometric execution can be blocked by the Lambda policy gate.
+5. Acceleration may change mechanics; it may not silently change semantics.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Jarvis-X
 
 Jarvis-X is a deterministic, auditable virtual machine with a reflex control
-layer, policy gate, transactional ledger, and an experimental 3D geometric
-visual-memory subsystem.
+layer, policy gate, transactional ledger, and experimental 3D geometric and
+multimodal reference runtimes.
 
 ## Install
 
@@ -15,21 +15,25 @@ pip install .
 
 ## Unified execution model
 
-The VM is the authoritative control plane. Bytecode and geometric operations
-both pass through policy, journaling, and trace boundaries.
+The VM is the authoritative control plane. Bytecode, geometric reconstruction,
+and MM3D multimodal cycles pass through policy, journaling, and trace boundaries.
 
 ```text
 Assembly -> Parser -> Assembler -> CodexVM -> Registers / Ledger / Trace
                                       |
                                       +-> V3D.PERMEATE
-                                           |
-Volume3D -> GeometricCodec -> LatentField -> SpatialMemory
-                                           |
-                                  spatial residual refinement
-                                           |
-                                     reconstruction
-                                           |
-                                bounded candidate commit
+                                      |      |
+                                      |   spatial visual memory
+                                      |
+                                      +-> MM3D.CYCLE
+                                             |
+                                  Z8 QCA -> factorized metric
+                                             |
+                                  geometric VQ encode/decode
+                                             |
+                                  classical bounded exploration
+                                             |
+                                      Lambda -> Omega -> Theta
 ```
 
 ## 3D visual-memory permeation
@@ -56,9 +60,46 @@ Run the deterministic demonstration:
 jarvisx visual-memory 12
 ```
 
-The command emits JSON containing selected mechanics, reconstruction loss,
-estimated operation count, all candidate objectives, and numerical refinement
-telemetry.
+## MM3D-AED-BCE-Ω⁴ operational kernel
+
+`src/jarvisx/mm3d_omega4.py` preserves the intended continuous cycle:
+
+```text
+Psi input
+  -> Z8 quantized cellular substrate
+  -> factorized geometric encoder
+  -> vector-quantized 3D latent code
+  -> bounded classical Phi-QAS exploration
+  -> geometric decoder
+  -> Lambda projection
+  -> deterministic Omega hash chain
+  -> bounded text/image/audio/video projections
+```
+
+The operational profile deliberately separates declared scaling targets from
+allocated runtime state:
+
+- `50T` remains a conceptual total-parameter target;
+- `0.5%` active means `250B`, not `500B`;
+- the default reference engine allocates a small, reported NumPy model;
+- configuration validation rejects profiles above the declared memory guard;
+- the 13.7 ms cycle goal is reported as a measured target, never assumed true.
+
+The voxel layout is exactly 384 bits: 16 token bytes, 12 visual bytes, 8 audio
+bytes, 6 motion bytes, one float32 attention weight, and two flag bytes. The
+Xi-cube is a contiguous NumPy structured array rather than millions of Python
+objects.
+
+Run one VM-authoritative cycle:
+
+```bash
+jarvisx mm3d-cycle
+jarvisx mm3d-cycle 65536
+```
+
+The command reports actual parameter count, conceptual parameter targets,
+allocated bytes, latent and projection shapes, Omega head, state hash, measured
+cycle time, and whether the 13.7 ms target was met.
 
 ## Local API and dashboard
 
@@ -75,6 +116,7 @@ Available API routes include:
 GET  /health
 POST /run
 POST /visual-memory
+POST /mm3d-cycle
 ```
 
 These development servers bind to loopback by default. Production exposure
@@ -83,8 +125,10 @@ process-isolation boundary.
 
 ## Invariants
 
-1. Equal initial state and input must produce equal geometric results.
+1. Equal initial state and input must produce equal reference results.
 2. Candidate mechanics must start from identical memory snapshots.
 3. A candidate cannot commit unless its declared objective improves.
-4. Geometric execution can be blocked by the Lambda policy gate.
-5. Acceleration may change mechanics; it may not silently change semantics.
+4. Geometric and MM3D execution can be blocked by the Lambda policy gate.
+5. Conceptual capacity must not be represented as physically allocated capacity.
+6. Classical Phi-QAS exploration must not be represented as quantum execution.
+7. Acceleration may change mechanics; it may not silently change semantics.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ These development servers bind to loopback by default. Production exposure
 requires an external authentication, authorisation, TLS, rate-limiting, and
 process-isolation boundary.
 
+## Validation
+
+The final permeation head passed GitHub Actions run `29700812842` across Python
+3.8, 3.9, 3.10, 3.11, and 3.12, together with pytest, coverage, mypy, Black, and
+isort.
+
 ## Invariants
 
 1. Equal initial state and input must produce equal reference results.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ The command reports actual parameter count, conceptual parameter targets,
 allocated bytes, latent and projection shapes, Omega head, state hash, measured
 cycle time, and whether the 13.7 ms target was met.
 
+The dimensional, memory, ledger, rendering, and distributed-execution corrections
+are documented in `docs/MM3D_OMEGA4_OPERATIONAL_AUDIT.md`.
+
 ## Local API and dashboard
 
 Jarvis-X uses its declared FastAPI/Uvicorn stack:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,43 @@ Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## 3D visual-memory permeation
+
+Jarvis-X now includes a dependency-free reference implementation of a
+transactional 3D visual-memory ANN. It encodes a scalar voxel volume into a
+compact geometric latent lattice, recalls associative memory, recursively
+projects reconstruction residuals back into the latent field, decodes the
+result, and evaluates a bounded set of mechanics candidates.
+
+```text
+Volume3D
+  -> GeometricCodec.encode
+  -> LatentField
+  -> SpatialMemory.read/write
+  -> recursive residual refinement
+  -> GeometricCodec.decode
+  -> objective and mechanics gate
+```
+
+The optimiser does not rewrite arbitrary source code. Every candidate is a
+validated `GeometricConfig`, every candidate runs from the same memory snapshot,
+and a change is committed only when its measured reconstruction-plus-compute
+objective improves over the baseline.
+
+Run the deterministic demonstration:
+
+```bash
+jarvisx visual-memory 12
+```
+
+The command emits JSON containing the selected mechanics, reconstruction loss,
+estimated operation count, candidate count, and auditable latent-refinement
+telemetry.

--- a/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
@@ -1,61 +1,65 @@
-# Dr Moagi 3D Visual Image Memory ANN Runtime
+# Dr Moagi 3D Visual Image Memory Runtime
 
 ## Status
 
-Executable reference permeation for Jarvis-X. The implementation lives in
-`src/jarvisx/geometric_memory.py` and is deliberately dependency-free,
-deterministic, bounded, and auditable.
+Executable deterministic reference semantics for Jarvis-X. The implementation
+lives in `src/jarvisx/geometric_memory.py` and is bounded, auditable, and
+integrated into the authoritative `CodexVM` control plane.
 
-It converts the earlier conceptual Encoder -> Memory -> Recursive Refinement ->
-Decoder architecture into a runnable geometric state-transition system.
+The module is ANN-compatible but is not yet a trained neural network. Its
+encoder, decoder, memory addressing, and residual update are explicit
+mathematical operators. Future tensor, GPU, and learned implementations must be
+verified against these reference semantics.
 
 ---
 
-## 1. State
+## 1. Unified state
 
-Let the observed 3D image be a scalar voxel field:
-
-\[
-X_t \in [0,1]^{D\times H\times W}.
-\]
-
-The compact geometric latent state is:
+Let the observed 3D image be:
 
 \[
-Z_t \in \mathbb{R}^{d\times h\times w\times c}.
+X_t\in[0,1]^{D\times H\times W}.
 \]
 
-The associative memory is a finite set of key-value slots:
+The compact latent state is:
+
+\[
+Z_t\in\mathbb R^{d\times h\times w\times c}.
+\]
+
+The finite associative memory is:
 
 \[
 \Omega_t=\{(k_i,v_i,u_i)\}_{i=1}^{S},
 \]
 
-where `u_i` is a deterministic usage counter.
-
-The mechanics state is the validated configuration:
+and the validated mechanics state is:
 
 \[
 \mathcal M_t=(d,h,w,c,S,K,\eta,\beta,\gamma,L_{max},\lambda_C).
 \]
 
-The fields respectively specify latent geometry, channel count, memory slots,
-refinement steps, learning rate, residual gain, memory gain, projection bound,
-and compute-cost weight.
+The VM-authoritative state includes bytecode execution and geometry:
+
+\[
+\Sigma_t=(R_t,M_t,PC_t,Z_t,\Omega_t,\mathcal M_t,J_t).
+\]
+
+A geometric transaction is identified as `V3D.PERMEATE`; it can be denied by
+the Lambda policy gate and is written to the VM ledger and tracer after a
+successful commit.
 
 ---
 
 ## 2. Geometric encoding
 
-The source volume is partitioned into a compact 3D lattice. Each latent cell
-encodes local mean intensity, variance, three directional gradients, radial
-position, and deterministic higher-channel mixtures:
+The source volume is partitioned into a compact 3D lattice. For every latent
+coordinate `p`, the associated source region `R_p` contributes local mean,
+variance, directional differences, and radial position:
 
 \[
 Z_0=E_G(X_t).
 \]
-
-For a source region `R_p` associated with latent coordinate `p`:
 
 \[
 \mu_p=\frac{1}{|R_p|}\sum_{x\in R_p}X_t(x),
@@ -63,65 +67,74 @@ For a source region `R_p` associated with latent coordinate `p`:
 \sigma_p^2=\frac{1}{|R_p|}\sum_{x\in R_p}(X_t(x)-\mu_p)^2.
 \]
 
-The first latent channel preserves coarse image intensity as `2 mu - 1`; the
-remaining channels preserve local geometric variation.
+The first channel preserves coarse intensity as `2 mu - 1`; remaining channels
+preserve local variation and deterministic higher-channel mixtures.
 
 ---
 
-## 3. Associative visual memory
+## 3. Associative memory
 
-A global query is formed by averaging the latent vectors:
+A global scene query is currently formed by averaging latent vectors:
 
 \[
 q_k=\frac{1}{dhw}\sum_p Z_k(p).
 \]
 
-Memory attention is cosine similarity with deterministic softmax weighting:
+Retrieval uses cosine similarity with an anti-monopoly usage penalty:
 
 \[
-a_i=\operatorname{softmax}_i\left(4\cos(q_k,k_i)+0.05u_i\right).
+a_i=\operatorname{softmax}_i\left(4\cos(q_k,k_i)-0.05u_i\right).
 \]
 
-The recalled vector is:
+The recalled correction is:
 
 \[
 r_k=\sum_i a_i v_i.
 \]
 
-The selected memory slot is updated by a bounded interpolation rather than an
-unconstrained overwrite.
+The negative usage term prevents repeatedly selected slots from acquiring an
+unbounded positive-selection advantage. Keys and values are updated through
+bounded interpolation rather than unconstrained replacement.
 
 ---
 
-## 4. Recursive latent refinement
+## 4. Spatial residual permeation
 
-The decoder produces a reconstructed voxel volume:
+The decoder produces:
 
 \[
 \hat X_k=D_G(Z_k).
 \]
 
-The residual is:
+The full residual field is retained:
 
 \[
-E_k=X^\star-\hat X_k.
+E_k(z,y,x)=X^\star(z,y,x)-\hat X_k(z,y,x).
 \]
 
-The reference implementation uses a deterministic residual summary and memory
-correction to update every latent vector:
+The residual encoder partitions this field using the same geometric map as the
+source encoder:
+
+\[
+\Delta Z_k(p)=E_G^{res}\left(E_k|_{R_p}\right).
+\]
+
+Each latent cell is updated from its own spatial residual rather than one global
+mean:
 
 \[
 Z_{k+1}(p)=\Pi_{[-L_{max},L_{max}]}
 \left[
-Z_k(p)+\eta\left(\beta\bar E_k+\gamma(r_k-Z_k(p))\right)
+Z_k(p)+\eta\left(
+\beta\Delta Z_k(p)+\gamma(r_k-Z_k(p))
+\right)
 \right].
 \]
 
-This is the executable inward turn: the system reconstructs its input, measures
-its own error, projects correction back into its geometric latent state, consults
-memory, and repeats.
+This prevents positive and negative errors in unrelated regions from cancelling
+before correction reaches the latent geometry.
 
-The implementation records numerical telemetry for each refinement step:
+Every refinement step records numerical telemetry:
 
 - reconstruction loss;
 - latent norm;
@@ -129,20 +142,19 @@ The implementation records numerical telemetry for each refinement step:
 - recalled-memory norm;
 - selected memory slot.
 
-These records are auditable latent-state telemetry. They are not textual private
-chain-of-thought traces.
+These values are auditable state telemetry, not textual private reasoning.
 
 ---
 
-## 5. Bounded self-optimisation
+## 5. Bounded inward optimisation
 
-Jarvis-X does not permit arbitrary source-code mutation through this runtime.
-The admissible candidate set is finite and declared. Current candidates vary:
+The runtime does not permit arbitrary source-code mutation. It evaluates a
+finite declared candidate set that may adjust:
 
-- learning rate down;
-- learning rate up;
+- learning rate down or up;
 - residual gain up;
-- one additional refinement step, provided the configured maximum is not crossed.
+- memory gain down or up;
+- refinement depth by one step within the configured maximum.
 
 Every candidate starts from an identical memory snapshot. Candidate cost is:
 
@@ -150,16 +162,10 @@ Every candidate starts from an identical memory snapshot. Candidate cost is:
 J(\mathcal M)=L_{recon}(\mathcal M)+\lambda_C\widehat C(\mathcal M),
 \]
 
-where:
+with:
 
 \[
 L_{recon}=\frac{1}{DHW}\|X^\star-\hat X\|_2^2.
-\]
-
-The deterministic operation estimate is:
-
-\[
-\widehat C= DHW(2c+3)+K(dhw)c(S+8).
 \]
 
 A mechanics change is committed only when:
@@ -168,12 +174,12 @@ A mechanics change is committed only when:
 J(\mathcal M')<J(\mathcal M_t).
 \]
 
-Ties preserve the baseline. The selected measurement is appended to the local
-optimisation journal.
+Ties preserve the baseline. The journal stores all candidate measurements for
+the experiment, not merely the winner.
 
 ---
 
-## 6. Transactional permeation cycle
+## 6. Transactional cycle
 
 ```text
 OBSERVE_VOLUME
@@ -184,18 +190,20 @@ FOR EACH CANDIDATE:
     RESTORE_IDENTICAL_MEMORY_SNAPSHOT
     RECALL_ASSOCIATIVE_MEMORY
     DECODE_VOLUME
-    COMPUTE_RESIDUAL
-    PROJECT_RESIDUAL_INTO_LATENT
+    COMPUTE_SPATIAL_RESIDUAL_FIELD
+    ENCODE_RESIDUAL_PER_LATENT_REGION
     UPDATE_MEMORY_SLOT
-    PROJECT_LATENT_BOUNDS
+    PROJECT_EACH_LATENT_CELL
     MEASURE_RECONSTRUCTION_AND_COST
 SELECT_MINIMUM_VALID_OBJECTIVE
+POLICY_CHECK_V3D_PERMEATE
 COMMIT_CONFIG_AND_MEMORY
-JOURNAL_MEASUREMENT
+JOURNAL_ALL_CANDIDATES
+WRITE_VM_LEDGER_AND_TRACE
 RETURN_RECONSTRUCTION_AND_TELEMETRY
 ```
 
-This operationally instantiates:
+This instantiates:
 
 \[
 \boxed{
@@ -204,66 +212,76 @@ This operationally instantiates:
 }
 \]
 
-with `Pi_Lambda` implemented through configuration validation, latent bounds,
-finite candidate enumeration, identical shadow snapshots, objective comparison,
-and conservative commit semantics.
+through validation, projection bounds, identical shadow snapshots, objective
+comparison, policy control, and conservative commit semantics.
 
 ---
 
-## 7. Cloud execution mapping
+## 7. Interfaces and isolation
 
-The current implementation is a portable reference kernel, not a high-throughput
-GPU trainer. Its contracts map directly onto a distributed cloud runtime:
+The CLI routes 3D execution through `CodexVM.run_visual_memory`. The FastAPI
+surface exposes:
 
-| Reference object | Cloud/GPU implementation |
-|---|---|
-| `Volume3D` | object-store chunk, Zarr/N5 volume, sparse voxel brick |
-| `LatentField` | sharded GPU tensor or 3D texture |
-| `SpatialMemory` | replicated key-value tensor or vector-memory service |
-| candidate snapshot | immutable checkpoint/object-store version |
-| candidate run | isolated GPU job, pod, or serverless accelerator task |
-| measurement | metrics stream and optimisation journal |
-| commit | atomic configuration pointer update |
+```text
+GET  /health
+POST /run
+POST /visual-memory
+```
 
-Candidate runs are embarrassingly parallel because they begin from the same
-snapshot. The commit gate remains serial and authoritative.
+Each HTTP or TCP request uses an isolated VM and in-memory ledger. Development
+servers bind to `127.0.0.1` by default. Production exposure still requires an
+external authentication, authorisation, TLS, rate-limiting, and process
+isolation boundary.
 
 ---
 
 ## 8. Verification
 
-`tests/test_geometric_memory.py` verifies:
+The test suite verifies:
 
 1. volume indexing and exact self-MSE;
 2. deterministic equality from identical initial state;
-3. output shape, latent shape, trace length, numerical finiteness, and voxel bounds;
-4. bounded candidate count, refinement-step ceiling, journal creation, and
-   non-regression of the selected objective relative to baseline.
-
-The CLI demonstration is:
-
-```bash
-jarvisx visual-memory 12
-```
-
-It returns the selected mechanics and the complete numerical refinement trace as
-JSON.
+3. shape, trace, finiteness, and voxel bounds;
+4. bounded candidate count and non-regression against baseline;
+5. full-candidate experiment journaling;
+6. spatial residual locality;
+7. repeated VM program execution after HALT;
+8. VM ledger and trace integration for `V3D.PERMEATE`;
+9. policy denial of geometric execution;
+10. FastAPI route integrity.
 
 ---
 
-## 9. Next executable progression
+## 9. Cloud and learned progression
 
-The reference runtime establishes semantics before acceleration. The next
-implementation layers should preserve this API while replacing kernels in order:
+The current kernel is a portable semantic oracle, not a high-throughput trainer.
+Its contracts map to future infrastructure as follows:
+
+| Reference object | Accelerated implementation |
+|---|---|
+| `Volume3D` | dense tensor, Zarr/N5 chunk, sparse voxel brick |
+| `LatentField` | sharded GPU tensor or 3D texture |
+| `SpatialMemory` | batched key-value tensor or memory service |
+| candidate snapshot | immutable checkpoint version |
+| candidate run | isolated GPU worker |
+| candidate journal | metrics and provenance stream |
+| commit | atomic authoritative configuration pointer |
+
+The progression order is:
 
 1. NumPy vectorisation;
-2. PyTorch/JAX differentiable residual projection;
-3. sparse voxel or Gaussian-splat input adapters;
-4. 3D Fourier-domain loss;
-5. GPU candidate batching;
-6. object-store checkpoints and cloud worker orchestration;
-7. visual WebGPU telemetry for the latent lattice and memory attention field.
+2. PyTorch or JAX differentiable spatial residual projection;
+3. learned encoder, decoder, and local memory attention;
+4. sparse voxel and Gaussian-splat adapters;
+5. 3D Fourier, gradient, and topology losses;
+6. GPU candidate batching;
+7. object-store checkpoints and cloud worker orchestration;
+8. WebGPU visual telemetry.
 
-The invariant is that acceleration may change mechanics, but it may not silently
-change the declared semantic, numerical, determinism, resource, or commit
-contract.
+The invariant is:
+
+\[
+\boxed{
+\text{Acceleration may change mechanics; it may not silently change meaning.}
+}
+\]

--- a/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
@@ -1,65 +1,68 @@
-# Dr Moagi 3D Visual Image Memory Runtime
+# Dr Moagi 3D Visual Image Memory ANN Runtime
 
 ## Status
 
-Executable deterministic reference semantics for Jarvis-X. The implementation
-lives in `src/jarvisx/geometric_memory.py` and is bounded, auditable, and
-integrated into the authoritative `CodexVM` control plane.
+Executable reference permeation for Jarvis-X. The implementation lives in
+`src/jarvisx/geometric_memory.py` and is deliberately dependency-free,
+deterministic, bounded, and auditable.
 
-The module is ANN-compatible but is not yet a trained neural network. Its
-encoder, decoder, memory addressing, and residual update are explicit
-mathematical operators. Future tensor, GPU, and learned implementations must be
-verified against these reference semantics.
+It converts the earlier conceptual Encoder -> Memory -> Recursive Refinement ->
+Decoder architecture into a runnable geometric state-transition system.
+
+The complementary multimodal `MM3D-AED-BCE-Ω⁴` reference kernel lives in
+`src/jarvisx/mm3d_omega4.py`. It adds an exact 384-bit voxel layout, a mod-8
+cellular substrate, factorized geometric VQ encoding, bounded classical latent
+exploration, Lambda projection, an Omega hash chain, Theta projections, and
+partitioned cloud-worker semantics. Its detailed arithmetic audit is in
+`docs/MM3D_OMEGA4_OPERATIONAL_AUDIT.md`.
 
 ---
 
-## 1. Unified state
+## 1. State
 
-Let the observed 3D image be:
-
-\[
-X_t\in[0,1]^{D\times H\times W}.
-\]
-
-The compact latent state is:
+Let the observed 3D image be a scalar voxel field:
 
 \[
-Z_t\in\mathbb R^{d\times h\times w\times c}.
+X_t \in [0,1]^{D\times H\times W}.
 \]
 
-The finite associative memory is:
+The compact geometric latent state is:
+
+\[
+Z_t \in \mathbb{R}^{d\times h\times w\times c}.
+\]
+
+The associative memory is a finite set of key-value slots:
 
 \[
 \Omega_t=\{(k_i,v_i,u_i)\}_{i=1}^{S},
 \]
 
-and the validated mechanics state is:
+where `u_i` is a deterministic usage counter.
+
+The mechanics state is the validated configuration:
 
 \[
 \mathcal M_t=(d,h,w,c,S,K,\eta,\beta,\gamma,L_{max},\lambda_C).
 \]
 
-The VM-authoritative state includes bytecode execution and geometry:
-
-\[
-\Sigma_t=(R_t,M_t,PC_t,Z_t,\Omega_t,\mathcal M_t,J_t).
-\]
-
-A geometric transaction is identified as `V3D.PERMEATE`; it can be denied by
-the Lambda policy gate and is written to the VM ledger and tracer after a
-successful commit.
+The fields respectively specify latent geometry, channel count, memory slots,
+refinement steps, learning rate, residual gain, memory gain, projection bound,
+and compute-cost weight.
 
 ---
 
 ## 2. Geometric encoding
 
-The source volume is partitioned into a compact 3D lattice. For every latent
-coordinate `p`, the associated source region `R_p` contributes local mean,
-variance, directional differences, and radial position:
+The source volume is partitioned into a compact 3D lattice. Each latent cell
+encodes local mean intensity, variance, three directional gradients, radial
+position, and deterministic higher-channel mixtures:
 
 \[
 Z_0=E_G(X_t).
 \]
+
+For a source region `R_p` associated with latent coordinate `p`:
 
 \[
 \mu_p=\frac{1}{|R_p|}\sum_{x\in R_p}X_t(x),
@@ -67,74 +70,72 @@ Z_0=E_G(X_t).
 \sigma_p^2=\frac{1}{|R_p|}\sum_{x\in R_p}(X_t(x)-\mu_p)^2.
 \]
 
-The first channel preserves coarse intensity as `2 mu - 1`; remaining channels
-preserve local variation and deterministic higher-channel mixtures.
+The first latent channel preserves coarse image intensity as `2 mu - 1`; the
+remaining channels preserve local geometric variation.
 
 ---
 
-## 3. Associative memory
+## 3. Associative visual memory
 
-A global scene query is currently formed by averaging latent vectors:
+A global query is formed by averaging the latent vectors:
 
 \[
 q_k=\frac{1}{dhw}\sum_p Z_k(p).
 \]
 
-Retrieval uses cosine similarity with an anti-monopoly usage penalty:
+Memory attention is cosine similarity with deterministic softmax weighting and
+an anti-monopoly usage penalty:
 
 \[
 a_i=\operatorname{softmax}_i\left(4\cos(q_k,k_i)-0.05u_i\right).
 \]
 
-The recalled correction is:
+The recalled vector is:
 
 \[
 r_k=\sum_i a_i v_i.
 \]
 
-The negative usage term prevents repeatedly selected slots from acquiring an
-unbounded positive-selection advantage. Keys and values are updated through
-bounded interpolation rather than unconstrained replacement.
+The selected memory slot is updated by a bounded interpolation rather than an
+unconstrained overwrite.
 
 ---
 
-## 4. Spatial residual permeation
+## 4. Recursive latent refinement
 
-The decoder produces:
+The decoder produces a reconstructed voxel volume:
 
 \[
 \hat X_k=D_G(Z_k).
 \]
 
-The full residual field is retained:
+The spatial residual is:
 
 \[
 E_k(z,y,x)=X^\star(z,y,x)-\hat X_k(z,y,x).
 \]
 
-The residual encoder partitions this field using the same geometric map as the
-source encoder:
+For latent cell `p`, the implementation summarizes only the corresponding
+source region `R_p`:
 
 \[
-\Delta Z_k(p)=E_G^{res}\left(E_k|_{R_p}\right).
+\bar E_k(p)=\frac{1}{|R_p|}\sum_{x\in R_p}E_k(x).
 \]
 
-Each latent cell is updated from its own spatial residual rather than one global
-mean:
+Each latent vector is updated with its own regional residual and recalled-memory
+correction:
 
 \[
 Z_{k+1}(p)=\Pi_{[-L_{max},L_{max}]}
 \left[
-Z_k(p)+\eta\left(
-\beta\Delta Z_k(p)+\gamma(r_k-Z_k(p))
-\right)
+Z_k(p)+\eta\left(\beta\bar E_k(p)+\gamma(r_k-Z_k(p))\right)
 \right].
 \]
 
-This prevents positive and negative errors in unrelated regions from cancelling
-before correction reaches the latent geometry.
+This preserves local geometry: positive and negative errors in unrelated regions
+cannot silently cancel into one global correction scalar.
 
-Every refinement step records numerical telemetry:
+The implementation records numerical telemetry for each refinement step:
 
 - reconstruction loss;
 - latent norm;
@@ -142,19 +143,22 @@ Every refinement step records numerical telemetry:
 - recalled-memory norm;
 - selected memory slot.
 
-These values are auditable state telemetry, not textual private reasoning.
+These records are auditable latent-state telemetry. They are not textual private
+chain-of-thought traces.
 
 ---
 
-## 5. Bounded inward optimisation
+## 5. Bounded self-optimisation
 
-The runtime does not permit arbitrary source-code mutation. It evaluates a
-finite declared candidate set that may adjust:
+Jarvis-X does not permit arbitrary source-code mutation through this runtime.
+The admissible candidate set is finite and declared. Current candidates vary:
 
-- learning rate down or up;
+- learning rate down;
+- learning rate up;
 - residual gain up;
-- memory gain down or up;
-- refinement depth by one step within the configured maximum.
+- memory gain down;
+- memory gain up;
+- one additional refinement step, provided the configured maximum is not crossed.
 
 Every candidate starts from an identical memory snapshot. Candidate cost is:
 
@@ -162,10 +166,16 @@ Every candidate starts from an identical memory snapshot. Candidate cost is:
 J(\mathcal M)=L_{recon}(\mathcal M)+\lambda_C\widehat C(\mathcal M),
 \]
 
-with:
+where:
 
 \[
 L_{recon}=\frac{1}{DHW}\|X^\star-\hat X\|_2^2.
+\]
+
+The deterministic operation estimate is:
+
+\[
+\widehat C= DHW(2c+3)+K(dhw)c(S+8).
 \]
 
 A mechanics change is committed only when:
@@ -174,12 +184,12 @@ A mechanics change is committed only when:
 J(\mathcal M')<J(\mathcal M_t).
 \]
 
-Ties preserve the baseline. The journal stores all candidate measurements for
-the experiment, not merely the winner.
+Ties preserve the baseline. Every evaluated candidate is appended to the local
+optimisation journal, with the selected result returned separately.
 
 ---
 
-## 6. Transactional cycle
+## 6. Transactional permeation cycle
 
 ```text
 OBSERVE_VOLUME
@@ -191,19 +201,18 @@ FOR EACH CANDIDATE:
     RECALL_ASSOCIATIVE_MEMORY
     DECODE_VOLUME
     COMPUTE_SPATIAL_RESIDUAL_FIELD
-    ENCODE_RESIDUAL_PER_LATENT_REGION
+    PROJECT_EACH_RESIDUAL_REGION_INTO_ITS_LATENT_CELL
     UPDATE_MEMORY_SLOT
-    PROJECT_EACH_LATENT_CELL
+    PROJECT_LATENT_BOUNDS
     MEASURE_RECONSTRUCTION_AND_COST
 SELECT_MINIMUM_VALID_OBJECTIVE
-POLICY_CHECK_V3D_PERMEATE
 COMMIT_CONFIG_AND_MEMORY
-JOURNAL_ALL_CANDIDATES
-WRITE_VM_LEDGER_AND_TRACE
+JOURNAL_ALL_MEASUREMENTS
+LEDGER_VM_EVENT
 RETURN_RECONSTRUCTION_AND_TELEMETRY
 ```
 
-This instantiates:
+This operationally instantiates:
 
 \[
 \boxed{
@@ -212,76 +221,77 @@ This instantiates:
 }
 \]
 
-through validation, projection bounds, identical shadow snapshots, objective
-comparison, policy control, and conservative commit semantics.
+with `Pi_Lambda` implemented through configuration validation, latent bounds,
+finite candidate enumeration, identical shadow snapshots, objective comparison,
+policy gating, VM-authoritative journaling, and conservative commit semantics.
 
 ---
 
-## 7. Interfaces and isolation
+## 7. Cloud execution mapping
 
-The CLI routes 3D execution through `CodexVM.run_visual_memory`. The FastAPI
-surface exposes:
+The current implementation is a portable reference kernel, not a high-throughput
+GPU trainer. Its contracts map directly onto a distributed cloud runtime:
 
-```text
-GET  /health
-POST /run
-POST /visual-memory
-```
+| Reference object | Cloud/GPU implementation |
+|---|---|
+| `Volume3D` | object-store chunk, Zarr/N5 volume, sparse voxel brick |
+| `LatentField` | sharded GPU tensor or 3D texture |
+| `SpatialMemory` | replicated key-value tensor or vector-memory service |
+| candidate snapshot | immutable checkpoint/object-store version |
+| candidate run | isolated GPU job, pod, or serverless accelerator task |
+| measurement | metrics stream and optimisation journal |
+| commit | atomic configuration pointer update |
 
-Each HTTP or TCP request uses an isolated VM and in-memory ledger. Development
-servers bind to `127.0.0.1` by default. Production exposure still requires an
-external authentication, authorisation, TLS, rate-limiting, and process
-isolation boundary.
+Candidate runs are embarrassingly parallel because they begin from the same
+snapshot. The commit gate remains serial and authoritative.
+
+The MM3D kernel additionally demonstrates column-partitioned factorized encoding:
+workers compute partial hidden projections and the authoritative node sums them
+before vector quantization and commit.
 
 ---
 
 ## 8. Verification
 
-The test suite verifies:
+`tests/test_geometric_memory.py`, `tests/test_system_permeation.py`, and
+`tests/test_mm3d_omega4.py` verify:
 
 1. volume indexing and exact self-MSE;
 2. deterministic equality from identical initial state;
-3. shape, trace, finiteness, and voxel bounds;
-4. bounded candidate count and non-regression against baseline;
-5. full-candidate experiment journaling;
-6. spatial residual locality;
-7. repeated VM program execution after HALT;
-8. VM ledger and trace integration for `V3D.PERMEATE`;
-9. policy denial of geometric execution;
-10. FastAPI route integrity.
+3. output shape, latent shape, trace length, numerical finiteness, and voxel bounds;
+4. bounded candidate count, refinement-step ceiling, complete journal creation,
+   and non-regression of the selected objective relative to baseline;
+5. repeated VM execution after HALT;
+6. VM-authoritative ledger and trace entries;
+7. Lambda policy blocking for both geometric and MM3D actions;
+8. exact 384-bit voxel serialization;
+9. mod-8 QCA state preservation;
+10. sequential/distributed MM3D state equivalence;
+11. Omega retained-window verification.
+
+The demonstrations are:
+
+```bash
+jarvisx visual-memory 12
+jarvisx mm3d-cycle
+```
 
 ---
 
-## 9. Cloud and learned progression
+## 9. Next executable progression
 
-The current kernel is a portable semantic oracle, not a high-throughput trainer.
-Its contracts map to future infrastructure as follows:
+The reference runtimes establish semantics before acceleration. The next
+implementation layers should preserve these APIs while replacing kernels in
+order:
 
-| Reference object | Accelerated implementation |
-|---|---|
-| `Volume3D` | dense tensor, Zarr/N5 chunk, sparse voxel brick |
-| `LatentField` | sharded GPU tensor or 3D texture |
-| `SpatialMemory` | batched key-value tensor or memory service |
-| candidate snapshot | immutable checkpoint version |
-| candidate run | isolated GPU worker |
-| candidate journal | metrics and provenance stream |
-| commit | atomic authoritative configuration pointer |
+1. broader NumPy vectorisation and sparse Xi storage;
+2. PyTorch/JAX differentiable residual projection;
+3. sparse voxel or Gaussian-splat input adapters;
+4. 3D Fourier-domain loss;
+5. GPU candidate batching;
+6. object-store checkpoints and cloud worker orchestration;
+7. visual WebGPU telemetry for the latent lattice and memory attention field.
 
-The progression order is:
-
-1. NumPy vectorisation;
-2. PyTorch or JAX differentiable spatial residual projection;
-3. learned encoder, decoder, and local memory attention;
-4. sparse voxel and Gaussian-splat adapters;
-5. 3D Fourier, gradient, and topology losses;
-6. GPU candidate batching;
-7. object-store checkpoints and cloud worker orchestration;
-8. WebGPU visual telemetry.
-
-The invariant is:
-
-\[
-\boxed{
-\text{Acceleration may change mechanics; it may not silently change meaning.}
-}
-\]
+The invariant is that acceleration may change mechanics, but it may not silently
+change the declared semantic, numerical, determinism, resource, or commit
+contract.

--- a/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_VISUAL_MEMORY_ANN_RUNTIME.md
@@ -1,0 +1,269 @@
+# Dr Moagi 3D Visual Image Memory ANN Runtime
+
+## Status
+
+Executable reference permeation for Jarvis-X. The implementation lives in
+`src/jarvisx/geometric_memory.py` and is deliberately dependency-free,
+deterministic, bounded, and auditable.
+
+It converts the earlier conceptual Encoder -> Memory -> Recursive Refinement ->
+Decoder architecture into a runnable geometric state-transition system.
+
+---
+
+## 1. State
+
+Let the observed 3D image be a scalar voxel field:
+
+\[
+X_t \in [0,1]^{D\times H\times W}.
+\]
+
+The compact geometric latent state is:
+
+\[
+Z_t \in \mathbb{R}^{d\times h\times w\times c}.
+\]
+
+The associative memory is a finite set of key-value slots:
+
+\[
+\Omega_t=\{(k_i,v_i,u_i)\}_{i=1}^{S},
+\]
+
+where `u_i` is a deterministic usage counter.
+
+The mechanics state is the validated configuration:
+
+\[
+\mathcal M_t=(d,h,w,c,S,K,\eta,\beta,\gamma,L_{max},\lambda_C).
+\]
+
+The fields respectively specify latent geometry, channel count, memory slots,
+refinement steps, learning rate, residual gain, memory gain, projection bound,
+and compute-cost weight.
+
+---
+
+## 2. Geometric encoding
+
+The source volume is partitioned into a compact 3D lattice. Each latent cell
+encodes local mean intensity, variance, three directional gradients, radial
+position, and deterministic higher-channel mixtures:
+
+\[
+Z_0=E_G(X_t).
+\]
+
+For a source region `R_p` associated with latent coordinate `p`:
+
+\[
+\mu_p=\frac{1}{|R_p|}\sum_{x\in R_p}X_t(x),
+\qquad
+\sigma_p^2=\frac{1}{|R_p|}\sum_{x\in R_p}(X_t(x)-\mu_p)^2.
+\]
+
+The first latent channel preserves coarse image intensity as `2 mu - 1`; the
+remaining channels preserve local geometric variation.
+
+---
+
+## 3. Associative visual memory
+
+A global query is formed by averaging the latent vectors:
+
+\[
+q_k=\frac{1}{dhw}\sum_p Z_k(p).
+\]
+
+Memory attention is cosine similarity with deterministic softmax weighting:
+
+\[
+a_i=\operatorname{softmax}_i\left(4\cos(q_k,k_i)+0.05u_i\right).
+\]
+
+The recalled vector is:
+
+\[
+r_k=\sum_i a_i v_i.
+\]
+
+The selected memory slot is updated by a bounded interpolation rather than an
+unconstrained overwrite.
+
+---
+
+## 4. Recursive latent refinement
+
+The decoder produces a reconstructed voxel volume:
+
+\[
+\hat X_k=D_G(Z_k).
+\]
+
+The residual is:
+
+\[
+E_k=X^\star-\hat X_k.
+\]
+
+The reference implementation uses a deterministic residual summary and memory
+correction to update every latent vector:
+
+\[
+Z_{k+1}(p)=\Pi_{[-L_{max},L_{max}]}
+\left[
+Z_k(p)+\eta\left(\beta\bar E_k+\gamma(r_k-Z_k(p))\right)
+\right].
+\]
+
+This is the executable inward turn: the system reconstructs its input, measures
+its own error, projects correction back into its geometric latent state, consults
+memory, and repeats.
+
+The implementation records numerical telemetry for each refinement step:
+
+- reconstruction loss;
+- latent norm;
+- residual norm;
+- recalled-memory norm;
+- selected memory slot.
+
+These records are auditable latent-state telemetry. They are not textual private
+chain-of-thought traces.
+
+---
+
+## 5. Bounded self-optimisation
+
+Jarvis-X does not permit arbitrary source-code mutation through this runtime.
+The admissible candidate set is finite and declared. Current candidates vary:
+
+- learning rate down;
+- learning rate up;
+- residual gain up;
+- one additional refinement step, provided the configured maximum is not crossed.
+
+Every candidate starts from an identical memory snapshot. Candidate cost is:
+
+\[
+J(\mathcal M)=L_{recon}(\mathcal M)+\lambda_C\widehat C(\mathcal M),
+\]
+
+where:
+
+\[
+L_{recon}=\frac{1}{DHW}\|X^\star-\hat X\|_2^2.
+\]
+
+The deterministic operation estimate is:
+
+\[
+\widehat C= DHW(2c+3)+K(dhw)c(S+8).
+\]
+
+A mechanics change is committed only when:
+
+\[
+J(\mathcal M')<J(\mathcal M_t).
+\]
+
+Ties preserve the baseline. The selected measurement is appended to the local
+optimisation journal.
+
+---
+
+## 6. Transactional permeation cycle
+
+```text
+OBSERVE_VOLUME
+ENCODE_GEOMETRY
+SNAPSHOT_MEMORY
+GENERATE_BOUNDED_CANDIDATES
+FOR EACH CANDIDATE:
+    RESTORE_IDENTICAL_MEMORY_SNAPSHOT
+    RECALL_ASSOCIATIVE_MEMORY
+    DECODE_VOLUME
+    COMPUTE_RESIDUAL
+    PROJECT_RESIDUAL_INTO_LATENT
+    UPDATE_MEMORY_SLOT
+    PROJECT_LATENT_BOUNDS
+    MEASURE_RECONSTRUCTION_AND_COST
+SELECT_MINIMUM_VALID_OBJECTIVE
+COMMIT_CONFIG_AND_MEMORY
+JOURNAL_MEASUREMENT
+RETURN_RECONSTRUCTION_AND_TELEMETRY
+```
+
+This operationally instantiates:
+
+\[
+\boxed{
+\Xi_{t+1}=\Pi_{\Lambda_t}
+[\Xi_t+P(\Xi_t)-E_t+\Omega_t+U_t]
+}
+\]
+
+with `Pi_Lambda` implemented through configuration validation, latent bounds,
+finite candidate enumeration, identical shadow snapshots, objective comparison,
+and conservative commit semantics.
+
+---
+
+## 7. Cloud execution mapping
+
+The current implementation is a portable reference kernel, not a high-throughput
+GPU trainer. Its contracts map directly onto a distributed cloud runtime:
+
+| Reference object | Cloud/GPU implementation |
+|---|---|
+| `Volume3D` | object-store chunk, Zarr/N5 volume, sparse voxel brick |
+| `LatentField` | sharded GPU tensor or 3D texture |
+| `SpatialMemory` | replicated key-value tensor or vector-memory service |
+| candidate snapshot | immutable checkpoint/object-store version |
+| candidate run | isolated GPU job, pod, or serverless accelerator task |
+| measurement | metrics stream and optimisation journal |
+| commit | atomic configuration pointer update |
+
+Candidate runs are embarrassingly parallel because they begin from the same
+snapshot. The commit gate remains serial and authoritative.
+
+---
+
+## 8. Verification
+
+`tests/test_geometric_memory.py` verifies:
+
+1. volume indexing and exact self-MSE;
+2. deterministic equality from identical initial state;
+3. output shape, latent shape, trace length, numerical finiteness, and voxel bounds;
+4. bounded candidate count, refinement-step ceiling, journal creation, and
+   non-regression of the selected objective relative to baseline.
+
+The CLI demonstration is:
+
+```bash
+jarvisx visual-memory 12
+```
+
+It returns the selected mechanics and the complete numerical refinement trace as
+JSON.
+
+---
+
+## 9. Next executable progression
+
+The reference runtime establishes semantics before acceleration. The next
+implementation layers should preserve this API while replacing kernels in order:
+
+1. NumPy vectorisation;
+2. PyTorch/JAX differentiable residual projection;
+3. sparse voxel or Gaussian-splat input adapters;
+4. 3D Fourier-domain loss;
+5. GPU candidate batching;
+6. object-store checkpoints and cloud worker orchestration;
+7. visual WebGPU telemetry for the latent lattice and memory attention field.
+
+The invariant is that acceleration may change mechanics, but it may not silently
+change the declared semantic, numerical, determinism, resource, or commit
+contract.

--- a/docs/MM3D_OMEGA4_OPERATIONAL_AUDIT.md
+++ b/docs/MM3D_OMEGA4_OPERATIONAL_AUDIT.md
@@ -1,0 +1,218 @@
+# MM3D-AED-BCE-Ω⁴-G50T-OPT Operational Audit
+
+## Status
+
+The submitted architecture is preserved as an operational reference kernel in
+`src/jarvisx/mm3d_omega4.py`. The implementation keeps the intended closed loop
+while correcting dimensional contradictions, unbounded allocations, invalid
+rendering shapes, nondeterministic ledger semantics, and the broken distributed
+merge path.
+
+## Canonical loop
+
+\[
+\Xi_{t+1}
+=
+\Pi_{\Lambda}
+\left[
+\mathcal D_{\Phi}
+\left(
+\mathcal E_{\Phi}(\Xi_t)
++
+\Phi_{QAS}(Z_t)
+\right)
+\right],
+\]
+
+followed by an immutable Ω record and bounded Θ projections.
+
+The current `PhiQAS` class is explicitly classical. It performs deterministic,
+bounded latent candidate exploration and does not claim quantum execution.
+
+## Defects in the submitted program
+
+### Voxel width
+
+The declared voxel width was 384 bits or 48 bytes, but the four `int8` feature
+arrays contained 336 elements. With the float and flags, `to_bytes()` emitted
+342 bytes. The operational layout interprets 128/96/64/48 as feature bits and
+stores 16/12/8/6 bytes respectively, followed by a float32 and two flag bytes:
+
+\[
+16+12+8+6+4+1+1=48\text{ bytes}.
+\]
+
+### Raw allocation floor
+
+Before Python-object overhead, the original declarations required approximately
+38.02 GiB:
+
+| Structure | Raw size |
+|---|---:|
+| Serialized 256³ voxel payload at 342 bytes | 5.34 GiB |
+| Python object-pointer cube | 0.125 GiB |
+| QCA state | 0.016 GiB |
+| Low-rank `L` | 0.25 GiB |
+| Dense `S` | 16 GiB |
+| Codebook | 0.25 GiB |
+| Encoder projection | 8 GiB |
+| Decoder projection | 8 GiB |
+| Temporary decoded latent volume | 0.031 GiB |
+
+The actual object-per-voxel implementation would consume substantially more and
+would require 16,777,216 Python-level constructor iterations.
+
+The corrected Xi-cube uses one contiguous 48-byte NumPy structured dtype. The
+reference configuration has a hard allocation guard, reports actual allocated
+bytes, and rejects an oversized profile before allocation.
+
+### Encoder and decoder dimensions
+
+The submitted encoder produced 32³ scalar values and reshaped them to
+`(32,32,32,1)` while comparing each scalar against 256-dimensional codebook
+vectors. The decoder then expanded the code to 32³×256 values but multiplied it
+by a matrix expecting only 32³ inputs.
+
+The corrected kernel uses a continuous latent matrix
+
+\[
+Z\in\mathbb R^{L\times C},
+\qquad L=s^3,
+\]
+
+where `C` is exactly the codebook width. Both encoder and decoder use consistent
+factorized maps.
+
+## Factorized metric
+
+The dense sparse-correction matrix is replaced with a positive diagonal plus
+low-rank factor:
+
+\[
+g=D+LL^T.
+\]
+
+The inverse action uses Woodbury:
+
+\[
+g^{-1}v
+=D^{-1}v
+-D^{-1}L
+\left(I+L^TD^{-1}L\right)^{-1}
+L^TD^{-1}v.
+\]
+
+This preserves the geometric mechanism without allocating a 65,536² dense
+matrix.
+
+## Vector quantization
+
+Continuous latent vectors are quantized by chunked matrix distance evaluation:
+
+\[
+\|z-c_j\|^2
+=
+\|z\|^2+\|c_j\|^2-2z^Tc_j.
+\]
+
+The implementation avoids a Python loop over every latent cell and every
+codebook entry.
+
+## Z8 substrate
+
+The six-neighbour Laplacian is computed with periodic `numpy.roll` operations,
+removing the undeclared SciPy dependency. Every update is performed in an
+integer accumulator and projected back into
+
+\[
+\mathbb Z_8=\{0,1,\ldots,7\},
+\]
+
+so the QCA state remains `uint8` rather than drifting to floating point.
+
+## Lambda projection
+
+The runtime enforces policy before execution and validates that the mask has the
+same dimension as the decoded state. Constrained coordinates are projected to
+the feasible boundary. `CodexVM` also gates the entire operation under the named
+`MM3D.CYCLE` action.
+
+## Omega chain
+
+Ω entries use logical sequence numbers and canonical JSON hashing. The chain
+uses full SHA3-256 hashes. When the retained window reaches capacity, the dropped
+entry hash becomes the new verification anchor, so the retained chain remains
+verifiable.
+
+## Theta projections
+
+All projections are shape-bounded and deterministic:
+
+- text returns deterministic numerical token IDs;
+- image repeats finite state into a configured RGB grid;
+- audio derives a bounded four-tone waveform from state values;
+- video rolls the deterministic image over a bounded frame count.
+
+These are reference projections, not production generative decoders.
+
+## Distributed execution
+
+The submitted distributed path encoded the full input on every node, selected a
+`LatentCode`, and then passed that object into `cycle()`, which expected an array.
+
+The corrected path partitions the factorized encoder's manifold columns. Each
+node computes a partial hidden projection:
+
+\[
+h_n=B_{[:,I_n]}x_{I_n},
+\qquad
+h=\sum_n h_n.
+\]
+
+The authoritative node then quantizes, decodes, applies Lambda, commits Omega,
+and renders Theta outputs.
+
+## Parameter accounting
+
+`50T` is retained as a conceptual scaling target rather than a false allocation
+claim. The reference result reports:
+
+- actual allocated parameter count;
+- actual allocated bytes;
+- conceptual total parameter target;
+- conceptual active parameter target.
+
+At 0.5% activity:
+
+\[
+50\times10^{12}\times0.005=250\times10^9,
+\]
+
+so the correct conceptual active count is 250 billion, not 500 billion.
+
+## Performance contract
+
+13.7 ms is a measured target. Every result reports the actual wall-clock cycle
+time and a Boolean `target_met`; no Python reference run is declared compliant
+without measurement.
+
+## Verification
+
+The tests cover:
+
+1. exact 48-byte voxel round-trip;
+2. deterministic mod-8 QCA evolution;
+3. conceptual-versus-operational parameter accounting;
+4. allocation-guard rejection of the submitted dense profile;
+5. deterministic cycle equality and Omega verification;
+6. Lambda rejection of empty input;
+7. equivalence of sequential and partitioned encoder state;
+8. retained-window Omega verification;
+9. VM policy, ledger, trace, CLI, and API integration.
+
+## Invariant
+
+```text
+Conceptual scale is metadata until physical allocation and measured execution
+prove otherwise.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "uvicorn>=0.23.0",
     "fastapi>=0.100.0",
+    "numpy>=1.24.0",
 ]
 
 [project.optional-dependencies]
@@ -74,14 +75,14 @@ omit = [
 [tool.black]
 line-length = 100
 target-version = ['py38']
-include = '\\.pyi?$'
+include = '\.pyi?$'
 extend-exclude = '''
 /(
-    \\.git
-  | \\.hg
-  | \\.mypy_cache
-  | \\.tox
-  | \\.venv
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
   | _build
   | buck-out
   | build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 uvicorn>=0.23.0
 fastapi>=0.100.0
+numpy>=1.24.0
 
 # Testing
 pytest>=7.0

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,11 +1,13 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
+import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from .assembler import Assembler
 from .core import CodexVM
+from .mm3d_omega4 import MM3DConfig
 from .parser import Parser
 
 app = FastAPI(title="Jarvis-X", version="0.1.0")
@@ -18,6 +20,12 @@ class RunRequest(BaseModel):
 class VisualMemoryRequest(BaseModel):
     size: int = Field(default=12, ge=4, le=64)
     auto_optimize: bool = True
+
+
+class MM3DRequest(BaseModel):
+    values: List[float]
+    manifold_dim: int = Field(default=4096, ge=64, le=65536)
+    seed: int = 0x4D4D3344
 
 
 def _execute_source(source: str) -> Dict[str, Any]:
@@ -58,6 +66,28 @@ def visual_memory(request: VisualMemoryRequest) -> Dict[str, Any]:
             auto_optimize=request.auto_optimize,
         )
         return result.summary()
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/mm3d-cycle")
+def mm3d_cycle(request: MM3DRequest) -> Dict[str, Any]:
+    try:
+        if not 1 <= len(request.values) <= 65536:
+            raise ValueError("MM3D values must contain 1 to 65536 elements")
+        config = MM3DConfig(
+            manifold_dim=request.manifold_dim,
+            seed=request.seed,
+        )
+        config.validate()
+        vm = CodexVM(ledger_path=None)
+        result = vm.run_mm3d_cycle(
+            np.asarray(request.values, dtype=np.float32),
+            config=config,
+        )
+        summary = result.summary()
+        vm.close()
+        return summary
     except (ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,22 +1,66 @@
-from flask import Flask, request, jsonify
+from typing import Any, Dict
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .assembler import Assembler
 from .core import CodexVM
 from .parser import Parser
-from .assembler import Assembler
 
-app = Flask(__name__)
-vm = CodexVM()
+app = FastAPI(title="Jarvis-X", version="0.1.0")
 
-@app.route("/run", methods=["POST"])
-def run_code():
-    source = request.json.get("source", "")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
-    vm.load(bytecode)
-    vm.run()
-    return jsonify({
-        "registers": vm.regs.snapshot(),
-        "ledger_entries": len(vm.ledger.chain)
-    })
 
-def start_api():
-    app.run(host="0.0.0.0", port=8080)
+class RunRequest(BaseModel):
+    source: str = Field(min_length=1, max_length=65536)
+
+
+class VisualMemoryRequest(BaseModel):
+    size: int = Field(default=12, ge=4, le=64)
+    auto_optimize: bool = True
+
+
+def _execute_source(source: str) -> Dict[str, Any]:
+    try:
+        ast = Parser().parse(source)
+        bytecode = Assembler().assemble(ast)
+        if not bytecode:
+            raise ValueError("source assembled to an empty program")
+        vm = CodexVM(ledger_path=None)
+        vm.load(bytecode)
+        vm.run()
+        return {
+            "registers": vm.regs.snapshot(),
+            "cycles": vm.cycles,
+            "ledger_entries": len(vm.ledger.chain),
+            "trace_entries": len(vm.tracer.log),
+        }
+    except (KeyError, ValueError, RuntimeError, IndexError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/run")
+def run_code(request: RunRequest) -> Dict[str, Any]:
+    return _execute_source(request.source)
+
+
+@app.post("/visual-memory")
+def visual_memory(request: VisualMemoryRequest) -> Dict[str, Any]:
+    try:
+        vm = CodexVM(ledger_path=None)
+        result = vm.run_visual_memory(
+            size=request.size,
+            auto_optimize=request.auto_optimize,
+        )
+        return result.summary()
+    except (ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def start_api(host: str = "127.0.0.1", port: int = 8080) -> None:
+    uvicorn.run(app, host=host, port=port)

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -7,7 +7,10 @@ from .parser import Parser
 
 
 def _usage() -> None:
-    print("Usage: jarvisx [run <file>|api|web|node|visual-memory [size]]")
+    print(
+        "Usage: jarvisx "
+        "[run <file>|api|web|node|visual-memory [size]|mm3d-cycle [manifold_dim]]"
+    )
 
 
 def main() -> None:
@@ -50,6 +53,20 @@ def main() -> None:
         vm = CodexVM(ledger_path=None)
         result = vm.run_visual_memory(size=size, auto_optimize=True)
         print(json.dumps(result.summary(), indent=2, sort_keys=True))
+
+    elif cmd == "mm3d-cycle":
+        import numpy as np
+
+        from .mm3d_omega4 import MM3DConfig
+
+        manifold_dim = int(sys.argv[2]) if len(sys.argv) > 2 else 4096
+        config = MM3DConfig(manifold_dim=manifold_dim)
+        config.validate()
+        psi = np.linspace(-1.0, 1.0, manifold_dim, dtype=np.float32)
+        vm = CodexVM(ledger_path=None)
+        result = vm.run_mm3d_cycle(psi, config=config)
+        print(json.dumps(result.summary(), indent=2, sort_keys=True))
+        vm.close()
 
     else:
         _usage()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,22 +1,32 @@
+import json
 import sys
-from .parser import Parser
+
+from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .api import start_api
-from .web import start_web
 from .node import CodexNode
+from .parser import Parser
+from .web import start_web
+
+
+def _usage():
+    print("Usage: jarvisx [run <file>|api|web|node|visual-memory [size]]")
+
 
 def main():
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
+        _usage()
         return
 
     cmd = sys.argv[1]
 
     if cmd == "run":
+        if len(sys.argv) < 3:
+            _usage()
+            return
         file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
+        with open(file) as source_file:
+            source = source_file.read()
         ast = Parser().parse(source)
         bytecode = Assembler().assemble(ast)
         vm = CodexVM()
@@ -33,6 +43,18 @@ def main():
     elif cmd == "node":
         node = CodexNode()
         node.start()
+
+    elif cmd == "visual-memory":
+        from .geometric_memory import VisualMemoryANN, make_demo_volume
+
+        size = int(sys.argv[2]) if len(sys.argv) > 2 else 12
+        volume = make_demo_volume(size)
+        result = VisualMemoryANN().permeate(volume, auto_optimize=True)
+        print(json.dumps(result.summary(), indent=2, sort_keys=True))
+
+    else:
+        _usage()
+
 
 if __name__ == "__main__":
     main()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,19 +1,16 @@
 import json
 import sys
 
-from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .node import CodexNode
 from .parser import Parser
-from .web import start_web
 
 
-def _usage():
+def _usage() -> None:
     print("Usage: jarvisx [run <file>|api|web|node|visual-memory [size]]")
 
 
-def main():
+def main() -> None:
     if len(sys.argv) < 2:
         _usage()
         return
@@ -24,8 +21,7 @@ def main():
         if len(sys.argv) < 3:
             _usage()
             return
-        file = sys.argv[2]
-        with open(file) as source_file:
+        with open(sys.argv[2], encoding="utf-8") as source_file:
             source = source_file.read()
         ast = Parser().parse(source)
         bytecode = Assembler().assemble(ast)
@@ -35,21 +31,24 @@ def main():
         print("Registers:", vm.regs.snapshot())
 
     elif cmd == "api":
+        from .api import start_api
+
         start_api()
 
     elif cmd == "web":
+        from .web import start_web
+
         start_web()
 
     elif cmd == "node":
-        node = CodexNode()
-        node.start()
+        from .node import CodexNode
+
+        CodexNode().start()
 
     elif cmd == "visual-memory":
-        from .geometric_memory import VisualMemoryANN, make_demo_volume
-
         size = int(sys.argv[2]) if len(sys.argv) > 2 else 12
-        volume = make_demo_volume(size)
-        result = VisualMemoryANN().permeate(volume, auto_optimize=True)
+        vm = CodexVM(ledger_path=None)
+        result = vm.run_visual_memory(size=size, auto_optimize=True)
         print(json.dumps(result.summary(), indent=2, sort_keys=True))
 
     else:

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,44 +1,65 @@
-from .registers import Registers
-from .memory import Memory
-from .decoder import Decoder
-from .executor import Executor
-from .ledger_store import PersistentLedger
-from .ethics import LambdaShield
-from .reflex import ReflexEngine
-from .sandbox import Sandbox
+from typing import Optional
+
 from .debugger import Debugger
+from .decoder import Decoder
+from .ethics import LambdaShield
+from .executor import Executor
+from .geometric_memory import (
+    PermeationResult,
+    VisualMemoryANN,
+    Volume3D,
+    make_demo_volume,
+)
+from .ledger_store import PersistentLedger
+from .memory import Memory
+from .reflex import ReflexEngine
+from .registers import Registers
+from .sandbox import Sandbox
 from .tracer import Tracer
 
+
 class CodexVM:
-    def __init__(self):
+    def __init__(self, ledger_path: Optional[str] = "omega_ledger.json"):
         self.regs = Registers()
         self.mem = Memory()
         self.decoder = Decoder()
         self.executor = Executor(self.regs)
-        self.ledger = PersistentLedger()
+        self.ledger = PersistentLedger(path=ledger_path)
         self.ethics = LambdaShield()
         self.reflex = ReflexEngine()
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
+        self.geometric = VisualMemoryANN()
         self.program = []
         self.cycles = 0
         self.running = True
 
-    def load(self, bytecode):
-        self.program = bytecode
+    def reset_execution(self) -> None:
+        """Reset request-local execution state without clearing registers."""
+
         self.regs["IP"] = 0
+        self.cycles = 0
+        self.running = True
+        self.tracer = Tracer()
 
-    def step(self):
+    def load(self, bytecode) -> None:
+        self.program = list(bytecode)
+        self.reset_execution()
+
+    def step(self) -> None:
         ip = self.regs["IP"]
-        instr = self.decoder.decode(self.program[ip])
+        if not 0 <= ip < len(self.program):
+            raise RuntimeError("instruction pointer outside loaded program")
 
+        instr = self.decoder.decode(self.program[ip])
         if not self.ethics.allow(instr):
-            raise RuntimeError("Ethics blocked instruction")
+            raise RuntimeError("policy blocked instruction")
 
         cont = self.executor.execute(instr)
-        self.ledger.log(self.regs.snapshot(), instr.opcode)
-        self.tracer.record(instr, self.regs.snapshot())
+        snapshot = self.regs.snapshot()
+        self.ledger.log(snapshot, instr.opcode)
+        self.tracer.record(instr, snapshot)
         self.reflex.stabilize(self.regs)
 
         self.regs["IP"] += 1
@@ -48,6 +69,36 @@ class CodexVM:
         if not cont:
             self.running = False
 
-    def run(self):
+    def run(self) -> None:
         while self.running:
             self.step()
+
+    def permeate_volume(
+        self,
+        observed: Volume3D,
+        target: Optional[Volume3D] = None,
+        auto_optimize: bool = True,
+    ) -> PermeationResult:
+        action = "V3D.PERMEATE"
+        if not self.ethics.allow_action(action):
+            raise RuntimeError("policy blocked geometric permeation")
+
+        result = self.geometric.permeate(
+            observed,
+            target=target,
+            auto_optimize=auto_optimize,
+        )
+        summary = result.summary()
+        self.ledger.log(summary, action)
+        self.tracer.record_event(action, summary)
+        return result
+
+    def run_visual_memory(
+        self,
+        size: int = 12,
+        auto_optimize: bool = True,
+    ) -> PermeationResult:
+        return self.permeate_volume(
+            make_demo_volume(size),
+            auto_optimize=auto_optimize,
+        )

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Optional
 
 from .debugger import Debugger
 from .decoder import Decoder
@@ -31,6 +31,7 @@ class CodexVM:
         self.debugger = Debugger(self)
         self.tracer = Tracer()
         self.geometric = VisualMemoryANN()
+        self._mm3d = None
         self.program = []
         self.cycles = 0
         self.running = True
@@ -102,3 +103,28 @@ class CodexVM:
             make_demo_volume(size),
             auto_optimize=auto_optimize,
         )
+
+    def run_mm3d_cycle(self, psi_input: Any, config=None):
+        """Execute the bounded MM3D Ω⁴ cycle under VM policy and journaling."""
+
+        action = "MM3D.CYCLE"
+        if not self.ethics.allow_action(action):
+            raise RuntimeError("policy blocked MM3D cycle")
+
+        from .mm3d_omega4 import MM3DEngine
+
+        if self._mm3d is None or (config is not None and self._mm3d.config != config):
+            if self._mm3d is not None:
+                self._mm3d.close()
+            self._mm3d = MM3DEngine(config)
+
+        result = self._mm3d.cycle(psi_input)
+        summary = result.summary()
+        self.ledger.log(summary, action)
+        self.tracer.record_event(action, summary)
+        return result
+
+    def close(self) -> None:
+        if self._mm3d is not None:
+            self._mm3d.close()
+            self._mm3d = None

--- a/src/jarvisx/ethics.py
+++ b/src/jarvisx/ethics.py
@@ -1,9 +1,16 @@
 class LambdaShield:
     def __init__(self):
         self.blocked = set()
+        self.blocked_actions = set()
 
     def block(self, opcode):
         self.blocked.add(opcode)
 
+    def block_action(self, action):
+        self.blocked_actions.add(str(action))
+
     def allow(self, instr):
         return instr.opcode not in self.blocked
+
+    def allow_action(self, action):
+        return str(action) not in self.blocked_actions

--- a/src/jarvisx/geometric_memory.py
+++ b/src/jarvisx/geometric_memory.py
@@ -1,0 +1,344 @@
+"""Deterministic 3D visual-memory ANN reference runtime.
+
+Pipeline:
+    Volume3D -> geometric encoder -> latent lattice -> associative memory
+             -> recursive residual refinement -> decoder -> bounded optimiser
+
+The optimiser may only choose declared configuration variants. It evaluates all
+variants from an identical memory snapshot and commits only a measured objective
+improvement, preserving deterministic replay and rollback semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import math
+from typing import Callable, List, Optional, Sequence, Tuple
+
+Shape3D = Tuple[int, int, int]
+Vector = Tuple[float, ...]
+
+
+def _prod(shape: Shape3D) -> int:
+    return shape[0] * shape[1] * shape[2]
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return lo if x < lo else hi if x > hi else x
+
+
+def _mean(xs: Sequence[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _norm(xs: Sequence[float]) -> float:
+    return math.sqrt(sum(x * x for x in xs))
+
+
+def _softmax(xs: Sequence[float]) -> List[float]:
+    peak = max(xs)
+    exps = [math.exp(x - peak) for x in xs]
+    total = sum(exps)
+    return [x / total for x in exps]
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    scale = _norm(a) * _norm(b)
+    return 0.0 if scale <= 1e-12 else sum(x * y for x, y in zip(a, b)) / scale
+
+
+@dataclass(frozen=True)
+class Volume3D:
+    shape: Shape3D
+    values: Tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if any(axis <= 0 for axis in self.shape) or len(self.values) != _prod(self.shape):
+            raise ValueError("invalid 3D volume")
+        if not all(math.isfinite(value) for value in self.values):
+            raise ValueError("volume values must be finite")
+
+    @classmethod
+    def from_function(cls, shape: Shape3D, fn: Callable[[int, int, int], float]) -> "Volume3D":
+        d, h, w = shape
+        return cls(shape, tuple(float(fn(z, y, x)) for z in range(d) for y in range(h) for x in range(w)))
+
+    def at(self, z: int, y: int, x: int) -> float:
+        d, h, w = self.shape
+        if not (0 <= z < d and 0 <= y < h and 0 <= x < w):
+            raise IndexError("voxel coordinate outside volume")
+        return self.values[x + w * (y + h * z)]
+
+    def mse(self, other: "Volume3D") -> float:
+        if self.shape != other.shape:
+            raise ValueError("MSE requires equal shapes")
+        return _mean([(a - b) ** 2 for a, b in zip(self.values, other.values)])
+
+
+@dataclass(frozen=True)
+class LatentField:
+    shape: Shape3D
+    channels: int
+    values: Tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if self.channels <= 0 or len(self.values) != _prod(self.shape) * self.channels:
+            raise ValueError("invalid latent field")
+
+    def vectors(self) -> List[Vector]:
+        return [self.values[i : i + self.channels] for i in range(0, len(self.values), self.channels)]
+
+    def vector(self, z: int, y: int, x: int) -> Vector:
+        d, h, w = self.shape
+        if not (0 <= z < d and 0 <= y < h and 0 <= x < w):
+            raise IndexError("latent coordinate outside field")
+        start = self.channels * (x + w * (y + h * z))
+        return self.values[start : start + self.channels]
+
+    @classmethod
+    def build(cls, shape: Shape3D, vectors: Sequence[Sequence[float]]) -> "LatentField":
+        if not vectors:
+            raise ValueError("latent field cannot be empty")
+        channels = len(vectors[0])
+        if len(vectors) != _prod(shape) or any(len(vector) != channels for vector in vectors):
+            raise ValueError("latent vector dimensions do not match")
+        return cls(shape, channels, tuple(value for vector in vectors for value in vector))
+
+
+@dataclass(frozen=True)
+class GeometricConfig:
+    latent_shape: Shape3D = (4, 4, 4)
+    channels: int = 6
+    memory_slots: int = 8
+    refinement_steps: int = 4
+    learning_rate: float = 0.18
+    residual_gain: float = 0.35
+    memory_gain: float = 0.12
+    max_abs_latent: float = 1.5
+    cost_weight: float = 1e-7
+    max_candidate_steps: int = 8
+
+    def validate(self) -> None:
+        if any(axis <= 0 for axis in self.latent_shape) or self.channels < 2 or self.memory_slots <= 0:
+            raise ValueError("invalid geometry or memory dimensions")
+        if not 1 <= self.refinement_steps <= self.max_candidate_steps:
+            raise ValueError("refinement_steps outside declared bounds")
+        if not 0.0 < self.learning_rate <= 1.0:
+            raise ValueError("learning_rate outside (0, 1]")
+        if not 0.0 <= self.residual_gain <= 1.0 or not 0.0 <= self.memory_gain <= 1.0:
+            raise ValueError("gains outside [0, 1]")
+        if self.max_abs_latent <= 0.0 or self.cost_weight < 0.0:
+            raise ValueError("invalid projection or cost bound")
+
+
+@dataclass(frozen=True)
+class MemorySlot:
+    key: Vector
+    value: Vector
+    usage: float = 0.0
+
+
+class SpatialMemory:
+    def __init__(self, count: int, channels: int) -> None:
+        self.channels = channels
+        self._slots = [
+            MemorySlot(tuple(0.05 * math.sin((i + 1) * (j + 1)) for j in range(channels)), (0.0,) * channels)
+            for i in range(count)
+        ]
+
+    def clone(self) -> "SpatialMemory":
+        clone = SpatialMemory(len(self._slots), self.channels)
+        clone._slots = list(self._slots)
+        return clone
+
+    def _attention(self, query: Sequence[float]) -> List[float]:
+        if len(query) != self.channels:
+            raise ValueError("memory query width mismatch")
+        return _softmax([4.0 * _cosine(query, slot.key) + 0.05 * slot.usage for slot in self._slots])
+
+    def read(self, query: Sequence[float]) -> Vector:
+        weights = self._attention(query)
+        return tuple(sum(weight * slot.value[c] for weight, slot in zip(weights, self._slots)) for c in range(self.channels))
+
+    def write(self, key: Sequence[float], value: Sequence[float], rate: float) -> int:
+        weights = self._attention(key)
+        index = max(range(len(weights)), key=lambda i: (weights[i], -self._slots[i].usage))
+        old = self._slots[index]
+        self._slots[index] = MemorySlot(
+            tuple((1.0 - rate) * a + rate * b for a, b in zip(old.key, key)),
+            tuple((1.0 - rate) * a + rate * b for a, b in zip(old.value, value)),
+            old.usage + 1.0,
+        )
+        return index
+
+
+@dataclass(frozen=True)
+class RefinementTrace:
+    """Auditable latent telemetry; not a textual private reasoning trace."""
+
+    step: int
+    reconstruction_loss: float
+    latent_norm: float
+    residual_norm: float
+    recalled_norm: float
+    memory_slot: int
+
+
+@dataclass(frozen=True)
+class CandidateMeasurement:
+    config: GeometricConfig
+    reconstruction_loss: float
+    estimated_operations: int
+    objective: float
+
+
+@dataclass(frozen=True)
+class PermeationResult:
+    reconstruction: Volume3D
+    latent: LatentField
+    trace: Tuple[RefinementTrace, ...]
+    selected: CandidateMeasurement
+    baseline: CandidateMeasurement
+    candidate_count: int
+    mechanics_changed: bool
+
+    def summary(self) -> dict:
+        return {
+            "shape": self.reconstruction.shape,
+            "latent_shape": self.latent.shape,
+            "channels": self.latent.channels,
+            "refinement_steps": self.selected.config.refinement_steps,
+            "loss": self.selected.reconstruction_loss,
+            "operations": self.selected.estimated_operations,
+            "objective": self.selected.objective,
+            "mechanics_changed": self.mechanics_changed,
+            "candidate_count": self.candidate_count,
+            "trace": [item.__dict__ for item in self.trace],
+        }
+
+
+class GeometricCodec:
+    def __init__(self, config: GeometricConfig) -> None:
+        self.config = config
+
+    @staticmethod
+    def _bounds(source: int, latent: int, index: int) -> Tuple[int, int]:
+        start = index * source // latent
+        return start, max(start + 1, (index + 1) * source // latent)
+
+    def encode(self, volume: Volume3D) -> LatentField:
+        sd, sh, sw = volume.shape
+        ld, lh, lw = self.config.latent_shape
+        vectors: List[Vector] = []
+        for lz in range(ld):
+            z0, z1 = self._bounds(sd, ld, lz)
+            for ly in range(lh):
+                y0, y1 = self._bounds(sh, lh, ly)
+                for lx in range(lw):
+                    x0, x1 = self._bounds(sw, lw, lx)
+                    samples = [volume.at(z, y, x) for z in range(z0, min(z1, sd)) for y in range(y0, min(y1, sh)) for x in range(x0, min(x1, sw))]
+                    mean = _mean(samples)
+                    variance = _mean([(value - mean) ** 2 for value in samples])
+                    cz, cy, cx = min(sd - 1, (z0 + z1 - 1) // 2), min(sh - 1, (y0 + y1 - 1) // 2), min(sw - 1, (x0 + x1 - 1) // 2)
+                    gradients = (
+                        volume.at(min(sd - 1, cz + 1), cy, cx) - volume.at(max(0, cz - 1), cy, cx),
+                        volume.at(cz, min(sh - 1, cy + 1), cx) - volume.at(cz, max(0, cy - 1), cx),
+                        volume.at(cz, cy, min(sw - 1, cx + 1)) - volume.at(cz, cy, max(0, cx - 1)),
+                    )
+                    radius = math.sqrt(((2 * lz + 1) / ld - 1) ** 2 + ((2 * ly + 1) / lh - 1) ** 2 + ((2 * lx + 1) / lw - 1) ** 2)
+                    basis = [2 * mean - 1, math.sqrt(max(0.0, variance)), gradients[2], gradients[1], gradients[0], radius]
+                    vector = [basis[c] if c < len(basis) else _mean([v * math.sin((c + 1) * (i + 1)) for i, v in enumerate(basis)]) for c in range(self.config.channels)]
+                    vectors.append(tuple(_clamp(v, -self.config.max_abs_latent, self.config.max_abs_latent) for v in vector))
+        return LatentField.build(self.config.latent_shape, vectors)
+
+    def decode(self, latent: LatentField, shape: Shape3D) -> Volume3D:
+        d, h, w = shape
+        ld, lh, lw = latent.shape
+
+        def sample(z: int, y: int, x: int) -> float:
+            vector = latent.vector(min(ld - 1, z * ld // d), min(lh - 1, y * lh // h), min(lw - 1, x * lw // w))
+            detail = 0.025 * sum(vector[2:5]) if len(vector) > 2 else 0.0
+            return _clamp(0.5 * (vector[0] + 1.0) + detail, 0.0, 1.0)
+
+        return Volume3D.from_function(shape, sample)
+
+
+class VisualMemoryANN:
+    """Transactional 3D visual memory with bounded inward optimisation."""
+
+    def __init__(self, config: Optional[GeometricConfig] = None) -> None:
+        self.config = config or GeometricConfig()
+        self.config.validate()
+        self.memory = SpatialMemory(self.config.memory_slots, self.config.channels)
+        self.journal: List[CandidateMeasurement] = []
+
+    @staticmethod
+    def _global(latent: LatentField) -> Vector:
+        vectors = latent.vectors()
+        return tuple(_mean([vector[c] for vector in vectors]) for c in range(latent.channels))
+
+    @staticmethod
+    def _operations(volume: Volume3D, config: GeometricConfig) -> int:
+        voxels, cells = _prod(volume.shape), _prod(config.latent_shape)
+        return voxels * (2 * config.channels + 3) + config.refinement_steps * cells * config.channels * (config.memory_slots + 8)
+
+    def _run(self, observed: Volume3D, target: Volume3D, config: GeometricConfig, memory: SpatialMemory):
+        codec, latent, trace = GeometricCodec(config), GeometricCodec(config).encode(observed), []
+        for step in range(config.refinement_steps):
+            query, recalled = self._global(latent), memory.read(self._global(latent))
+            reconstruction = codec.decode(latent, target.shape)
+            residual = tuple(expected - actual for expected, actual in zip(target.values, reconstruction.values))
+            residual_mean = _mean(residual)
+            slot = memory.write(query, tuple(residual_mean * math.cos(c + 1) for c in range(config.channels)), config.learning_rate)
+            vectors = []
+            for vector in latent.vectors():
+                vectors.append(tuple(_clamp(value + config.learning_rate * (config.residual_gain * residual_mean + config.memory_gain * (recalled[c] - value)), -config.max_abs_latent, config.max_abs_latent) for c, value in enumerate(vector)))
+            latent = LatentField.build(latent.shape, vectors)
+            post = codec.decode(latent, target.shape)
+            trace.append(RefinementTrace(step, post.mse(target), _norm(latent.values) / math.sqrt(len(latent.values)), _norm(residual) / math.sqrt(len(residual)), _norm(recalled), slot))
+        reconstruction = codec.decode(latent, target.shape)
+        loss, operations = reconstruction.mse(target), self._operations(observed, config)
+        measurement = CandidateMeasurement(config, loss, operations, loss + config.cost_weight * operations)
+        return reconstruction, latent, tuple(trace), measurement, memory
+
+    def _candidates(self) -> Tuple[GeometricConfig, ...]:
+        c = self.config
+        proposals = [c, replace(c, learning_rate=max(0.01, c.learning_rate * 0.75)), replace(c, learning_rate=min(1.0, c.learning_rate * 1.25)), replace(c, residual_gain=min(1.0, c.residual_gain + 0.1))]
+        if c.refinement_steps < c.max_candidate_steps:
+            proposals.append(replace(c, refinement_steps=c.refinement_steps + 1))
+        unique: List[GeometricConfig] = []
+        for proposal in proposals:
+            proposal.validate()
+            if proposal not in unique:
+                unique.append(proposal)
+        return tuple(unique)
+
+    def permeate(self, observed: Volume3D, target: Optional[Volume3D] = None, auto_optimize: bool = True) -> PermeationResult:
+        target = target or observed
+        if observed.shape != target.shape:
+            raise ValueError("observed and target volumes must have equal shapes")
+        candidates = self._candidates() if auto_optimize else (self.config,)
+        snapshot = self.memory.clone()
+        runs = [self._run(observed, target, candidate, snapshot.clone()) for candidate in candidates]
+        baseline = runs[0]
+        index = min(range(len(runs)), key=lambda i: (runs[i][3].objective, i))
+        selected = runs[index]
+        changed = index != 0 and selected[3].objective < baseline[3].objective
+        self.config, self.memory = selected[3].config, selected[4]
+        self.journal.append(selected[3])
+        return PermeationResult(selected[0], selected[1], selected[2], selected[3], baseline[3], len(candidates), changed)
+
+
+def make_demo_volume(size: int = 12) -> Volume3D:
+    if size < 4:
+        raise ValueError("demo size must be at least 4")
+    centre, scale = (size - 1) / 2.0, max(1.0, (size - 1) / 2.0)
+
+    def field(z: int, y: int, x: int) -> float:
+        nx, ny, nz = (x - centre) / scale, (y - centre) / scale, (z - centre) / scale
+        radius = math.sqrt(nx * nx + ny * ny + nz * nz)
+        shell = math.exp(-10.0 * (radius - 0.58) ** 2)
+        wave = 0.12 * (math.sin(5 * nx) * math.cos(4 * ny) * math.sin(3 * nz) + 1.0)
+        return _clamp(0.82 * shell + wave, 0.0, 1.0)
+
+    return Volume3D.from_function((size, size, size), field)

--- a/src/jarvisx/geometric_memory.py
+++ b/src/jarvisx/geometric_memory.py
@@ -1,12 +1,12 @@
-"""Deterministic 3D visual-memory ANN reference runtime.
+"""Deterministic 3D visual-memory reference runtime.
 
 Pipeline:
     Volume3D -> geometric encoder -> latent lattice -> associative memory
-             -> recursive residual refinement -> decoder -> bounded optimiser
+             -> spatial residual refinement -> decoder -> bounded optimiser
 
-The optimiser may only choose declared configuration variants. It evaluates all
-variants from an identical memory snapshot and commits only a measured objective
-improvement, preserving deterministic replay and rollback semantics.
+This module is the executable semantic oracle for later tensor, GPU, and learned
+implementations. Every candidate runs from an identical memory snapshot, and
+only a strictly better measured objective may replace the baseline mechanics.
 """
 
 from __future__ import annotations
@@ -44,7 +44,9 @@ def _softmax(xs: Sequence[float]) -> List[float]:
 
 def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
     scale = _norm(a) * _norm(b)
-    return 0.0 if scale <= 1e-12 else sum(x * y for x, y in zip(a, b)) / scale
+    if scale <= 1e-12:
+        return 0.0
+    return sum(x * y for x, y in zip(a, b)) / scale
 
 
 @dataclass(frozen=True)
@@ -53,15 +55,25 @@ class Volume3D:
     values: Tuple[float, ...]
 
     def __post_init__(self) -> None:
-        if any(axis <= 0 for axis in self.shape) or len(self.values) != _prod(self.shape):
-            raise ValueError("invalid 3D volume")
+        if any(axis <= 0 for axis in self.shape):
+            raise ValueError("volume axes must be positive")
+        if len(self.values) != _prod(self.shape):
+            raise ValueError("volume data length does not match shape")
         if not all(math.isfinite(value) for value in self.values):
             raise ValueError("volume values must be finite")
 
     @classmethod
-    def from_function(cls, shape: Shape3D, fn: Callable[[int, int, int], float]) -> "Volume3D":
+    def from_function(
+        cls, shape: Shape3D, fn: Callable[[int, int, int], float]
+    ) -> "Volume3D":
         d, h, w = shape
-        return cls(shape, tuple(float(fn(z, y, x)) for z in range(d) for y in range(h) for x in range(w)))
+        values = tuple(
+            float(fn(z, y, x))
+            for z in range(d)
+            for y in range(h)
+            for x in range(w)
+        )
+        return cls(shape, values)
 
     def at(self, z: int, y: int, x: int) -> float:
         d, h, w = self.shape
@@ -74,6 +86,14 @@ class Volume3D:
             raise ValueError("MSE requires equal shapes")
         return _mean([(a - b) ** 2 for a, b in zip(self.values, other.values)])
 
+    def subtract(self, other: "Volume3D") -> "Volume3D":
+        if self.shape != other.shape:
+            raise ValueError("subtraction requires equal shapes")
+        return Volume3D(
+            self.shape,
+            tuple(a - b for a, b in zip(self.values, other.values)),
+        )
+
 
 @dataclass(frozen=True)
 class LatentField:
@@ -82,11 +102,16 @@ class LatentField:
     values: Tuple[float, ...]
 
     def __post_init__(self) -> None:
-        if self.channels <= 0 or len(self.values) != _prod(self.shape) * self.channels:
-            raise ValueError("invalid latent field")
+        if self.channels <= 0:
+            raise ValueError("latent channels must be positive")
+        if len(self.values) != _prod(self.shape) * self.channels:
+            raise ValueError("latent data length does not match geometry")
 
     def vectors(self) -> List[Vector]:
-        return [self.values[i : i + self.channels] for i in range(0, len(self.values), self.channels)]
+        return [
+            self.values[i : i + self.channels]
+            for i in range(0, len(self.values), self.channels)
+        ]
 
     def vector(self, z: int, y: int, x: int) -> Vector:
         d, h, w = self.shape
@@ -96,13 +121,21 @@ class LatentField:
         return self.values[start : start + self.channels]
 
     @classmethod
-    def build(cls, shape: Shape3D, vectors: Sequence[Sequence[float]]) -> "LatentField":
+    def build(
+        cls, shape: Shape3D, vectors: Sequence[Sequence[float]]
+    ) -> "LatentField":
         if not vectors:
             raise ValueError("latent field cannot be empty")
         channels = len(vectors[0])
-        if len(vectors) != _prod(shape) or any(len(vector) != channels for vector in vectors):
-            raise ValueError("latent vector dimensions do not match")
-        return cls(shape, channels, tuple(value for vector in vectors for value in vector))
+        if len(vectors) != _prod(shape):
+            raise ValueError("latent vector count does not match shape")
+        if any(len(vector) != channels for vector in vectors):
+            raise ValueError("latent vector widths do not match")
+        return cls(
+            shape,
+            channels,
+            tuple(value for vector in vectors for value in vector),
+        )
 
 
 @dataclass(frozen=True)
@@ -119,14 +152,18 @@ class GeometricConfig:
     max_candidate_steps: int = 8
 
     def validate(self) -> None:
-        if any(axis <= 0 for axis in self.latent_shape) or self.channels < 2 or self.memory_slots <= 0:
-            raise ValueError("invalid geometry or memory dimensions")
+        if any(axis <= 0 for axis in self.latent_shape):
+            raise ValueError("latent axes must be positive")
+        if self.channels < 2 or self.memory_slots <= 0:
+            raise ValueError("invalid channel or memory dimensions")
         if not 1 <= self.refinement_steps <= self.max_candidate_steps:
             raise ValueError("refinement_steps outside declared bounds")
         if not 0.0 < self.learning_rate <= 1.0:
             raise ValueError("learning_rate outside (0, 1]")
-        if not 0.0 <= self.residual_gain <= 1.0 or not 0.0 <= self.memory_gain <= 1.0:
-            raise ValueError("gains outside [0, 1]")
+        if not 0.0 <= self.residual_gain <= 1.0:
+            raise ValueError("residual_gain outside [0, 1]")
+        if not 0.0 <= self.memory_gain <= 1.0:
+            raise ValueError("memory_gain outside [0, 1]")
         if self.max_abs_latent <= 0.0 or self.cost_weight < 0.0:
             raise ValueError("invalid projection or cost bound")
 
@@ -139,10 +176,18 @@ class MemorySlot:
 
 
 class SpatialMemory:
+    """Finite content-addressed memory with anti-monopoly usage pressure."""
+
     def __init__(self, count: int, channels: int) -> None:
         self.channels = channels
         self._slots = [
-            MemorySlot(tuple(0.05 * math.sin((i + 1) * (j + 1)) for j in range(channels)), (0.0,) * channels)
+            MemorySlot(
+                tuple(
+                    0.05 * math.sin((i + 1) * (j + 1))
+                    for j in range(channels)
+                ),
+                (0.0,) * channels,
+            )
             for i in range(count)
         ]
 
@@ -151,22 +196,51 @@ class SpatialMemory:
         clone._slots = list(self._slots)
         return clone
 
+    def snapshot(self) -> Tuple[MemorySlot, ...]:
+        return tuple(self._slots)
+
     def _attention(self, query: Sequence[float]) -> List[float]:
         if len(query) != self.channels:
             raise ValueError("memory query width mismatch")
-        return _softmax([4.0 * _cosine(query, slot.key) + 0.05 * slot.usage for slot in self._slots])
+        scores = [
+            4.0 * _cosine(query, slot.key) - 0.05 * slot.usage
+            for slot in self._slots
+        ]
+        return _softmax(scores)
 
     def read(self, query: Sequence[float]) -> Vector:
         weights = self._attention(query)
-        return tuple(sum(weight * slot.value[c] for weight, slot in zip(weights, self._slots)) for c in range(self.channels))
+        return tuple(
+            sum(
+                weight * slot.value[channel]
+                for weight, slot in zip(weights, self._slots)
+            )
+            for channel in range(self.channels)
+        )
 
-    def write(self, key: Sequence[float], value: Sequence[float], rate: float) -> int:
+    def write(
+        self,
+        key: Sequence[float],
+        value: Sequence[float],
+        rate: float,
+    ) -> int:
+        if len(value) != self.channels:
+            raise ValueError("memory value width mismatch")
         weights = self._attention(key)
-        index = max(range(len(weights)), key=lambda i: (weights[i], -self._slots[i].usage))
+        index = max(
+            range(len(weights)),
+            key=lambda i: (weights[i], -self._slots[i].usage, -i),
+        )
         old = self._slots[index]
         self._slots[index] = MemorySlot(
-            tuple((1.0 - rate) * a + rate * b for a, b in zip(old.key, key)),
-            tuple((1.0 - rate) * a + rate * b for a, b in zip(old.value, value)),
+            tuple(
+                (1.0 - rate) * previous + rate * current
+                for previous, current in zip(old.key, key)
+            ),
+            tuple(
+                (1.0 - rate) * previous + rate * current
+                for previous, current in zip(old.value, value)
+            ),
             old.usage + 1.0,
         )
         return index
@@ -174,7 +248,7 @@ class SpatialMemory:
 
 @dataclass(frozen=True)
 class RefinementTrace:
-    """Auditable latent telemetry; not a textual private reasoning trace."""
+    """Auditable numerical telemetry, not a textual reasoning trace."""
 
     step: int
     reconstruction_loss: float
@@ -199,8 +273,12 @@ class PermeationResult:
     trace: Tuple[RefinementTrace, ...]
     selected: CandidateMeasurement
     baseline: CandidateMeasurement
-    candidate_count: int
+    candidates: Tuple[CandidateMeasurement, ...]
     mechanics_changed: bool
+
+    @property
+    def candidate_count(self) -> int:
+        return len(self.candidates)
 
     def summary(self) -> dict:
         return {
@@ -213,6 +291,9 @@ class PermeationResult:
             "objective": self.selected.objective,
             "mechanics_changed": self.mechanics_changed,
             "candidate_count": self.candidate_count,
+            "candidate_objectives": [
+                measurement.objective for measurement in self.candidates
+            ],
             "trace": [item.__dict__ for item in self.trace],
         }
 
@@ -226,29 +307,93 @@ class GeometricCodec:
         start = index * source // latent
         return start, max(start + 1, (index + 1) * source // latent)
 
-    def encode(self, volume: Volume3D) -> LatentField:
+    def _regions(self, volume: Volume3D):
         sd, sh, sw = volume.shape
         ld, lh, lw = self.config.latent_shape
-        vectors: List[Vector] = []
         for lz in range(ld):
             z0, z1 = self._bounds(sd, ld, lz)
             for ly in range(lh):
                 y0, y1 = self._bounds(sh, lh, ly)
                 for lx in range(lw):
                     x0, x1 = self._bounds(sw, lw, lx)
-                    samples = [volume.at(z, y, x) for z in range(z0, min(z1, sd)) for y in range(y0, min(y1, sh)) for x in range(x0, min(x1, sw))]
-                    mean = _mean(samples)
-                    variance = _mean([(value - mean) ** 2 for value in samples])
-                    cz, cy, cx = min(sd - 1, (z0 + z1 - 1) // 2), min(sh - 1, (y0 + y1 - 1) // 2), min(sw - 1, (x0 + x1 - 1) // 2)
+                    samples = [
+                        volume.at(z, y, x)
+                        for z in range(z0, min(z1, sd))
+                        for y in range(y0, min(y1, sh))
+                        for x in range(x0, min(x1, sw))
+                    ]
+                    cz = min(sd - 1, (z0 + z1 - 1) // 2)
+                    cy = min(sh - 1, (y0 + y1 - 1) // 2)
+                    cx = min(sw - 1, (x0 + x1 - 1) // 2)
                     gradients = (
-                        volume.at(min(sd - 1, cz + 1), cy, cx) - volume.at(max(0, cz - 1), cy, cx),
-                        volume.at(cz, min(sh - 1, cy + 1), cx) - volume.at(cz, max(0, cy - 1), cx),
-                        volume.at(cz, cy, min(sw - 1, cx + 1)) - volume.at(cz, cy, max(0, cx - 1)),
+                        volume.at(min(sd - 1, cz + 1), cy, cx)
+                        - volume.at(max(0, cz - 1), cy, cx),
+                        volume.at(cz, min(sh - 1, cy + 1), cx)
+                        - volume.at(cz, max(0, cy - 1), cx),
+                        volume.at(cz, cy, min(sw - 1, cx + 1))
+                        - volume.at(cz, cy, max(0, cx - 1)),
                     )
-                    radius = math.sqrt(((2 * lz + 1) / ld - 1) ** 2 + ((2 * ly + 1) / lh - 1) ** 2 + ((2 * lx + 1) / lw - 1) ** 2)
-                    basis = [2 * mean - 1, math.sqrt(max(0.0, variance)), gradients[2], gradients[1], gradients[0], radius]
-                    vector = [basis[c] if c < len(basis) else _mean([v * math.sin((c + 1) * (i + 1)) for i, v in enumerate(basis)]) for c in range(self.config.channels)]
-                    vectors.append(tuple(_clamp(v, -self.config.max_abs_latent, self.config.max_abs_latent) for v in vector))
+                    yield lz, ly, lx, samples, gradients
+
+    def _expand_basis(self, basis: Sequence[float]) -> Vector:
+        vector = [
+            basis[channel]
+            if channel < len(basis)
+            else _mean(
+                [
+                    value * math.sin((channel + 1) * (index + 1))
+                    for index, value in enumerate(basis)
+                ]
+            )
+            for channel in range(self.config.channels)
+        ]
+        return tuple(
+            _clamp(
+                value,
+                -self.config.max_abs_latent,
+                self.config.max_abs_latent,
+            )
+            for value in vector
+        )
+
+    def encode(self, volume: Volume3D) -> LatentField:
+        ld, lh, lw = self.config.latent_shape
+        vectors: List[Vector] = []
+        for lz, ly, lx, samples, gradients in self._regions(volume):
+            mean = _mean(samples)
+            variance = _mean([(value - mean) ** 2 for value in samples])
+            radius = math.sqrt(
+                ((2 * lz + 1) / ld - 1) ** 2
+                + ((2 * ly + 1) / lh - 1) ** 2
+                + ((2 * lx + 1) / lw - 1) ** 2
+            )
+            basis = [
+                2.0 * mean - 1.0,
+                math.sqrt(max(0.0, variance)),
+                gradients[2],
+                gradients[1],
+                gradients[0],
+                radius,
+            ]
+            vectors.append(self._expand_basis(basis))
+        return LatentField.build(self.config.latent_shape, vectors)
+
+    def encode_residual(self, residual: Volume3D) -> LatentField:
+        """Project spatial reconstruction error into matching latent cells."""
+
+        vectors: List[Vector] = []
+        for _, _, _, samples, gradients in self._regions(residual):
+            mean = _mean(samples)
+            rms = math.sqrt(_mean([value * value for value in samples]))
+            basis = [
+                mean,
+                rms,
+                gradients[2],
+                gradients[1],
+                gradients[0],
+                _mean([abs(value) for value in samples]),
+            ]
+            vectors.append(self._expand_basis(basis))
         return LatentField.build(self.config.latent_shape, vectors)
 
     def decode(self, latent: LatentField, shape: Shape3D) -> Volume3D:
@@ -256,9 +401,17 @@ class GeometricCodec:
         ld, lh, lw = latent.shape
 
         def sample(z: int, y: int, x: int) -> float:
-            vector = latent.vector(min(ld - 1, z * ld // d), min(lh - 1, y * lh // h), min(lw - 1, x * lw // w))
+            vector = latent.vector(
+                min(ld - 1, z * ld // d),
+                min(lh - 1, y * lh // h),
+                min(lw - 1, x * lw // w),
+            )
             detail = 0.025 * sum(vector[2:5]) if len(vector) > 2 else 0.0
-            return _clamp(0.5 * (vector[0] + 1.0) + detail, 0.0, 1.0)
+            return _clamp(
+                0.5 * (vector[0] + 1.0) + detail,
+                0.0,
+                1.0,
+            )
 
         return Volume3D.from_function(shape, sample)
 
@@ -269,43 +422,137 @@ class VisualMemoryANN:
     def __init__(self, config: Optional[GeometricConfig] = None) -> None:
         self.config = config or GeometricConfig()
         self.config.validate()
-        self.memory = SpatialMemory(self.config.memory_slots, self.config.channels)
-        self.journal: List[CandidateMeasurement] = []
+        self.memory = SpatialMemory(
+            self.config.memory_slots,
+            self.config.channels,
+        )
+        self.journal: List[Tuple[CandidateMeasurement, ...]] = []
 
     @staticmethod
     def _global(latent: LatentField) -> Vector:
         vectors = latent.vectors()
-        return tuple(_mean([vector[c] for vector in vectors]) for c in range(latent.channels))
+        return tuple(
+            _mean([vector[channel] for vector in vectors])
+            for channel in range(latent.channels)
+        )
 
     @staticmethod
     def _operations(volume: Volume3D, config: GeometricConfig) -> int:
-        voxels, cells = _prod(volume.shape), _prod(config.latent_shape)
-        return voxels * (2 * config.channels + 3) + config.refinement_steps * cells * config.channels * (config.memory_slots + 8)
+        voxels = _prod(volume.shape)
+        cells = _prod(config.latent_shape)
+        encode_decode = voxels * (2 * config.channels + 3)
+        refine = (
+            config.refinement_steps
+            * cells
+            * config.channels
+            * (config.memory_slots + 10)
+        )
+        return encode_decode + refine
 
-    def _run(self, observed: Volume3D, target: Volume3D, config: GeometricConfig, memory: SpatialMemory):
-        codec, latent, trace = GeometricCodec(config), GeometricCodec(config).encode(observed), []
+    def _run(
+        self,
+        observed: Volume3D,
+        target: Volume3D,
+        config: GeometricConfig,
+        memory: SpatialMemory,
+    ):
+        codec = GeometricCodec(config)
+        latent = codec.encode(observed)
+        trace: List[RefinementTrace] = []
+
         for step in range(config.refinement_steps):
-            query, recalled = self._global(latent), memory.read(self._global(latent))
+            query = self._global(latent)
+            recalled = memory.read(query)
             reconstruction = codec.decode(latent, target.shape)
-            residual = tuple(expected - actual for expected, actual in zip(target.values, reconstruction.values))
-            residual_mean = _mean(residual)
-            slot = memory.write(query, tuple(residual_mean * math.cos(c + 1) for c in range(config.channels)), config.learning_rate)
+            residual_volume = target.subtract(reconstruction)
+            residual_latent = codec.encode_residual(residual_volume)
+            residual_summary = self._global(residual_latent)
+            slot = memory.write(
+                query,
+                residual_summary,
+                config.learning_rate,
+            )
+
             vectors = []
-            for vector in latent.vectors():
-                vectors.append(tuple(_clamp(value + config.learning_rate * (config.residual_gain * residual_mean + config.memory_gain * (recalled[c] - value)), -config.max_abs_latent, config.max_abs_latent) for c, value in enumerate(vector)))
+            for vector, local_residual in zip(
+                latent.vectors(),
+                residual_latent.vectors(),
+            ):
+                updated = tuple(
+                    _clamp(
+                        value
+                        + config.learning_rate
+                        * (
+                            config.residual_gain * local_residual[channel]
+                            + config.memory_gain
+                            * (recalled[channel] - value)
+                        ),
+                        -config.max_abs_latent,
+                        config.max_abs_latent,
+                    )
+                    for channel, value in enumerate(vector)
+                )
+                vectors.append(updated)
+
             latent = LatentField.build(latent.shape, vectors)
             post = codec.decode(latent, target.shape)
-            trace.append(RefinementTrace(step, post.mse(target), _norm(latent.values) / math.sqrt(len(latent.values)), _norm(residual) / math.sqrt(len(residual)), _norm(recalled), slot))
+            trace.append(
+                RefinementTrace(
+                    step=step,
+                    reconstruction_loss=post.mse(target),
+                    latent_norm=_norm(latent.values)
+                    / math.sqrt(len(latent.values)),
+                    residual_norm=_norm(residual_volume.values)
+                    / math.sqrt(len(residual_volume.values)),
+                    recalled_norm=_norm(recalled),
+                    memory_slot=slot,
+                )
+            )
+
         reconstruction = codec.decode(latent, target.shape)
-        loss, operations = reconstruction.mse(target), self._operations(observed, config)
-        measurement = CandidateMeasurement(config, loss, operations, loss + config.cost_weight * operations)
+        loss = reconstruction.mse(target)
+        operations = self._operations(observed, config)
+        measurement = CandidateMeasurement(
+            config,
+            loss,
+            operations,
+            loss + config.cost_weight * operations,
+        )
         return reconstruction, latent, tuple(trace), measurement, memory
 
     def _candidates(self) -> Tuple[GeometricConfig, ...]:
-        c = self.config
-        proposals = [c, replace(c, learning_rate=max(0.01, c.learning_rate * 0.75)), replace(c, learning_rate=min(1.0, c.learning_rate * 1.25)), replace(c, residual_gain=min(1.0, c.residual_gain + 0.1))]
-        if c.refinement_steps < c.max_candidate_steps:
-            proposals.append(replace(c, refinement_steps=c.refinement_steps + 1))
+        current = self.config
+        proposals = [
+            current,
+            replace(
+                current,
+                learning_rate=max(0.01, current.learning_rate * 0.75),
+            ),
+            replace(
+                current,
+                learning_rate=min(1.0, current.learning_rate * 1.25),
+            ),
+            replace(
+                current,
+                residual_gain=min(1.0, current.residual_gain + 0.1),
+            ),
+            replace(
+                current,
+                memory_gain=max(0.0, current.memory_gain * 0.75),
+            ),
+            replace(
+                current,
+                memory_gain=min(1.0, current.memory_gain * 1.25),
+            ),
+        ]
+        if current.refinement_steps < current.max_candidate_steps:
+            proposals.append(
+                replace(
+                    current,
+                    refinement_steps=current.refinement_steps + 1,
+                )
+            )
+
         unique: List[GeometricConfig] = []
         for proposal in proposals:
             proposal.validate()
@@ -313,32 +560,75 @@ class VisualMemoryANN:
                 unique.append(proposal)
         return tuple(unique)
 
-    def permeate(self, observed: Volume3D, target: Optional[Volume3D] = None, auto_optimize: bool = True) -> PermeationResult:
+    def permeate(
+        self,
+        observed: Volume3D,
+        target: Optional[Volume3D] = None,
+        auto_optimize: bool = True,
+    ) -> PermeationResult:
         target = target or observed
         if observed.shape != target.shape:
             raise ValueError("observed and target volumes must have equal shapes")
+
         candidates = self._candidates() if auto_optimize else (self.config,)
         snapshot = self.memory.clone()
-        runs = [self._run(observed, target, candidate, snapshot.clone()) for candidate in candidates]
+        runs = [
+            self._run(
+                observed,
+                target,
+                candidate,
+                snapshot.clone(),
+            )
+            for candidate in candidates
+        ]
         baseline = runs[0]
-        index = min(range(len(runs)), key=lambda i: (runs[i][3].objective, i))
+        index = min(
+            range(len(runs)),
+            key=lambda candidate_index: (
+                runs[candidate_index][3].objective,
+                candidate_index,
+            ),
+        )
         selected = runs[index]
-        changed = index != 0 and selected[3].objective < baseline[3].objective
-        self.config, self.memory = selected[3].config, selected[4]
-        self.journal.append(selected[3])
-        return PermeationResult(selected[0], selected[1], selected[2], selected[3], baseline[3], len(candidates), changed)
+        changed = (
+            index != 0
+            and selected[3].objective < baseline[3].objective
+        )
+
+        self.config = selected[3].config
+        self.memory = selected[4]
+        measurements = tuple(run[3] for run in runs)
+        self.journal.append(measurements)
+
+        return PermeationResult(
+            reconstruction=selected[0],
+            latent=selected[1],
+            trace=selected[2],
+            selected=selected[3],
+            baseline=baseline[3],
+            candidates=measurements,
+            mechanics_changed=changed,
+        )
 
 
 def make_demo_volume(size: int = 12) -> Volume3D:
     if size < 4:
         raise ValueError("demo size must be at least 4")
-    centre, scale = (size - 1) / 2.0, max(1.0, (size - 1) / 2.0)
+    centre = (size - 1) / 2.0
+    scale = max(1.0, (size - 1) / 2.0)
 
     def field(z: int, y: int, x: int) -> float:
-        nx, ny, nz = (x - centre) / scale, (y - centre) / scale, (z - centre) / scale
+        nx = (x - centre) / scale
+        ny = (y - centre) / scale
+        nz = (z - centre) / scale
         radius = math.sqrt(nx * nx + ny * ny + nz * nz)
         shell = math.exp(-10.0 * (radius - 0.58) ** 2)
-        wave = 0.12 * (math.sin(5 * nx) * math.cos(4 * ny) * math.sin(3 * nz) + 1.0)
+        wave = 0.12 * (
+            math.sin(5 * nx)
+            * math.cos(4 * ny)
+            * math.sin(3 * nz)
+            + 1.0
+        )
         return _clamp(0.82 * shell + wave, 0.0, 1.0)
 
     return Volume3D.from_function((size, size, size), field)

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,14 @@
 import hashlib
 import time
 
+
 class OmegaLedger:
     def __init__(self):
         self.chain = []
 
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
+        payload_text = f"{time.time()}|{state}|{opcode}"
+        payload_bytes = payload_text.encode()
         prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        entry_hash = hashlib.sha256(prev + payload_bytes).hexdigest()
+        self.chain.append({"hash": entry_hash, "payload": payload_text})

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -1,16 +1,20 @@
 import json
 import os
+from typing import Optional
+
 from .ledger import OmegaLedger
 
+
 class PersistentLedger(OmegaLedger):
-    def __init__(self, path="omega_ledger.json"):
+    def __init__(self, path: Optional[str] = "omega_ledger.json"):
         super().__init__()
         self.path = path
-        if os.path.exists(path):
-            with open(path) as f:
-                self.chain = json.load(f)
+        if path and os.path.exists(path):
+            with open(path, encoding="utf-8") as ledger_file:
+                self.chain = json.load(ledger_file)
 
     def log(self, state, opcode):
         super().log(state, opcode)
-        with open(self.path, "w") as f:
-            json.dump(self.chain, f, indent=2)
+        if self.path:
+            with open(self.path, "w", encoding="utf-8") as ledger_file:
+                json.dump(self.chain, ledger_file, indent=2)

--- a/src/jarvisx/mm3d_omega4.py
+++ b/src/jarvisx/mm3d_omega4.py
@@ -1,0 +1,791 @@
+"""Bounded operational MM3D-AED-BCE-Ω⁴ reference kernel.
+
+Preserves the intended Ξ→encode→explore→decode→ΠΛ→Ω→Θ cycle while
+separating the 50T conceptual target from the executable allocation profile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import struct
+import time
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
+from enum import Enum, auto
+from typing import Any, Callable, Deque, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+MODULUS = 8
+VOXEL_BITS = 384
+VOXEL_BYTES = 48
+TOKEN_BYTES, VISUAL_BYTES, AUDIO_BYTES, MOTION_BYTES = 16, 12, 8, 6
+VOXEL_DTYPE = np.dtype(
+    [
+        ("token_embedding", np.int8, (TOKEN_BYTES,)),
+        ("visual_feature", np.int8, (VISUAL_BYTES,)),
+        ("audio_spectral", np.int8, (AUDIO_BYTES,)),
+        ("motion_vector", np.int8, (MOTION_BYTES,)),
+        ("attention_weight", "<f4"),
+        ("ethical_flag", np.uint8),
+        ("reserved", np.uint8),
+    ],
+    align=False,
+)
+assert VOXEL_DTYPE.itemsize == VOXEL_BYTES
+
+
+class Modality(Enum):
+    TEXT = auto()
+    IMAGE = auto()
+    AUDIO = auto()
+    VIDEO = auto()
+    MOTION = auto()
+
+
+@dataclass(frozen=True)
+class MM3DConfig:
+    xi_size: int = 32
+    manifold_dim: int = 4096
+    latent_size: int = 8
+    codebook_size: int = 1024
+    codebook_dim: int = 16
+    projection_rank: int = 32
+    metric_rank: int = 16
+    exploration_depth: int = 6
+    render_image_size: int = 32
+    render_video_frames: int = 4
+    render_audio_samples: int = 2048
+    omega_capacity: int = 10000
+    target_cycle_ms: float = 13.7
+    seed: int = 0x4D4D3344
+    max_reference_bytes: int = 512 * 1024 * 1024
+    conceptual_parameters_total: int = 50_000_000_000_000
+    conceptual_active_fraction: float = 0.005
+
+    @property
+    def latent_tokens(self) -> int:
+        return self.latent_size**3
+
+    @property
+    def conceptual_parameters_active(self) -> int:
+        return int(self.conceptual_parameters_total * self.conceptual_active_fraction)
+
+    def estimated_reference_bytes(self) -> int:
+        latent_flat = self.latent_tokens * self.codebook_dim
+        scalars = (
+            self.manifold_dim * self.metric_rank
+            + self.metric_rank
+            + self.projection_rank * self.manifold_dim
+            + 2 * latent_flat * self.projection_rank
+            + self.manifold_dim * self.projection_rank
+            + self.codebook_size * self.codebook_dim
+        )
+        return int(4 * scalars + self.xi_size**3 * (VOXEL_BYTES + 1))
+
+    def validate(self) -> None:
+        dimensions = (
+            self.xi_size,
+            self.manifold_dim,
+            self.latent_size,
+            self.codebook_size,
+            self.codebook_dim,
+            self.projection_rank,
+            self.metric_rank,
+            self.exploration_depth,
+            self.render_image_size,
+            self.render_video_frames,
+            self.render_audio_samples,
+            self.omega_capacity,
+        )
+        if any(value <= 0 for value in dimensions):
+            raise ValueError("MM3D dimensions and capacities must be positive")
+        if not 0.0 < self.conceptual_active_fraction <= 1.0:
+            raise ValueError("conceptual_active_fraction must be in (0, 1]")
+        if self.estimated_reference_bytes() > self.max_reference_bytes:
+            raise ValueError("reference configuration exceeds allocation guard")
+
+
+@dataclass
+class Voxel:
+    """Exact 384-bit voxel; original feature dimensions are interpreted as bits."""
+
+    token_embedding: np.ndarray = field(
+        default_factory=lambda: np.zeros(TOKEN_BYTES, dtype=np.int8)
+    )
+    visual_feature: np.ndarray = field(
+        default_factory=lambda: np.zeros(VISUAL_BYTES, dtype=np.int8)
+    )
+    audio_spectral: np.ndarray = field(
+        default_factory=lambda: np.zeros(AUDIO_BYTES, dtype=np.int8)
+    )
+    motion_vector: np.ndarray = field(
+        default_factory=lambda: np.zeros(MOTION_BYTES, dtype=np.int8)
+    )
+    attention_weight: np.float32 = np.float32(0.0)
+    ethical_flag: np.uint8 = np.uint8(0)
+    reserved: np.uint8 = np.uint8(0)
+
+    def __post_init__(self) -> None:
+        for name, width in (
+            ("token_embedding", TOKEN_BYTES),
+            ("visual_feature", VISUAL_BYTES),
+            ("audio_spectral", AUDIO_BYTES),
+            ("motion_vector", MOTION_BYTES),
+        ):
+            value = np.asarray(getattr(self, name), dtype=np.int8)
+            if value.shape != (width,):
+                raise ValueError(f"{name} must have shape ({width},)")
+            setattr(self, name, value.copy())
+        self.attention_weight = np.float32(self.attention_weight)
+        self.ethical_flag = np.uint8(self.ethical_flag)
+        self.reserved = np.uint8(self.reserved)
+
+    def to_bytes(self) -> bytes:
+        payload = b"".join(
+            (
+                self.token_embedding.tobytes(),
+                self.visual_feature.tobytes(),
+                self.audio_spectral.tobytes(),
+                self.motion_vector.tobytes(),
+                struct.pack(
+                    "<fBB",
+                    float(self.attention_weight),
+                    int(self.ethical_flag),
+                    int(self.reserved),
+                ),
+            )
+        )
+        if len(payload) != VOXEL_BYTES:
+            raise RuntimeError("voxel serialization violated the 48-byte contract")
+        return payload
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "Voxel":
+        if len(data) != VOXEL_BYTES:
+            raise ValueError("voxel payload must be exactly 48 bytes")
+        boundaries = (0, 16, 28, 36, 42)
+        attention, ethical, reserved = struct.unpack("<fBB", data[42:48])
+        return cls(
+            np.frombuffer(data[boundaries[0] : boundaries[1]], dtype=np.int8).copy(),
+            np.frombuffer(data[boundaries[1] : boundaries[2]], dtype=np.int8).copy(),
+            np.frombuffer(data[boundaries[2] : boundaries[3]], dtype=np.int8).copy(),
+            np.frombuffer(data[boundaries[3] : boundaries[4]], dtype=np.int8).copy(),
+            attention,
+            ethical,
+            reserved,
+        )
+
+
+class Z8QCA:
+    def __init__(self, size: int, seed: int = 0) -> None:
+        if size <= 0:
+            raise ValueError("QCA size must be positive")
+        self.size = size
+        self.state = np.random.default_rng(seed).integers(
+            0, MODULUS, size=(size, size, size), dtype=np.uint8
+        )
+
+    def laplacian(self) -> np.ndarray:
+        state = self.state.astype(np.int16)
+        neighbors = sum(
+            np.roll(state, shift, axis=axis)
+            for axis in range(3)
+            for shift in (-1, 1)
+        )
+        return neighbors - 6 * state
+
+    def update(self, diffusion_gain: int = 1, reaction_gain: int = 1) -> None:
+        if min(diffusion_gain, reaction_gain) < 0:
+            raise ValueError("QCA gains must be non-negative")
+        state = self.state.astype(np.int16)
+        reaction = state * (MODULUS - state) // 2
+        self.state = np.mod(
+            state + diffusion_gain * self.laplacian() + reaction_gain * reaction,
+            MODULUS,
+        ).astype(np.uint8)
+
+    def get_region(
+        self, x: int, y: int, z: int, w: int, h: int, d: int
+    ) -> np.ndarray:
+        if min(w, h, d) <= 0:
+            raise ValueError("region dimensions must be positive")
+        axes = [
+            np.mod(np.arange(start, start + width), self.size)
+            for start, width in ((x, w), (y, h), (z, d))
+        ]
+        return self.state[np.ix_(*axes)].copy()
+
+
+class XiCube:
+    """Contiguous 48-byte voxel lattice; no millions of Python objects."""
+
+    def __init__(self, size: int, seed: int = 0) -> None:
+        self.size = size
+        self.data = np.zeros((size, size, size), dtype=VOXEL_DTYPE)
+        self.qca = Z8QCA(size, seed)
+
+    @property
+    def allocated_bytes(self) -> int:
+        return int(self.data.nbytes + self.qca.state.nbytes)
+
+    def _index(self, x: int, y: int, z: int) -> Tuple[int, int, int]:
+        return x % self.size, y % self.size, z % self.size
+
+    def load(self, x: int, y: int, z: int) -> Voxel:
+        item = self.data[self._index(x, y, z)]
+        return Voxel(*(item[name] for name in VOXEL_DTYPE.names or ()))
+
+    def store(self, x: int, y: int, z: int, voxel: Voxel) -> None:
+        item = self.data[self._index(x, y, z)]
+        for name in VOXEL_DTYPE.names or ():
+            item[name] = getattr(voxel, name)
+
+    def encode_region(
+        self, region: Tuple[int, int, int, int, int, int]
+    ) -> np.ndarray:
+        values = self.qca.get_region(*region)
+        return values.reshape(-1).astype(np.float32) / np.float32(MODULUS - 1)
+
+    def get_ethical_mask(self) -> np.ndarray:
+        return self.data["ethical_flag"] > 0
+
+
+@dataclass(frozen=True)
+class LatentCode:
+    codes: np.ndarray
+    continuous: Optional[np.ndarray] = None
+
+    def validate(self, config: MM3DConfig) -> None:
+        expected = (config.latent_size,) * 3
+        if self.codes.shape != expected or self.codes.dtype.kind not in "iu":
+            raise ValueError(f"latent codes must be integer {expected}")
+        if np.any(self.codes < 0) or np.any(self.codes >= config.codebook_size):
+            raise ValueError("latent code outside codebook")
+        if self.continuous is not None and self.continuous.shape != (
+            config.latent_tokens,
+            config.codebook_dim,
+        ):
+            raise ValueError("continuous latent shape mismatch")
+
+
+class FactorizedMetric:
+    def __init__(self, dimension: int, rank: int, rng: np.random.Generator) -> None:
+        self.diagonal = np.ones(dimension, dtype=np.float32)
+        self.low_rank = rng.standard_normal(
+            (dimension, rank), dtype=np.float32
+        ) / np.float32(math.sqrt(dimension))
+
+    def inverse_apply(self, vector: np.ndarray) -> np.ndarray:
+        inv_diag = 1.0 / self.diagonal
+        dinv_l = inv_diag[:, None] * self.low_rank
+        middle = (
+            np.eye(self.low_rank.shape[1], dtype=np.float32)
+            + self.low_rank.T @ dinv_l
+        )
+        return (
+            inv_diag * vector
+            - dinv_l
+            @ np.linalg.solve(middle, self.low_rank.T @ (inv_diag * vector))
+        ).astype(np.float32)
+
+    @property
+    def parameter_count(self) -> int:
+        return int(self.diagonal.size + self.low_rank.size)
+
+
+class GeometricAutoEncoder:
+    """Low-rank metric projection plus vector quantization."""
+
+    def __init__(self, config: MM3DConfig) -> None:
+        config.validate()
+        self.config = config
+        rng = np.random.default_rng(config.seed ^ 0xE0C0DE)
+        latent_flat = config.latent_tokens * config.codebook_dim
+
+        def matrix(shape: Tuple[int, int], fan_in: int) -> np.ndarray:
+            return rng.standard_normal(shape, dtype=np.float32) / np.float32(
+                math.sqrt(fan_in)
+            )
+
+        self.metric = FactorizedMetric(config.manifold_dim, config.metric_rank, rng)
+        self.encode_right = matrix(
+            (config.projection_rank, config.manifold_dim), config.manifold_dim
+        )
+        self.encode_left = matrix(
+            (latent_flat, config.projection_rank), config.projection_rank
+        )
+        self.decode_right = matrix(
+            (config.projection_rank, latent_flat), latent_flat
+        )
+        self.decode_left = matrix(
+            (config.manifold_dim, config.projection_rank), config.projection_rank
+        )
+        self.codebook = rng.standard_normal(
+            (config.codebook_size, config.codebook_dim), dtype=np.float32
+        ) * np.float32(0.1)
+        self.codebook_norm = np.sum(self.codebook * self.codebook, axis=1)
+
+    @property
+    def parameter_count(self) -> int:
+        arrays = (
+            self.encode_right,
+            self.encode_left,
+            self.decode_right,
+            self.decode_left,
+            self.codebook,
+        )
+        return self.metric.parameter_count + sum(int(array.size) for array in arrays)
+
+    @property
+    def allocated_bytes(self) -> int:
+        arrays = (
+            self.metric.diagonal,
+            self.metric.low_rank,
+            self.encode_right,
+            self.encode_left,
+            self.decode_right,
+            self.decode_left,
+            self.codebook,
+            self.codebook_norm,
+        )
+        return sum(int(array.nbytes) for array in arrays)
+
+    def prepare_input(self, values: np.ndarray) -> np.ndarray:
+        flat = np.nan_to_num(np.asarray(values, dtype=np.float32).reshape(-1))
+        output = np.zeros(self.config.manifold_dim, dtype=np.float32)
+        output[: min(flat.size, output.size)] = flat[: output.size]
+        return output
+
+    def metric_prepare(self, values: np.ndarray) -> np.ndarray:
+        return self.metric.inverse_apply(self.prepare_input(values))
+
+    def project_partition(
+        self, values: np.ndarray, start: int, stop: int
+    ) -> np.ndarray:
+        if not 0 <= start <= stop <= self.config.manifold_dim:
+            raise ValueError("invalid manifold partition")
+        return self.encode_right[:, start:stop] @ values[start:stop]
+
+    def quantize(self, vectors: np.ndarray, chunk_size: int = 256) -> np.ndarray:
+        vectors = np.asarray(vectors, dtype=np.float32)
+        if vectors.ndim != 2 or vectors.shape[1] != self.config.codebook_dim:
+            raise ValueError("quantization width mismatch")
+        codes = np.empty(vectors.shape[0], dtype=np.int32)
+        for start in range(0, len(vectors), chunk_size):
+            chunk = vectors[start : start + chunk_size]
+            distances = (
+                np.sum(chunk * chunk, axis=1)[:, None]
+                + self.codebook_norm[None, :]
+            )
+            distances -= 2.0 * chunk @ self.codebook.T
+            codes[start : start + len(chunk)] = np.argmin(distances, axis=1)
+        return codes
+
+    def encode_from_hidden(self, hidden: np.ndarray) -> LatentCode:
+        continuous = np.tanh(self.encode_left @ np.tanh(hidden)).reshape(
+            self.config.latent_tokens, self.config.codebook_dim
+        )
+        codes = self.quantize(continuous).reshape((self.config.latent_size,) * 3)
+        latent = LatentCode(codes.astype(np.int32), continuous)
+        latent.validate(self.config)
+        return latent
+
+    def encode(self, values: np.ndarray) -> LatentCode:
+        metric_values = self.metric_prepare(values)
+        return self.encode_from_hidden(self.encode_right @ metric_values)
+
+    def dequantize(self, latent: LatentCode) -> np.ndarray:
+        latent.validate(self.config)
+        return self.codebook[latent.codes.reshape(-1)]
+
+    def decode(self, latent: LatentCode) -> np.ndarray:
+        hidden = np.tanh(self.decode_right @ self.dequantize(latent).reshape(-1))
+        reconstructed = self.decode_left @ hidden
+        return (reconstructed + 0.01 * np.tanh(reconstructed)).astype(np.float32)
+
+
+class PhiQAS:
+    """Classical deterministic latent candidate exploration, not quantum hardware."""
+
+    def __init__(self, autoencoder: GeometricAutoEncoder) -> None:
+        self.autoencoder = autoencoder
+
+    def _score(self, vectors: np.ndarray) -> float:
+        codes = self.autoencoder.quantize(vectors)
+        quantized = self.autoencoder.codebook[codes]
+        error = float(np.mean((vectors - quantized) ** 2))
+        grid = vectors.reshape(
+            (self.autoencoder.config.latent_size,) * 3 + (-1,)
+        )
+        smoothness = sum(
+            float(np.mean((grid - np.roll(grid, 1, axis=axis)) ** 2))
+            for axis in range(3)
+        )
+        phase = math.cos(float(np.sum(vectors)) / math.sqrt(vectors.size))
+        return error + 0.01 * smoothness - 1e-4 * phase
+
+    def explore(self, latent: LatentCode, depth: int) -> LatentCode:
+        if depth <= 0:
+            raise ValueError("exploration depth must be positive")
+        base = (
+            latent.continuous.copy()
+            if latent.continuous is not None
+            else self.autoencoder.dequantize(latent)
+        )
+        digest = hashlib.sha3_256(
+            latent.codes.tobytes() + struct.pack("<I", depth)
+        ).digest()
+        rng = np.random.default_rng(
+            int.from_bytes(digest[:8], "little") ^ self.autoencoder.config.seed
+        )
+        candidates = [base]
+        for index in range(depth):
+            noise = rng.standard_normal(base.shape, dtype=np.float32)
+            candidates.append(
+                np.clip(
+                    base + noise * np.float32(0.02 / math.sqrt(index + 1)),
+                    -1.0,
+                    1.0,
+                )
+            )
+        best = min(
+            enumerate(candidates),
+            key=lambda item: (self._score(item[1]), item[0]),
+        )[1]
+        result = LatentCode(
+            self.autoencoder.quantize(best)
+            .reshape(latent.codes.shape)
+            .astype(np.int32),
+            best,
+        )
+        result.validate(self.autoencoder.config)
+        return result
+
+
+class LambdaConstraint:
+    def __init__(
+        self, policies: Optional[Sequence[Callable[[Any], bool]]] = None
+    ) -> None:
+        self.policies = list(policies or [])
+        self.violation_count = 0
+
+    def require(self, operation: Any) -> None:
+        if any(not bool(policy(operation)) for policy in self.policies):
+            self.violation_count += 1
+            raise RuntimeError("Lambda constraint rejected operation")
+
+    def project(self, state: np.ndarray, mask: np.ndarray) -> np.ndarray:
+        state = np.asarray(state, dtype=np.float32).reshape(-1)
+        mask = np.asarray(mask, dtype=bool).reshape(-1)
+        if state.shape != mask.shape:
+            raise ValueError("Lambda mask must match state")
+        safe = state.copy()
+        safe[mask] = 0.0
+        return safe
+
+
+@dataclass(frozen=True)
+class OmegaEntry:
+    sequence: int
+    instruction_hash: str
+    voxel_region: Tuple[int, int, int, int, int, int]
+    ethical_flag: int
+    result_hash: str
+    prev_hash: str = ""
+
+    def compute_hash(self) -> str:
+        payload = json.dumps(
+            {
+                "sequence": self.sequence,
+                "instruction_hash": self.instruction_hash,
+                "voxel_region": self.voxel_region,
+                "ethical_flag": self.ethical_flag,
+                "result_hash": self.result_hash,
+                "prev_hash": self.prev_hash,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha3_256(payload.encode()).hexdigest()
+
+
+class OmegaMemory:
+    GENESIS = "0" * 64
+
+    def __init__(self, capacity: int = 10000) -> None:
+        self.capacity = capacity
+        self.chain: Deque[Tuple[str, OmegaEntry]] = deque()
+        self.anchor_hash = self.GENESIS
+        self.head_hash = self.GENESIS
+        self.next_sequence = 0
+
+    def append(self, entry: OmegaEntry) -> str:
+        if entry.sequence != self.next_sequence:
+            raise ValueError("Omega sequence is not contiguous")
+        committed = replace(entry, prev_hash=self.head_hash)
+        entry_hash = committed.compute_hash()
+        if len(self.chain) >= self.capacity:
+            self.anchor_hash = self.chain.popleft()[0]
+        self.chain.append((entry_hash, committed))
+        self.head_hash = entry_hash
+        self.next_sequence += 1
+        return entry_hash
+
+    def verify(self) -> bool:
+        previous = self.anchor_hash
+        for entry_hash, entry in self.chain:
+            if entry.prev_hash != previous or entry.compute_hash() != entry_hash:
+                return False
+            previous = entry_hash
+        return previous == self.head_hash
+
+
+class ThetaProjection:
+    def __init__(self, config: MM3DConfig) -> None:
+        self.config = config
+
+    @staticmethod
+    def _repeat(state: np.ndarray, count: int) -> np.ndarray:
+        flat = np.asarray(state, dtype=np.float32).reshape(-1)
+        if not flat.size:
+            raise ValueError("cannot render empty state")
+        return np.resize(flat, count)
+
+    def render_text(self, state: np.ndarray, vocab_size: int = 4096) -> str:
+        indices = np.argsort(
+            -self._repeat(state, vocab_size), kind="stable"
+        )[:32]
+        return " ".join(str(int(index)) for index in indices)
+
+    def render_image(self, state: np.ndarray) -> np.ndarray:
+        size = self.config.render_image_size
+        values = self._repeat(state, size * size * 3)
+        return (
+            np.clip(np.tanh(values) * 127.5 + 127.5, 0, 255)
+            .reshape(size, size, 3)
+            .astype(np.uint8)
+        )
+
+    def render_audio(self, state: np.ndarray) -> np.ndarray:
+        values = self._repeat(state, 8)
+        frequencies = 110.0 + 770.0 / (1.0 + np.exp(-values[:4]))
+        amplitudes = 0.1 * np.tanh(values[4:])
+        timeline = (
+            np.arange(self.config.render_audio_samples, dtype=np.float32) / 24000.0
+        )
+        return np.sum(
+            [
+                amplitude * np.sin(2 * math.pi * frequency * timeline)
+                for frequency, amplitude in zip(frequencies, amplitudes)
+            ],
+            axis=0,
+            dtype=np.float32,
+        )
+
+    def render_video(self, state: np.ndarray) -> np.ndarray:
+        image = self.render_image(state)
+        return np.stack(
+            [
+                np.roll(image, frame, axis=1)
+                for frame in range(self.config.render_video_frames)
+            ]
+        )
+
+
+@dataclass(frozen=True)
+class MM3DCycleResult:
+    latent_code: np.ndarray
+    safe_state: np.ndarray
+    text: str
+    image: np.ndarray
+    audio: np.ndarray
+    video: np.ndarray
+    cycle_time_ms: float
+    cycle_number: int
+    omega_head: str
+    xi_state_hash: str
+    target_cycle_ms: float
+    actual_parameter_count: int
+    conceptual_parameter_count: int
+    conceptual_active_parameter_count: int
+    allocated_bytes: int
+
+    def summary(self) -> Dict[str, Any]:
+        return {
+            "cycle_number": self.cycle_number,
+            "cycle_time_ms": self.cycle_time_ms,
+            "target_cycle_ms": self.target_cycle_ms,
+            "target_met": self.cycle_time_ms <= self.target_cycle_ms,
+            "omega_head": self.omega_head,
+            "xi_state_hash": self.xi_state_hash,
+            "latent_shape": list(self.latent_code.shape),
+            "image_shape": list(self.image.shape),
+            "audio_shape": list(self.audio.shape),
+            "video_shape": list(self.video.shape),
+            "text_preview": self.text[:80],
+            "actual_parameter_count": self.actual_parameter_count,
+            "conceptual_parameter_count": self.conceptual_parameter_count,
+            "conceptual_active_parameter_count": self.conceptual_active_parameter_count,
+            "allocated_bytes": self.allocated_bytes,
+        }
+
+
+class CloudNode:
+    def __init__(self, node_id: int) -> None:
+        self.node_id = node_id
+        self.claimed_ranges: List[Tuple[int, int]] = []
+        self.executor = ThreadPoolExecutor(max_workers=1)
+
+    async def dispatch(self, func: Callable[..., Any], *args: Any) -> Any:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(self.executor, func, *args)
+
+    def claim_range(self, start: int, stop: int) -> None:
+        self.claimed_ranges.append((start, stop))
+
+    def close(self) -> None:
+        self.executor.shutdown(wait=True)
+
+
+class MM3DEngine:
+    """Bounded operational Ξ→Φ→Λ→Ω→Θ cycle."""
+
+    def __init__(self, config: Optional[MM3DConfig] = None) -> None:
+        self.config = config or MM3DConfig()
+        self.config.validate()
+        self.xi = XiCube(self.config.xi_size, self.config.seed)
+        self.encoder = GeometricAutoEncoder(self.config)
+        self.qas = PhiQAS(self.encoder)
+        self.lam = LambdaConstraint(
+            [
+                lambda operation: isinstance(operation, dict),
+                lambda operation: operation.get("action") == "MM3D.CYCLE",
+                lambda operation: int(operation.get("input_elements", 0)) > 0,
+            ]
+        )
+        self.omega = OmegaMemory(self.config.omega_capacity)
+        self.theta = ThetaProjection(self.config)
+        self.nodes: List[CloudNode] = []
+        self.cycle_count = 0
+
+    @property
+    def allocated_bytes(self) -> int:
+        return self.xi.allocated_bytes + self.encoder.allocated_bytes
+
+    def add_cloud_node(self, node: CloudNode) -> None:
+        if any(existing.node_id == node.node_id for existing in self.nodes):
+            raise ValueError("duplicate node id")
+        self.nodes.append(node)
+
+    def _ethical_mask(self) -> np.ndarray:
+        raw = self.xi.get_ethical_mask().reshape(-1)
+        mask = np.zeros(self.config.manifold_dim, dtype=bool)
+        mask[: min(mask.size, raw.size)] = raw[: mask.size]
+        return mask
+
+    def _finish(
+        self, latent: LatentCode, operation: Dict[str, Any], started: float
+    ) -> MM3DCycleResult:
+        optimized = self.qas.explore(latent, self.config.exploration_depth)
+        safe = self.lam.project(
+            self.encoder.decode(optimized), self._ethical_mask()
+        )
+        state_hash = hashlib.sha3_256(safe.tobytes()).hexdigest()
+        instruction_hash = hashlib.sha3_256(
+            json.dumps(operation, sort_keys=True, separators=(",", ":")).encode()
+        ).hexdigest()
+        head = self.omega.append(
+            OmegaEntry(
+                self.omega.next_sequence,
+                instruction_hash,
+                (
+                    0,
+                    0,
+                    0,
+                    self.config.xi_size,
+                    self.config.xi_size,
+                    self.config.xi_size,
+                ),
+                int(np.any(self._ethical_mask())),
+                state_hash,
+            )
+        )
+        self.cycle_count += 1
+        return MM3DCycleResult(
+            optimized.codes.copy(),
+            safe,
+            self.theta.render_text(safe),
+            self.theta.render_image(safe),
+            self.theta.render_audio(safe),
+            self.theta.render_video(safe),
+            (time.perf_counter() - started) * 1000.0,
+            self.cycle_count,
+            head,
+            state_hash[:16],
+            self.config.target_cycle_ms,
+            self.encoder.parameter_count,
+            self.config.conceptual_parameters_total,
+            self.config.conceptual_parameters_active,
+            self.allocated_bytes,
+        )
+
+    def cycle(self, psi_input: np.ndarray, sop: Any = None) -> MM3DCycleResult:
+        started = time.perf_counter()
+        values = np.asarray(psi_input)
+        operation = {
+            "action": "MM3D.CYCLE",
+            "input_elements": int(values.size),
+            "sop_type": type(sop).__name__ if sop is not None else None,
+        }
+        self.lam.require(operation)
+        self.xi.qca.update()
+        return self._finish(self.encoder.encode(values), operation, started)
+
+    async def distributed_cycle(
+        self, psi_input: np.ndarray, sop: Any = None
+    ) -> MM3DCycleResult:
+        if not self.nodes:
+            return self.cycle(psi_input, sop)
+        started = time.perf_counter()
+        values = np.asarray(psi_input)
+        operation = {
+            "action": "MM3D.CYCLE",
+            "input_elements": int(values.size),
+            "sop_type": type(sop).__name__ if sop is not None else None,
+            "distributed_nodes": len(self.nodes),
+        }
+        self.lam.require(operation)
+        metric_values = self.encoder.metric_prepare(values)
+        boundaries = np.linspace(
+            0,
+            self.config.manifold_dim,
+            len(self.nodes) + 1,
+            dtype=np.int64,
+        )
+        futures = []
+        for index, node in enumerate(self.nodes):
+            start, stop = int(boundaries[index]), int(boundaries[index + 1])
+            node.claim_range(start, stop)
+            futures.append(
+                node.dispatch(
+                    self.encoder.project_partition,
+                    metric_values,
+                    start,
+                    stop,
+                )
+            )
+        partials = await asyncio.gather(*futures)
+        hidden = np.sum(np.stack(partials), axis=0)
+        latent = self.encoder.encode_from_hidden(hidden)
+        self.xi.qca.update()
+        return self._finish(latent, operation, started)
+
+    def close(self) -> None:
+        for node in self.nodes:
+            node.close()
+        self.nodes.clear()

--- a/src/jarvisx/node.py
+++ b/src/jarvisx/node.py
@@ -1,26 +1,50 @@
 import socket
+
+from .assembler import Assembler
 from .core import CodexVM
 from .parser import Parser
-from .assembler import Assembler
+
 
 class CodexNode:
-    def __init__(self, host="0.0.0.0", port=9000):
+    def __init__(
+        self,
+        host="127.0.0.1",
+        port=9000,
+        max_request_bytes=65536,
+        timeout_seconds=10.0,
+    ):
         self.host = host
         self.port = port
-        self.vm = CodexVM()
+        self.max_request_bytes = max_request_bytes
+        self.timeout_seconds = timeout_seconds
+
+    def _execute(self, source):
+        vm = CodexVM(ledger_path=None)
+        ast = Parser().parse(source)
+        bytecode = Assembler().assemble(ast)
+        if not bytecode:
+            raise ValueError("source assembled to an empty program")
+        vm.load(bytecode)
+        vm.run()
+        return vm.regs.snapshot()
 
     def start(self):
-        s = socket.socket()
-        s.bind((self.host, self.port))
-        s.listen(5)
-        print(f"CodexNode listening on {self.port}")
+        with socket.socket() as server:
+            server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server.bind((self.host, self.port))
+            server.listen(5)
+            print(f"CodexNode listening on {self.host}:{self.port}")
 
-        while True:
-            conn, _ = s.accept()
-            data = conn.recv(4096).decode()
-            ast = Parser().parse(data)
-            bytecode = Assembler().assemble(ast)
-            self.vm.load(bytecode)
-            self.vm.run()
-            conn.send(str(self.vm.regs.snapshot()).encode())
-            conn.close()
+            while True:
+                conn, _ = server.accept()
+                with conn:
+                    conn.settimeout(self.timeout_seconds)
+                    try:
+                        data = conn.recv(self.max_request_bytes + 1)
+                        if len(data) > self.max_request_bytes:
+                            raise ValueError("request exceeds configured limit")
+                        source = data.decode("utf-8")
+                        result = self._execute(source)
+                        conn.sendall(str(result).encode("utf-8"))
+                    except Exception as exc:
+                        conn.sendall(f"ERROR: {exc}".encode("utf-8"))

--- a/src/jarvisx/reflex.py
+++ b/src/jarvisx/reflex.py
@@ -1,6 +1,9 @@
 class ReflexEngine:
+    def __init__(self):
+        self.last_delta = 0
+
     def stabilize(self, regs):
         psi = regs["Ψ"]
         phi = regs["Φ"]
-        delta = int(0.1 * (psi - phi))
-        regs["Φ"] += delta
+        self.last_delta = int(0.1 * (psi - phi))
+        return self.last_delta

--- a/src/jarvisx/tracer.py
+++ b/src/jarvisx/tracer.py
@@ -4,3 +4,6 @@ class Tracer:
 
     def record(self, instr, regs):
         self.log.append((instr.opcode, regs.copy()))
+
+    def record_event(self, event, state):
+        self.log.append((str(event), dict(state)))

--- a/src/jarvisx/web.py
+++ b/src/jarvisx/web.py
@@ -1,42 +1,75 @@
-from flask import Flask, render_template_string, request
-from .core import CodexVM
-from .parser import Parser
-from .assembler import Assembler
+import uvicorn
+from fastapi.responses import HTMLResponse
 
-app = Flask(__name__)
-vm = CodexVM()
+from .api import app
 
-HTML = """
-<!DOCTYPE html>
-<html>
+HTML = """<!DOCTYPE html>
+<html lang="en">
 <head>
-  <title>Jarvis-X Dashboard</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Jarvis-X Control Panel</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 2rem; max-width: 900px; }
+    textarea { width: 100%; min-height: 12rem; font-family: monospace; }
+    button { margin: .5rem .5rem .5rem 0; padding: .65rem 1rem; }
+    pre { background: #111; color: #eee; padding: 1rem; overflow: auto; }
+  </style>
 </head>
 <body>
   <h1>Jarvis-X Control Panel</h1>
-  <form method="post">
-    <textarea name="code" rows="10" cols="60"></textarea><br>
-    <button type="submit">Run</button>
-  </form>
-  {% if result %}
-    <h3>Registers</h3>
-    <pre>{{ result }}</pre>
-  {% endif %}
+  <p>Local development interface. Network exposure requires an external
+     authentication and TLS boundary.</p>
+  <textarea id="source">SET Ψ 10
+SET Φ 20
+ADD A Ψ Φ
+HALT</textarea>
+  <div>
+    <button onclick="runVm()">Run VM</button>
+    <button onclick="runVisualMemory()">Run 3D Visual Memory</button>
+  </div>
+  <pre id="output">Ready.</pre>
+  <script>
+    async function post(path, payload) {
+      const response = await fetch(path, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify(payload)
+      });
+      const data = await response.json();
+      if (!response.ok) throw new Error(JSON.stringify(data));
+      return data;
+    }
+    async function runVm() {
+      try {
+        output.textContent = JSON.stringify(
+          await post("/run", {source: source.value}), null, 2
+        );
+      } catch (error) {
+        output.textContent = String(error);
+      }
+    }
+    async function runVisualMemory() {
+      try {
+        output.textContent = JSON.stringify(
+          await post("/visual-memory", {size: 12, auto_optimize: true}),
+          null,
+          2
+        );
+      } catch (error) {
+        output.textContent = String(error);
+      }
+    }
+  </script>
 </body>
 </html>
 """
 
-@app.route("/", methods=["GET","POST"])
-def home():
-    result = None
-    if request.method == "POST":
-        source = request.form["code"]
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm.load(bytecode)
-        vm.run()
-        result = vm.regs.snapshot()
-    return render_template_string(HTML, result=result)
 
-def start_web():
-    app.run(host="0.0.0.0", port=5000)
+@app.get("/", response_class=HTMLResponse)
+def home() -> HTMLResponse:
+    return HTMLResponse(HTML)
+
+
+def start_web(host: str = "127.0.0.1", port: int = 5000) -> None:
+    uvicorn.run(app, host=host, port=port)

--- a/tests/test_geometric_memory.py
+++ b/tests/test_geometric_memory.py
@@ -1,0 +1,54 @@
+import math
+
+from jarvisx.geometric_memory import GeometricConfig, VisualMemoryANN, Volume3D, make_demo_volume
+
+
+def test_volume_index_and_mse():
+    volume = Volume3D.from_function((2, 2, 2), lambda z, y, x: z + y + x)
+    assert volume.at(1, 1, 1) == 3.0
+    assert volume.mse(volume) == 0.0
+
+
+def test_permeation_is_deterministic_from_equal_state():
+    volume = make_demo_volume(8)
+    config = GeometricConfig(
+        latent_shape=(2, 2, 2),
+        refinement_steps=2,
+        max_candidate_steps=3,
+    )
+    left = VisualMemoryANN(config).permeate(volume)
+    right = VisualMemoryANN(config).permeate(volume)
+
+    assert left.reconstruction.values == right.reconstruction.values
+    assert left.selected == right.selected
+    assert left.trace == right.trace
+
+
+def test_permeation_shapes_trace_and_bounds():
+    volume = make_demo_volume(8)
+    config = GeometricConfig(latent_shape=(2, 2, 2), channels=6, refinement_steps=3)
+    result = VisualMemoryANN(config).permeate(volume, auto_optimize=False)
+
+    assert result.reconstruction.shape == volume.shape
+    assert result.latent.shape == config.latent_shape
+    assert result.latent.channels == config.channels
+    assert len(result.trace) == config.refinement_steps
+    assert all(0.0 <= value <= 1.0 for value in result.reconstruction.values)
+    assert math.isfinite(result.selected.objective)
+
+
+def test_auto_optimization_is_bounded_and_journaled():
+    volume = make_demo_volume(8)
+    engine = VisualMemoryANN(
+        GeometricConfig(
+            latent_shape=(2, 2, 2),
+            refinement_steps=2,
+            max_candidate_steps=3,
+        )
+    )
+    result = engine.permeate(volume, auto_optimize=True)
+
+    assert 1 <= result.candidate_count <= 5
+    assert engine.config.refinement_steps <= engine.config.max_candidate_steps
+    assert len(engine.journal) == 1
+    assert result.selected.objective <= result.baseline.objective + 1e-15

--- a/tests/test_geometric_memory.py
+++ b/tests/test_geometric_memory.py
@@ -1,6 +1,12 @@
 import math
 
-from jarvisx.geometric_memory import GeometricConfig, VisualMemoryANN, Volume3D, make_demo_volume
+from jarvisx.geometric_memory import (
+    GeometricCodec,
+    GeometricConfig,
+    VisualMemoryANN,
+    Volume3D,
+    make_demo_volume,
+)
 
 
 def test_volume_index_and_mse():
@@ -22,12 +28,20 @@ def test_permeation_is_deterministic_from_equal_state():
     assert left.reconstruction.values == right.reconstruction.values
     assert left.selected == right.selected
     assert left.trace == right.trace
+    assert left.candidates == right.candidates
 
 
 def test_permeation_shapes_trace_and_bounds():
     volume = make_demo_volume(8)
-    config = GeometricConfig(latent_shape=(2, 2, 2), channels=6, refinement_steps=3)
-    result = VisualMemoryANN(config).permeate(volume, auto_optimize=False)
+    config = GeometricConfig(
+        latent_shape=(2, 2, 2),
+        channels=6,
+        refinement_steps=3,
+    )
+    result = VisualMemoryANN(config).permeate(
+        volume,
+        auto_optimize=False,
+    )
 
     assert result.reconstruction.shape == volume.shape
     assert result.latent.shape == config.latent_shape
@@ -48,7 +62,23 @@ def test_auto_optimization_is_bounded_and_journaled():
     )
     result = engine.permeate(volume, auto_optimize=True)
 
-    assert 1 <= result.candidate_count <= 5
+    assert 1 <= result.candidate_count <= 7
     assert engine.config.refinement_steps <= engine.config.max_candidate_steps
     assert len(engine.journal) == 1
+    assert engine.journal[0] == result.candidates
     assert result.selected.objective <= result.baseline.objective + 1e-15
+
+
+def test_spatial_residual_projection_preserves_locality():
+    config = GeometricConfig(
+        latent_shape=(2, 2, 2),
+        refinement_steps=1,
+    )
+    residual = Volume3D.from_function(
+        (4, 4, 4),
+        lambda z, y, x: 1.0 if z < 2 and y < 2 and x < 2 else 0.0,
+    )
+    latent = GeometricCodec(config).encode_residual(residual)
+
+    assert latent.vector(0, 0, 0)[0] > 0.9
+    assert latent.vector(1, 1, 1)[0] == 0.0

--- a/tests/test_mm3d_omega4.py
+++ b/tests/test_mm3d_omega4.py
@@ -1,0 +1,147 @@
+import asyncio
+
+import numpy as np
+import pytest
+
+from jarvisx.mm3d_omega4 import (
+    CloudNode,
+    MM3DConfig,
+    MM3DEngine,
+    OmegaEntry,
+    OmegaMemory,
+    Voxel,
+    Z8QCA,
+)
+
+
+def tiny_config(**overrides):
+    values = dict(
+        xi_size=8,
+        manifold_dim=256,
+        latent_size=4,
+        codebook_size=128,
+        codebook_dim=8,
+        projection_rank=8,
+        metric_rank=4,
+        exploration_depth=2,
+        render_image_size=8,
+        render_video_frames=2,
+        render_audio_samples=128,
+        omega_capacity=8,
+        max_reference_bytes=32 * 1024 * 1024,
+        seed=12345,
+    )
+    values.update(overrides)
+    return MM3DConfig(**values)
+
+
+def test_voxel_is_exactly_384_bits_and_round_trips():
+    voxel = Voxel(
+        token_embedding=np.arange(16, dtype=np.int8),
+        visual_feature=np.arange(12, dtype=np.int8),
+        audio_spectral=np.arange(8, dtype=np.int8),
+        motion_vector=np.arange(6, dtype=np.int8),
+        attention_weight=np.float32(0.25),
+        ethical_flag=np.uint8(1),
+    )
+    payload = voxel.to_bytes()
+    restored = Voxel.from_bytes(payload)
+
+    assert len(payload) == 48
+    assert np.array_equal(restored.token_embedding, voxel.token_embedding)
+    assert restored.attention_weight == voxel.attention_weight
+    assert restored.ethical_flag == 1
+
+
+def test_qca_preserves_mod8_uint8_state_deterministically():
+    left = Z8QCA(8, seed=7)
+    right = Z8QCA(8, seed=7)
+
+    left.update()
+    right.update()
+
+    assert left.state.dtype == np.uint8
+    assert np.array_equal(left.state, right.state)
+    assert int(left.state.min()) >= 0
+    assert int(left.state.max()) < 8
+
+
+def test_config_separates_conceptual_target_from_operational_allocation():
+    config = tiny_config()
+    config.validate()
+
+    assert config.conceptual_parameters_total == 50_000_000_000_000
+    assert config.conceptual_parameters_active == 250_000_000_000
+    assert config.estimated_reference_bytes() < config.max_reference_bytes
+
+    impossible = MM3DConfig(
+        xi_size=256,
+        manifold_dim=65536,
+        latent_size=32,
+        codebook_size=262144,
+        codebook_dim=256,
+        projection_rank=1024,
+        metric_rank=1024,
+        max_reference_bytes=512 * 1024 * 1024,
+    )
+    with pytest.raises(ValueError, match="allocation guard"):
+        impossible.validate()
+
+
+def test_cycle_is_deterministic_and_ledger_verifies():
+    config = tiny_config()
+    psi = np.linspace(-1.0, 1.0, config.manifold_dim, dtype=np.float32)
+    left = MM3DEngine(config)
+    right = MM3DEngine(config)
+
+    left_result = left.cycle(psi)
+    right_result = right.cycle(psi)
+
+    assert np.array_equal(left_result.latent_code, right_result.latent_code)
+    assert np.array_equal(left_result.safe_state, right_result.safe_state)
+    assert left_result.xi_state_hash == right_result.xi_state_hash
+    assert left.omega.verify()
+    assert right.omega.verify()
+    assert left_result.actual_parameter_count < left_result.conceptual_parameter_count
+    assert isinstance(left_result.summary()["target_met"], bool)
+
+
+def test_empty_input_is_rejected_by_lambda_policy():
+    engine = MM3DEngine(tiny_config())
+    with pytest.raises(RuntimeError, match="Lambda constraint"):
+        engine.cycle(np.array([], dtype=np.float32))
+
+
+def test_distributed_projection_matches_sequential_state():
+    config = tiny_config()
+    psi = np.linspace(-0.5, 0.5, config.manifold_dim, dtype=np.float32)
+    sequential = MM3DEngine(config)
+    distributed = MM3DEngine(config)
+    distributed.add_cloud_node(CloudNode(0))
+    distributed.add_cloud_node(CloudNode(1))
+
+    expected = sequential.cycle(psi)
+    actual = asyncio.run(distributed.distributed_cycle(psi))
+    distributed.close()
+
+    assert np.array_equal(actual.latent_code, expected.latent_code)
+    assert np.allclose(actual.safe_state, expected.safe_state, atol=1e-6)
+    assert distributed.omega.verify()
+
+
+def test_omega_retained_window_remains_verifiable():
+    memory = OmegaMemory(capacity=2)
+    for sequence in range(4):
+        memory.append(
+            OmegaEntry(
+                sequence=sequence,
+                instruction_hash=f"instruction-{sequence}",
+                voxel_region=(0, 0, 0, 1, 1, 1),
+                ethical_flag=0,
+                result_hash=f"result-{sequence}",
+            )
+        )
+
+    assert len(memory.chain) == 2
+    assert memory.anchor_hash != OmegaMemory.GENESIS
+    assert memory.verify()

--- a/tests/test_system_permeation.py
+++ b/tests/test_system_permeation.py
@@ -1,11 +1,32 @@
+import numpy as np
+
 from jarvisx.api import app
 from jarvisx.assembler import Assembler
 from jarvisx.core import CodexVM
+from jarvisx.mm3d_omega4 import MM3DConfig
 from jarvisx.parser import Parser
 
 
 def assemble(source):
     return Assembler().assemble(Parser().parse(source))
+
+
+def tiny_mm3d_config():
+    return MM3DConfig(
+        xi_size=8,
+        manifold_dim=256,
+        latent_size=4,
+        codebook_size=128,
+        codebook_dim=8,
+        projection_rank=8,
+        metric_rank=4,
+        exploration_depth=2,
+        render_image_size=8,
+        render_video_frames=2,
+        render_audio_samples=128,
+        max_reference_bytes=32 * 1024 * 1024,
+        seed=12345,
+    )
 
 
 def test_vm_can_execute_multiple_loaded_programs():
@@ -42,8 +63,35 @@ def test_policy_gate_can_block_geometric_permeation():
         raise AssertionError("blocked geometric action was executed")
 
 
+def test_mm3d_cycle_is_vm_authoritative_and_audited():
+    config = tiny_mm3d_config()
+    psi = np.linspace(-1.0, 1.0, config.manifold_dim, dtype=np.float32)
+    vm = CodexVM(ledger_path=None)
+
+    result = vm.run_mm3d_cycle(psi, config=config)
+
+    assert result.latent_code.shape == (4, 4, 4)
+    assert vm.ledger.chain[-1]["payload"].endswith("|MM3D.CYCLE")
+    assert vm.tracer.log[-1][0] == "MM3D.CYCLE"
+    vm.close()
+
+
+def test_policy_gate_can_block_mm3d_cycle():
+    config = tiny_mm3d_config()
+    vm = CodexVM(ledger_path=None)
+    vm.ethics.block_action("MM3D.CYCLE")
+
+    try:
+        vm.run_mm3d_cycle(np.ones(config.manifold_dim), config=config)
+    except RuntimeError as exc:
+        assert "policy blocked" in str(exc)
+    else:
+        raise AssertionError("blocked MM3D action was executed")
+
+
 def test_fastapi_surface_matches_declared_runtime_stack():
     paths = {route.path for route in app.routes}
     assert "/health" in paths
     assert "/run" in paths
     assert "/visual-memory" in paths
+    assert "/mm3d-cycle" in paths

--- a/tests/test_system_permeation.py
+++ b/tests/test_system_permeation.py
@@ -1,0 +1,49 @@
+from jarvisx.api import app
+from jarvisx.assembler import Assembler
+from jarvisx.core import CodexVM
+from jarvisx.parser import Parser
+
+
+def assemble(source):
+    return Assembler().assemble(Parser().parse(source))
+
+
+def test_vm_can_execute_multiple_loaded_programs():
+    vm = CodexVM(ledger_path=None)
+    vm.load(assemble("SET A 5\nHALT"))
+    vm.run()
+    assert vm.regs["A"] == 5
+    assert vm.cycles == 2
+
+    vm.load(assemble("SET B 7\nHALT"))
+    vm.run()
+    assert vm.regs["B"] == 7
+    assert vm.cycles == 2
+
+
+def test_geometric_permeation_is_vm_authoritative_and_audited():
+    vm = CodexVM(ledger_path=None)
+    result = vm.run_visual_memory(size=8)
+
+    assert result.reconstruction.shape == (8, 8, 8)
+    assert vm.ledger.chain[-1]["payload"].endswith("|V3D.PERMEATE")
+    assert vm.tracer.log[-1][0] == "V3D.PERMEATE"
+
+
+def test_policy_gate_can_block_geometric_permeation():
+    vm = CodexVM(ledger_path=None)
+    vm.ethics.block_action("V3D.PERMEATE")
+
+    try:
+        vm.run_visual_memory(size=8)
+    except RuntimeError as exc:
+        assert "policy blocked" in str(exc)
+    else:
+        raise AssertionError("blocked geometric action was executed")
+
+
+def test_fastapi_surface_matches_declared_runtime_stack():
+    paths = {route.path for route in app.routes}
+    assert "/health" in paths
+    assert "/run" in paths
+    assert "/visual-memory" in paths


### PR DESCRIPTION
## What this permeation delivers

This draft PR now contains two VM-authoritative 3D reference subsystems:

1. `V3D.PERMEATE`: deterministic spatial visual memory with bounded mechanics selection.
2. `MM3D.CYCLE`: a corrected operational `MM3D-AED-BCE-Ω⁴-G50T-OPT` kernel.

Both operations pass through the Jarvis-X Lambda policy gate and write committed summaries to the VM ledger and tracer.

## Spatial visual-memory runtime

- encodes scalar 3D volumes into a geometric latent lattice
- replaces global residual averaging with per-region spatial residual projection
- uses finite associative memory with anti-monopoly usage pressure
- evaluates every validated candidate from an identical memory snapshot
- journals all candidate measurements
- commits only a strictly improved reconstruction-plus-compute objective

## MM3D Omega4 operational correction

The submitted architecture was not executable at its declared dimensions. This PR preserves its intended mechanics while correcting the contracts:

- makes the cognitive voxel exactly 384 bits / 48 bytes
- replaces a 256³ Python-object cube with a contiguous NumPy structured lattice
- adds a hard pre-allocation memory guard
- replaces the dense 65,536² correction matrix with a diagonal-plus-low-rank metric and Woodbury inverse action
- makes encoder, latent, codebook, and decoder dimensions consistent
- implements chunked vector quantization
- keeps the Z8 cellular automaton integer, modulo 8, deterministic, and SciPy-free
- defines `PhiQAS` explicitly as bounded classical latent exploration, not quantum execution
- uses logical sequence numbers and full SHA3-256 canonical Omega entries
- fixes bounded text, image, audio, and video projection shapes
- replaces the broken distributed merge path with partitioned low-rank hidden projections and authoritative reduction

## Honest scaling and performance accounting

- `50T` is retained as a conceptual parameter target, not allocated state
- 0.5% of 50T is correctly reported as 250B active conceptual parameters
- every result reports actual parameter count and actual allocated bytes
- the 13.7 ms cycle target is measured and returned with `target_met`; it is never assumed
- the original dense declarations have an approximately 38.02 GiB raw allocation floor before Python-object overhead and are rejected by the reference allocation guard

## VM, CLI, and API integration

- `CodexVM.run_mm3d_cycle(...)`
- `jarvisx mm3d-cycle [manifold_dim]`
- `POST /mm3d-cycle`
- request-local VM instances for network calls
- loopback server defaults
- declared NumPy dependency

## Verification

Tests cover exact voxel serialization, deterministic mod-8 evolution, dimensional validity, allocation-guard rejection, deterministic cycle equality, Lambda rejection, Omega retained-window verification, sequential/distributed state equivalence, VM ledger/trace authority, policy blocking, CLI integration, and API route integration.

GitHub Actions run `29700866715` completed successfully against head `432731c`:

- Python 3.8: passed
- Python 3.9: passed
- Python 3.10: passed
- Python 3.11: passed
- Python 3.12: passed
- pytest and coverage: passed
- mypy: passed
- Black: passed
- isort: passed

## Current boundary

This is a deterministic operational oracle. It does not claim learned weights, back-propagation, GPU acceleration, physical 50T allocation, quantum computation, production generative decoders, or a real multi-host cloud scheduler.

```text
Conceptual scale is metadata until physical allocation and measured execution prove otherwise.
Acceleration may change mechanics; it may not silently change semantics.
```