### PR TITLE
Permeate MM3D-AED-BCE-Ω⁴ cosmogram runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control layer and policy gate.
+
+## Architecture
+
+The repository includes the canonical MM3D-AED-BCE-Ω⁴-G50T-OPT cosmogram: a three-dimensional auto-encoding, policy-projection, Z8 substrate-evolution, codebook-decoding, and chained SHA3-256 trace cycle.
+
+- [MM3D-AED-BCE-Ω⁴ cosmogram specification](docs/MM3D_AED_BCE_OMEGA4_COSMOGRAM.md)
+- Reference runtime: `src/jarvisx/mm3d_cosmogram.py`
+- Determinism and ledger tests: `tests/test_mm3d_cosmogram.py`
+
+The operational law is:
+
+\[
+X_{t+1}=D_{\mathcal C_t}\circ R_8\circ\Pi_{\Lambda_t}\circ E_{\Phi}(X_t)
+\]
+
+with chained provenance:
+
+\[
+\Omega_{t+1}=H(\Omega_t\|H(\operatorname{canon}(X_{t+1}))\|M_{t+1}).
+\]
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```

--- a/docs/MM3D_AED_BCE_OMEGA4_COSMOGRAM.md
+++ b/docs/MM3D_AED_BCE_OMEGA4_COSMOGRAM.md
@@ -1,0 +1,475 @@
+# MM3D-AED-BCE-Ω⁴-G50T-OPT Cosmogram
+
+## Status
+
+Canonical operational specification for the three-dimensional Dr Moagi auto-encoding, policy projection, substrate evolution, decoding, and cryptographic trace cycle.
+
+This specification preserves the original cosmogram while making its algebra, information-loss conditions, policy semantics, topology, and ledger guarantees explicit enough to implement and test.
+
+---
+
+## 1. Canonical State Transition
+
+To avoid overloading `Ψ` as both state and decoder, the executable form uses distinct symbols:
+
+\[
+\boxed{
+\begin{aligned}
+Z_t &= E_{\Phi}(X_t),\\
+\bar Z_t &= \Pi_{\Lambda_t}(Z_t),\\
+\Xi_{t+1} &= R_{8}(\bar Z_t;G_t,W_t),\\
+\widehat X_{t+1} &= D_{\mathcal C_t}(\Xi_{t+1}),\\
+\omega_{t+1} &= \operatorname{SHA3\!\!-256}(\operatorname{canon}(\widehat X_{t+1})),\\
+\Omega_{t+1} &= \operatorname{SHA3\!\!-256}(\Omega_t\|\omega_{t+1}\|M_{t+1}).
+\end{aligned}
+}
+\]
+
+where:
+
+- \(X_t\) is the concrete multimodal 3D state;
+- \(E_{\Phi}\) is the encoder;
+- \(Z_t\in\mathbb Z_{2^{18}}^{32^3}\) is the encoded lattice;
+- \(\Pi_{\Lambda_t}\) is the admissibility or policy projector;
+- \(R_8\) is the graph-local reaction/diffusion operator over \(\mathbb Z_8\);
+- \(D_{\mathcal C_t}\) is decoding through versioned codebook \(\mathcal C_t\);
+- \(\omega_{t+1}\) is the content digest of the decoded state;
+- \(\Omega_{t+1}\) is the chained ledger digest;
+- \(M_{t+1}\) binds cycle number, configuration fingerprint, codebook version, topology, and policy version.
+
+The compact cosmogram remains:
+
+\[
+\boxed{
+X_{t+1}=D_{\mathcal C_t}
+\left(
+R_8\left(
+\Pi_{\Lambda_t}\left(E_{\Phi}(X_t)\right)
+\right)
+\right)
+}
+\]
+
+with the separate ledger recurrence:
+
+\[
+\boxed{
+\Omega_{t+1}=H(\Omega_t\|H(\operatorname{canon}(X_{t+1}))\|M_{t+1}).
+}
+\]
+
+---
+
+## 2. Three-Dimensional Addressing
+
+For side length \(S=32\), a coordinate is:
+
+\[
+\mathbf r=(x,y,z),\qquad 0\le x,y,z<S.
+\]
+
+The canonical row-major flattening is:
+
+\[
+\boxed{
+i(x,y,z)=x+S(y+Sz)
+}
+\]
+
+and the lattice contains:
+
+\[
+S^3=32^3=32768
+\]
+
+cells.
+
+The reference runtime supports two explicit topology contracts:
+
+- **bounded**: neighbours outside the cube do not exist;
+- **periodic**: coordinates wrap modulo \(S\), producing a 3-torus.
+
+Topology is part of the configuration fingerprint because changing it changes the transition law.
+
+---
+
+## 3. Auto-Encoding
+
+The proposed low-rank form is:
+
+\[
+\Phi(\Psi_t)=(A+UDV^T)^{-1}\Psi_t.
+\]
+
+This is well-defined only when \(A+UDV^T\) is invertible in the selected arithmetic domain. Over a field, the Woodbury identity gives:
+
+\[
+(A+UDV^T)^{-1}
+=A^{-1}-A^{-1}U(D^{-1}+V^TA^{-1}U)^{-1}V^TA^{-1},
+\]
+
+provided all required inverses exist.
+
+Over \(\mathbb Z_{2^{18}}\), invertibility is stricter because the modulus is composite. A scalar is a unit only when it is odd, and a matrix is invertible only when its determinant is a unit modulo \(2^{18}\). Therefore, the encoder contract must declare:
+
+1. arithmetic domain;
+2. quantisation rule;
+3. rounding rule;
+4. matrix version;
+5. inverse-validity test;
+6. overflow behaviour.
+
+### Information bound
+
+A general 384-bit voxel cannot be mapped injectively into one 18-bit index:
+
+\[
+2^{384}>2^{18}.
+\]
+
+Thus exact reconstruction is possible only when at least one of the following is true:
+
+- the admissible source domain has at most \(2^{18}\) states;
+- additional side information is retained;
+- the codebook contains an externally anchored identity mapping;
+- the mapping is distributed across multiple indices;
+- the mode is explicitly lossy or semantic rather than bit-exact.
+
+The reference implementation therefore treats the default 384-bit-to-18-bit projection as **compressive**, not lossless.
+
+---
+
+## 4. Policy Projection
+
+The original expression:
+
+\[
+\Phi(\Psi_t)\land(1-\Lambda)
+\]
+
+is valid only when \(\Lambda\) is a binary bit mask and subtraction is defined with the intended width. The width-safe bitwise form is:
+
+\[
+\boxed{
+\bar Z=Z\land(\neg\Lambda\land M_w)
+}
+\]
+
+where \(M_w=2^w-1\) limits complement to \(w\) bits.
+
+For semantic policy, the stronger formulation is a projector:
+
+\[
+\boxed{
+\Pi_{\Lambda_t}(z_i)=
+\begin{cases}
+z_i,&\Lambda_t(i)=\text{allow},\\
+z_{\varnothing},&\Lambda_t(i)=\text{deny},
+\end{cases}
+}
+\]
+
+where \(z_{\varnothing}\) is a declared neutral or void index.
+
+Required properties are:
+
+\[
+\Pi_{\Lambda}(\Pi_{\Lambda}(Z))=\Pi_{\Lambda}(Z)
+\]
+
+and:
+
+\[
+\Pi_{\Lambda}(Z)\in\mathcal A_{\Lambda},
+\]
+
+where \(\mathcal A_{\Lambda}\) is the admissible state set.
+
+The reference runtime uses this idempotent projection semantics.
+
+---
+
+## 5. Substrate Evolution
+
+For cell \(i\) with neighbourhood \(N(i)\):
+
+\[
+\boxed{
+\Xi_{t+1}(i)
+=
+\left[
+2^s
+\left(
+\bar Z_t(i)+
+\sum_{j\in N(i)}w_{ij}\bar Z_t(j)
+\right)
+\right]\bmod 8
+}
+\]
+
+The default contract is:
+
+- six-neighbour von Neumann stencil;
+- integer neighbour weights;
+- shift \(s=1\);
+- output in \(\mathbb Z_8\);
+- synchronous update from one immutable input lattice.
+
+### Reversibility condition
+
+Multiplication by two modulo eight is not bijective:
+
+\[
+2x\bmod 8\in\{0,2,4,6\}.
+\]
+
+Consequently, the left-shift rule is not generally reversible and does not by itself preserve Shannon entropy or information. It is a many-to-one reaction rule.
+
+When reversible evolution is required, use a permutation of \(\mathbb Z_8\), for example:
+
+\[
+R(x)=(ax+b)\bmod 8,
+\]
+
+with odd \(a\in\{1,3,5,7\}\), combined with a reversible neighbourhood coupling and retained boundary state.
+
+The current engine preserves determinism, not automatic reversibility.
+
+---
+
+## 6. Codebook Decoding
+
+The decoder is:
+
+\[
+\boxed{
+D_{\mathcal C_t}(\Xi)(i)=\mathcal C_t[\Xi(i)].
+}
+\]
+
+A valid codebook contract declares:
+
+- codebook version and digest;
+- total key domain;
+- neutral atom;
+- collision policy;
+- modality and schema per atom;
+- canonical byte encoding;
+- compatibility rules across versions.
+
+Decoding is total when every substrate index maps to an atom or to the neutral atom.
+
+Exact inverse reconstruction requires:
+
+\[
+D_{\mathcal C_t}(E_{\Phi}(X))=X
+\]
+
+for every \(X\) in the declared exact-mode domain. In compressive mode the weaker criterion is:
+
+\[
+d(D_{\mathcal C_t}(E_{\Phi}(X)),X)\le\varepsilon.
+\]
+
+---
+
+## 7. Ω Ledger
+
+A SHA3-256 digest identifies content but does not alone make storage immutable. Tamper evidence requires chaining:
+
+\[
+\boxed{
+\Omega_{t+1}
+=H(\Omega_t\|\omega_{t+1}\|M_{t+1}).
+}
+\]
+
+The metadata commitment \(M_{t+1}\) includes:
+
+```text
+cycle
+configuration_fingerprint
+encoder_version
+policy_version
+codebook_version
+topology
+reaction_rule
+canonicalisation_version
+previous_chain_hash
+```
+
+The persistence layer should add:
+
+- append-only writes;
+- atomic commit;
+- durable flush policy;
+- checkpoint and recovery;
+- optional signatures or external anchoring;
+- replay verification from the genesis hash.
+
+The reference implementation separates:
+
+```text
+state_hash = SHA3-256(canonical_decoded_state)
+chain_hash = SHA3-256(previous_chain_hash || state_hash || cycle || config_hash)
+```
+
+---
+
+## 8. Reality Gap
+
+The invariant \(\gamma=\infty\) is interpreted as an epistemic and architectural constraint:
+
+\[
+\boxed{
+\text{model state}\neq\text{reality itself}
+}
+\]
+
+It means:
+
+- finite encoded state is a representation, not ontological identity;
+- parameters execute transformations but do not contain open reality;
+- unmodelled residuals remain possible;
+- validation is external to self-description;
+- the engine must retain uncertainty, provenance, and correction paths.
+
+It is not used as a floating-point infinity in lattice arithmetic.
+
+---
+
+## 9. Transactional Cycle
+
+Each committed cycle follows:
+
+```text
+1. VALIDATE_INPUT
+2. ENCODE_384_TO_18
+3. PROJECT_POLICY
+4. EVOLVE_Z8_3D
+5. DECODE_CODEBOOK
+6. CANONICALISE_OUTPUT
+7. HASH_STATE_SHA3_256
+8. CHAIN_OMEGA
+9. VERIFY_RECEIPT
+10. COMMIT_ATOMICALLY
+```
+
+A cycle is invalid when any of these conditions fail:
+
+- voxel count differs from \(S^3\);
+- voxel width differs from 384 bits;
+- encoded index leaves \([0,2^{18})\);
+- policy mask shape differs from the lattice;
+- evolved value leaves \([0,8)\);
+- codebook schema is unresolved;
+- canonical encoding is ambiguous;
+- previous Ω hash does not match;
+- configuration fingerprint changes without a version transition.
+
+---
+
+## 10. Determinism Contract
+
+Given identical:
+
+\[
+(X_t,\Lambda_t,\mathcal C_t,G_t,W_t,M_t,\Omega_t),
+\]
+
+two conforming implementations must produce identical:
+
+\[
+(Z_t,\bar Z_t,\Xi_{t+1},\widehat X_{t+1},\omega_{t+1},\Omega_{t+1}).
+\]
+
+This requires:
+
+- fixed iteration order;
+- synchronous lattice update;
+- integer arithmetic;
+- explicit boundary behaviour;
+- canonical serialization;
+- stable SHA3-256;
+- version-bound configuration.
+
+---
+
+## 11. Reference Runtime Mapping
+
+The executable implementation is in:
+
+```text
+src/jarvisx/mm3d_cosmogram.py
+```
+
+Core types:
+
+```text
+CosmogramConfig
+CosmogramReceipt
+MM3DCosmogram
+```
+
+Operational methods:
+
+```text
+encode(voxels)
+project_policy(encoded, allow)
+evolve(masked)
+decode(evolved)
+step(voxels, allow)
+verify()
+```
+
+The default implementation uses SHA3-256 as a deterministic compressive encoder into \(\mathbb Z_{2^{18}}\). A production matrix encoder can replace this stage only after satisfying the inverse and quantisation contracts above.
+
+---
+
+## 12. Test Invariants
+
+The test suite verifies:
+
+1. identical inputs produce identical complete receipts;
+2. denied cells become the neutral index before evolution;
+3. each Ω chain hash commits to its predecessor;
+4. bounded and periodic topology are distinct configuration contracts;
+5. malformed voxel widths are rejected;
+6. complete receipt replay validates from genesis.
+
+---
+
+## 13. Final Permeated Law
+
+\[
+\boxed{
+\begin{aligned}
+X_{t+1}
+&=D_{\mathcal C_t}
+\circ R_8
+\circ\Pi_{\Lambda_t}
+\circ E_{\Phi}(X_t),\\
+\omega_{t+1}
+&=H(\operatorname{canon}(X_{t+1})),\\
+\Omega_{t+1}
+&=H(\Omega_t\|\omega_{t+1}\|M_{t+1}),\\
+\gamma&=\infty.
+\end{aligned}
+}
+\]
+
+Operationally:
+
+```text
+Reality sample
+    -> compressive geometric encoding
+    -> admissibility projection
+    -> deterministic 3D reaction/diffusion
+    -> versioned semantic decoding
+    -> canonical state digest
+    -> chained Ω receipt
+    -> verified atomic commit
+    -> next cycle
+```
+
+The cosmogram is therefore a deterministic, policy-bounded, codebook-decoded, cryptographically traceable state-transition machine. Its exactness is conditional on the encoder domain and codebook contract; its ledger is tamper-evident when chained and durably committed; and its reality-gap invariant prevents representation from being mistaken for reality.

--- a/src/jarvisx/mm3d_cosmogram.py
+++ b/src/jarvisx/mm3d_cosmogram.py
@@ -1,0 +1,272 @@
+"""Deterministic reference runtime for the MM3D-AED-BCE-Ω⁴ cosmogram.
+
+The runtime implements a bounded five-stage cycle:
+
+    encode -> policy project -> Z8 evolve -> codebook decode -> SHA3 ledger
+
+It intentionally separates a state digest from the chained ledger digest. A digest
+proves content identity; chaining and append-only storage provide tamper evidence.
+"""
+
+from dataclasses import dataclass
+import hashlib
+import json
+from typing import Iterable, Mapping, Optional, Sequence, Tuple
+
+
+Voxel = bytes
+Lattice = Tuple[int, ...]
+DecodedState = Tuple[bytes, ...]
+
+
+@dataclass(frozen=True)
+class CosmogramConfig:
+    """Static execution contract for one cosmogram instance."""
+
+    side: int = 32
+    voxel_bits: int = 384
+    latent_modulus: int = 1 << 18
+    reaction_modulus: int = 8
+    shift: int = 1
+    neighbor_weight: int = 1
+    boundary: str = "bounded"
+    neutral_index: int = 0
+    reality_gap: str = "gamma=infinity"
+
+    def __post_init__(self) -> None:
+        if self.side <= 0:
+            raise ValueError("side must be positive")
+        if self.voxel_bits <= 0 or self.voxel_bits % 8 != 0:
+            raise ValueError("voxel_bits must be a positive multiple of 8")
+        if self.latent_modulus <= 1:
+            raise ValueError("latent_modulus must exceed one")
+        if self.reaction_modulus <= 1:
+            raise ValueError("reaction_modulus must exceed one")
+        if self.shift < 0:
+            raise ValueError("shift must be non-negative")
+        if self.boundary not in {"bounded", "periodic"}:
+            raise ValueError("boundary must be 'bounded' or 'periodic'")
+        if not 0 <= self.neutral_index < self.latent_modulus:
+            raise ValueError("neutral_index must lie in the latent index range")
+
+    @property
+    def cell_count(self) -> int:
+        return self.side ** 3
+
+    @property
+    def voxel_bytes(self) -> int:
+        return self.voxel_bits // 8
+
+    def fingerprint(self) -> bytes:
+        payload = json.dumps(
+            {
+                "boundary": self.boundary,
+                "latent_modulus": self.latent_modulus,
+                "neighbor_weight": self.neighbor_weight,
+                "neutral_index": self.neutral_index,
+                "reaction_modulus": self.reaction_modulus,
+                "reality_gap": self.reality_gap,
+                "shift": self.shift,
+                "side": self.side,
+                "voxel_bits": self.voxel_bits,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha3_256(payload).digest()
+
+
+@dataclass(frozen=True)
+class CosmogramReceipt:
+    """Complete deterministic receipt for one committed cycle."""
+
+    cycle: int
+    encoded: Lattice
+    masked: Lattice
+    evolved: Lattice
+    decoded: DecodedState
+    state_hash: str
+    previous_chain_hash: str
+    chain_hash: str
+
+
+class MM3DCosmogram:
+    """Reference implementation of the recursive 3D Dr Moagi cycle.
+
+    The default encoder is deliberately compressive: each 384-bit voxel is mapped
+    to an 18-bit index using SHA3-256. Exact reconstruction therefore requires the
+    supplied codebook/domain contract; the hash projection itself is not invertible.
+    """
+
+    GENESIS_HASH = "0" * 64
+
+    def __init__(
+        self,
+        codebook: Mapping[int, bytes],
+        config: Optional[CosmogramConfig] = None,
+        neutral_atom: bytes = b"<VOID>",
+    ) -> None:
+        self.config = config or CosmogramConfig()
+        self.codebook = dict(codebook)
+        self.neutral_atom = bytes(neutral_atom)
+        self._cycle = 0
+        self._chain_hash = self.GENESIS_HASH
+        self._receipts = []  # type: list[CosmogramReceipt]
+
+    @property
+    def receipts(self) -> Tuple[CosmogramReceipt, ...]:
+        return tuple(self._receipts)
+
+    @property
+    def chain_hash(self) -> str:
+        return self._chain_hash
+
+    def encode(self, voxels: Sequence[Voxel]) -> Lattice:
+        self._validate_voxels(voxels)
+        mask = self.config.latent_modulus - 1
+        power_of_two = self.config.latent_modulus & mask == 0
+        encoded = []
+        for voxel in voxels:
+            digest_value = int.from_bytes(hashlib.sha3_256(voxel).digest(), "big")
+            index = digest_value & mask if power_of_two else digest_value % self.config.latent_modulus
+            encoded.append(index)
+        return tuple(encoded)
+
+    def project_policy(self, encoded: Sequence[int], allow: Sequence[bool]) -> Lattice:
+        self._validate_lattice(encoded, self.config.latent_modulus, "encoded")
+        if len(allow) != self.config.cell_count:
+            raise ValueError("policy mask length must equal side^3")
+        return tuple(
+            value if bool(is_allowed) else self.config.neutral_index
+            for value, is_allowed in zip(encoded, allow)
+        )
+
+    def evolve(self, masked: Sequence[int]) -> Lattice:
+        self._validate_lattice(masked, self.config.latent_modulus, "masked")
+        side = self.config.side
+        modulus = self.config.reaction_modulus
+        multiplier = 1 << self.config.shift
+        output = [0] * self.config.cell_count
+
+        for z in range(side):
+            for y in range(side):
+                for x in range(side):
+                    index = self._flat_index(x, y, z)
+                    total = masked[index]
+                    for nx, ny, nz in self._neighbors(x, y, z):
+                        total += self.config.neighbor_weight * masked[
+                            self._flat_index(nx, ny, nz)
+                        ]
+                    output[index] = (total * multiplier) % modulus
+        return tuple(output)
+
+    def decode(self, evolved: Sequence[int]) -> DecodedState:
+        self._validate_lattice(evolved, self.config.reaction_modulus, "evolved")
+        return tuple(self.codebook.get(index, self.neutral_atom) for index in evolved)
+
+    def step(self, voxels: Sequence[Voxel], allow: Sequence[bool]) -> CosmogramReceipt:
+        encoded = self.encode(voxels)
+        masked = self.project_policy(encoded, allow)
+        evolved = self.evolve(masked)
+        decoded = self.decode(evolved)
+
+        state_digest = hashlib.sha3_256(self._canonical_decoded(decoded)).digest()
+        previous = self._chain_hash
+        chain_payload = (
+            bytes.fromhex(previous)
+            + state_digest
+            + self._cycle.to_bytes(8, "big", signed=False)
+            + self.config.fingerprint()
+        )
+        chain_hash = hashlib.sha3_256(chain_payload).hexdigest()
+
+        receipt = CosmogramReceipt(
+            cycle=self._cycle,
+            encoded=encoded,
+            masked=masked,
+            evolved=evolved,
+            decoded=decoded,
+            state_hash=state_digest.hex(),
+            previous_chain_hash=previous,
+            chain_hash=chain_hash,
+        )
+        self._receipts.append(receipt)
+        self._chain_hash = chain_hash
+        self._cycle += 1
+        return receipt
+
+    def verify(self) -> bool:
+        previous = self.GENESIS_HASH
+        expected_cycle = 0
+        for receipt in self._receipts:
+            if receipt.cycle != expected_cycle:
+                return False
+            if receipt.previous_chain_hash != previous:
+                return False
+            state_digest = hashlib.sha3_256(
+                self._canonical_decoded(receipt.decoded)
+            ).digest()
+            if receipt.state_hash != state_digest.hex():
+                return False
+            payload = (
+                bytes.fromhex(previous)
+                + state_digest
+                + receipt.cycle.to_bytes(8, "big", signed=False)
+                + self.config.fingerprint()
+            )
+            expected = hashlib.sha3_256(payload).hexdigest()
+            if receipt.chain_hash != expected:
+                return False
+            previous = expected
+            expected_cycle += 1
+        return previous == self._chain_hash
+
+    def _validate_voxels(self, voxels: Sequence[Voxel]) -> None:
+        if len(voxels) != self.config.cell_count:
+            raise ValueError("voxel count must equal side^3")
+        for voxel in voxels:
+            if not isinstance(voxel, (bytes, bytearray, memoryview)):
+                raise TypeError("each voxel must be bytes-like")
+            if len(voxel) != self.config.voxel_bytes:
+                raise ValueError(
+                    "each voxel must contain exactly {} bytes".format(
+                        self.config.voxel_bytes
+                    )
+                )
+
+    def _validate_lattice(self, values: Sequence[int], modulus: int, label: str) -> None:
+        if len(values) != self.config.cell_count:
+            raise ValueError("{} lattice length must equal side^3".format(label))
+        if any(not isinstance(value, int) or not 0 <= value < modulus for value in values):
+            raise ValueError(
+                "{} lattice values must be integers in [0, {})".format(label, modulus)
+            )
+
+    def _flat_index(self, x: int, y: int, z: int) -> int:
+        side = self.config.side
+        return x + side * (y + side * z)
+
+    def _neighbors(self, x: int, y: int, z: int) -> Iterable[Tuple[int, int, int]]:
+        side = self.config.side
+        for dx, dy, dz in (
+            (-1, 0, 0),
+            (1, 0, 0),
+            (0, -1, 0),
+            (0, 1, 0),
+            (0, 0, -1),
+            (0, 0, 1),
+        ):
+            nx, ny, nz = x + dx, y + dy, z + dz
+            if self.config.boundary == "periodic":
+                yield nx % side, ny % side, nz % side
+            elif 0 <= nx < side and 0 <= ny < side and 0 <= nz < side:
+                yield nx, ny, nz
+
+    @staticmethod
+    def _canonical_decoded(decoded: Sequence[bytes]) -> bytes:
+        payload = bytearray()
+        for atom in decoded:
+            raw = bytes(atom)
+            payload.extend(len(raw).to_bytes(4, "big", signed=False))
+            payload.extend(raw)
+        return bytes(payload)

--- a/tests/test_mm3d_cosmogram.py
+++ b/tests/test_mm3d_cosmogram.py
@@ -1,0 +1,75 @@
+import pytest
+
+from jarvisx.mm3d_cosmogram import CosmogramConfig, MM3DCosmogram
+
+
+def make_voxels(config, seed=0):
+    return tuple(
+        bytes([(seed + index) % 256]) * config.voxel_bytes
+        for index in range(config.cell_count)
+    )
+
+
+def make_engine(boundary="bounded"):
+    config = CosmogramConfig(side=2, boundary=boundary)
+    codebook = {index: "atom:{}".format(index).encode() for index in range(8)}
+    return MM3DCosmogram(codebook=codebook, config=config), config
+
+
+def test_cycle_is_deterministic():
+    engine_a, config = make_engine()
+    engine_b, _ = make_engine()
+    voxels = make_voxels(config)
+    allow = (True,) * config.cell_count
+
+    receipt_a = engine_a.step(voxels, allow)
+    receipt_b = engine_b.step(voxels, allow)
+
+    assert receipt_a == receipt_b
+    assert engine_a.verify()
+    assert engine_b.verify()
+
+
+def test_policy_projection_replaces_forbidden_cells_with_neutral_index():
+    engine, config = make_engine()
+    voxels = make_voxels(config)
+    allow = (False, True, True, True, True, True, True, True)
+
+    receipt = engine.step(voxels, allow)
+
+    assert receipt.masked[0] == config.neutral_index
+    assert receipt.masked[1:] == receipt.encoded[1:]
+
+
+def test_ledger_hash_chains_across_cycles():
+    engine, config = make_engine()
+    allow = (True,) * config.cell_count
+
+    first = engine.step(make_voxels(config, seed=1), allow)
+    second = engine.step(make_voxels(config, seed=2), allow)
+
+    assert second.previous_chain_hash == first.chain_hash
+    assert second.chain_hash != first.chain_hash
+    assert engine.verify()
+
+
+def test_periodic_and_bounded_topologies_are_distinct_contracts():
+    bounded, config = make_engine("bounded")
+    periodic, _ = make_engine("periodic")
+    voxels = make_voxels(config)
+    allow = (True,) * config.cell_count
+
+    bounded_receipt = bounded.step(voxels, allow)
+    periodic_receipt = periodic.step(voxels, allow)
+
+    assert bounded_receipt.evolved != periodic_receipt.evolved
+    assert bounded_receipt.chain_hash != periodic_receipt.chain_hash
+
+
+def test_rejects_wrong_voxel_width():
+    engine, config = make_engine()
+    voxels = [b"x" * config.voxel_bytes for _ in range(config.cell_count)]
+    voxels[0] = b"short"
+
+    with pytest.raises(ValueError, match="exactly"):
+        engine.step(tuple(voxels), (True,) * config.cell_count)


### PR DESCRIPTION
## What changed

- adds a deterministic reference runtime for the MM3D-AED-BCE-Ω⁴ cosmogram
- implements 384-bit voxel encoding into an 18-bit lattice, Λ policy projection, synchronous 3D Z8 evolution, codebook decoding, and SHA3-256 Ω chaining
- adds complete cycle receipts and replay verification
- adds tests for deterministic execution, policy pruning, chained provenance, topology contracts, and input validation
- adds the canonical mathematical specification and links it from the README

## Mathematical hardening

The specification preserves the original cosmogram while making its guarantees precise:

- 384 bits to one 18-bit index is compressive unless the source domain or side information makes the map injective
- left shift modulo eight is deterministic but not generally reversible or entropy-preserving
- policy masking is represented as an idempotent admissibility projector with a neutral state
- a SHA3 state digest is separated from the chained Ω ledger digest
- `γ = ∞` is treated as an epistemic reality-gap invariant, not a floating-point lattice operation

## Validation

A local isolated run completed successfully:

```text
5 passed
```

The branch is four commits ahead of `main`, with no divergence.