### PR TITLE
Operationalise sparse tetration 3D brick-field automaton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,99 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex
-control layer and policy gate.
+Jarvis-X is a deterministic, auditable virtual machine with a reflex control
+layer, policy gate, and an operational sparse 3-D auto-encoding/decoding
+simulation automaton.
+
+## Operational 3-D automaton
+
+The automaton exposes a virtual address universe of
+
+\[
+(1000^{1000})\times(1000^{1000})\times(1000^{1000})=10^{9000}
+\]
+
+cells without allocating a dense tensor. Exact arbitrary-precision coordinates
+identify the universe; untouched cells are reconstructed procedurally, while
+only the bounded causal frontier is physically materialised.
+
+Each transaction performs:
+
+```text
+activate
+→ encode the local 3-D neighbourhood
+→ evolve the latent ANN state
+→ decode the proposed field
+→ calculate residual error
+→ update Ω correction memory
+→ apply diffusion and local automaton dynamics
+→ project through Λ validity constraints
+→ commit or roll back atomically
+→ append the deterministic journal hash
+```
+
+A bounded mechanics optimiser can shadow-test declared parameter candidates and
+adopt one only when it is valid and improves the measured objective. It does
+not perform unrestricted source rewriting.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
-pip install .
+pip install -e .
+```
+
+## Run the sparse universe
+
+```bash
+jarvisx universe
+jarvisx automaton --steps 20 --side 3
+jarvisx automaton --steps 20 --side 3 --auto-optimize --json
+```
+
+Module execution is equivalent:
+
+```bash
+python -m jarvisx automaton --steps 20
+```
+
+## Run the bytecode VM
+
+```bash
+jarvisx run program.jx
+```
+
+## Run the API
+
+```bash
+jarvisx api
+```
+
+The service exposes:
+
+- `GET /health`
+- `POST /run`
+- `GET /automaton`
+- `POST /automaton/step`
+
+Example automaton transaction:
+
+```bash
+curl -X POST http://localhost:8080/automaton/step \
+  -H 'content-type: application/json' \
+  -d '{"injections":[{"x":0,"y":0,"z":0,"value":1.0}]}'
+```
+
+## Test
+
+```bash
+pytest
+```
+
+The reference tests verify deterministic replay, procedural reconstruction,
+sparse frontier budgeting, autoencoder dimensions, transactional commits,
+journal chaining, and rollback on failed validity checks.
+
+See [`docs/SPARSE_3D_AUTOMATON.md`](docs/SPARSE_3D_AUTOMATON.md) for the
+operational mathematics and execution model.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,78 @@
 # Jarvis-X
 
-Jarvis-X is a deterministic, auditable virtual machine with a reflex control
-layer, policy gate, and an operational sparse 3-D auto-encoding/decoding
-simulation automaton.
+Jarvis-X is a deterministic virtual machine and a transactional sparse-field
+runtime with auto-encoding, residual correction, policy projection, and replayable
+journaling.
 
-## Operational 3-D automaton
+## Sparse tetration field
 
-The automaton exposes a virtual address universe of
+The operational field is indexed over the symbolic universe
 
 \[
-(1000^{1000})\times(1000^{1000})\times(1000^{1000})=10^{9000}
+T_1=1000,\qquad T_{k+1}=1000^{T_k},\qquad
+\mathcal U_k=\{0,\ldots,T_k-1\}^3.
 \]
 
-cells without allocating a dense tensor. Exact arbitrary-precision coordinates
-identify the universe; untouched cells are reconstructed procedurally, while
-only the bounded causal frontier is physically materialised.
+No dense matrix of \(|\mathcal U_k|=T_k^3\) cells is allocated. Physical state is
 
-Each transaction performs:
+\[
+\Sigma_t=(\mathcal A_t,B_t,Z_t,\Omega_t,J_t),
+\]
+
+where \(\mathcal A_t\) contains at most `max_active_bricks` materialised brick
+addresses. Each brick is
+
+\[
+B_t(\mathbf r)\in\mathbb R^{3\times4\times4\times4}
+\]
+
+and therefore contains 192 scalar values.
+
+The default `--tower-height 2` gives an axis of \(1000^{1000}\). Higher towers
+remain symbolic. Because a completely arbitrary raw coordinate at height three
+or above would itself require an impractical number of bits, executable addresses
+use a finite chart identifier plus exact signed local offsets.
+
+## Operational cycle
 
 ```text
-activate
-→ encode the local 3-D neighbourhood
-→ evolve the latent ANN state
-→ decode the proposed field
-→ calculate residual error
-→ update Ω correction memory
-→ apply diffusion and local automaton dynamics
-→ project through Λ validity constraints
-→ commit or roll back atomically
-→ append the deterministic journal hash
+resolve symbolic address
+→ hash into a collision-chained sparse directory
+→ apply the active mask by directory membership
+→ project all 192 brick values through W_enc
+→ condition the latent state with W_omega Ω
+→ softmax route to one expert (top-1)
+→ apply the selected latent expert
+→ reconstruct all 192 values through W_dec
+→ calculate E = decoded - observed
+→ update Ω' = ρΩ - ηE
+→ evaluate the six-face Laplacian across brick boundaries
+→ project each value into [16, 235]
+→ verify budgets and finiteness
+→ atomically commit or roll back
+→ append the deterministic SHA-256 journal link
 ```
 
-A bounded mechanics optimiser can shadow-test declared parameter candidates and
-adopt one only when it is valid and improves the measured objective. It does
-not perform unrestricted source rewriting.
+The explicit diffusion condition is enforced:
+
+\[
+\Delta tD\le\frac16,
+\]
+
+and persistent memory requires
+
+\[
+0<\rho<1.
+\]
+
+The physical cost is tied to the materialised frontier:
+
+\[
+T_{cycle}=O\!\left(M_t(192d+d^2+192\cdot6)\right),
+\qquad M_{memory}=O(M_t),
+\]
+
+not to \(|\mathcal U_k|\).
 
 ## Install
 
@@ -44,46 +83,45 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
-## Run the sparse universe
+## Run
 
 ```bash
-jarvisx universe
-jarvisx automaton --steps 20 --side 3
-jarvisx automaton --steps 20 --side 3 --auto-optimize --json
-```
-
-Module execution is equivalent:
-
-```bash
+jarvisx universe --tower-height 2
+jarvisx universe --tower-height 4
+jarvisx automaton --steps 20 --tower-height 2
+jarvisx automaton --steps 20 --tower-height 4 --max-active 128 --json
 python -m jarvisx automaton --steps 20
 ```
 
-## Run the bytecode VM
+## Bytecode VM
 
 ```bash
 jarvisx run program.jx
 ```
 
-## Run the API
+## API
 
 ```bash
 jarvisx api
 ```
 
-The service exposes:
+Endpoints:
 
 - `GET /health`
+- `GET /universe?tower_height=4`
 - `POST /run`
-- `GET /automaton`
-- `POST /automaton/step`
+- `GET /field` and `GET /automaton`
+- `POST /field/step` and `POST /automaton/step`
 
-Example automaton transaction:
+Scalar brick stimulus:
 
 ```bash
-curl -X POST http://localhost:8080/automaton/step \
+curl -X POST http://localhost:8080/field/step \
   -H 'content-type: application/json' \
-  -d '{"injections":[{"x":0,"y":0,"z":0,"value":1.0}]}'
+  -d '{"injections":[{"chart":"origin","x":0,"y":0,"z":0,"value":24.0}]}'
 ```
+
+A full observation may instead provide `values` with exactly 192 numbers.
 
 ## Test
 
@@ -91,9 +129,9 @@ curl -X POST http://localhost:8080/automaton/step \
 pytest
 ```
 
-The reference tests verify deterministic replay, procedural reconstruction,
-sparse frontier budgeting, autoencoder dimensions, transactional commits,
-journal chaining, and rollback on failed validity checks.
+The regression suite covers collision chaining, full encoder and decoder
+projection, softmax/top-1 routing, cross-brick diffusion, stability constraints,
+sparse frontier budgets, exact replay, projection bounds, and rollback.
 
-See [`docs/SPARSE_3D_AUTOMATON.md`](docs/SPARSE_3D_AUTOMATON.md) for the
-operational mathematics and execution model.
+See [`docs/SPARSE_3D_AUTOMATON.md`](docs/SPARSE_3D_AUTOMATON.md) for the complete
+operational mathematics.

--- a/docs/SPARSE_3D_AUTOMATON.md
+++ b/docs/SPARSE_3D_AUTOMATON.md
@@ -1,192 +1,309 @@
-# Sparse 3-D Auto-Encoding/Decoding Processing Automaton
+# Sparse Tetration 3-D Auto-Encoding/Decoding Field Automaton
 
-## Operational status
+## 1. Virtual address manifold
 
-This module converts the Jarvis-X geometric automaton specification into a
-runnable, deterministic Python reference implementation.
-
-The nominal coordinate universe is
+Define the base-1000 tetration tower
 
 \[
-\mathcal U = \{0,\ldots,1000^{1000}-1\}^3
-\]
-
-and therefore contains
-
-\[
-|\mathcal U|=(1000^{1000})^3=10^{9000}
-\]
-
-virtual cells. The implementation does **not** allocate a dense tensor of this
-size. It uses exact arbitrary-precision coordinates, a deterministic procedural
-background field, and a bounded sparse active frontier.
-
-## State
-
-For each materialised coordinate \(\mathbf r=(x,y,z)\), the committed cell state
-is
-
-\[
-C_{\mathbf r,t}=(B_{\mathbf r,t},\Omega_{\mathbf r,t},a_{\mathbf r,t},v_{\mathbf r,t})
-\]
-
-where:
-
-- \(B\) is the scalar field value;
-- \(\Omega\) is persistent residual memory;
-- \(a\) counts inactive cycles for pruning;
-- \(v\) is the cell revision.
-
-The global state is
-
-\[
-\Sigma_t=(\mathcal A_t,C_t,\mathcal M_t,J_t)
-\]
-
-with active frontier \(\mathcal A_t\), mechanics \(\mathcal M_t\), and
-transaction journal hash \(J_t\).
-
-## Local 3-D autoencoder
-
-Each cell reads the seven-value axis-aligned neighbourhood
-
-\[
-V_{\mathbf r,t}=
-(B_{\mathbf r,t},B_{\mathbf r+e_x,t},B_{\mathbf r-e_x,t},
- B_{\mathbf r+e_y,t},B_{\mathbf r-e_y,t},
- B_{\mathbf r+e_z,t},B_{\mathbf r-e_z,t}).
-\]
-
-The deterministic ANN executes
-
-\[
-Z_{\mathbf r,t}=E_\theta(V_{\mathbf r,t}),
+T_1=1000,
 \qquad
-\widehat Z_{\mathbf r,t+1}=P_\theta(Z_{\mathbf r,t},\Omega_{\mathbf r,t}),
+T_{k+1}=1000^{T_k}.
+\]
+
+The virtual cubic universe is
+
+\[
+\mathcal U_k=\{0,\ldots,T_k-1\}^3,
+\qquad
+|\mathcal U_k|=T_k^3.
+\]
+
+`TetrationUniverse` stores only this symbolic definition. It never allocates
+\(T_k^3\) cells.
+
+For an explicit raw coordinate, the theoretical naming length is
+
+\[
+b_k=3\left\lceil\log_2T_k\right\rceil
+=3\left\lceil T_{k-1}\log_2 1000\right\rceil.
+\]
+
+At \(k=2\), this is 29,898 bits. For \(k\ge3\), even the raw coordinate string is
+impractical. The executable runtime therefore uses a finite symbolic chart ID and
+exact signed local offsets:
+
+\[
+\mathbf r=(k,\text{chart},x,y,z).
+\]
+
+This is a compressed coordinate description and a local chart, not a claim that
+all arbitrary raw tetration coordinates fit in memory.
+
+## 2. Physical state
+
+Only materialised bricks exist in RAM:
+
+\[
+\Sigma_t=(\mathcal A_t,B_t,Z_t,\Omega_t,\mathcal D_t,J_t).
+\]
+
+- \(\mathcal A_t\): bounded active brick set;
+- \(B_t(\mathbf r)\in\mathbb R^{3\times4\times4\times4}\): 192-value brick;
+- \(Z_t\): transient latent state;
+- \(\Omega_t(\mathbf r)\in\mathbb R^{192}\): correction memory;
+- \(\mathcal D_t\): collision-chained sparse directory;
+- \(J_t\): deterministic journal hash.
+
+The invariant is
+
+\[
+\operatorname{cost}(t)=O(M_t),
+\qquad
+M_t=|\mathcal D_t|,
+\qquad
+O(M_t)\ne O(|\mathcal U_k|).
+\]
+
+## 3. Sparse allocation and active mask
+
+The finite directory uses
+
+\[
+\operatorname{idx}(\mathbf r)=
+\bigl(
+5147x\oplus9293y\oplus11257z\oplus H(\text{chart},k)
+\bigr)\bmod P.
+\]
+
+Each slot contains a collision chain. Equality is checked against the full
+canonical address, so collisions do not alias state.
+
+The active mask is a predicate:
+
+\[
+W_{\mathcal M}(\mathbf r)=
+\begin{cases}
+1,&\mathbf r\in\mathcal A_t,\\
+0,&\text{otherwise}.
+\end{cases}
+\]
+
+In code this is directory membership and threshold testing, not a dense tensor
+multiplication.
+
+## 4. Full brick encoder
+
+Flatten the whole brick:
+
+\[
+b_{\mathbf r}=\operatorname{flat}(B_t(\mathbf r))\in\mathbb R^{192}.
+\]
+
+After box normalisation, encoding is
+
+\[
+z_{\mathbf r}=\tanh(W_{enc}b_{\mathbf r}+c_{enc}),
+\qquad
+W_{enc}\in\mathbb R^{d\times192}.
+\]
+
+All 192 values participate. No prefix such as `flat[:16]` is used.
+
+## 5. Omega conditioning and top-1 MoE
+
+Correction memory conditions the latent state:
+
+\[
+\widetilde z_{\mathbf r}=
+\tanh\left(z_{\mathbf r}+W_\Omega\Omega_t(\mathbf r)\right),
+\qquad
+W_\Omega\in\mathbb R^{d\times192}.
+\]
+
+For experts \(i=1,\ldots,N_E\),
+
+\[
+\ell_i=R_i^T\widetilde z,
+\qquad
+g_i=\frac{e^{\ell_i}}{\sum_j e^{\ell_j}},
+\qquad
+k^*=\arg\max_i g_i.
+\]
+
+Routing is explicitly **top-1**:
+
+\[
+z'_{\mathbf r}=E_{k^*}(\widetilde z_{\mathbf r}).
+\]
+
+The committed brick records `expert_index = k*` for auditing.
+
+## 6. Full decoder
+
+The decoder is a full matrix projection:
+
+\[
+\widehat b_{\mathbf r}=W_{dec}z'_{\mathbf r}+c_{dec},
+\qquad
+W_{dec}\in\mathbb R^{192\times d},
 \]
 
 \[
-\widehat V_{\mathbf r,t+1}=D_\theta(\widehat Z_{\mathbf r,t+1}).
+\widehat V(\mathbf r)=
+\operatorname{reshape}_{3\times4\times4\times4}(\widehat b_{\mathbf r}).
 \]
 
-The centre reconstruction residual is
+It does not replace the brick with `mean(z) * ones`.
+
+## 7. Residual and Omega recurrence
 
 \[
-E_{\mathbf r,t}=\widehat V_{\mathbf r,t+1}[0]-B_{\mathbf r,t}.
+E_{\mathbf r,t}=\widehat V(\mathbf r)-B_t(\mathbf r).
 \]
 
-## Automaton update
-
-Persistent correction memory evolves as
+Omega is a leaky integral:
 
 \[
-\Omega_{\mathbf r,t+1}
-=\rho_\Omega\Omega_{\mathbf r,t}-\eta_\Omega E_{\mathbf r,t}.
+\Omega_{t+1}(\mathbf r)=
+\rho\Omega_t(\mathbf r)-\eta E_{\mathbf r,t},
+\qquad
+0<\rho<1.
 \]
 
-The six-neighbour discrete Laplacian is
+The characteristic decay time is approximately
 
 \[
-\nabla_h^2 B_{\mathbf r,t}
-=\sum_{\mathbf q\in\mathcal N(\mathbf r)}
-(B_{\mathbf q,t}-B_{\mathbf r,t}).
+\tau_\Omega\approx\frac{1}{1-\rho}
 \]
 
-The transaction proposal is
+cycles when \(\rho\) is close to one.
+
+## 8. True cross-brick six-face diffusion
+
+For every channel and voxel, the discrete Laplacian is
 
 \[
-\widetilde B_{\mathbf r,t+1}=B_{\mathbf r,t}+\Delta t
-\left[D\nabla_h^2B_{\mathbf r,t}-K E_{\mathbf r,t}
-+\Omega_{\mathbf r,t+1}\right].
+\Delta B_t(\mathbf r,u)=
+\sum_{q\in\mathcal N_6(\mathbf r,u)}B_t(q)-6B_t(\mathbf r,u).
 \]
 
-The candidate state is committed only after the \(\Lambda\) verification gate
-checks finiteness, coordinate validity, magnitude bounds, energy budget, and
-active-cell budget:
+At an internal voxel, neighbours are read from the same brick. At a face voxel,
+the neighbour is resolved through the sparse directory into the adjacent brick,
+using the opposite face coordinate. This is not `np.roll` with periodic wrapping
+inside one brick.
+
+## 9. Projection
+
+For the box constraint
 
 \[
-\Sigma_{t+1}=\operatorname{COMMIT}
-\left(\Pi_\Lambda[\widetilde\Sigma_{t+1}]\right).
+\Lambda=[16,235]^{192},
 \]
 
-Failure produces an atomic rollback to \(\Sigma_t\).
-
-## Procedural storage
-
-An untouched cell is reconstructed as
+the orthogonal projection is element-wise clipping:
 
 \[
-B_{\mathbf r,0}=H(s,\mathbf r)
+\Pi_\Lambda(v)_j=\min(235,\max(16,v_j)).
 \]
 
-using keyed BLAKE2b. Sampling a virtual coordinate therefore does not allocate
-it. A cell is materialised only when it is injected, becomes active, or lies on
-the immediate causal boundary of an active cell.
-
-For \(A_t\) active cells, latent dimension \(d\), and constant neighbourhood
-size \(k=6\), one cycle is approximately
+For a general admissible set,
 
 \[
-T_t=O(A_t(d+k)),\qquad M_t=O(A_t).
+\Pi_\Lambda(v)=\arg\min_{y\in\Lambda}\|y-v\|_2.
 \]
 
-The nominal \(10^{9000}\) universe affects address range, not dense runtime
-cost.
+## 10. Operational transaction
 
-## Bounded inward optimisation
-
-`BoundedMechanicsOptimizer` tests a finite declared set of mechanics candidates
-on forked shadow states. A candidate is adopted only when every transaction
-commits and its score is lower than the baseline:
+For each active brick and its causal face frontier:
 
 \[
-C=\sum_t \operatorname{MSE}_t+\lambda_A|\mathcal A_t|.
+\widetilde B_{t+1}=B_t+\Delta t\left[
+D\Delta B_t
+-K\left(\mathcal D_\theta(\mathcal G_{MoE}(\mathcal E_\theta(B_t)\mid\Omega_t))-B_t\right)
++\Omega_{t+1}+U_t
+\right].
 \]
 
-No source code is rewritten and no candidate can bypass the same verification
-gate used by the baseline engine.
+Then
 
-## Run
+\[
+B_{t+1}=\Pi_\Lambda(\widetilde B_{t+1}).
+\]
 
-```bash
-pip install -e .
-jarvisx universe
-jarvisx automaton --steps 20 --side 3
-jarvisx automaton --steps 20 --side 3 --auto-optimize --json
-```
+The unified sparse-field form is
 
-Equivalent module execution:
-
-```bash
-python -m jarvisx automaton --steps 20
-```
-
-## API
-
-```bash
-jarvisx api
-```
-
-Endpoints:
-
-- `GET /health`
-- `POST /run`
-- `GET /automaton`
-- `POST /automaton/step`
-
-Example step body:
-
-```json
-{
-  "injections": [
-    {"x": 0, "y": 0, "z": 0, "value": 1.0}
-  ]
+\[
+\boxed{
+\Sigma_{t+1}=\Pi_\Lambda\left[
+\Sigma_t+W_{\mathcal M}\odot
+\left(D\Delta\Sigma_t
+-K(\mathcal D_\theta(\mathcal G_{MoE}(\mathcal E_\theta(\Sigma_t)\mid\Omega_t))-\Sigma_t)
++\Omega_{t+1}+U_t\right)
+\right]
 }
+\]
+
+where \(W_{\mathcal M}\) denotes sparse scheduling semantics rather than a
+materialised dense mask.
+
+All updates are calculated against an immutable transaction snapshot. The
+candidate is checked for finite values, projection bounds, Omega bounds, expert
+index validity, relative energy, and materialisation budget before the directory
+and journal are replaced atomically.
+
+## 11. Frontier control
+
+The next frontier is
+
+\[
+\mathcal F_t=\mathcal A_t\cup\partial_6\mathcal A_t.
+\]
+
+It is ranked and capped by `max_active_bricks`. A brick is pruned after
+`prune_after` low-activity cycles when both deviation from its procedural
+background and Omega magnitude fall below `activation_threshold`.
+
+Without thresholding and pruning, six-face expansion may grow as much as
+
+\[
+M_{t+1}\lesssim7M_t
+\]
+
+before overlap, eventually exhausting the finite cache.
+
+## 12. Stability contract
+
+The reference explicit scheme enforces
+
+\[
+\Delta tD\le\frac16,
+\qquad
+\Delta tK\le1,
+\qquad
+0<\rho<1.
+\]
+
+It also clips the projected field, bounds Omega, caps active bricks, and rolls
+back non-finite or over-energy candidates.
+
+## 13. Complexity
+
+For latent dimension \(d\) and \(M_t\) materialised bricks:
+
+\[
+T_t=O\left(M_t(192d+d^2+192\cdot6)\right),
+\qquad
+S_t=O(M_t\cdot192).
+\]
+
+The tetration height changes the symbolic address description. It does not change
+the number of bricks physically evaluated in one cycle.
+
+## 14. Run
+
+```bash
+jarvisx universe --tower-height 2
+jarvisx universe --tower-height 4
+jarvisx automaton --steps 20 --tower-height 4 --max-active 128
+pytest tests/test_tetration_field.py
 ```
-
-## Determinism
-
-Given the same seed, mechanics, initial state, and ordered input transactions,
-the engine produces the same state and SHA-256 journal chain. Tests cover exact
-replay, sparse budgeting, coordinate wrapping, procedural reconstruction,
-transaction commit, and rollback.

--- a/docs/SPARSE_3D_AUTOMATON.md
+++ b/docs/SPARSE_3D_AUTOMATON.md
@@ -1,0 +1,192 @@
+# Sparse 3-D Auto-Encoding/Decoding Processing Automaton
+
+## Operational status
+
+This module converts the Jarvis-X geometric automaton specification into a
+runnable, deterministic Python reference implementation.
+
+The nominal coordinate universe is
+
+\[
+\mathcal U = \{0,\ldots,1000^{1000}-1\}^3
+\]
+
+and therefore contains
+
+\[
+|\mathcal U|=(1000^{1000})^3=10^{9000}
+\]
+
+virtual cells. The implementation does **not** allocate a dense tensor of this
+size. It uses exact arbitrary-precision coordinates, a deterministic procedural
+background field, and a bounded sparse active frontier.
+
+## State
+
+For each materialised coordinate \(\mathbf r=(x,y,z)\), the committed cell state
+is
+
+\[
+C_{\mathbf r,t}=(B_{\mathbf r,t},\Omega_{\mathbf r,t},a_{\mathbf r,t},v_{\mathbf r,t})
+\]
+
+where:
+
+- \(B\) is the scalar field value;
+- \(\Omega\) is persistent residual memory;
+- \(a\) counts inactive cycles for pruning;
+- \(v\) is the cell revision.
+
+The global state is
+
+\[
+\Sigma_t=(\mathcal A_t,C_t,\mathcal M_t,J_t)
+\]
+
+with active frontier \(\mathcal A_t\), mechanics \(\mathcal M_t\), and
+transaction journal hash \(J_t\).
+
+## Local 3-D autoencoder
+
+Each cell reads the seven-value axis-aligned neighbourhood
+
+\[
+V_{\mathbf r,t}=
+(B_{\mathbf r,t},B_{\mathbf r+e_x,t},B_{\mathbf r-e_x,t},
+ B_{\mathbf r+e_y,t},B_{\mathbf r-e_y,t},
+ B_{\mathbf r+e_z,t},B_{\mathbf r-e_z,t}).
+\]
+
+The deterministic ANN executes
+
+\[
+Z_{\mathbf r,t}=E_\theta(V_{\mathbf r,t}),
+\qquad
+\widehat Z_{\mathbf r,t+1}=P_\theta(Z_{\mathbf r,t},\Omega_{\mathbf r,t}),
+\]
+
+\[
+\widehat V_{\mathbf r,t+1}=D_\theta(\widehat Z_{\mathbf r,t+1}).
+\]
+
+The centre reconstruction residual is
+
+\[
+E_{\mathbf r,t}=\widehat V_{\mathbf r,t+1}[0]-B_{\mathbf r,t}.
+\]
+
+## Automaton update
+
+Persistent correction memory evolves as
+
+\[
+\Omega_{\mathbf r,t+1}
+=\rho_\Omega\Omega_{\mathbf r,t}-\eta_\Omega E_{\mathbf r,t}.
+\]
+
+The six-neighbour discrete Laplacian is
+
+\[
+\nabla_h^2 B_{\mathbf r,t}
+=\sum_{\mathbf q\in\mathcal N(\mathbf r)}
+(B_{\mathbf q,t}-B_{\mathbf r,t}).
+\]
+
+The transaction proposal is
+
+\[
+\widetilde B_{\mathbf r,t+1}=B_{\mathbf r,t}+\Delta t
+\left[D\nabla_h^2B_{\mathbf r,t}-K E_{\mathbf r,t}
++\Omega_{\mathbf r,t+1}\right].
+\]
+
+The candidate state is committed only after the \(\Lambda\) verification gate
+checks finiteness, coordinate validity, magnitude bounds, energy budget, and
+active-cell budget:
+
+\[
+\Sigma_{t+1}=\operatorname{COMMIT}
+\left(\Pi_\Lambda[\widetilde\Sigma_{t+1}]\right).
+\]
+
+Failure produces an atomic rollback to \(\Sigma_t\).
+
+## Procedural storage
+
+An untouched cell is reconstructed as
+
+\[
+B_{\mathbf r,0}=H(s,\mathbf r)
+\]
+
+using keyed BLAKE2b. Sampling a virtual coordinate therefore does not allocate
+it. A cell is materialised only when it is injected, becomes active, or lies on
+the immediate causal boundary of an active cell.
+
+For \(A_t\) active cells, latent dimension \(d\), and constant neighbourhood
+size \(k=6\), one cycle is approximately
+
+\[
+T_t=O(A_t(d+k)),\qquad M_t=O(A_t).
+\]
+
+The nominal \(10^{9000}\) universe affects address range, not dense runtime
+cost.
+
+## Bounded inward optimisation
+
+`BoundedMechanicsOptimizer` tests a finite declared set of mechanics candidates
+on forked shadow states. A candidate is adopted only when every transaction
+commits and its score is lower than the baseline:
+
+\[
+C=\sum_t \operatorname{MSE}_t+\lambda_A|\mathcal A_t|.
+\]
+
+No source code is rewritten and no candidate can bypass the same verification
+gate used by the baseline engine.
+
+## Run
+
+```bash
+pip install -e .
+jarvisx universe
+jarvisx automaton --steps 20 --side 3
+jarvisx automaton --steps 20 --side 3 --auto-optimize --json
+```
+
+Equivalent module execution:
+
+```bash
+python -m jarvisx automaton --steps 20
+```
+
+## API
+
+```bash
+jarvisx api
+```
+
+Endpoints:
+
+- `GET /health`
+- `POST /run`
+- `GET /automaton`
+- `POST /automaton/step`
+
+Example step body:
+
+```json
+{
+  "injections": [
+    {"x": 0, "y": 0, "z": 0, "value": 1.0}
+  ]
+}
+```
+
+## Determinism
+
+Given the same seed, mechanics, initial state, and ordered input transactions,
+the engine produces the same state and SHA-256 journal chain. Tests cover exact
+replay, sparse budgeting, coordinate wrapping, procedural reconstruction,
+transaction commit, and rollback.

--- a/docs/SPARSE_3D_AUTOMATON.md
+++ b/docs/SPARSE_3D_AUTOMATON.md
@@ -41,7 +41,8 @@ all arbitrary raw tetration coordinates fit in memory.
 
 ## 2. Physical state
 
-Only materialised bricks exist in RAM:
+Only materialised bricks and their same-key latent and correction records exist
+in RAM:
 
 \[
 \Sigma_t=(\mathcal A_t,B_t,Z_t,\Omega_t,\mathcal D_t,J_t).
@@ -49,10 +50,20 @@ Only materialised bricks exist in RAM:
 
 - \(\mathcal A_t\): bounded active brick set;
 - \(B_t(\mathbf r)\in\mathbb R^{3\times4\times4\times4}\): 192-value brick;
-- \(Z_t\): transient latent state;
+- \(Z_t(\mathbf r)\in\mathbb R^d\): committed sparse latent repository;
 - \(\Omega_t(\mathbf r)\in\mathbb R^{192}\): correction memory;
 - \(\mathcal D_t\): collision-chained sparse directory;
-- \(J_t\): deterministic journal hash.
+- \(J_t\): deterministic journal hash sealing \(B_t,Z_t,\Omega_t\).
+
+For every committed address,
+
+\[
+\mathbf r\in\operatorname{keys}(B_t)
+\Longleftrightarrow
+\mathbf r\in\operatorname{keys}(Z_t)
+\Longleftrightarrow
+\mathbf r\in\operatorname{keys}(\Omega_t).
+\]
 
 The invariant is
 
@@ -96,13 +107,16 @@ multiplication.
 Flatten the whole brick:
 
 \[
-b_{\mathbf r}=\operatorname{flat}(B_t(\mathbf r))\in\mathbb R^{192}.
+b_{\mathbf r}=
+\operatorname{flat}(B_t(\mathbf r))
+\in\mathbb R^{192}.
 \]
 
 After box normalisation, encoding is
 
 \[
-z_{\mathbf r}=\tanh(W_{enc}b_{\mathbf r}+c_{enc}),
+z_{\mathbf r}=
+\tanh(W_{enc}b_{\mathbf r}+c_{enc}),
 \qquad
 W_{enc}\in\mathbb R^{d\times192}.
 \]
@@ -136,7 +150,10 @@ Routing is explicitly **top-1**:
 z'_{\mathbf r}=E_{k^*}(\widetilde z_{\mathbf r}).
 \]
 
-The committed brick records `expert_index = k*` for auditing.
+`BrickState.expert_index` records the expert that generated the transition. After
+\(B_{t+1}\) and \(\Omega_{t+1}\) are formed, the committed latent repository is
+re-encoded from that resulting state. Its next-state router may legitimately
+select another expert.
 
 ## 6. Full decoder
 
@@ -219,7 +236,13 @@ For each active brick and its causal face frontier:
 \[
 \widetilde B_{t+1}=B_t+\Delta t\left[
 D\Delta B_t
--K\left(\mathcal D_\theta(\mathcal G_{MoE}(\mathcal E_\theta(B_t)\mid\Omega_t))-B_t\right)
+-K\left(
+\mathcal D_\theta(
+\mathcal G_{MoE}(
+\mathcal E_\theta(B_t)\mid\Omega_t
+)
+)-B_t
+\right)
 +\Omega_{t+1}+U_t
 \right].
 \]
@@ -227,7 +250,18 @@ D\Delta B_t
 Then
 
 \[
-B_{t+1}=\Pi_\Lambda(\widetilde B_{t+1}).
+B_{t+1}=\Pi_\Lambda(\widetilde B_{t+1}),
+\]
+
+and the same retained sparse keys are re-encoded:
+
+\[
+Z_{t+1}(\mathbf r)=
+\mathcal G_{MoE}
+\left(
+\mathcal E_\theta(B_{t+1}(\mathbf r))\mid
+\Omega_{t+1}(\mathbf r)
+\right).
 \]
 
 The unified sparse-field form is
@@ -236,9 +270,17 @@ The unified sparse-field form is
 \boxed{
 \Sigma_{t+1}=\Pi_\Lambda\left[
 \Sigma_t+W_{\mathcal M}\odot
-\left(D\Delta\Sigma_t
--K(\mathcal D_\theta(\mathcal G_{MoE}(\mathcal E_\theta(\Sigma_t)\mid\Omega_t))-\Sigma_t)
-+\Omega_{t+1}+U_t\right)
+\left(
+D\Delta\Sigma_t
+-K(
+\mathcal D_\theta(
+\mathcal G_{MoE}(
+\mathcal E_\theta(\Sigma_t)\mid\Omega_t
+)
+)-\Sigma_t
+)
++\Omega_{t+1}+U_t
+\right)
 \right]
 }
 \]
@@ -246,22 +288,32 @@ The unified sparse-field form is
 where \(W_{\mathcal M}\) denotes sparse scheduling semantics rather than a
 materialised dense mask.
 
-All updates are calculated against an immutable transaction snapshot. The
-candidate is checked for finite values, projection bounds, Omega bounds, expert
-index validity, relative energy, and materialisation budget before the directory
-and journal are replaced atomically.
+All updates are calculated against an immutable transaction snapshot. A commit
+is accepted only when:
+
+- every field and Omega value is finite and in its declared bounds;
+- every latent vector is finite and has dimension \(d\);
+- the retained key sets for \(B,Z,\Omega\) agree;
+- relative energy and materialisation budgets pass;
+- the journal seals the committed field and sparse latent repository.
+
+If latent construction or sealing fails after the field proposal, the prior
+field directory, latent repository, Omega state, cycle, metrics, and journal hash
+are restored.
 
 ## 11. Frontier control
 
 The next frontier is
 
 \[
-\mathcal F_t=\mathcal A_t\cup\partial_6\mathcal A_t.
+\mathcal F_t=
+\mathcal A_t\cup\partial_6\mathcal A_t.
 \]
 
 It is ranked and capped by `max_active_bricks`. A brick is pruned after
 `prune_after` low-activity cycles when both deviation from its procedural
-background and Omega magnitude fall below `activation_threshold`.
+background and Omega magnitude fall below `activation_threshold`. Its latent
+entry is pruned in the same transaction.
 
 Without thresholding and pruning, six-face expansion may grow as much as
 
@@ -283,8 +335,8 @@ The reference explicit scheme enforces
 0<\rho<1.
 \]
 
-It also clips the projected field, bounds Omega, caps active bricks, and rolls
-back non-finite or over-energy candidates.
+It also clips the projected field, bounds Omega, caps active bricks, validates
+latent dimensions, and rolls back non-finite or over-energy candidates.
 
 ## 13. Complexity
 
@@ -292,12 +344,15 @@ For latent dimension \(d\) and \(M_t\) materialised bricks:
 
 \[
 T_t=O\left(M_t(192d+d^2+192\cdot6)\right),
-\qquad
-S_t=O(M_t\cdot192).
 \]
 
-The tetration height changes the symbolic address description. It does not change
-the number of bricks physically evaluated in one cycle.
+\[
+S_t=O\left(M_t(192+d+192)\right),
+\]
+
+corresponding to sparse storage of \(B_t,Z_t,\Omega_t\). The tetration height
+changes the symbolic address description. It does not change the number of
+bricks physically evaluated in one cycle.
 
 ## 14. Run
 
@@ -305,5 +360,5 @@ the number of bricks physically evaluated in one cycle.
 jarvisx universe --tower-height 2
 jarvisx universe --tower-height 4
 jarvisx automaton --steps 20 --tower-height 4 --max-active 128
-pytest tests/test_tetration_field.py
+pytest tests/test_tetration_field.py tests/test_operational_field.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarvisx"
-version = "0.1.0"
-description = "Jarvis-X: A powerful assembly language interpreter and virtual machine"
+version = "0.2.0"
+description = "Jarvis-X deterministic VM and sparse 3-D auto-encoding/decoding automaton"
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
 authors = [{name = "Lord-Xido"}]
-keywords = ["assembly", "interpreter", "virtual-machine"]
+keywords = [
+    "assembly",
+    "interpreter",
+    "virtual-machine",
+    "autoencoder",
+    "cellular-automaton",
+    "sparse-computing",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -61,7 +68,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]
@@ -77,11 +84,11 @@ target-version = ['py38']
 include = '\\.pyi?$'
 extend-exclude = '''
 /(
-    \\.git
-  | \\.hg
-  | \\.mypy_cache
-  | \\.tox
-  | \\.venv
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
   | _build
   | buck-out
   | build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarvisx"
-version = "0.2.0"
-description = "Jarvis-X deterministic VM and sparse 3-D auto-encoding/decoding automaton"
+version = "0.3.0"
+description = "Jarvis-X deterministic VM and sparse tetration brick-field automaton"
 readme = "README.md"
 requires-python = ">=3.8"
 license = {text = "MIT"}
@@ -17,6 +17,8 @@ keywords = [
     "autoencoder",
     "cellular-automaton",
     "sparse-computing",
+    "tetration",
+    "mixture-of-experts",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -81,7 +83,7 @@ omit = [
 [tool.black]
 line-length = 100
 target-version = ['py38']
-include = '\\.pyi?$'
+include = '\.pyi?$'
 extend-exclude = '''
 /(
     \.git

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ long_description = readme_file.read_text(encoding="utf-8") if readme_file.exists
 
 setup(
     name="jarvisx",
-    version="0.2.0",
-    description="Jarvis-X deterministic VM and sparse 3-D auto-encoding/decoding automaton",
+    version="0.3.0",
+    description="Jarvis-X deterministic VM and sparse tetration brick-field automaton",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Lord-Xido",

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
-from setuptools import setup, find_packages
 from pathlib import Path
 
-# Read long description from README
+from setuptools import find_packages, setup
+
 readme_file = Path(__file__).parent / "README.md"
 long_description = readme_file.read_text(encoding="utf-8") if readme_file.exists() else ""
 
 setup(
     name="jarvisx",
-    version="0.1.0",
-    description="Jarvis-X: A powerful assembly language interpreter and virtual machine",
+    version="0.2.0",
+    description="Jarvis-X deterministic VM and sparse 3-D auto-encoding/decoding automaton",
     long_description=long_description,
     long_description_content_type="text/markdown",
     author="Lord-Xido",
@@ -29,11 +29,7 @@ setup(
             "mypy>=1.0",
         ],
     },
-    entry_points={
-        "console_scripts": [
-            "jarvisx=jarvisx.cli:main",
-        ],
-    },
+    entry_points={"console_scripts": ["jarvisx=jarvisx.cli:main"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/src/jarvisx/__init__.py
+++ b/src/jarvisx/__init__.py
@@ -26,10 +26,13 @@ from .tetration_field import (
     FieldStepMetrics,
     SparseHashDirectory,
     TetrationAddress,
-    TetrationFieldAutomaton,
+    TetrationFieldAutomaton as ReferenceTetrationFieldAutomaton,
     TetrationUniverse,
     make_brick_pulse,
 )
+from .operational_field import OperationalTetrationFieldAutomaton
+
+TetrationFieldAutomaton = OperationalTetrationFieldAutomaton
 
 __version__ = "0.3.0"
 
@@ -57,6 +60,8 @@ __all__ = [
     "FieldStepMetrics",
     "SparseHashDirectory",
     "TetrationAddress",
+    "ReferenceTetrationFieldAutomaton",
+    "OperationalTetrationFieldAutomaton",
     "TetrationFieldAutomaton",
     "TetrationUniverse",
     "make_brick_pulse",

--- a/src/jarvisx/__init__.py
+++ b/src/jarvisx/__init__.py
@@ -1,4 +1,4 @@
-"""Jarvis-X deterministic virtual machine and sparse 3-D automaton."""
+"""Jarvis-X deterministic VM and sparse geometric automata."""
 
 from .automaton import (
     ADDRESS_DEPTH,
@@ -15,8 +15,23 @@ from .automaton import (
     StepMetrics,
     make_echo_injections,
 )
+from .tetration_field import (
+    BASE,
+    BRICK_SIZE,
+    CHANNELS,
+    EDGE,
+    BrickAutoencoderMoE,
+    BrickState,
+    FieldMechanics,
+    FieldStepMetrics,
+    SparseHashDirectory,
+    TetrationAddress,
+    TetrationFieldAutomaton,
+    TetrationUniverse,
+    make_brick_pulse,
+)
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "ADDRESS_DEPTH",
@@ -32,4 +47,17 @@ __all__ = [
     "Sparse3DAutomaton",
     "StepMetrics",
     "make_echo_injections",
+    "BASE",
+    "BRICK_SIZE",
+    "CHANNELS",
+    "EDGE",
+    "BrickAutoencoderMoE",
+    "BrickState",
+    "FieldMechanics",
+    "FieldStepMetrics",
+    "SparseHashDirectory",
+    "TetrationAddress",
+    "TetrationFieldAutomaton",
+    "TetrationUniverse",
+    "make_brick_pulse",
 ]

--- a/src/jarvisx/__init__.py
+++ b/src/jarvisx/__init__.py
@@ -1,0 +1,35 @@
+"""Jarvis-X deterministic virtual machine and sparse 3-D automaton."""
+
+from .automaton import (
+    ADDRESS_DEPTH,
+    AXIS_SIZE,
+    RADIX,
+    VIRTUAL_CELL_EXPONENT,
+    BoundedMechanicsOptimizer,
+    CellState,
+    Coordinate3D,
+    DeterministicAutoencoder,
+    Mechanics,
+    OptimizationResult,
+    Sparse3DAutomaton,
+    StepMetrics,
+    make_echo_injections,
+)
+
+__version__ = "0.2.0"
+
+__all__ = [
+    "ADDRESS_DEPTH",
+    "AXIS_SIZE",
+    "RADIX",
+    "VIRTUAL_CELL_EXPONENT",
+    "BoundedMechanicsOptimizer",
+    "CellState",
+    "Coordinate3D",
+    "DeterministicAutoencoder",
+    "Mechanics",
+    "OptimizationResult",
+    "Sparse3DAutomaton",
+    "StepMetrics",
+    "make_echo_injections",
+]

--- a/src/jarvisx/__main__.py
+++ b/src/jarvisx/__main__.py
@@ -1,0 +1,7 @@
+"""Execute Jarvis-X with ``python -m jarvisx``."""
+
+from .cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,57 +1,66 @@
-"""FastAPI service for the Jarvis-X VM and sparse 3-D automaton."""
-
+"""FastAPI service for the Jarvis-X VM and tetration field automaton."""
 from __future__ import annotations
 
 from threading import RLock
-from typing import List
+from typing import Dict, List, Optional, Union
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from .assembler import Assembler
-from .automaton import Coordinate3D, Sparse3DAutomaton
 from .core import CodexVM
 from .parser import Parser
+from .tetration_field import (
+    BRICK_SIZE,
+    TetrationAddress,
+    TetrationFieldAutomaton,
+    TetrationUniverse,
+)
 
 app = FastAPI(
     title="Jarvis-X",
-    version="0.2.0",
-    description="Deterministic VM plus transactional sparse 3-D autoencoder automaton.",
+    version="0.3.0",
+    description="Deterministic VM plus transactional sparse tetration brick field.",
 )
-_automaton = Sparse3DAutomaton()
-_automaton_lock = RLock()
+_field = TetrationFieldAutomaton()
+_field_lock = RLock()
 
 
 class RunRequest(BaseModel):
     source: str = ""
 
 
-class CellInjection(BaseModel):
-    x: int = Field(ge=0)
-    y: int = Field(ge=0)
-    z: int = Field(ge=0)
-    value: float
+class BrickInjection(BaseModel):
+    chart: str = "origin"
+    x: int = 0
+    y: int = 0
+    z: int = 0
+    value: Optional[float] = None
+    values: Optional[List[float]] = None
 
 
-class AutomatonStepRequest(BaseModel):
-    injections: List[CellInjection] = Field(default_factory=list)
+class FieldStepRequest(BaseModel):
+    injections: List[BrickInjection] = Field(default_factory=list)
 
 
 @app.get("/health")
 def health() -> dict:
-    return {
-        "status": "ok",
-        "service": "jarvisx",
-        "automaton_cycle": _automaton.cycle,
-    }
+    return {"status": "ok", "service": "jarvisx", "field_cycle": _field.cycle}
+
+
+@app.get("/universe")
+def universe(tower_height: int = 2) -> dict:
+    try:
+        return TetrationUniverse(height=tower_height).descriptor()
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @app.post("/run")
 def run_code(payload: RunRequest) -> dict:
     try:
-        ast = Parser().parse(payload.source)
-        bytecode = Assembler().assemble(ast)
+        bytecode = Assembler().assemble(Parser().parse(payload.source))
         vm = CodexVM()
         vm.load(bytecode)
         vm.run()
@@ -65,24 +74,47 @@ def run_code(payload: RunRequest) -> dict:
 
 
 @app.get("/automaton")
-def automaton_state() -> dict:
-    with _automaton_lock:
-        return _automaton.snapshot()
+@app.get("/field")
+def field_state() -> dict:
+    with _field_lock:
+        return _field.snapshot()
+
+
+def _merge_observation(
+    current: Optional[Union[float, List[float]]],
+    incoming: Union[float, List[float]],
+) -> Union[float, List[float]]:
+    if current is None:
+        return incoming
+    if isinstance(current, list) or isinstance(incoming, list):
+        left = current if isinstance(current, list) else [current] * BRICK_SIZE
+        right = incoming if isinstance(incoming, list) else [incoming] * BRICK_SIZE
+        return [a + b for a, b in zip(left, right)]
+    return current + incoming
 
 
 @app.post("/automaton/step")
-def automaton_step(payload: AutomatonStepRequest) -> dict:
-    injections = {}
+@app.post("/field/step")
+def field_step(payload: FieldStepRequest) -> dict:
+    injections: Dict[TetrationAddress, Union[float, List[float]]] = {}
     try:
         for item in payload.injections:
-            coordinate = Coordinate3D(item.x, item.y, item.z)
-            injections[coordinate] = injections.get(coordinate, 0.0) + item.value
+            if item.values is not None:
+                if len(item.values) != BRICK_SIZE:
+                    raise ValueError(f"values must contain {BRICK_SIZE} numbers")
+                observation: Union[float, List[float]] = item.values
+            elif item.value is not None:
+                observation = item.value
+            else:
+                raise ValueError("each injection requires value or values")
+            address = TetrationAddress(_field.universe.height, item.chart, item.x, item.y, item.z)
+            injections[address] = _merge_observation(injections.get(address), observation)
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    with _automaton_lock:
-        metrics = _automaton.step(injections)
-        response = _automaton.snapshot()
+    with _field_lock:
+        metrics = _field.step(injections)
+        response = _field.snapshot()
         response["transaction"] = metrics.to_dict()
         if not metrics.committed:
             raise HTTPException(status_code=409, detail=response)

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -10,20 +10,16 @@ from pydantic import BaseModel, Field
 
 from .assembler import Assembler
 from .core import CodexVM
+from .operational_field import OperationalTetrationFieldAutomaton
 from .parser import Parser
-from .tetration_field import (
-    BRICK_SIZE,
-    TetrationAddress,
-    TetrationFieldAutomaton,
-    TetrationUniverse,
-)
+from .tetration_field import BRICK_SIZE, TetrationAddress, TetrationUniverse
 
 app = FastAPI(
     title="Jarvis-X",
     version="0.3.0",
     description="Deterministic VM plus transactional sparse tetration brick field.",
 )
-_field = TetrationFieldAutomaton()
+_field = OperationalTetrationFieldAutomaton()
 _field_lock = RLock()
 
 

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,22 +1,93 @@
-from flask import Flask, request, jsonify
+"""FastAPI service for the Jarvis-X VM and sparse 3-D automaton."""
+
+from __future__ import annotations
+
+from threading import RLock
+from typing import List
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .assembler import Assembler
+from .automaton import Coordinate3D, Sparse3DAutomaton
 from .core import CodexVM
 from .parser import Parser
-from .assembler import Assembler
 
-app = Flask(__name__)
-vm = CodexVM()
+app = FastAPI(
+    title="Jarvis-X",
+    version="0.2.0",
+    description="Deterministic VM plus transactional sparse 3-D autoencoder automaton.",
+)
+_automaton = Sparse3DAutomaton()
+_automaton_lock = RLock()
 
-@app.route("/run", methods=["POST"])
-def run_code():
-    source = request.json.get("source", "")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
-    vm.load(bytecode)
-    vm.run()
-    return jsonify({
-        "registers": vm.regs.snapshot(),
-        "ledger_entries": len(vm.ledger.chain)
-    })
 
-def start_api():
-    app.run(host="0.0.0.0", port=8080)
+class RunRequest(BaseModel):
+    source: str = ""
+
+
+class CellInjection(BaseModel):
+    x: int = Field(ge=0)
+    y: int = Field(ge=0)
+    z: int = Field(ge=0)
+    value: float
+
+
+class AutomatonStepRequest(BaseModel):
+    injections: List[CellInjection] = Field(default_factory=list)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {
+        "status": "ok",
+        "service": "jarvisx",
+        "automaton_cycle": _automaton.cycle,
+    }
+
+
+@app.post("/run")
+def run_code(payload: RunRequest) -> dict:
+    try:
+        ast = Parser().parse(payload.source)
+        bytecode = Assembler().assemble(ast)
+        vm = CodexVM()
+        vm.load(bytecode)
+        vm.run()
+        return {
+            "registers": vm.regs.snapshot(),
+            "ledger_entries": len(vm.ledger.chain),
+            "cycles": vm.cycles,
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.get("/automaton")
+def automaton_state() -> dict:
+    with _automaton_lock:
+        return _automaton.snapshot()
+
+
+@app.post("/automaton/step")
+def automaton_step(payload: AutomatonStepRequest) -> dict:
+    injections = {}
+    try:
+        for item in payload.injections:
+            coordinate = Coordinate3D(item.x, item.y, item.z)
+            injections[coordinate] = injections.get(coordinate, 0.0) + item.value
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    with _automaton_lock:
+        metrics = _automaton.step(injections)
+        response = _automaton.snapshot()
+        response["transaction"] = metrics.to_dict()
+        if not metrics.committed:
+            raise HTTPException(status_code=409, detail=response)
+        return response
+
+
+def start_api() -> None:
+    uvicorn.run("jarvisx.api:app", host="0.0.0.0", port=8080, reload=False)

--- a/src/jarvisx/automaton.py
+++ b/src/jarvisx/automaton.py
@@ -1,0 +1,649 @@
+"""Sparse 3-D auto-encoding/decoding simulation automaton.
+
+The nominal universe contains ``(1000**1000)**3 == 10**9000`` cells. The
+runtime never allocates that tensor. Coordinates are exact Python integers,
+untouched cells are reconstructed from a deterministic procedural field, and
+only a bounded causal frontier is materialised.
+
+The committed update law is the executable form of::
+
+    Sigma[t+1] = Pi_Lambda(
+        Sigma[t]
+        + P_theta(E_theta(Sigma[t]))
+        - K * error[t]
+        + Omega[t]
+        + input[t]
+    )
+
+All proposals are calculated against an immutable snapshot, verified, and then
+committed atomically. A failed verification leaves the prior state untouched.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import struct
+from dataclasses import asdict, dataclass, replace
+from typing import Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+RADIX = 1000
+ADDRESS_DEPTH = 1000
+AXIS_SIZE = RADIX ** ADDRESS_DEPTH
+VIRTUAL_CELL_EXPONENT = 9000
+LOCAL_INPUT_DIM = 7
+
+
+@dataclass(frozen=True, order=True)
+class Coordinate3D:
+    """One exact coordinate in the ``1000**1000`` cubical address space."""
+
+    x: int
+    y: int
+    z: int
+
+    def __post_init__(self) -> None:
+        for name, value in (("x", self.x), ("y", self.y), ("z", self.z)):
+            if not isinstance(value, int):
+                raise TypeError("{} must be an integer".format(name))
+            if value < 0 or value >= AXIS_SIZE:
+                raise ValueError("{} must satisfy 0 <= {} < 1000**1000".format(name, name))
+
+    def offset(self, dx: int = 0, dy: int = 0, dz: int = 0) -> "Coordinate3D":
+        return Coordinate3D(
+            (self.x + dx) % AXIS_SIZE,
+            (self.y + dy) % AXIS_SIZE,
+            (self.z + dz) % AXIS_SIZE,
+        )
+
+    def radix_prefix(self, digits: int = 4) -> Tuple[Tuple[int, ...], ...]:
+        if digits < 1 or digits > ADDRESS_DEPTH:
+            raise ValueError("digits must be in [1, 1000]")
+        divisor = RADIX ** (ADDRESS_DEPTH - digits)
+
+        def axis_prefix(value: int) -> Tuple[int, ...]:
+            head = value // divisor
+            out = [0] * digits
+            for index in range(digits - 1, -1, -1):
+                out[index] = head % RADIX
+                head //= RADIX
+            return tuple(out)
+
+        return axis_prefix(self.x), axis_prefix(self.y), axis_prefix(self.z)
+
+
+@dataclass(frozen=True)
+class CellState:
+    value: float
+    omega: float = 0.0
+    inactive_steps: int = 0
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class Mechanics:
+    diffusion: float = 0.06
+    error_gain: float = 0.55
+    omega_retention: float = 0.88
+    omega_rate: float = 0.12
+    time_step: float = 0.18
+    activation_threshold: float = 0.03
+    prune_after: int = 8
+    max_abs_value: float = 4.0
+    max_energy: float = 1000000.0
+    max_active_cells: int = 10000
+
+    def validate(self) -> None:
+        bounded = {
+            "diffusion": (self.diffusion, 0.0, 1.0),
+            "error_gain": (self.error_gain, 0.0, 4.0),
+            "omega_retention": (self.omega_retention, 0.0, 1.0),
+            "omega_rate": (self.omega_rate, 0.0, 1.0),
+            "time_step": (self.time_step, 0.0, 1.0),
+            "activation_threshold": (self.activation_threshold, 0.0, self.max_abs_value),
+        }
+        for name, (value, lower, upper) in bounded.items():
+            if not math.isfinite(value) or value < lower or value > upper:
+                raise ValueError("{} must be finite and in [{}, {}]".format(name, lower, upper))
+        if self.prune_after < 1:
+            raise ValueError("prune_after must be positive")
+        if self.max_abs_value <= 0.0 or not math.isfinite(self.max_abs_value):
+            raise ValueError("max_abs_value must be finite and positive")
+        if self.max_energy <= 0.0 or not math.isfinite(self.max_energy):
+            raise ValueError("max_energy must be finite and positive")
+        if self.max_active_cells < 1:
+            raise ValueError("max_active_cells must be positive")
+
+
+@dataclass(frozen=True)
+class StepMetrics:
+    cycle: int
+    materialised_cells: int
+    active_cells: int
+    frontier_cells: int
+    reconstruction_mse: float
+    energy: float
+    committed: bool
+    journal_hash: str
+    rollback_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    adopted: bool
+    baseline_score: float
+    candidate_score: float
+    previous_mechanics: Mechanics
+    selected_mechanics: Mechanics
+
+
+class DeterministicAutoencoder:
+    """Dependency-free deterministic ANN for a local 3-D neighbourhood."""
+
+    def __init__(self, latent_dim: int = 8, seed: int = 1337) -> None:
+        if latent_dim < 2:
+            raise ValueError("latent_dim must be at least 2")
+        self.input_dim = LOCAL_INPUT_DIM
+        self.latent_dim = int(latent_dim)
+        rng = random.Random(int(seed))
+        encoder_scale = 1.0 / math.sqrt(float(self.input_dim))
+        transition_scale = 0.45 / math.sqrt(float(self.latent_dim))
+        self._encoder = tuple(
+            tuple(rng.uniform(-encoder_scale, encoder_scale) for _ in range(self.input_dim))
+            for _ in range(self.latent_dim)
+        )
+        self._encoder_bias = tuple(rng.uniform(-0.02, 0.02) for _ in range(self.latent_dim))
+        self._transition = tuple(
+            tuple(rng.uniform(-transition_scale, transition_scale) for _ in range(self.latent_dim))
+            for _ in range(self.latent_dim)
+        )
+        normalizers = []
+        for input_index in range(self.input_dim):
+            norm = sum(
+                self._encoder[latent_index][input_index] ** 2
+                for latent_index in range(self.latent_dim)
+            )
+            normalizers.append(max(norm, 1e-9))
+        self._decoder = tuple(
+            tuple(
+                self._encoder[latent_index][input_index] / normalizers[input_index]
+                for latent_index in range(self.latent_dim)
+            )
+            for input_index in range(self.input_dim)
+        )
+
+    @staticmethod
+    def _dot(weights: Sequence[float], values: Sequence[float]) -> float:
+        return sum(weight * value for weight, value in zip(weights, values))
+
+    def encode(self, neighbourhood: Sequence[float]) -> Tuple[float, ...]:
+        if len(neighbourhood) != self.input_dim:
+            raise ValueError("neighbourhood must contain exactly 7 values")
+        return tuple(
+            math.tanh(self._dot(row, neighbourhood) + bias)
+            for row, bias in zip(self._encoder, self._encoder_bias)
+        )
+
+    def evolve(self, latent: Sequence[float], omega: float = 0.0) -> Tuple[float, ...]:
+        if len(latent) != self.latent_dim:
+            raise ValueError("latent state has the wrong dimension")
+        bounded_omega = math.tanh(float(omega))
+        return tuple(
+            math.tanh(0.72 * latent[index] + self._dot(row, latent) + 0.08 * bounded_omega)
+            for index, row in enumerate(self._transition)
+        )
+
+    def decode(self, latent: Sequence[float]) -> Tuple[float, ...]:
+        if len(latent) != self.latent_dim:
+            raise ValueError("latent state has the wrong dimension")
+        return tuple(math.tanh(self._dot(row, latent)) for row in self._decoder)
+
+
+class Sparse3DAutomaton:
+    """Transactional sparse simulation of the 10**9000-cell universe."""
+
+    _OFFSETS = (
+        (1, 0, 0),
+        (-1, 0, 0),
+        (0, 1, 0),
+        (0, -1, 0),
+        (0, 0, 1),
+        (0, 0, -1),
+    )
+
+    def __init__(
+        self,
+        seed: int = 1337,
+        latent_dim: int = 8,
+        mechanics: Optional[Mechanics] = None,
+    ) -> None:
+        self.seed = int(seed)
+        self.mechanics = mechanics or Mechanics()
+        self.mechanics.validate()
+        self.autoencoder = DeterministicAutoencoder(latent_dim=latent_dim, seed=self.seed)
+        self._cells: Dict[Coordinate3D, CellState] = {}
+        self.cycle = 0
+        self.journal_hash = "0" * 64
+        self.last_metrics = StepMetrics(
+            cycle=0,
+            materialised_cells=0,
+            active_cells=0,
+            frontier_cells=0,
+            reconstruction_mse=0.0,
+            energy=0.0,
+            committed=True,
+            journal_hash=self.journal_hash,
+        )
+
+    @property
+    def materialised_cells(self) -> int:
+        return len(self._cells)
+
+    @property
+    def cells(self) -> Mapping[Coordinate3D, CellState]:
+        return dict(self._cells)
+
+    @staticmethod
+    def universe_descriptor() -> Dict[str, object]:
+        return {
+            "radix": RADIX,
+            "address_depth": ADDRESS_DEPTH,
+            "axis_size": "1000^1000",
+            "axis_power_of_ten": 3000,
+            "axis_decimal_digits": 3001,
+            "virtual_cells": "10^9000",
+            "virtual_cell_exponent": VIRTUAL_CELL_EXPONENT,
+            "storage_model": "procedural-universe/sparse-active-frontier",
+        }
+
+    def _coordinate_bytes(self, coordinate: Coordinate3D) -> bytes:
+        byte_width = (AXIS_SIZE.bit_length() + 7) // 8
+        return b"".join(
+            value.to_bytes(byte_width, byteorder="big", signed=False)
+            for value in (coordinate.x, coordinate.y, coordinate.z)
+        )
+
+    def procedural_value(self, coordinate: Coordinate3D) -> float:
+        key = int(self.seed & ((1 << 128) - 1)).to_bytes(16, "big", signed=False)
+        digest = hashlib.blake2b(
+            self._coordinate_bytes(coordinate), key=key, digest_size=8
+        ).digest()
+        raw = int.from_bytes(digest, byteorder="big", signed=False)
+        unit = raw / float((1 << 64) - 1)
+        return (unit - 0.5) * 0.02
+
+    def sample(self, coordinate: Coordinate3D) -> float:
+        state = self._cells.get(coordinate)
+        return state.value if state is not None else self.procedural_value(coordinate)
+
+    def inject(self, coordinate: Coordinate3D, value: float) -> None:
+        value = float(value)
+        if not math.isfinite(value):
+            raise ValueError("injected value must be finite")
+        current = self._cells.get(coordinate)
+        if current is None:
+            current = CellState(value=self.procedural_value(coordinate))
+        proposal = current.value + value
+        proposal = max(-self.mechanics.max_abs_value, min(self.mechanics.max_abs_value, proposal))
+        self._cells[coordinate] = CellState(
+            value=proposal,
+            omega=current.omega,
+            inactive_steps=0,
+            revision=current.revision + 1,
+        )
+
+    def active_coordinates(self) -> Tuple[Coordinate3D, ...]:
+        threshold = self.mechanics.activation_threshold
+        return tuple(
+            sorted(
+                coordinate
+                for coordinate, state in self._cells.items()
+                if abs(state.value) + abs(state.omega) >= threshold
+            )
+        )
+
+    def _neighbours(self, coordinate: Coordinate3D) -> Tuple[Coordinate3D, ...]:
+        return tuple(coordinate.offset(*offset) for offset in self._OFFSETS)
+
+    def _value_from(
+        self, cells: Mapping[Coordinate3D, CellState], coordinate: Coordinate3D
+    ) -> float:
+        state = cells.get(coordinate)
+        return state.value if state is not None else self.procedural_value(coordinate)
+
+    def _frontier(
+        self, cells: Mapping[Coordinate3D, CellState]
+    ) -> Tuple[Coordinate3D, ...]:
+        threshold = self.mechanics.activation_threshold
+        active = {
+            coordinate
+            for coordinate, state in cells.items()
+            if abs(state.value) + abs(state.omega) >= threshold or state.inactive_steps == 0
+        }
+        frontier = set(active)
+        for coordinate in active:
+            frontier.update(self._neighbours(coordinate))
+        if len(frontier) <= self.mechanics.max_active_cells:
+            return tuple(sorted(frontier))
+
+        def score(coordinate: Coordinate3D) -> Tuple[float, Coordinate3D]:
+            state = cells.get(coordinate)
+            magnitude = (
+                abs(state.value) + abs(state.omega)
+                if state is not None
+                else abs(self.procedural_value(coordinate))
+            )
+            return (-magnitude, coordinate)
+
+        selected = sorted(frontier, key=score)[: self.mechanics.max_active_cells]
+        return tuple(sorted(selected))
+
+    def _cap_candidate(
+        self, candidate: Mapping[Coordinate3D, CellState]
+    ) -> Dict[Coordinate3D, CellState]:
+        if len(candidate) <= self.mechanics.max_active_cells:
+            return dict(candidate)
+        ranked = sorted(
+            candidate.items(),
+            key=lambda item: (-(abs(item[1].value) + abs(item[1].omega)), item[0]),
+        )
+        return dict(ranked[: self.mechanics.max_active_cells])
+
+    def _verify(
+        self, candidate: Mapping[Coordinate3D, CellState]
+    ) -> Tuple[bool, Optional[str], float]:
+        if len(candidate) > self.mechanics.max_active_cells:
+            return False, "active-cell budget exceeded", math.inf
+        energy = 0.0
+        for coordinate, state in candidate.items():
+            if not isinstance(coordinate, Coordinate3D):
+                return False, "invalid coordinate type", math.inf
+            if not math.isfinite(state.value) or not math.isfinite(state.omega):
+                return False, "non-finite state", math.inf
+            if abs(state.value) > self.mechanics.max_abs_value + 1e-12:
+                return False, "value bound exceeded", math.inf
+            energy += state.value * state.value + state.omega * state.omega
+        if not math.isfinite(energy) or energy > self.mechanics.max_energy:
+            return False, "energy budget exceeded", energy
+        return True, None, energy
+
+    def _journal(
+        self, cells: Mapping[Coordinate3D, CellState], cycle: int
+    ) -> str:
+        digest = hashlib.sha256()
+        digest.update(bytes.fromhex(self.journal_hash))
+        digest.update(struct.pack(">Q", cycle))
+        mechanics_payload = json.dumps(
+            asdict(self.mechanics), sort_keys=True, separators=(",", ":")
+        )
+        digest.update(mechanics_payload.encode("utf-8"))
+        for coordinate in sorted(cells):
+            digest.update(self._coordinate_bytes(coordinate))
+            state = cells[coordinate]
+            digest.update(
+                struct.pack(
+                    ">ddII",
+                    state.value,
+                    state.omega,
+                    state.inactive_steps,
+                    state.revision,
+                )
+            )
+        return digest.hexdigest()
+
+    def step(
+        self,
+        injections: Optional[Mapping[Coordinate3D, float]] = None,
+    ) -> StepMetrics:
+        before = dict(self._cells)
+        working = dict(before)
+        if injections:
+            for coordinate in sorted(injections):
+                value = float(injections[coordinate])
+                if not math.isfinite(value):
+                    return self._rollback_metrics("non-finite injection", 0, 0.0)
+                current = working.get(coordinate)
+                if current is None:
+                    current = CellState(value=self.procedural_value(coordinate))
+                injected = max(
+                    -self.mechanics.max_abs_value,
+                    min(self.mechanics.max_abs_value, current.value + value),
+                )
+                working[coordinate] = CellState(
+                    value=injected,
+                    omega=current.omega,
+                    inactive_steps=0,
+                    revision=current.revision + 1,
+                )
+
+        frontier = self._frontier(working)
+        proposed_updates: Dict[Coordinate3D, CellState] = {}
+        squared_error = 0.0
+        for coordinate in frontier:
+            centre_state = working.get(coordinate)
+            centre_value = self._value_from(working, coordinate)
+            centre_omega = centre_state.omega if centre_state is not None else 0.0
+            neighbours = self._neighbours(coordinate)
+            neighbour_values = tuple(
+                self._value_from(working, neighbour) for neighbour in neighbours
+            )
+            neighbourhood = (centre_value,) + neighbour_values
+            latent = self.autoencoder.encode(neighbourhood)
+            predicted_latent = self.autoencoder.evolve(latent, centre_omega)
+            reconstruction = self.autoencoder.decode(predicted_latent)
+            residual = reconstruction[0] - centre_value
+            squared_error += residual * residual
+            laplacian = sum(value - centre_value for value in neighbour_values)
+            omega_next = (
+                self.mechanics.omega_retention * centre_omega
+                - self.mechanics.omega_rate * residual
+            )
+            proposal = centre_value + self.mechanics.time_step * (
+                self.mechanics.diffusion * laplacian
+                - self.mechanics.error_gain * residual
+                + omega_next
+            )
+            proposal = max(
+                -self.mechanics.max_abs_value,
+                min(self.mechanics.max_abs_value, proposal),
+            )
+            activity = abs(proposal) + abs(omega_next)
+            inactive_steps = (
+                0
+                if activity >= self.mechanics.activation_threshold
+                else ((centre_state.inactive_steps + 1) if centre_state is not None else 1)
+            )
+            proposed_updates[coordinate] = CellState(
+                value=proposal,
+                omega=omega_next,
+                inactive_steps=inactive_steps,
+                revision=(centre_state.revision if centre_state is not None else 0) + 1,
+            )
+
+        candidate: Dict[Coordinate3D, CellState] = {}
+        frontier_set = set(frontier)
+        for coordinate, state in working.items():
+            if coordinate in frontier_set:
+                continue
+            aged = replace(state, inactive_steps=state.inactive_steps + 1)
+            baseline = self.procedural_value(coordinate)
+            should_prune = (
+                aged.inactive_steps >= self.mechanics.prune_after
+                and abs(aged.value - baseline) < self.mechanics.activation_threshold
+                and abs(aged.omega) < self.mechanics.activation_threshold
+            )
+            if not should_prune:
+                candidate[coordinate] = aged
+        for coordinate, state in proposed_updates.items():
+            baseline = self.procedural_value(coordinate)
+            should_prune = (
+                state.inactive_steps >= self.mechanics.prune_after
+                and abs(state.value - baseline) < self.mechanics.activation_threshold
+                and abs(state.omega) < self.mechanics.activation_threshold
+            )
+            if not should_prune:
+                candidate[coordinate] = state
+
+        candidate = self._cap_candidate(candidate)
+        valid, reason, energy = self._verify(candidate)
+        mse = squared_error / float(max(1, len(frontier)))
+        if not valid:
+            self._cells = before
+            return self._rollback_metrics(
+                reason or "verification failed", len(frontier), mse, energy
+            )
+
+        self._cells = candidate
+        self.cycle += 1
+        self.journal_hash = self._journal(candidate, self.cycle)
+        active_count = len(self.active_coordinates())
+        self.last_metrics = StepMetrics(
+            cycle=self.cycle,
+            materialised_cells=len(candidate),
+            active_cells=active_count,
+            frontier_cells=len(frontier),
+            reconstruction_mse=mse,
+            energy=energy,
+            committed=True,
+            journal_hash=self.journal_hash,
+        )
+        return self.last_metrics
+
+    def _rollback_metrics(
+        self,
+        reason: str,
+        frontier_cells: int,
+        mse: float,
+        energy: float = 0.0,
+    ) -> StepMetrics:
+        self.last_metrics = StepMetrics(
+            cycle=self.cycle,
+            materialised_cells=len(self._cells),
+            active_cells=len(self.active_coordinates()),
+            frontier_cells=frontier_cells,
+            reconstruction_mse=mse,
+            energy=energy,
+            committed=False,
+            journal_hash=self.journal_hash,
+            rollback_reason=reason,
+        )
+        return self.last_metrics
+
+    def fork(self, mechanics: Optional[Mechanics] = None) -> "Sparse3DAutomaton":
+        clone = Sparse3DAutomaton(
+            seed=self.seed,
+            latent_dim=self.autoencoder.latent_dim,
+            mechanics=mechanics or self.mechanics,
+        )
+        clone._cells = dict(self._cells)
+        clone.cycle = self.cycle
+        clone.journal_hash = self.journal_hash
+        clone.last_metrics = self.last_metrics
+        return clone
+
+    def state_digest(self) -> str:
+        return self._journal(self._cells, self.cycle)
+
+    def snapshot(self) -> Dict[str, object]:
+        active = self.active_coordinates()
+        return {
+            "universe": self.universe_descriptor(),
+            "cycle": self.cycle,
+            "materialised_cells": len(self._cells),
+            "active_cells": len(active),
+            "journal_hash": self.journal_hash,
+            "mechanics": asdict(self.mechanics),
+            "last_metrics": self.last_metrics.to_dict(),
+        }
+
+
+class BoundedMechanicsOptimizer:
+    """Shadow-test declared mechanics and adopt only a better valid result."""
+
+    def __init__(self, active_cell_penalty: float = 1e-5) -> None:
+        if active_cell_penalty < 0.0:
+            raise ValueError("active_cell_penalty must be non-negative")
+        self.active_cell_penalty = float(active_cell_penalty)
+
+    def _score(
+        self,
+        engine: Sparse3DAutomaton,
+        workload: Sequence[Mapping[Coordinate3D, float]],
+    ) -> float:
+        score = 0.0
+        for injections in workload:
+            metrics = engine.step(injections)
+            if not metrics.committed:
+                return math.inf
+            score += metrics.reconstruction_mse
+            score += self.active_cell_penalty * metrics.materialised_cells
+        return score
+
+    def optimize(
+        self,
+        engine: Sparse3DAutomaton,
+        workload: Sequence[Mapping[Coordinate3D, float]],
+        candidates: Optional[Iterable[Mechanics]] = None,
+    ) -> OptimizationResult:
+        if not workload:
+            raise ValueError("workload must contain at least one transaction")
+        previous = engine.mechanics
+        baseline_score = self._score(engine.fork(previous), workload)
+        if candidates is None:
+            candidates = (
+                replace(previous, diffusion=max(0.0, previous.diffusion - 0.02)),
+                replace(previous, diffusion=min(1.0, previous.diffusion + 0.02)),
+                replace(previous, error_gain=max(0.0, previous.error_gain - 0.10)),
+                replace(previous, error_gain=min(4.0, previous.error_gain + 0.10)),
+                replace(
+                    previous,
+                    activation_threshold=min(
+                        previous.max_abs_value,
+                        previous.activation_threshold * 1.25,
+                    ),
+                ),
+            )
+        best_score = baseline_score
+        best = previous
+        for candidate in candidates:
+            candidate.validate()
+            score = self._score(engine.fork(candidate), workload)
+            if score + 1e-15 < best_score:
+                best_score = score
+                best = candidate
+        adopted = best != previous
+        if adopted:
+            engine.mechanics = best
+        return OptimizationResult(
+            adopted=adopted,
+            baseline_score=baseline_score,
+            candidate_score=best_score,
+            previous_mechanics=previous,
+            selected_mechanics=best,
+        )
+
+
+def make_echo_injections(
+    side: int = 3,
+    amplitude: float = 1.0,
+    origin: Optional[Coordinate3D] = None,
+) -> Dict[Coordinate3D, float]:
+    if side < 1 or side > 21 or side % 2 == 0:
+        raise ValueError("side must be an odd integer in [1, 21]")
+    if not math.isfinite(amplitude):
+        raise ValueError("amplitude must be finite")
+    origin = origin or Coordinate3D(0, 0, 0)
+    radius = side // 2
+    injections: Dict[Coordinate3D, float] = {}
+    for dz in range(-radius, radius + 1):
+        for dy in range(-radius, radius + 1):
+            for dx in range(-radius, radius + 1):
+                distance_squared = dx * dx + dy * dy + dz * dz
+                value = amplitude * math.exp(-0.65 * distance_squared)
+                injections[origin.offset(dx, dy, dz)] = value
+    return injections

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,10 +1,8 @@
-"""Command-line interface for the Jarvis-X VM and sparse 3-D automaton."""
-
+"""Command-line interface for the Jarvis-X VM and tetration field automaton."""
 from __future__ import annotations
 
 import argparse
 import json
-from dataclasses import asdict
 from pathlib import Path
 from typing import Optional, Sequence
 
@@ -12,35 +10,35 @@ from typing import Optional, Sequence
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="jarvisx",
-        description="Jarvis-X deterministic VM and sparse 3-D processing automaton",
+        description="Jarvis-X deterministic VM and sparse tetration field automaton",
     )
     subparsers = parser.add_subparsers(dest="command")
-
     run_parser = subparsers.add_parser("run", help="assemble and execute a Jarvis-X source file")
     run_parser.add_argument("file", type=Path)
-
     subparsers.add_parser("api", help="start the FastAPI service")
     subparsers.add_parser("web", help="start the existing Jarvis-X web interface")
     subparsers.add_parser("node", help="start a Jarvis-X node")
 
-    automaton_parser = subparsers.add_parser(
+    automaton = subparsers.add_parser(
         "automaton",
         aliases=["simulate"],
-        help="run the sparse 10^9000-cell virtual 3-D automaton",
+        help="run the sparse brick field over a symbolic tetration address manifold",
     )
-    automaton_parser.add_argument("--steps", type=int, default=12)
-    automaton_parser.add_argument("--side", type=int, default=3)
-    automaton_parser.add_argument("--amplitude", type=float, default=1.0)
-    automaton_parser.add_argument("--seed", type=int, default=1337)
-    automaton_parser.add_argument("--latent-dim", type=int, default=8)
-    automaton_parser.add_argument("--max-active", type=int, default=10000)
-    automaton_parser.add_argument("--auto-optimize", action="store_true")
-    automaton_parser.add_argument("--json", action="store_true", dest="as_json")
+    automaton.add_argument("--steps", type=int, default=12)
+    automaton.add_argument("--tower-height", type=int, default=2)
+    automaton.add_argument("--chart", default="origin")
+    automaton.add_argument("--amplitude", type=float, default=48.0)
+    automaton.add_argument("--seed", type=int, default=1337)
+    automaton.add_argument("--latent-dim", type=int, default=16)
+    automaton.add_argument("--experts", type=int, default=4)
+    automaton.add_argument("--max-active", type=int, default=128)
+    automaton.add_argument("--buckets", type=int, default=257)
+    automaton.add_argument("--json", action="store_true", dest="as_json")
 
-    subparsers.add_parser(
-        "universe",
-        help="print the exact virtual-universe descriptor without allocating it",
+    universe = subparsers.add_parser(
+        "universe", help="print the symbolic tetration-universe descriptor"
     )
+    universe.add_argument("--tower-height", type=int, default=2)
     return parser
 
 
@@ -50,8 +48,7 @@ def _run_source(path: Path) -> int:
     from .parser import Parser
 
     source = path.read_text(encoding="utf-8")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
+    bytecode = Assembler().assemble(Parser().parse(source))
     vm = CodexVM()
     vm.load(bytecode)
     vm.run()
@@ -60,85 +57,71 @@ def _run_source(path: Path) -> int:
 
 
 def _run_automaton(args: argparse.Namespace) -> int:
-    from .automaton import (
-        BoundedMechanicsOptimizer,
-        Coordinate3D,
-        Mechanics,
-        Sparse3DAutomaton,
-        make_echo_injections,
+    from .tetration_field import (
+        FieldMechanics,
+        TetrationAddress,
+        TetrationFieldAutomaton,
+        TetrationUniverse,
+        make_brick_pulse,
     )
 
     if args.steps < 1:
         raise SystemExit("--steps must be positive")
+    if args.tower_height < 1:
+        raise SystemExit("--tower-height must be positive")
     if args.max_active < 7:
         raise SystemExit("--max-active must be at least 7")
+    if args.buckets < 1:
+        raise SystemExit("--buckets must be positive")
 
-    mechanics = Mechanics(max_active_cells=args.max_active)
-    engine = Sparse3DAutomaton(
-        seed=args.seed,
-        latent_dim=args.latent_dim,
+    universe = TetrationUniverse(height=args.tower_height)
+    mechanics = FieldMechanics(max_active_bricks=args.max_active)
+    engine = TetrationFieldAutomaton(
+        universe=universe,
         mechanics=mechanics,
+        latent_dim=args.latent_dim,
+        expert_count=args.experts,
+        seed=args.seed,
+        bucket_count=args.buckets,
     )
-    pulse = make_echo_injections(
-        side=args.side,
-        amplitude=args.amplitude,
-        origin=Coordinate3D(0, 0, 0),
-    )
-
-    optimization = None
-    if args.auto_optimize:
-        optimizer = BoundedMechanicsOptimizer()
-        optimization = optimizer.optimize(engine, [pulse, {}, {}])
+    origin = TetrationAddress(args.tower_height, args.chart, 0, 0, 0)
+    pulse = {origin: make_brick_pulse(args.amplitude)}
 
     metrics = []
     for step_index in range(args.steps):
-        step_inputs = pulse if step_index == 0 else None
-        result = engine.step(step_inputs)
+        result = engine.step(pulse if step_index == 0 else None)
         metrics.append(result.to_dict())
         if not result.committed:
             break
 
     payload = engine.snapshot()
     payload["metrics"] = metrics
-    if optimization is not None:
-        payload["optimization"] = {
-            "adopted": optimization.adopted,
-            "baseline_score": optimization.baseline_score,
-            "candidate_score": optimization.candidate_score,
-            "previous_mechanics": asdict(optimization.previous_mechanics),
-            "selected_mechanics": asdict(optimization.selected_mechanics),
-        }
-
     if args.as_json:
         print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        universe = payload["universe"]
-        print("Jarvis-X sparse 3-D auto-encoding/decoding automaton")
-        print("Virtual axis:", universe["axis_size"], "positions")
-        print("Virtual cells:", universe["virtual_cells"])
-        if optimization is not None:
-            print(
-                "Bounded mechanics optimization:",
-                "adopted" if optimization.adopted else "baseline retained",
+        return 0
+
+    descriptor = payload["universe"]
+    print("Jarvis-X sparse tetration field automaton")
+    print("Virtual axis:", descriptor["axis_size"])
+    print("Virtual cells:", descriptor["virtual_cells"])
+    print("Coordinate naming:", descriptor["coordinate_bits"], "bits")
+    print("Brick:", payload["brick_shape"], "router:", payload["router"])
+    for item in metrics:
+        status = "COMMIT" if item["committed"] else "ROLLBACK"
+        print(
+            "cycle={cycle:>3} status={status:<8} active={active_bricks:>4} "
+            "materialised={materialised_bricks:>4} frontier={frontier_bricks:>4} "
+            "mse={reconstruction_mse:.6f} collisions={collisions}".format(
+                status=status, **item
             )
-        for item in metrics:
-            status = "COMMIT" if item["committed"] else "ROLLBACK"
-            print(
-                "cycle={cycle:>3} status={status:<8} active={active_cells:>5} "
-                "materialised={materialised_cells:>5} frontier={frontier_cells:>5} "
-                "mse={reconstruction_mse:.6f} energy={energy:.6f}".format(
-                    status=status,
-                    **item
-                )
-            )
-        print("Journal:", payload["journal_hash"])
+        )
+    print("Journal:", payload["journal_hash"])
     return 0
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-
     if args.command is None:
         parser.print_help()
         return 0
@@ -157,17 +140,21 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "node":
         from .node import CodexNode
 
-        node = CodexNode()
-        node.start()
+        CodexNode().start()
         return 0
     if args.command in ("automaton", "simulate"):
         return _run_automaton(args)
     if args.command == "universe":
-        from .automaton import Sparse3DAutomaton
+        from .tetration_field import TetrationUniverse
 
-        print(json.dumps(Sparse3DAutomaton.universe_descriptor(), indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                TetrationUniverse(height=args.tower_height).descriptor(),
+                indent=2,
+                sort_keys=True,
+            )
+        )
         return 0
-
     parser.error("unknown command: {}".format(args.command))
     return 2
 

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,38 +1,176 @@
-import sys
-from .parser import Parser
-from .assembler import Assembler
-from .core import CodexVM
-from .api import start_api
-from .web import start_web
-from .node import CodexNode
+"""Command-line interface for the Jarvis-X VM and sparse 3-D automaton."""
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
-        return
+from __future__ import annotations
 
-    cmd = sys.argv[1]
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Optional, Sequence
 
-    if cmd == "run":
-        file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm = CodexVM()
-        vm.load(bytecode)
-        vm.run()
-        print("Registers:", vm.regs.snapshot())
 
-    elif cmd == "api":
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx",
+        description="Jarvis-X deterministic VM and sparse 3-D processing automaton",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+
+    run_parser = subparsers.add_parser("run", help="assemble and execute a Jarvis-X source file")
+    run_parser.add_argument("file", type=Path)
+
+    subparsers.add_parser("api", help="start the FastAPI service")
+    subparsers.add_parser("web", help="start the existing Jarvis-X web interface")
+    subparsers.add_parser("node", help="start a Jarvis-X node")
+
+    automaton_parser = subparsers.add_parser(
+        "automaton",
+        aliases=["simulate"],
+        help="run the sparse 10^9000-cell virtual 3-D automaton",
+    )
+    automaton_parser.add_argument("--steps", type=int, default=12)
+    automaton_parser.add_argument("--side", type=int, default=3)
+    automaton_parser.add_argument("--amplitude", type=float, default=1.0)
+    automaton_parser.add_argument("--seed", type=int, default=1337)
+    automaton_parser.add_argument("--latent-dim", type=int, default=8)
+    automaton_parser.add_argument("--max-active", type=int, default=10000)
+    automaton_parser.add_argument("--auto-optimize", action="store_true")
+    automaton_parser.add_argument("--json", action="store_true", dest="as_json")
+
+    subparsers.add_parser(
+        "universe",
+        help="print the exact virtual-universe descriptor without allocating it",
+    )
+    return parser
+
+
+def _run_source(path: Path) -> int:
+    from .assembler import Assembler
+    from .core import CodexVM
+    from .parser import Parser
+
+    source = path.read_text(encoding="utf-8")
+    ast = Parser().parse(source)
+    bytecode = Assembler().assemble(ast)
+    vm = CodexVM()
+    vm.load(bytecode)
+    vm.run()
+    print("Registers:", vm.regs.snapshot())
+    return 0
+
+
+def _run_automaton(args: argparse.Namespace) -> int:
+    from .automaton import (
+        BoundedMechanicsOptimizer,
+        Coordinate3D,
+        Mechanics,
+        Sparse3DAutomaton,
+        make_echo_injections,
+    )
+
+    if args.steps < 1:
+        raise SystemExit("--steps must be positive")
+    if args.max_active < 7:
+        raise SystemExit("--max-active must be at least 7")
+
+    mechanics = Mechanics(max_active_cells=args.max_active)
+    engine = Sparse3DAutomaton(
+        seed=args.seed,
+        latent_dim=args.latent_dim,
+        mechanics=mechanics,
+    )
+    pulse = make_echo_injections(
+        side=args.side,
+        amplitude=args.amplitude,
+        origin=Coordinate3D(0, 0, 0),
+    )
+
+    optimization = None
+    if args.auto_optimize:
+        optimizer = BoundedMechanicsOptimizer()
+        optimization = optimizer.optimize(engine, [pulse, {}, {}])
+
+    metrics = []
+    for step_index in range(args.steps):
+        step_inputs = pulse if step_index == 0 else None
+        result = engine.step(step_inputs)
+        metrics.append(result.to_dict())
+        if not result.committed:
+            break
+
+    payload = engine.snapshot()
+    payload["metrics"] = metrics
+    if optimization is not None:
+        payload["optimization"] = {
+            "adopted": optimization.adopted,
+            "baseline_score": optimization.baseline_score,
+            "candidate_score": optimization.candidate_score,
+            "previous_mechanics": asdict(optimization.previous_mechanics),
+            "selected_mechanics": asdict(optimization.selected_mechanics),
+        }
+
+    if args.as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        universe = payload["universe"]
+        print("Jarvis-X sparse 3-D auto-encoding/decoding automaton")
+        print("Virtual axis:", universe["axis_size"], "positions")
+        print("Virtual cells:", universe["virtual_cells"])
+        if optimization is not None:
+            print(
+                "Bounded mechanics optimization:",
+                "adopted" if optimization.adopted else "baseline retained",
+            )
+        for item in metrics:
+            status = "COMMIT" if item["committed"] else "ROLLBACK"
+            print(
+                "cycle={cycle:>3} status={status:<8} active={active_cells:>5} "
+                "materialised={materialised_cells:>5} frontier={frontier_cells:>5} "
+                "mse={reconstruction_mse:.6f} energy={energy:.6f}".format(
+                    status=status,
+                    **item
+                )
+            )
+        print("Journal:", payload["journal_hash"])
+    return 0
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+    if args.command == "run":
+        return _run_source(args.file)
+    if args.command == "api":
+        from .api import start_api
+
         start_api()
+        return 0
+    if args.command == "web":
+        from .web import start_web
 
-    elif cmd == "web":
         start_web()
+        return 0
+    if args.command == "node":
+        from .node import CodexNode
 
-    elif cmd == "node":
         node = CodexNode()
         node.start()
+        return 0
+    if args.command in ("automaton", "simulate"):
+        return _run_automaton(args)
+    if args.command == "universe":
+        from .automaton import Sparse3DAutomaton
+
+        print(json.dumps(Sparse3DAutomaton.universe_descriptor(), indent=2, sort_keys=True))
+        return 0
+
+    parser.error("unknown command: {}".format(args.command))
+    return 2
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -57,10 +57,10 @@ def _run_source(path: Path) -> int:
 
 
 def _run_automaton(args: argparse.Namespace) -> int:
+    from .operational_field import OperationalTetrationFieldAutomaton
     from .tetration_field import (
         FieldMechanics,
         TetrationAddress,
-        TetrationFieldAutomaton,
         TetrationUniverse,
         make_brick_pulse,
     )
@@ -76,7 +76,7 @@ def _run_automaton(args: argparse.Namespace) -> int:
 
     universe = TetrationUniverse(height=args.tower_height)
     mechanics = FieldMechanics(max_active_bricks=args.max_active)
-    engine = TetrationFieldAutomaton(
+    engine = OperationalTetrationFieldAutomaton(
         universe=universe,
         mechanics=mechanics,
         latent_dim=args.latent_dim,
@@ -106,6 +106,7 @@ def _run_automaton(args: argparse.Namespace) -> int:
     print("Virtual cells:", descriptor["virtual_cells"])
     print("Coordinate naming:", descriptor["coordinate_bits"], "bits")
     print("Brick:", payload["brick_shape"], "router:", payload["router"])
+    print("Committed latent states:", payload["latent_repository_entries"])
     for item in metrics:
         status = "COMMIT" if item["committed"] else "ROLLBACK"
         print(

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,23 +1,41 @@
-from .registers import Registers
-from .memory import Memory
+"""Deterministic Jarvis-X bytecode virtual machine."""
+
+from pathlib import Path
+from typing import Union
+
+from .debugger import Debugger
 from .decoder import Decoder
+from .ethics import LambdaShield
 from .executor import Executor
 from .ledger_store import PersistentLedger
-from .ethics import LambdaShield
+from .memory import Memory
 from .reflex import ReflexEngine
+from .registers import Registers
 from .sandbox import Sandbox
-from .debugger import Debugger
 from .tracer import Tracer
 
+
 class CodexVM:
-    def __init__(self):
+    """Execute bytecode without hidden register mutation.
+
+    Reflex stabilization remains available, but it is opt-in. Applying it after
+    every instruction by default changes architectural operands between `SET`
+    and `ADD`, violating the ISA's deterministic arithmetic semantics.
+    """
+
+    def __init__(
+        self,
+        reflex_enabled: bool = False,
+        ledger_path: Union[str, Path] = "omega_ledger.json",
+    ):
         self.regs = Registers()
         self.mem = Memory()
         self.decoder = Decoder()
         self.executor = Executor(self.regs)
-        self.ledger = PersistentLedger()
+        self.ledger = PersistentLedger(ledger_path)
         self.ethics = LambdaShield()
         self.reflex = ReflexEngine()
+        self.reflex_enabled = bool(reflex_enabled)
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
@@ -28,18 +46,24 @@ class CodexVM:
     def load(self, bytecode):
         self.program = bytecode
         self.regs["IP"] = 0
+        self.running = True
 
     def step(self):
         ip = self.regs["IP"]
+        if ip < 0 or ip >= len(self.program):
+            raise RuntimeError("instruction pointer is outside the loaded program")
         instr = self.decoder.decode(self.program[ip])
 
         if not self.ethics.allow(instr):
             raise RuntimeError("Ethics blocked instruction")
 
         cont = self.executor.execute(instr)
-        self.ledger.log(self.regs.snapshot(), instr.opcode)
-        self.tracer.record(instr, self.regs.snapshot())
-        self.reflex.stabilize(self.regs)
+        if self.reflex_enabled:
+            self.reflex.stabilize(self.regs)
+
+        snapshot = self.regs.snapshot()
+        self.ledger.log(snapshot, instr.opcode)
+        self.tracer.record(instr, snapshot)
 
         self.regs["IP"] += 1
         self.cycles += 1

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,32 @@
+"""Deterministic hash-chained execution ledger."""
+
 import hashlib
-import time
+import json
+from typing import Dict, Mapping
+
 
 class OmegaLedger:
+    """Append canonical JSON records to a deterministic SHA-256 chain."""
+
     def __init__(self):
         self.chain = []
 
-    def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+    def log(self, state: Mapping[str, int], opcode: int) -> Dict[str, object]:
+        payload = {
+            "sequence": len(self.chain),
+            "opcode": int(opcode),
+            "state": dict(state),
+        }
+        canonical = json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        previous = self.chain[-1]["hash"].encode("ascii") if self.chain else b""
+        record = {
+            "hash": hashlib.sha256(previous + canonical).hexdigest(),
+            "payload": payload,
+        }
+        self.chain.append(record)
+        return record

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -1,16 +1,30 @@
+"""Persistent storage for the deterministic Omega ledger."""
+
 import json
 import os
+from pathlib import Path
+from typing import Mapping, Union
+
 from .ledger import OmegaLedger
 
-class PersistentLedger(OmegaLedger):
-    def __init__(self, path="omega_ledger.json"):
-        super().__init__()
-        self.path = path
-        if os.path.exists(path):
-            with open(path) as f:
-                self.chain = json.load(f)
 
-    def log(self, state, opcode):
-        super().log(state, opcode)
-        with open(self.path, "w") as f:
-            json.dump(self.chain, f, indent=2)
+class PersistentLedger(OmegaLedger):
+    def __init__(self, path: Union[str, Path] = "omega_ledger.json"):
+        super().__init__()
+        self.path = Path(path)
+        if self.path.exists():
+            with self.path.open(encoding="utf-8") as handle:
+                loaded = json.load(handle)
+            if not isinstance(loaded, list):
+                raise ValueError("ledger file must contain a JSON list")
+            self.chain = loaded
+
+    def log(self, state: Mapping[str, int], opcode: int):
+        record = super().log(state, opcode)
+        temporary = self.path.with_name(self.path.name + ".tmp")
+        with temporary.open("w", encoding="utf-8") as handle:
+            json.dump(self.chain, handle, ensure_ascii=False, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, self.path)
+        return record

--- a/src/jarvisx/operational_field.py
+++ b/src/jarvisx/operational_field.py
@@ -20,10 +20,9 @@ from .tetration_field import (
 class OperationalTetrationFieldAutomaton(TetrationFieldAutomaton):
     """Extend the brick field so B, Z and Omega commit as one transaction.
 
-    The base field calculates latent states while processing each frontier brick.
-    This operational wrapper reconstructs the committed latent state for every
-    retained brick, validates it, binds it into the journal, and restores the
-    prior field transaction if latent sealing fails.
+    `BrickState.expert_index` records the expert used to produce a transition.
+    The committed latent repository is then re-encoded from the resulting B and
+    Omega state. Its next-state router may legitimately choose another expert.
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -33,14 +32,14 @@ class OperationalTetrationFieldAutomaton(TetrationFieldAutomaton):
     def _evolved_latent(self, state: BrickState) -> Tuple[float, ...]:
         latent = self.network.encode(state.values)
         conditioned = self.network.condition_with_omega(latent, state.omega)
-        expert, _ = self.network.route(conditioned)
-        if expert != state.expert_index:
-            raise ValueError("committed expert index does not match latent router")
+        next_expert, _ = self.network.route(conditioned)
         return tuple(
             math.tanh(
                 conditioned[index]
-                + self.network._dot(self.network.experts[expert][index], conditioned)
-                + self.network.expert_bias[expert][index]
+                + self.network._dot(
+                    self.network.experts[next_expert][index], conditioned
+                )
+                + self.network.expert_bias[next_expert][index]
             )
             for index in range(self.network.latent_dim)
         )
@@ -87,7 +86,9 @@ class OperationalTetrationFieldAutomaton(TetrationFieldAutomaton):
             return metrics
 
         try:
-            candidate_latents = self._build_latent_repository(self.directory.to_dict())
+            candidate_latents = self._build_latent_repository(
+                self.directory.to_dict()
+            )
             sealed_hash = self._seal_latents(candidate_latents)
         except (TypeError, ValueError, OverflowError) as exc:
             self.directory = previous_directory

--- a/src/jarvisx/operational_field.py
+++ b/src/jarvisx/operational_field.py
@@ -1,0 +1,128 @@
+"""Operational tetration field with committed sparse latent state."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+from dataclasses import replace
+from typing import Dict, Mapping, Optional, Tuple
+
+from .tetration_field import (
+    BrickState,
+    FieldStepMetrics,
+    Observation,
+    TetrationAddress,
+    TetrationFieldAutomaton,
+)
+
+
+class OperationalTetrationFieldAutomaton(TetrationFieldAutomaton):
+    """Extend the brick field so B, Z and Omega commit as one transaction.
+
+    The base field calculates latent states while processing each frontier brick.
+    This operational wrapper reconstructs the committed latent state for every
+    retained brick, validates it, binds it into the journal, and restores the
+    prior field transaction if latent sealing fails.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.latent_repository: Dict[TetrationAddress, Tuple[float, ...]] = {}
+
+    def _evolved_latent(self, state: BrickState) -> Tuple[float, ...]:
+        latent = self.network.encode(state.values)
+        conditioned = self.network.condition_with_omega(latent, state.omega)
+        expert, _ = self.network.route(conditioned)
+        if expert != state.expert_index:
+            raise ValueError("committed expert index does not match latent router")
+        return tuple(
+            math.tanh(
+                conditioned[index]
+                + self.network._dot(self.network.experts[expert][index], conditioned)
+                + self.network.expert_bias[expert][index]
+            )
+            for index in range(self.network.latent_dim)
+        )
+
+    def _build_latent_repository(
+        self, states: Mapping[TetrationAddress, BrickState]
+    ) -> Dict[TetrationAddress, Tuple[float, ...]]:
+        repository = {
+            address: self._evolved_latent(state)
+            for address, state in sorted(states.items())
+        }
+        for latent in repository.values():
+            if len(latent) != self.network.latent_dim:
+                raise ValueError("latent state has the wrong dimension")
+            if not all(math.isfinite(value) for value in latent):
+                raise ValueError("latent repository contains a non-finite value")
+        return repository
+
+    def _seal_latents(
+        self, repository: Mapping[TetrationAddress, Tuple[float, ...]]
+    ) -> str:
+        digest = hashlib.sha256(bytes.fromhex(self.journal_hash))
+        digest.update(b"JARVIS-X-SPARSE-Z-V1")
+        for address in sorted(repository):
+            latent = repository[address]
+            digest.update(address.canonical_bytes())
+            digest.update(struct.pack(">I", len(latent)))
+            for value in latent:
+                digest.update(struct.pack(">d", value))
+        return digest.hexdigest()
+
+    def step(
+        self,
+        injections: Optional[Mapping[TetrationAddress, Observation]] = None,
+    ) -> FieldStepMetrics:
+        previous_directory = self.directory
+        previous_cycle = self.cycle
+        previous_hash = self.journal_hash
+        previous_metrics = self.last_metrics
+        previous_latents = dict(self.latent_repository)
+
+        metrics = super().step(injections)
+        if not metrics.committed:
+            return metrics
+
+        try:
+            candidate_latents = self._build_latent_repository(self.directory.to_dict())
+            sealed_hash = self._seal_latents(candidate_latents)
+        except (TypeError, ValueError, OverflowError) as exc:
+            self.directory = previous_directory
+            self.cycle = previous_cycle
+            self.journal_hash = previous_hash
+            self.last_metrics = previous_metrics
+            self.latent_repository = previous_latents
+            self.last_metrics = self._metrics(
+                committed=False,
+                frontier=metrics.frontier_bricks,
+                mse=metrics.reconstruction_mse,
+                energy=metrics.relative_energy,
+                reason="latent commit failed: {}".format(exc),
+            )
+            return self.last_metrics
+
+        self.latent_repository = candidate_latents
+        self.journal_hash = sealed_hash
+        self.last_metrics = replace(metrics, journal_hash=sealed_hash)
+        return self.last_metrics
+
+    def latent_state(
+        self, address: TetrationAddress
+    ) -> Optional[Tuple[float, ...]]:
+        return self.latent_repository.get(address)
+
+    def snapshot(self) -> Dict[str, object]:
+        state = super().snapshot()
+        state.update(
+            {
+                "latent_repository_entries": len(self.latent_repository),
+                "physical_state": ["active_frontier", "B", "Z", "Omega"],
+                "memory_model": "O(M_t * (192 + d + 192)) for B, Z and Omega",
+                "journal_hash": self.journal_hash,
+                "last_metrics": self.last_metrics.to_dict(),
+            }
+        )
+        return state

--- a/src/jarvisx/tetration_field.py
+++ b/src/jarvisx/tetration_field.py
@@ -1,0 +1,703 @@
+"""Sparse brick field over a symbolic tetration address manifold."""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import random
+import struct
+from dataclasses import asdict, dataclass, replace
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple, Union
+
+BASE = 1000
+CHANNELS = 3
+EDGE = 4
+BRICK_SIZE = CHANNELS * EDGE * EDGE * EDGE
+FACES = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+
+
+def _tower(base: int, height: int) -> str:
+    if height == 1:
+        return str(base)
+    if height == 2:
+        return f"{base}^{base}"
+    return f"{base}↑↑{height}"
+
+
+@dataclass(frozen=True)
+class TetrationUniverse:
+    height: int = 2
+    base: int = BASE
+
+    def __post_init__(self) -> None:
+        if self.base < 2 or self.height < 1:
+            raise ValueError("base >= 2 and height >= 1 are required")
+
+    @property
+    def coordinate_bits_if_materialisable(self) -> Optional[int]:
+        if self.height == 1:
+            return 3 * math.ceil(math.log2(self.base))
+        if self.height == 2:
+            return 3 * math.ceil(self.base * math.log2(self.base))
+        return None
+
+    @property
+    def axis_expression(self) -> str:
+        return _tower(self.base, self.height)
+
+    def descriptor(self) -> Dict[str, object]:
+        axis = _tower(self.base, self.height)
+        if self.height == 1:
+            bits = self.coordinate_bits_if_materialisable
+            bits_expr = str(bits)
+        elif self.height == 2:
+            bits = self.coordinate_bits_if_materialisable
+            bits_expr = str(bits)
+        else:
+            bits = None
+            bits_expr = f"3*ceil(({_tower(self.base, self.height - 1)})*log2({self.base}))"
+        return {
+            "base": self.base,
+            "tower_height": self.height,
+            "axis_size": axis,
+            "virtual_cells": f"({axis})^3",
+            "coordinate_bits": bits_expr,
+            "coordinate_bits_materialised": bits,
+            "storage_model": "symbolic-address-manifold/sparse-collision-chained-field",
+        }
+
+
+@dataclass(frozen=True, order=True)
+class TetrationAddress:
+    tower_height: int
+    chart: str
+    x: int
+    y: int
+    z: int
+
+    def __post_init__(self) -> None:
+        if self.tower_height < 1 or not self.chart:
+            raise ValueError("tower_height must be positive and chart non-empty")
+        if not all(isinstance(v, int) for v in (self.x, self.y, self.z)):
+            raise TypeError("x, y and z must be integers")
+
+    def offset(self, dx: int = 0, dy: int = 0, dz: int = 0) -> "TetrationAddress":
+        return TetrationAddress(self.tower_height, self.chart, self.x + dx, self.y + dy, self.z + dz)
+
+    def canonical_bytes(self) -> bytes:
+        return json.dumps(
+            [self.tower_height, self.chart, str(self.x), str(self.y), str(self.z)],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class BrickState:
+    values: Tuple[float, ...]
+    omega: Tuple[float, ...]
+    inactive_steps: int = 0
+    revision: int = 0
+    expert_index: int = 0
+
+    def __post_init__(self) -> None:
+        if len(self.values) != BRICK_SIZE or len(self.omega) != BRICK_SIZE:
+            raise ValueError(f"values and omega must each contain {BRICK_SIZE} elements")
+
+
+class SparseHashDirectory:
+    """Finite hash table using explicit collision chains."""
+
+    def __init__(self, bucket_count: int = 257) -> None:
+        if bucket_count < 1:
+            raise ValueError("bucket_count must be positive")
+        self.bucket_count = bucket_count
+        self._buckets: List[List[Tuple[TetrationAddress, BrickState]]] = [
+            [] for _ in range(bucket_count)
+        ]
+        self._size = 0
+
+    def _get_allocated_index(self, address: TetrationAddress) -> int:
+        chart = int.from_bytes(
+            hashlib.blake2b(address.chart.encode("utf-8"), digest_size=8).digest(), "big"
+        )
+        mixed = (
+            address.x * 5147
+            ^ address.y * 9293
+            ^ address.z * 11257
+            ^ address.tower_height * 131071
+            ^ chart
+        )
+        return mixed % self.bucket_count
+
+    def get(self, address: TetrationAddress) -> Optional[BrickState]:
+        for key, value in self._buckets[self._get_allocated_index(address)]:
+            if key == address:
+                return value
+        return None
+
+    def set(self, address: TetrationAddress, state: BrickState) -> None:
+        bucket = self._buckets[self._get_allocated_index(address)]
+        for i, (key, _) in enumerate(bucket):
+            if key == address:
+                bucket[i] = (address, state)
+                return
+        bucket.append((address, state))
+        self._size += 1
+
+    def items(self) -> Iterator[Tuple[TetrationAddress, BrickState]]:
+        for bucket in self._buckets:
+            yield from bucket
+
+    def to_dict(self) -> Dict[TetrationAddress, BrickState]:
+        return dict(self.items())
+
+    @classmethod
+    def from_mapping(
+        cls, mapping: Mapping[TetrationAddress, BrickState], bucket_count: int
+    ) -> "SparseHashDirectory":
+        out = cls(bucket_count)
+        for address in sorted(mapping):
+            out.set(address, mapping[address])
+        return out
+
+    def collision_count(self) -> int:
+        return sum(max(0, len(bucket) - 1) for bucket in self._buckets)
+
+    def __len__(self) -> int:
+        return self._size
+
+
+@dataclass(frozen=True)
+class FieldMechanics:
+    diffusion: float = 0.04
+    error_gain: float = 0.45
+    omega_retention: float = 0.90
+    omega_rate: float = 0.08
+    time_step: float = 0.10
+    activation_threshold: float = 0.50
+    prune_after: int = 6
+    max_active_bricks: int = 128
+    clip_min: float = 16.0
+    clip_max: float = 235.0
+    omega_limit: float = 512.0
+    max_energy: float = 1.0e10
+
+    def validate(self) -> None:
+        values = tuple(asdict(self).values())
+        if not all(math.isfinite(float(v)) for v in values):
+            raise ValueError("mechanics must be finite")
+        if self.diffusion < 0 or self.error_gain < 0 or self.omega_rate < 0:
+            raise ValueError("D, K and eta must be non-negative")
+        if not 0 < self.omega_retention < 1:
+            raise ValueError("omega_retention must satisfy 0 < rho < 1")
+        if self.time_step <= 0 or self.time_step * self.diffusion > 1 / 6:
+            raise ValueError("explicit six-face diffusion requires dt > 0 and dt*D <= 1/6")
+        if self.time_step * self.error_gain > 1:
+            raise ValueError("residual feedback requires dt*K <= 1")
+        if self.activation_threshold <= 0 or self.prune_after < 1 or self.max_active_bricks < 1:
+            raise ValueError("threshold, prune_after and max_active_bricks must be positive")
+        if self.clip_min >= self.clip_max or self.omega_limit <= 0 or self.max_energy <= 0:
+            raise ValueError("invalid projection or energy bounds")
+
+
+@dataclass(frozen=True)
+class FieldStepMetrics:
+    cycle: int
+    materialised_bricks: int
+    active_bricks: int
+    frontier_bricks: int
+    reconstruction_mse: float
+    relative_energy: float
+    expert_histogram: Tuple[int, ...]
+    collisions: int
+    committed: bool
+    journal_hash: str
+    rollback_reason: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        out = asdict(self)
+        out["expert_histogram"] = list(self.expert_histogram)
+        return out
+
+
+class BrickAutoencoderMoE:
+    """Full 192→d→192 projection with Omega conditioning and softmax/top-1 routing."""
+
+    def __init__(
+        self,
+        latent_dim: int = 16,
+        expert_count: int = 4,
+        seed: int = 1337,
+        clip_min: float = 16.0,
+        clip_max: float = 235.0,
+    ) -> None:
+        if latent_dim < 2 or expert_count < 1 or clip_min >= clip_max:
+            raise ValueError("invalid network dimensions or projection box")
+        self.latent_dim = latent_dim
+        self.expert_count = expert_count
+        self.mid = (clip_min + clip_max) / 2
+        self.half = (clip_max - clip_min) / 2
+        rng = random.Random(seed)
+        enc = 1 / math.sqrt(BRICK_SIZE)
+        om = 0.35 / math.sqrt(BRICK_SIZE)
+        ex = 0.20 / math.sqrt(latent_dim)
+        rt = 1 / math.sqrt(latent_dim)
+        self.encoder = tuple(
+            tuple(rng.uniform(-enc, enc) for _ in range(BRICK_SIZE))
+            for _ in range(latent_dim)
+        )
+        self.encoder_bias = tuple(rng.uniform(-0.02, 0.02) for _ in range(latent_dim))
+        self.omega_projection = tuple(
+            tuple(rng.uniform(-om, om) for _ in range(BRICK_SIZE))
+            for _ in range(latent_dim)
+        )
+        self.router = tuple(
+            tuple(rng.uniform(-rt, rt) for _ in range(latent_dim))
+            for _ in range(expert_count)
+        )
+        self.experts = tuple(
+            tuple(
+                tuple(rng.uniform(-ex, ex) for _ in range(latent_dim))
+                for _ in range(latent_dim)
+            )
+            for _ in range(expert_count)
+        )
+        self.expert_bias = tuple(
+            tuple(rng.uniform(-0.01, 0.01) for _ in range(latent_dim))
+            for _ in range(expert_count)
+        )
+        norms = [
+            max(sum(self.encoder[i][j] ** 2 for i in range(latent_dim)), 1e-9)
+            for j in range(BRICK_SIZE)
+        ]
+        self.decoder = tuple(
+            tuple(self.encoder[i][j] / norms[j] for i in range(latent_dim))
+            for j in range(BRICK_SIZE)
+        )
+
+    @staticmethod
+    def _dot(row: Sequence[float], vector: Sequence[float]) -> float:
+        return sum(a * b for a, b in zip(row, vector))
+
+    def encode(self, values: Sequence[float]) -> Tuple[float, ...]:
+        if len(values) != BRICK_SIZE:
+            raise ValueError(f"brick must contain {BRICK_SIZE} values")
+        flat = tuple((float(v) - self.mid) / self.half for v in values)
+        return tuple(
+            math.tanh(self._dot(row, flat) + bias)
+            for row, bias in zip(self.encoder, self.encoder_bias)
+        )
+
+    def condition_with_omega(
+        self, latent: Sequence[float], omega: Sequence[float]
+    ) -> Tuple[float, ...]:
+        if len(latent) != self.latent_dim or len(omega) != BRICK_SIZE:
+            raise ValueError("invalid latent or omega shape")
+        omega_flat = tuple(float(v) / self.half for v in omega)
+        return tuple(
+            math.tanh(latent[i] + self._dot(self.omega_projection[i], omega_flat))
+            for i in range(self.latent_dim)
+        )
+
+    def route(self, conditioned: Sequence[float]) -> Tuple[int, Tuple[float, ...]]:
+        if len(conditioned) != self.latent_dim:
+            raise ValueError("conditioned latent state has the wrong dimension")
+        logits = tuple(self._dot(row, conditioned) for row in self.router)
+        peak = max(logits)
+        exp = tuple(math.exp(v - peak) for v in logits)
+        total = sum(exp)
+        gates = tuple(v / total for v in exp)
+        expert = max(range(self.expert_count), key=lambda i: (gates[i], -i))
+        return expert, gates
+
+    def decode(self, latent: Sequence[float]) -> Tuple[float, ...]:
+        if len(latent) != self.latent_dim:
+            raise ValueError("latent state has the wrong dimension")
+        return tuple(self.mid + self.half * self._dot(row, latent) for row in self.decoder)
+
+    def forward(
+        self, values: Sequence[float], omega: Sequence[float]
+    ) -> Tuple[Tuple[float, ...], int, Tuple[float, ...]]:
+        if len(values) != BRICK_SIZE or len(omega) != BRICK_SIZE:
+            raise ValueError(f"brick and omega must each contain {BRICK_SIZE} values")
+        z = self.encode(values)
+        conditioned = self.condition_with_omega(z, omega)
+        expert, gates = self.route(conditioned)
+        evolved = tuple(
+            math.tanh(
+                conditioned[i]
+                + self._dot(self.experts[expert][i], conditioned)
+                + self.expert_bias[expert][i]
+            )
+            for i in range(self.latent_dim)
+        )
+        decoded = self.decode(evolved)
+        return decoded, expert, gates
+
+
+Observation = Union[float, Sequence[float]]
+
+
+class TetrationFieldAutomaton:
+    def __init__(
+        self,
+        universe: Optional[TetrationUniverse] = None,
+        mechanics: Optional[FieldMechanics] = None,
+        latent_dim: int = 16,
+        expert_count: int = 4,
+        seed: int = 1337,
+        bucket_count: int = 257,
+    ) -> None:
+        self.universe = universe or TetrationUniverse()
+        self.mechanics = mechanics or FieldMechanics()
+        self.mechanics.validate()
+        self.seed = seed
+        self.directory = SparseHashDirectory(bucket_count)
+        self.network = BrickAutoencoderMoE(
+            latent_dim, expert_count, seed, self.mechanics.clip_min, self.mechanics.clip_max
+        )
+        self._background: Dict[TetrationAddress, Tuple[float, ...]] = {}
+        self.cycle = 0
+        self.journal_hash = "0" * 64
+        self.last_metrics = self._metrics(True)
+
+    def _metrics(
+        self,
+        committed: bool,
+        frontier: int = 0,
+        mse: float = 0.0,
+        energy: float = 0.0,
+        experts: Optional[Tuple[int, ...]] = None,
+        reason: Optional[str] = None,
+    ) -> FieldStepMetrics:
+        return FieldStepMetrics(
+            self.cycle,
+            len(self.directory),
+            len(self.active_addresses()),
+            frontier,
+            mse,
+            energy,
+            experts or tuple(0 for _ in range(self.network.expert_count)),
+            self.directory.collision_count(),
+            committed,
+            self.journal_hash,
+            reason,
+        )
+
+    def _check_address(self, address: TetrationAddress) -> None:
+        if address.tower_height != self.universe.height:
+            raise ValueError("address tower height does not match universe")
+
+    def procedural_brick(self, address: TetrationAddress) -> Tuple[float, ...]:
+        self._check_address(address)
+        if address not in self._background:
+            digest = hashlib.blake2b(
+                address.canonical_bytes(), key=str(self.seed).encode(), digest_size=32
+            ).digest()
+            self._background[address] = tuple(
+                self.mechanics.clip_min + 0.25 + ((digest[i % 32] / 255) - 0.5) * 0.5
+                for i in range(BRICK_SIZE)
+            )
+        return self._background[address]
+
+    @staticmethod
+    def flat_index(channel: int, x: int, y: int, z: int) -> int:
+        return (((channel * EDGE + z) * EDGE + y) * EDGE + x)
+
+    _flat_index = flat_index
+
+    def _resolve(
+        self, address: TetrationAddress, x: int, y: int, z: int
+    ) -> Tuple[TetrationAddress, int, int, int]:
+        dx = dy = dz = 0
+        if x < 0:
+            x += EDGE
+            dx = -1
+        elif x >= EDGE:
+            x -= EDGE
+            dx = 1
+        if y < 0:
+            y += EDGE
+            dy = -1
+        elif y >= EDGE:
+            y -= EDGE
+            dy = 1
+        if z < 0:
+            z += EDGE
+            dz = -1
+        elif z >= EDGE:
+            z -= EDGE
+            dz = 1
+        return address.offset(dx, dy, dz), x, y, z
+
+    def _values(
+        self, states: Mapping[TetrationAddress, BrickState], address: TetrationAddress
+    ) -> Tuple[float, ...]:
+        state = states.get(address)
+        return state.values if state else self.procedural_brick(address)
+
+    def _voxel(
+        self,
+        states: Mapping[TetrationAddress, BrickState],
+        address: TetrationAddress,
+        channel: int,
+        x: int,
+        y: int,
+        z: int,
+    ) -> float:
+        address, x, y, z = self._resolve(address, x, y, z)
+        return self._values(states, address)[self.flat_index(channel, x, y, z)]
+
+    _voxel_value = _voxel
+
+    def _laplacian(
+        self,
+        states: Mapping[TetrationAddress, BrickState],
+        address: TetrationAddress,
+        channel: int,
+        x: int,
+        y: int,
+        z: int,
+        centre: float,
+    ) -> float:
+        return (
+            self._voxel(states, address, channel, x + 1, y, z)
+            + self._voxel(states, address, channel, x - 1, y, z)
+            + self._voxel(states, address, channel, x, y + 1, z)
+            + self._voxel(states, address, channel, x, y - 1, z)
+            + self._voxel(states, address, channel, x, y, z + 1)
+            + self._voxel(states, address, channel, x, y, z - 1)
+            - 6 * centre
+        )
+
+    def _activity(self, address: TetrationAddress, state: BrickState) -> float:
+        background = self.procedural_brick(address)
+        return max(
+            max(abs(v - b) for v, b in zip(state.values, background)),
+            max(abs(v) for v in state.omega),
+        )
+
+    def active_addresses(
+        self, states: Optional[Mapping[TetrationAddress, BrickState]] = None
+    ) -> Tuple[TetrationAddress, ...]:
+        states = states if states is not None else self.directory.to_dict()
+        return tuple(
+            sorted(
+                a
+                for a, s in states.items()
+                if self._activity(a, s) >= self.mechanics.activation_threshold
+                or s.inactive_steps == 0
+            )
+        )
+
+    def _frontier(
+        self, states: Mapping[TetrationAddress, BrickState]
+    ) -> Tuple[TetrationAddress, ...]:
+        active = set(self.active_addresses(states))
+        frontier = set(active)
+        for address in active:
+            frontier.update(address.offset(*face) for face in FACES)
+        if len(frontier) <= self.mechanics.max_active_bricks:
+            return tuple(sorted(frontier))
+        ranked = sorted(
+            frontier,
+            key=lambda a: (
+                -self._activity(a, states[a]) if a in states else 0.0,
+                a,
+            ),
+        )
+        return tuple(sorted(ranked[: self.mechanics.max_active_bricks]))
+
+    def _observation(self, value: Observation) -> Tuple[float, ...]:
+        if isinstance(value, (int, float)):
+            return tuple(float(value) for _ in range(BRICK_SIZE))
+        out = tuple(float(v) for v in value)
+        if len(out) != BRICK_SIZE:
+            raise ValueError(f"observation must contain {BRICK_SIZE} values")
+        return out
+
+    def _inject(
+        self,
+        states: Dict[TetrationAddress, BrickState],
+        injections: Mapping[TetrationAddress, Observation],
+    ) -> None:
+        for address in sorted(injections):
+            self._check_address(address)
+            delta = self._observation(injections[address])
+            current = states.get(address) or BrickState(
+                self.procedural_brick(address), tuple(0.0 for _ in range(BRICK_SIZE))
+            )
+            values = tuple(
+                min(self.mechanics.clip_max, max(self.mechanics.clip_min, v + u))
+                for v, u in zip(current.values, delta)
+            )
+            states[address] = replace(
+                current, values=values, inactive_steps=0, revision=current.revision + 1
+            )
+
+    def _verify(
+        self, candidate: Mapping[TetrationAddress, BrickState]
+    ) -> Tuple[bool, Optional[str], float]:
+        if len(candidate) > self.mechanics.max_active_bricks:
+            return False, "active-brick budget exceeded", math.inf
+        energy = 0.0
+        for address, state in candidate.items():
+            self._check_address(address)
+            if not 0 <= state.expert_index < self.network.expert_count:
+                return False, "expert index out of range", math.inf
+            for value, omega, base in zip(state.values, state.omega, self.procedural_brick(address)):
+                if not math.isfinite(value) or not math.isfinite(omega):
+                    return False, "non-finite field state", math.inf
+                if not self.mechanics.clip_min <= value <= self.mechanics.clip_max:
+                    return False, "projection bound exceeded", math.inf
+                if abs(omega) > self.mechanics.omega_limit:
+                    return False, "omega bound exceeded", math.inf
+                energy += (value - base) ** 2 + omega**2
+        if energy > self.mechanics.max_energy:
+            return False, "relative energy budget exceeded", energy
+        return True, None, energy
+
+    def _journal(self, states: Mapping[TetrationAddress, BrickState], cycle: int) -> str:
+        digest = hashlib.sha256(bytes.fromhex(self.journal_hash))
+        digest.update(struct.pack(">Q", cycle))
+        digest.update(json.dumps(asdict(self.mechanics), sort_keys=True).encode())
+        digest.update(json.dumps(self.universe.descriptor(), sort_keys=True).encode())
+        for address in sorted(states):
+            state = states[address]
+            digest.update(address.canonical_bytes())
+            digest.update(struct.pack(">III", state.inactive_steps, state.revision, state.expert_index))
+            for value in state.values + state.omega:
+                digest.update(struct.pack(">d", value))
+        return digest.hexdigest()
+
+    def step(
+        self, injections: Optional[Mapping[TetrationAddress, Observation]] = None
+    ) -> FieldStepMetrics:
+        working = self.directory.to_dict()
+        try:
+            if injections:
+                self._inject(working, injections)
+        except (TypeError, ValueError) as exc:
+            self.last_metrics = self._metrics(False, reason=str(exc))
+            return self.last_metrics
+        frontier = self._frontier(working)
+        updates: Dict[TetrationAddress, BrickState] = {}
+        histogram = [0] * self.network.expert_count
+        squared_error = 0.0
+        for address in frontier:
+            current = working.get(address)
+            values = self._values(working, address)
+            omega = current.omega if current else tuple(0.0 for _ in range(BRICK_SIZE))
+            decoded, expert, _ = self.network.forward(values, omega)
+            histogram[expert] += 1
+            residual = tuple(p - b for p, b in zip(decoded, values))
+            squared_error += sum(e * e for e in residual)
+            omega_next = tuple(
+                min(
+                    self.mechanics.omega_limit,
+                    max(
+                        -self.mechanics.omega_limit,
+                        self.mechanics.omega_retention * o - self.mechanics.omega_rate * e,
+                    ),
+                )
+                for o, e in zip(omega, residual)
+            )
+            proposal = [0.0] * BRICK_SIZE
+            for c in range(CHANNELS):
+                for z in range(EDGE):
+                    for y in range(EDGE):
+                        for x in range(EDGE):
+                            i = self.flat_index(c, x, y, z)
+                            delta = self._laplacian(working, address, c, x, y, z, values[i])
+                            raw = values[i] + self.mechanics.time_step * (
+                                self.mechanics.diffusion * delta
+                                - self.mechanics.error_gain * residual[i]
+                                + omega_next[i]
+                            )
+                            proposal[i] = min(
+                                self.mechanics.clip_max, max(self.mechanics.clip_min, raw)
+                            )
+            provisional = BrickState(
+                tuple(proposal),
+                omega_next,
+                revision=(current.revision if current else 0) + 1,
+                expert_index=expert,
+            )
+            inactive = (
+                0
+                if self._activity(address, provisional) >= self.mechanics.activation_threshold
+                else (current.inactive_steps + 1 if current else 1)
+            )
+            updates[address] = replace(provisional, inactive_steps=inactive)
+
+        candidate: Dict[TetrationAddress, BrickState] = {}
+        frontier_set = set(frontier)
+        for address, state in working.items():
+            if address not in frontier_set:
+                aged = replace(state, inactive_steps=state.inactive_steps + 1)
+                if not (
+                    aged.inactive_steps >= self.mechanics.prune_after
+                    and self._activity(address, aged) < self.mechanics.activation_threshold
+                ):
+                    candidate[address] = aged
+        for address, state in updates.items():
+            if not (
+                state.inactive_steps >= self.mechanics.prune_after
+                and self._activity(address, state) < self.mechanics.activation_threshold
+            ):
+                candidate[address] = state
+        if len(candidate) > self.mechanics.max_active_bricks:
+            candidate = dict(
+                sorted(
+                    candidate.items(),
+                    key=lambda item: (-self._activity(item[0], item[1]), item[0]),
+                )[: self.mechanics.max_active_bricks]
+            )
+        valid, reason, energy = self._verify(candidate)
+        mse = squared_error / max(1, len(frontier) * BRICK_SIZE)
+        if not valid:
+            self.last_metrics = self._metrics(False, len(frontier), mse, energy, reason=reason)
+            return self.last_metrics
+        self.cycle += 1
+        self.journal_hash = self._journal(candidate, self.cycle)
+        self.directory = SparseHashDirectory.from_mapping(candidate, self.directory.bucket_count)
+        self.last_metrics = self._metrics(
+            True, len(frontier), mse, energy, tuple(histogram)
+        )
+        return self.last_metrics
+
+    def snapshot(self) -> Dict[str, object]:
+        return {
+            "universe": self.universe.descriptor(),
+            "cycle": self.cycle,
+            "materialised_bricks": len(self.directory),
+            "active_bricks": len(self.active_addresses()),
+            "bucket_count": self.directory.bucket_count,
+            "collisions": self.directory.collision_count(),
+            "brick_shape": [CHANNELS, EDGE, EDGE, EDGE],
+            "brick_values": BRICK_SIZE,
+            "latent_dim": self.network.latent_dim,
+            "expert_count": self.network.expert_count,
+            "router": "softmax/top-1",
+            "mechanics": asdict(self.mechanics),
+            "journal_hash": self.journal_hash,
+            "last_metrics": self.last_metrics.to_dict(),
+            "cost_model": "O(M_t * (192*d + d^2 + 192*6))",
+        }
+
+
+def make_brick_pulse(amplitude: float = 48.0) -> Tuple[float, ...]:
+    if not math.isfinite(amplitude):
+        raise ValueError("amplitude must be finite")
+    out = [0.0] * BRICK_SIZE
+    centre = (EDGE - 1) / 2
+    for c in range(CHANNELS):
+        for z in range(EDGE):
+            for y in range(EDGE):
+                for x in range(EDGE):
+                    d2 = (x - centre) ** 2 + (y - centre) ** 2 + (z - centre) ** 2
+                    out[TetrationFieldAutomaton.flat_index(c, x, y, z)] = (
+                        amplitude * (1 - 0.15 * c) * math.exp(-0.75 * d2)
+                    )
+    return tuple(out)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,0 +1,30 @@
+import json
+
+from jarvisx.ledger import OmegaLedger
+from jarvisx.ledger_store import PersistentLedger
+
+
+def test_omega_ledger_is_deterministic_and_json_serializable():
+    left = OmegaLedger()
+    right = OmegaLedger()
+    state = {"A": 30, "IP": 2, "Ω": 0}
+
+    left_record = left.log(state, 3)
+    right_record = right.log(state, 3)
+
+    assert left_record == right_record
+    assert left_record["payload"]["sequence"] == 0
+    assert json.loads(json.dumps(left.chain, ensure_ascii=False)) == left.chain
+
+
+def test_persistent_ledger_round_trips_atomically(tmp_path):
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(path)
+    record = ledger.log({"A": 7, "IP": 1}, 1)
+
+    assert path.exists()
+    assert not (tmp_path / "omega.json.tmp").exists()
+    assert json.loads(path.read_text(encoding="utf-8")) == ledger.chain
+
+    restored = PersistentLedger(path)
+    assert restored.chain == [record]

--- a/tests/test_operational_field.py
+++ b/tests/test_operational_field.py
@@ -1,0 +1,71 @@
+from jarvisx.operational_field import OperationalTetrationFieldAutomaton
+from jarvisx.tetration_field import (
+    FieldMechanics,
+    TetrationAddress,
+    make_brick_pulse,
+)
+
+
+def origin():
+    return TetrationAddress(2, "origin", 0, 0, 0)
+
+
+def make_engine(seed=1337):
+    return OperationalTetrationFieldAutomaton(
+        mechanics=FieldMechanics(max_active_bricks=32),
+        latent_dim=8,
+        expert_count=3,
+        seed=seed,
+        bucket_count=17,
+    )
+
+
+def test_operational_commit_materialises_matching_latent_repository():
+    engine = make_engine()
+    metrics = engine.step({origin(): make_brick_pulse(20.0)})
+
+    assert metrics.committed
+    assert len(engine.latent_repository) == metrics.materialised_bricks
+    assert set(engine.latent_repository) == set(engine.directory.to_dict())
+    assert all(len(latent) == 8 for latent in engine.latent_repository.values())
+
+    snapshot = engine.snapshot()
+    assert snapshot["physical_state"] == ["active_frontier", "B", "Z", "Omega"]
+    assert snapshot["latent_repository_entries"] == snapshot["materialised_bricks"]
+    assert snapshot["journal_hash"] == metrics.journal_hash
+
+
+def test_operational_replay_includes_latent_state_and_sealed_journal():
+    left = make_engine(seed=91)
+    right = make_engine(seed=91)
+    workload = [{origin(): make_brick_pulse(18.0)}, None, None]
+
+    for injections in workload:
+        assert left.step(injections) == right.step(injections)
+
+    assert left.directory.to_dict() == right.directory.to_dict()
+    assert left.latent_repository == right.latent_repository
+    assert left.journal_hash == right.journal_hash
+
+
+def test_latent_failure_rolls_back_B_Z_and_omega_atomically(monkeypatch):
+    engine = make_engine(seed=17)
+    assert engine.step({origin(): make_brick_pulse(16.0)}).committed
+
+    previous_cycle = engine.cycle
+    previous_hash = engine.journal_hash
+    previous_field = engine.directory.to_dict()
+    previous_latents = dict(engine.latent_repository)
+
+    def reject_latents(_states):
+        raise ValueError("forced latent verification failure")
+
+    monkeypatch.setattr(engine, "_build_latent_repository", reject_latents)
+    metrics = engine.step()
+
+    assert not metrics.committed
+    assert metrics.rollback_reason.startswith("latent commit failed")
+    assert engine.cycle == previous_cycle
+    assert engine.journal_hash == previous_hash
+    assert engine.directory.to_dict() == previous_field
+    assert engine.latent_repository == previous_latents

--- a/tests/test_sparse_automaton.py
+++ b/tests/test_sparse_automaton.py
@@ -1,0 +1,119 @@
+import math
+
+import pytest
+
+from jarvisx.automaton import (
+    ADDRESS_DEPTH,
+    AXIS_SIZE,
+    RADIX,
+    BoundedMechanicsOptimizer,
+    Coordinate3D,
+    DeterministicAutoencoder,
+    Mechanics,
+    Sparse3DAutomaton,
+    make_echo_injections,
+)
+
+
+def test_virtual_universe_is_exactly_described_without_dense_allocation():
+    descriptor = Sparse3DAutomaton.universe_descriptor()
+    assert RADIX == 1000
+    assert ADDRESS_DEPTH == 1000
+    assert AXIS_SIZE == 10**3000
+    assert descriptor["virtual_cells"] == "10^9000"
+    assert descriptor["virtual_cell_exponent"] == 9000
+
+
+def test_coordinate_wraps_at_the_virtual_axis_boundary():
+    origin = Coordinate3D(0, 0, 0)
+    wrapped = origin.offset(-1, 0, 0)
+    assert wrapped.x == AXIS_SIZE - 1
+    assert wrapped.offset(1, 0, 0) == origin
+
+
+def test_procedural_field_is_deterministic_and_unmaterialised():
+    coordinate = Coordinate3D(123, 456, 789)
+    left = Sparse3DAutomaton(seed=17)
+    right = Sparse3DAutomaton(seed=17)
+    assert left.materialised_cells == 0
+    assert left.procedural_value(coordinate) == right.procedural_value(coordinate)
+    assert left.materialised_cells == 0
+
+
+def test_autoencoder_has_bounded_deterministic_dimensions():
+    network = DeterministicAutoencoder(latent_dim=6, seed=9)
+    neighbourhood = (1.0, 0.5, -0.5, 0.25, -0.25, 0.1, -0.1)
+    latent = network.encode(neighbourhood)
+    evolved = network.evolve(latent, omega=0.2)
+    reconstruction = network.decode(evolved)
+    assert len(latent) == 6
+    assert len(evolved) == 6
+    assert len(reconstruction) == 7
+    assert all(-1.0 <= value <= 1.0 for value in latent + evolved + reconstruction)
+
+
+def test_transaction_commits_and_advances_hash_chain():
+    engine = Sparse3DAutomaton(seed=21)
+    before_hash = engine.journal_hash
+    pulse = make_echo_injections(side=3, amplitude=1.0)
+    metrics = engine.step(pulse)
+    assert metrics.committed
+    assert metrics.cycle == 1
+    assert metrics.materialised_cells > 0
+    assert metrics.journal_hash != before_hash
+    assert engine.journal_hash == metrics.journal_hash
+
+
+def test_replay_is_bit_deterministic():
+    pulse = make_echo_injections(side=3, amplitude=0.75)
+    first = Sparse3DAutomaton(seed=1337)
+    second = Sparse3DAutomaton(seed=1337)
+    for index in range(5):
+        inputs = pulse if index == 0 else None
+        left = first.step(inputs)
+        right = second.step(inputs)
+        assert left == right
+    assert first.state_digest() == second.state_digest()
+    assert first.cells == second.cells
+
+
+def test_sparse_budget_is_enforced_by_frontier_selection():
+    mechanics = Mechanics(max_active_cells=32)
+    engine = Sparse3DAutomaton(seed=3, mechanics=mechanics)
+    pulse = make_echo_injections(side=5, amplitude=1.0)
+    metrics = engine.step(pulse)
+    assert metrics.committed
+    assert metrics.materialised_cells <= mechanics.max_active_cells
+    assert metrics.frontier_cells <= mechanics.max_active_cells
+
+
+def test_failed_energy_verification_rolls_back_atomically():
+    mechanics = Mechanics(max_energy=1e-12, max_active_cells=128)
+    engine = Sparse3DAutomaton(seed=5, mechanics=mechanics)
+    digest_before = engine.state_digest()
+    metrics = engine.step({Coordinate3D(1, 1, 1): 1.0})
+    assert not metrics.committed
+    assert metrics.rollback_reason == "energy budget exceeded"
+    assert engine.cycle == 0
+    assert engine.materialised_cells == 0
+    assert engine.state_digest() == digest_before
+
+
+def test_bounded_optimizer_never_accepts_invalid_candidate():
+    engine = Sparse3DAutomaton(seed=8)
+    pulse = make_echo_injections(side=1, amplitude=0.4)
+    optimizer = BoundedMechanicsOptimizer()
+    invalid = Mechanics(diffusion=2.0)
+    with pytest.raises(ValueError):
+        optimizer.optimize(engine, [pulse], candidates=[invalid])
+
+
+def test_bounded_optimizer_returns_declared_mechanics():
+    engine = Sparse3DAutomaton(seed=11)
+    pulse = make_echo_injections(side=1, amplitude=0.2)
+    optimizer = BoundedMechanicsOptimizer()
+    result = optimizer.optimize(engine, [pulse, {}])
+    assert math.isfinite(result.baseline_score)
+    assert math.isfinite(result.candidate_score)
+    assert result.candidate_score <= result.baseline_score + 1e-15
+    assert engine.mechanics == result.selected_mechanics

--- a/tests/test_tetration_field.py
+++ b/tests/test_tetration_field.py
@@ -1,0 +1,131 @@
+import math
+
+import pytest
+
+from jarvisx.tetration_field import (
+    BRICK_SIZE,
+    BrickAutoencoderMoE,
+    BrickState,
+    FieldMechanics,
+    SparseHashDirectory,
+    TetrationAddress,
+    TetrationFieldAutomaton,
+    TetrationUniverse,
+    make_brick_pulse,
+)
+
+
+def origin(height=2):
+    return TetrationAddress(height, "origin", 0, 0, 0)
+
+
+def test_tetration_descriptor_height_two():
+    universe = TetrationUniverse(height=2)
+    descriptor = universe.descriptor()
+    assert descriptor["axis_size"] == "1000^1000"
+    assert descriptor["virtual_cells"] == "(1000^1000)^3"
+    assert descriptor["coordinate_bits_materialised"] == 29898
+
+
+def test_higher_tower_remains_symbolic():
+    universe = TetrationUniverse(height=4)
+    assert universe.coordinate_bits_if_materialisable is None
+    assert universe.axis_expression == "1000↑↑4"
+
+
+def test_hash_directory_collision_chaining():
+    directory = SparseHashDirectory(bucket_count=1)
+    zero = tuple(0.0 for _ in range(BRICK_SIZE))
+    a = origin()
+    b = a.offset(1, 0, 0)
+    directory.set(a, BrickState(zero, zero))
+    directory.set(b, BrickState(tuple(1.0 for _ in range(BRICK_SIZE)), zero))
+    assert len(directory) == 2
+    assert directory.collision_count() == 1
+    assert directory.get(a).values[0] == 0.0
+    assert directory.get(b).values[0] == 1.0
+
+
+def test_full_projection_and_top_one_router():
+    network = BrickAutoencoderMoE(latent_dim=8, expert_count=3, seed=7)
+    values = tuple(16.0 + (index % 11) for index in range(BRICK_SIZE))
+    omega = tuple(0.1 for _ in range(BRICK_SIZE))
+    latent = network.encode(values)
+    conditioned = network.condition_with_omega(latent, omega)
+    expert, gates = network.route(conditioned)
+    decoded, forward_expert, _ = network.forward(values, omega)
+    assert len(latent) == 8
+    assert len(decoded) == BRICK_SIZE
+    assert forward_expert == expert
+    assert math.isclose(sum(gates), 1.0, rel_tol=1e-12)
+    assert len(set(round(value, 8) for value in decoded)) > 1
+
+
+def test_stability_contract_rejects_rho_one():
+    with pytest.raises(ValueError):
+        FieldMechanics(omega_retention=1.0).validate()
+
+
+def test_cross_brick_laplacian_reads_neighbour_brick():
+    engine = TetrationFieldAutomaton(seed=3)
+    a = origin()
+    b = a.offset(1, 0, 0)
+    base_a = list(engine.procedural_brick(a))
+    base_b = list(engine.procedural_brick(b))
+    idx_a = engine._flat_index(0, 3, 1, 1)
+    idx_b = engine._flat_index(0, 0, 1, 1)
+    base_a[idx_a] = 20.0
+    base_b[idx_b] = 100.0
+    zero = tuple(0.0 for _ in range(BRICK_SIZE))
+    states = {
+        a: BrickState(tuple(base_a), zero),
+        b: BrickState(tuple(base_b), zero),
+    }
+    lap = engine._laplacian(states, a, 0, 3, 1, 1, 20.0)
+    local_other_five = (
+        engine._voxel_value(states, a, 0, 2, 1, 1)
+        + engine._voxel_value(states, a, 0, 3, 2, 1)
+        + engine._voxel_value(states, a, 0, 3, 0, 1)
+        + engine._voxel_value(states, a, 0, 3, 1, 2)
+        + engine._voxel_value(states, a, 0, 3, 1, 0)
+    )
+    assert math.isclose(lap, 100.0 + local_other_five - 120.0)
+
+
+def test_transaction_is_sparse_and_commits():
+    engine = TetrationFieldAutomaton(
+        mechanics=FieldMechanics(max_active_bricks=32),
+        latent_dim=8,
+        expert_count=3,
+    )
+    metrics = engine.step({origin(): make_brick_pulse(24.0)})
+    assert metrics.committed
+    assert metrics.materialised_bricks <= 32
+    assert metrics.frontier_bricks <= 32
+    assert sum(metrics.expert_histogram) == metrics.frontier_bricks
+    assert engine.snapshot()["universe"]["virtual_cells"] == "(1000^1000)^3"
+
+
+def test_exact_replay():
+    kwargs = dict(
+        mechanics=FieldMechanics(max_active_bricks=32),
+        latent_dim=8,
+        expert_count=3,
+        seed=99,
+        bucket_count=17,
+    )
+    left = TetrationFieldAutomaton(**kwargs)
+    right = TetrationFieldAutomaton(**kwargs)
+    workload = [{origin(): make_brick_pulse(20.0)}, None, None]
+    for injections in workload:
+        assert left.step(injections).to_dict() == right.step(injections).to_dict()
+    assert left.journal_hash == right.journal_hash
+
+
+def test_failed_injection_rolls_back():
+    engine = TetrationFieldAutomaton()
+    before = engine.snapshot()
+    metrics = engine.step({origin(): [1.0, 2.0]})
+    assert not metrics.committed
+    assert engine.snapshot()["cycle"] == before["cycle"]
+    assert engine.snapshot()["journal_hash"] == before["journal_hash"]


### PR DESCRIPTION
## What changed

This revision corrects the execution model from a sparse scalar cube to a sparse **brick field over a symbolic tetration address manifold**.

- defines `T_1 = 1000`, `T_{k+1} = 1000^{T_k}` and `U_k = {0,…,T_k-1}^3` symbolically
- keeps physical cost tied to the bounded materialised frontier `M_t`, never to `|U_k|`
- represents executable high-tower addresses as a finite chart identifier plus exact signed local offsets
- stores `3×4×4×4 = 192` values per materialised brick
- adds a finite hash directory with explicit collision chaining
- treats the active mask as sparse directory membership and threshold scheduling
- replaces partial encoding with a full `192 → d` projection
- conditions the latent state through `W_omega Omega`
- implements softmax routing with an audited **top-1** expert index
- replaces constant mean decoding with a full `d → 192` decoder projection
- implements `Omega_{t+1} = rho Omega_t - eta E_t` with `0 < rho < 1`
- implements the six-face discrete Laplacian across neighbouring bricks rather than periodic in-brick wrapping
- projects field values into `[16, 235]`
- commits a same-key sparse latent repository `Z_t` alongside `B_t` and `Omega_t`
- seals the committed latent repository into the deterministic journal
- rolls back the field, latent repository, Omega state, cycle, metrics, and journal together if latent verification fails
- enforces `dt*D <= 1/6`, `dt*K <= 1`, Omega bounds, energy limits, active-brick caps, pruning, atomic rollback, and deterministic journal chaining
- routes the CLI, package default, and FastAPI surfaces through the operational tetration field runtime
- retains the earlier scalar and transaction-local field classes as compatibility/reference layers
- updates package metadata to `0.3.0`

## Operational cycle

```text
symbolic address
→ collision-chained sparse lookup
→ active frontier
→ full brick encoder
→ Omega conditioning
→ softmax/top-1 MoE
→ full brick decoder
→ residual
→ leaky Omega recurrence
→ cross-brick six-face diffusion
→ Lambda box projection
→ re-encode committed Z
→ verify B/Z/Omega key and dimension invariants
→ commit or rollback all sparse stores
→ seal journal
```

## Physical state and complexity

```text
Sigma_t = (A_t, B_t, Z_t, Omega_t)
```

For latent dimension `d` and `M_t` materialised bricks:

```text
Time   O(M_t * (192*d + d^2 + 192*6))
Memory O(M_t * (192 + d + 192))
```

The tetration height changes the symbolic address description, not the number of bricks physically evaluated per cycle.

## VM integration corrections

The full repository test run exposed two pre-existing VM defects, both fixed here:

1. `OmegaLedger` stored a byte payload that `PersistentLedger` could not serialize with `json.dump`. Ledger records are now canonical JSON, deterministically hash-chained by sequence, and persisted with atomic replacement.
2. `CodexVM` applied reflex stabilization after every bytecode instruction, silently changing `Phi` between `SET` and `ADD` and turning `10 + 20` into `29`. Reflex execution is now explicit and opt-in, preserving ordinary ISA semantics by default.

## Validation

Regression coverage includes:

- tetration descriptors and symbolic higher towers
- hash collision chaining
- full nonconstant `192 → d → 192` projection
- softmax/top-1 routing
- `0 < rho < 1`
- cross-brick face diffusion
- sparse frontier caps and pruning
- exact replay
- malformed-observation rollback
- committed latent-repository key/dimension invariants
- B/Z/Omega replay and journal determinism
- forced latent failure with atomic restoration
- JSON-serializable deterministic VM ledger
- ordinary VM arithmetic without hidden reflex mutation

GitHub Actions `Jarvis-X CI` run #349 is fully green:

- Python 3.8: pytest, coverage, Codecov — pass
- Python 3.9: pytest, coverage, Codecov — pass
- Python 3.10: pytest, coverage, Codecov — pass
- Python 3.11: pytest, coverage, Codecov — pass
- Python 3.12: pytest, coverage, Codecov — pass
- Black/isort code-quality job — pass
- mypy type-check job — pass

## Review status

Draft and mergeable. The central review question is whether the symbolic chart address contract and finite frontier policy are the correct operational boundary for higher tetration towers.