### PR TITLE
Add Hugging Face safetensors model-weight exporter

### DIFF
--- a/hf_model/__init__.py
+++ b/hf_model/__init__.py
@@ -1,0 +1,6 @@
+"""Hugging Face model implementation for Jarvis-X."""
+
+from .configuration_jarvisx import JarvisXConfig
+from .modeling_jarvisx import JarvisXModel, JarvisXOutput
+
+__all__ = ["JarvisXConfig", "JarvisXModel", "JarvisXOutput"]

--- a/hf_model/configuration_jarvisx.py
+++ b/hf_model/configuration_jarvisx.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from transformers import PreTrainedConfig
+
+
+class JarvisXConfig(PreTrainedConfig):
+    """Configuration for the Jarvis-X auto-encoding state-transition model."""
+
+    model_type = "jarvisx"
+
+    def __init__(
+        self,
+        input_dim: int = 512,
+        hidden_dim: int = 512,
+        latent_dim: int = 128,
+        output_dim: int = 512,
+        transition_layers: int = 2,
+        omega_decay: float = 0.95,
+        omega_rate: float = 0.10,
+        initializer_range: float = 0.02,
+        layer_norm_eps: float = 1e-5,
+        **kwargs: Any,
+    ) -> None:
+        if min(input_dim, hidden_dim, latent_dim, output_dim) <= 0:
+            raise ValueError("All model dimensions must be positive.")
+        if transition_layers < 1:
+            raise ValueError("transition_layers must be at least 1.")
+        if not 0.0 <= omega_decay <= 1.0:
+            raise ValueError("omega_decay must be in [0, 1].")
+        if not 0.0 <= omega_rate <= 1.0:
+            raise ValueError("omega_rate must be in [0, 1].")
+
+        self.input_dim = int(input_dim)
+        self.hidden_dim = int(hidden_dim)
+        self.latent_dim = int(latent_dim)
+        self.output_dim = int(output_dim)
+        self.transition_layers = int(transition_layers)
+        self.omega_decay = float(omega_decay)
+        self.omega_rate = float(omega_rate)
+        self.initializer_range = float(initializer_range)
+        self.layer_norm_eps = float(layer_norm_eps)
+        super().__init__(**kwargs)

--- a/hf_model/modeling_jarvisx.py
+++ b/hf_model/modeling_jarvisx.py
@@ -1,0 +1,210 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+import torch
+from torch import nn
+from torch.nn import functional as F
+from transformers import PreTrainedModel
+from transformers.utils import ModelOutput
+
+try:
+    from .configuration_jarvisx import JarvisXConfig
+except ImportError:  # Hugging Face dynamic module fallback.
+    from configuration_jarvisx import JarvisXConfig
+
+
+@dataclass
+class JarvisXOutput(ModelOutput):
+    loss: Optional[torch.Tensor] = None
+    last_hidden_state: Optional[torch.Tensor] = None
+    latent_state: Optional[torch.Tensor] = None
+    reconstruction: Optional[torch.Tensor] = None
+    omega_state: Optional[torch.Tensor] = None
+    lambda_gate: Optional[torch.Tensor] = None
+    prediction_error: Optional[torch.Tensor] = None
+
+
+class JarvisXModel(PreTrainedModel):
+    """Bounded recurrent autoencoder implementing Jarvis-X state evolution.
+
+    Per step:
+        prediction = P(state)
+        error      = prediction - encoded_observation
+        omega'     = decay * omega + rate * correction(-error)
+        proposal   = state + prediction - error + omega'
+        state'     = Lambda(state, proposal)
+    """
+
+    config_class = JarvisXConfig
+    base_model_prefix = "jarvisx"
+    main_input_name = "input_values"
+
+    def __init__(self, config: JarvisXConfig) -> None:
+        super().__init__(config)
+
+        self.encoder = nn.Sequential(
+            nn.Linear(config.input_dim, config.hidden_dim),
+            nn.GELU(),
+            nn.LayerNorm(config.hidden_dim, eps=config.layer_norm_eps),
+        )
+
+        transition = []
+        for _ in range(config.transition_layers):
+            transition.extend(
+                [
+                    nn.Linear(config.hidden_dim, config.hidden_dim),
+                    nn.GELU(),
+                    nn.LayerNorm(config.hidden_dim, eps=config.layer_norm_eps),
+                ]
+            )
+        self.predictor = nn.Sequential(*transition)
+
+        self.omega_projection = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.hidden_dim),
+            nn.Tanh(),
+        )
+        self.lambda_gate = nn.Linear(config.hidden_dim * 4, config.hidden_dim)
+        self.state_norm = nn.LayerNorm(config.hidden_dim, eps=config.layer_norm_eps)
+        self.latent_projection = nn.Sequential(
+            nn.Linear(config.hidden_dim, config.latent_dim),
+            nn.Tanh(),
+        )
+        self.decoder = nn.Sequential(
+            nn.Linear(config.latent_dim, config.hidden_dim),
+            nn.GELU(),
+            nn.LayerNorm(config.hidden_dim, eps=config.layer_norm_eps),
+            nn.Linear(config.hidden_dim, config.output_dim),
+        )
+        self.post_init()
+
+    def _init_weights(self, module: nn.Module) -> None:
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=self.config.initializer_range)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.LayerNorm):
+            module.bias.data.zero_()
+            module.weight.data.fill_(1.0)
+
+    def forward(
+        self,
+        input_values: torch.Tensor,
+        initial_state: Optional[torch.Tensor] = None,
+        omega_state: Optional[torch.Tensor] = None,
+        target_values: Optional[torch.Tensor] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[JarvisXOutput, Tuple[torch.Tensor, ...]]:
+        return_dict = return_dict if return_dict is not None else getattr(
+            self.config, "return_dict", True
+        )
+
+        if input_values is None:
+            raise ValueError("input_values is required.")
+
+        squeeze_sequence = False
+        if input_values.ndim == 2:
+            input_values = input_values.unsqueeze(1)
+            squeeze_sequence = True
+        if input_values.ndim != 3:
+            raise ValueError(
+                "input_values must have shape [batch, input_dim] or "
+                "[batch, sequence, input_dim]."
+            )
+        if input_values.shape[-1] != self.config.input_dim:
+            raise ValueError(
+                f"Expected input_dim={self.config.input_dim}, "
+                f"received {input_values.shape[-1]}."
+            )
+
+        batch_size, sequence_length, _ = input_values.shape
+        reference = input_values
+        expected_state_shape = (batch_size, self.config.hidden_dim)
+
+        if initial_state is None:
+            state = reference.new_zeros(expected_state_shape)
+        else:
+            if tuple(initial_state.shape) != expected_state_shape:
+                raise ValueError(f"initial_state must have shape {expected_state_shape}.")
+            state = initial_state.to(device=reference.device, dtype=reference.dtype)
+
+        if omega_state is None:
+            omega = reference.new_zeros(expected_state_shape)
+        else:
+            if tuple(omega_state.shape) != expected_state_shape:
+                raise ValueError(f"omega_state must have shape {expected_state_shape}.")
+            omega = omega_state.to(device=reference.device, dtype=reference.dtype)
+
+        hidden_steps = []
+        latent_steps = []
+        reconstruction_steps = []
+        gate_steps = []
+        error_steps = []
+
+        for step in range(sequence_length):
+            encoded = self.encoder(input_values[:, step, :])
+            prediction = self.predictor(state)
+            error = prediction - encoded
+
+            correction = self.omega_projection(-error)
+            omega = self.config.omega_decay * omega + self.config.omega_rate * correction
+
+            proposal = state + prediction - error + omega
+            gate_features = torch.cat((state, encoded, prediction, omega), dim=-1)
+            gate = torch.sigmoid(self.lambda_gate(gate_features))
+            state = self.state_norm((1.0 - gate) * state + gate * proposal)
+
+            latent = self.latent_projection(state)
+            reconstruction = self.decoder(latent)
+
+            hidden_steps.append(state)
+            latent_steps.append(latent)
+            reconstruction_steps.append(reconstruction)
+            gate_steps.append(gate)
+            error_steps.append(error)
+
+        hidden_sequence = torch.stack(hidden_steps, dim=1)
+        latent_sequence = torch.stack(latent_steps, dim=1)
+        reconstruction_sequence = torch.stack(reconstruction_steps, dim=1)
+        gate_sequence = torch.stack(gate_steps, dim=1)
+        error_sequence = torch.stack(error_steps, dim=1)
+
+        loss = None
+        if target_values is not None:
+            if target_values.ndim == 2:
+                target_values = target_values.unsqueeze(1)
+            if tuple(target_values.shape) != tuple(reconstruction_sequence.shape):
+                raise ValueError(
+                    "target_values must match reconstruction shape "
+                    f"{tuple(reconstruction_sequence.shape)}."
+                )
+            loss = F.mse_loss(reconstruction_sequence, target_values)
+        elif self.config.output_dim == self.config.input_dim:
+            loss = F.mse_loss(reconstruction_sequence, input_values)
+
+        if squeeze_sequence:
+            hidden_sequence = hidden_sequence[:, 0, :]
+            latent_sequence = latent_sequence[:, 0, :]
+            reconstruction_sequence = reconstruction_sequence[:, 0, :]
+            gate_sequence = gate_sequence[:, 0, :]
+            error_sequence = error_sequence[:, 0, :]
+
+        if not return_dict:
+            values = (
+                hidden_sequence,
+                latent_sequence,
+                reconstruction_sequence,
+                omega,
+                gate_sequence,
+                error_sequence,
+            )
+            return ((loss,) + values) if loss is not None else values
+
+        return JarvisXOutput(
+            loss=loss,
+            last_hidden_state=hidden_sequence,
+            latent_state=latent_sequence,
+            reconstruction=reconstruction_sequence,
+            omega_state=omega,
+            lambda_gate=gate_sequence,
+            prediction_error=error_sequence,
+        )

--- a/requirements-huggingface.txt
+++ b/requirements-huggingface.txt
@@ -1,0 +1,4 @@
+torch>=2.2
+transformers>=4.45
+huggingface_hub>=0.25
+safetensors>=0.4

--- a/scripts/export_huggingface_model.py
+++ b/scripts/export_huggingface_model.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Export Jarvis-X weights in Hugging Face safetensors format.
+
+Without --checkpoint, this creates deterministic initialized weights. They are
+structurally valid but are not trained weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import shutil
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from hf_model import JarvisXConfig, JarvisXModel  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", default="build/huggingface/JarvisX")
+    parser.add_argument("--repo-id", default="LordXido/JarvisX")
+    parser.add_argument("--checkpoint", type=Path)
+    parser.add_argument("--strict-checkpoint", action="store_true")
+    parser.add_argument("--input-dim", type=int, default=512)
+    parser.add_argument("--hidden-dim", type=int, default=512)
+    parser.add_argument("--latent-dim", type=int, default=128)
+    parser.add_argument("--output-dim", type=int, default=512)
+    parser.add_argument("--transition-layers", type=int, default=2)
+    parser.add_argument("--omega-decay", type=float, default=0.95)
+    parser.add_argument("--omega-rate", type=float, default=0.10)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--max-shard-size", default="5GB")
+    parser.add_argument("--push", action="store_true")
+    parser.add_argument("--private", action="store_true")
+    parser.add_argument("--token", help="Prefer HF_TOKEN or `hf auth login`.")
+    parser.add_argument("--commit-message", default="Upload Jarvis-X safetensors checkpoint")
+    parser.add_argument("--overwrite", action="store_true")
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_checkpoint(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+    if path.suffix == ".safetensors":
+        from safetensors.torch import load_file
+
+        payload = load_file(str(path), device="cpu")
+    else:
+        import torch
+
+        try:
+            payload = torch.load(str(path), map_location="cpu", weights_only=True)
+        except TypeError:
+            payload = torch.load(str(path), map_location="cpu")
+
+    if isinstance(payload, dict) and isinstance(payload.get("state_dict"), dict):
+        payload = payload["state_dict"]
+    if not isinstance(payload, dict):
+        raise TypeError("Checkpoint must contain a state_dict mapping.")
+
+    state_dict = {}
+    for key, value in payload.items():
+        if hasattr(value, "shape"):
+            state_dict[key[7:] if key.startswith("module.") else key] = value
+    if not state_dict:
+        raise ValueError("No tensor weights were found in the checkpoint.")
+    return state_dict
+
+
+def make_model_card(repo_id: str, manifest: Dict[str, Any]) -> str:
+    config = manifest["config"]
+    return f'''---
+license: mit
+library_name: transformers
+pipeline_tag: feature-extraction
+tags:
+- jarvis-x
+- custom-code
+- autoencoder
+- state-space-model
+- safetensors
+---
+
+# Jarvis-X
+
+Jarvis-X is a custom `transformers` model implementing a bounded recurrent
+auto-encoding state transition with prediction, residual correction, Ω-memory,
+and a learned Λ projection gate.
+
+## Checkpoint status
+
+**{manifest["weight_status"]}**
+
+- Parameters: `{manifest["parameter_count"]:,}`
+- Seed: `{manifest["seed"]}`
+- Input / hidden / latent / output: `{config["input_dim"]} / {config["hidden_dim"]} / {config["latent_dim"]} / {config["output_dim"]}`
+
+## Load
+
+```python
+import torch
+from transformers import AutoModel
+
+model = AutoModel.from_pretrained("{repo_id}", trust_remote_code=True).eval()
+x = torch.randn(1, 8, model.config.input_dim)
+
+with torch.inference_mode():
+    output = model(input_values=x)
+
+print(output.reconstruction.shape)
+print(output.omega_state.shape)
+```
+
+Inspect the custom model code and pin a specific Hub revision in
+security-sensitive deployments.
+'''
+
+
+def upload(output_dir: Path, args: argparse.Namespace) -> str:
+    from huggingface_hub import HfApi, get_token
+
+    token = args.token or os.getenv("HF_TOKEN") or get_token()
+    if not token:
+        raise RuntimeError("Run `hf auth login` or set a write-enabled HF_TOKEN.")
+
+    api = HfApi(token=token)
+    api.create_repo(
+        repo_id=args.repo_id,
+        repo_type="model",
+        private=args.private,
+        exist_ok=True,
+    )
+    return str(
+        api.upload_folder(
+            folder_path=str(output_dir),
+            repo_id=args.repo_id,
+            repo_type="model",
+            commit_message=args.commit_message,
+            ignore_patterns=["__pycache__/*", "*.pyc"],
+        )
+    )
+
+
+def main() -> int:
+    args = parse_args()
+    output_dir = Path(args.output_dir).expanduser().resolve()
+
+    if output_dir.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"{output_dir} exists; pass --overwrite to replace it.")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    import torch
+
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(args.seed)
+    torch.use_deterministic_algorithms(True)
+
+    config = JarvisXConfig(
+        input_dim=args.input_dim,
+        hidden_dim=args.hidden_dim,
+        latent_dim=args.latent_dim,
+        output_dim=args.output_dim,
+        transition_layers=args.transition_layers,
+        omega_decay=args.omega_decay,
+        omega_rate=args.omega_rate,
+        architectures=["JarvisXModel"],
+        auto_map={
+            "AutoConfig": "configuration_jarvisx.JarvisXConfig",
+            "AutoModel": "modeling_jarvisx.JarvisXModel",
+        },
+    )
+    model = JarvisXModel(config).cpu().eval()
+
+    if args.checkpoint:
+        incompatible = model.load_state_dict(
+            load_checkpoint(args.checkpoint), strict=args.strict_checkpoint
+        )
+        if not args.strict_checkpoint:
+            if incompatible.missing_keys:
+                print("Missing keys:", incompatible.missing_keys)
+            if incompatible.unexpected_keys:
+                print("Unexpected keys:", incompatible.unexpected_keys)
+        weight_status = f"Imported checkpoint from `{args.checkpoint.name}`."
+    else:
+        weight_status = (
+            "Deterministically initialized baseline; these weights are not trained. "
+            "Train the model or pass --checkpoint before production use."
+        )
+
+    smoke_input = torch.zeros(2, 3, args.input_dim)
+    with torch.inference_mode():
+        smoke_output = model(input_values=smoke_input)
+    expected_shape = (2, 3, args.output_dim)
+    if tuple(smoke_output.reconstruction.shape) != expected_shape:
+        raise RuntimeError("Model smoke test failed.")
+    if not torch.isfinite(smoke_output.reconstruction).all():
+        raise RuntimeError("Model produced non-finite values.")
+
+    model.save_pretrained(
+        str(output_dir),
+        safe_serialization=True,
+        max_shard_size=args.max_shard_size,
+    )
+    shutil.copy2(REPO_ROOT / "hf_model/configuration_jarvisx.py", output_dir)
+    shutil.copy2(REPO_ROOT / "hf_model/modeling_jarvisx.py", output_dir)
+
+    weight_files = sorted(output_dir.glob("*.safetensors"))
+    if not weight_files:
+        raise RuntimeError("No safetensors weights were produced.")
+
+    manifest = {
+        "format": "safetensors",
+        "architecture": "JarvisXModel",
+        "weight_status": weight_status,
+        "seed": args.seed,
+        "parameter_count": sum(p.numel() for p in model.parameters()),
+        "config": {
+            "input_dim": args.input_dim,
+            "hidden_dim": args.hidden_dim,
+            "latent_dim": args.latent_dim,
+            "output_dim": args.output_dim,
+            "transition_layers": args.transition_layers,
+            "omega_decay": args.omega_decay,
+            "omega_rate": args.omega_rate,
+        },
+        "files": [
+            {
+                "name": path.name,
+                "bytes": path.stat().st_size,
+                "sha256": sha256_file(path),
+            }
+            for path in weight_files
+        ],
+    }
+    (output_dir / "weights_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "README.md").write_text(
+        make_model_card(args.repo_id, manifest), encoding="utf-8"
+    )
+
+    from transformers import AutoModel
+
+    loaded = AutoModel.from_pretrained(
+        str(output_dir), trust_remote_code=True, local_files_only=True
+    ).eval()
+    with torch.inference_mode():
+        reloaded = loaded(input_values=smoke_input)
+    if tuple(reloaded.reconstruction.shape) != expected_shape:
+        raise RuntimeError("AutoModel reload validation failed.")
+
+    for cache_dir in output_dir.rglob("__pycache__"):
+        shutil.rmtree(cache_dir, ignore_errors=True)
+
+    print(json.dumps(manifest, indent=2))
+    print(f"Built model: {output_dir}")
+    if args.push:
+        print(f"Uploaded: {upload(output_dir, args)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a Hugging Face-compatible Jarvis-X model implementation and an exporter that generates `config.json`, custom model code, `model.safetensors`, a model card, and a SHA-256 weights manifest.

## Included

- `JarvisXConfig` and `JarvisXModel`
- recurrent prediction → error → Ω-memory → Λ-gated state transition
- deterministic initialized baseline generation
- optional import of an existing `.safetensors`, `.pt`, or `.bin` checkpoint
- local smoke test and `AutoModel.from_pretrained(..., trust_remote_code=True)` reload validation
- optional upload to `LordXido/JarvisX` through `huggingface_hub`
- isolated Hugging Face dependency file

## Run

```bash
pip install -r requirements-huggingface.txt
hf auth login
python scripts/export_huggingface_model.py \
  --repo-id LordXido/JarvisX \
  --push
```

Without `--checkpoint`, the generated weights are explicitly labeled as deterministic initialized weights, not trained weights.

## Validation performed

- Python syntax compilation
- deterministic model build
- safetensors serialization
- finite-output smoke test
- local Hugging Face `AutoModel` reload