### PR TITLE
Permeate bitwise Dr Moagi 3D runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,42 @@ Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
+```
+
+## Dr Moagi M.M ROM Ω³ 6400³ reference runtime
+
+The repository includes a sparse, bit-accurate reference implementation of the
+3D auto-encoding and decoding engine. It models a logical 6400 × 6400 × 6400
+lattice of 128-bit cells without allocating the full 4.194304 TB address space.
+
+```python
+from jarvisx.dr_moagi_3d import DrMoagiEngine, REQUIRED_VERIFICATION
+
+engine = DrMoagiEngine()
+decoded, committed, coordinate = engine.cycle(
+    b"ABCDEF",
+    REQUIRED_VERIFICATION,
+    candidate_loss=1,
+    active_loss=2,
+)
+
+assert decoded == b"ABCDEF"
+assert committed
+print(coordinate)
+```
+
+Run the focused tests with:
+
+```bash
+pip install -e ".[test]"
+pytest -q tests/test_dr_moagi_3d.py
+```
+
+See `docs/DR_MOAGI_3D_BITWISE_RUNTIME.md` for the address equations, 128-bit
+cell and instruction layouts, fixed-point datapath, Ω update and Λ commit gate.

--- a/docs/DR_MOAGI_3D_BITWISE_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_BITWISE_RUNTIME.md
@@ -1,0 +1,228 @@
+# Dr Moagi M.M ROM Ω³ — Bitwise 6400³ Runtime
+
+## Status
+
+Executable sparse reference implementation of the bit-level Dr Moagi 3D auto-encoding and decoding equation.
+
+This module operationalises the mathematical specifications in:
+
+- `docs/DR_MOAGI_3D_SWARM_BYTECODE_PERMEATED_MATHEMATICS.md`
+- `docs/Dr_Moagi_Equation_3D_Autoencoder_v4.txt`
+
+It is a deterministic reference runtime, not a claim that a physical 4.194304 TB deployment already exists.
+
+## Logical substrate
+
+The virtual lattice is:
+
+\[
+6400^3=262{,}144{,}000{,}000\text{ cells}.
+\]
+
+Each cell is 128 bits or 16 bytes:
+
+\[
+262{,}144{,}000{,}000\times16
+=4{,}194{,}304{,}000{,}000\text{ bytes}.
+\]
+
+The runtime materialises only addressed cells in a sparse dictionary.
+
+Each axis is divided into 100 blocks of 64 cells. A cloud cube therefore contains:
+
+\[
+64^3\times16=4{,}194{,}304\text{ bytes}=4\text{ MiB}.
+\]
+
+## Address equations
+
+For coordinate \(r=(x,y,z)\), with every component in `[0, 6399]`:
+
+\[
+a=x+6400(y+6400z),
+\qquad b=a\ll4.
+\]
+
+The global cell address needs 38 bits; the byte address needs 42 bits.
+
+For sparse cloud routing:
+
+\[
+x=64c_x+l_x,\quad y=64c_y+l_y,\quad z=64c_z+l_z,
+\]
+
+\[
+C=c_x+100(c_y+100c_z),
+\]
+
+\[
+L=l_x\;|\;(l_y\ll6)\;|\;(l_z\ll12),
+\]
+
+\[
+K=(C\ll18)\;|\;L.
+\]
+
+## 128-bit cell
+
+```text
+127       120 119       112 111          96 95           80
++-------------+-------------+----------------+---------------+
+| CLASS 8     | STATE 8     | VERSION 16     | EVIDENCE 16   |
++-------------+-------------+----------------+---------------+
+| PARENT 32                                                   |
++-------------------------------------------------------------+
+| PAYLOAD 48                                                  |
++-------------------------------------------------------------+
+47                                                            0
+```
+
+A latent payload packs six signed eight-bit symbols.
+
+## 128-bit instruction
+
+```text
+127      120 119      112 111       100 99         88
++-----------+------------+-------------+--------------+
+| OPCODE 8  | MODE 8     | DST 12      | SRC 12       |
++-----------+------------+-------------+--------------+
+| CELL ADDRESS 38                                      |
++------------------------------------------------------+
+| IMMEDIATE 50                                         |
++------------------------------------------------------+
+49                                                     0
+```
+
+The ISA includes the external pipeline and inward operations:
+
+```text
+OBSERVE NORMALISE ENCODE QUANTISE ROUTE3D READROM WRITETX
+FUSE EXECUTE DECODE COMPARE OMEGA VERIFY COMMIT ROLLBACK
+SELF_SCAN SELF_ENCODE SELF_FORK SELF_MUTATE SELF_COMPILE
+SELF_TEST SELF_SCORE SELF_SEAL
+```
+
+## Fixed-point datapath
+
+Input byte \(u\) is normalised to signed Q1.14:
+
+\[
+x_q=(u-128)\ll7.
+\]
+
+The encoder uses signed multiply-accumulate arithmetic:
+
+\[
+z_i=
+\operatorname{sat}_{16}
+\left(
+\operatorname{roundshift}_{14}
+\left[
+(b_i\ll14)+\sum_j w_{ij}x_j
+\right]
+\right).
+\]
+
+Latents are quantised to signed bytes:
+
+\[
+q_i=\operatorname{sat}_8(\operatorname{roundshift}_7(z_i)),
+\qquad
+\widetilde z_i=q_i\ll7.
+\]
+
+Three latent dimensions route the cell into the 3D lattice:
+
+\[
+r_i=\min\left(6399,\frac{(z_i+16384)6400}{32768}\right).
+\]
+
+The decoder applies the inverse fixed-point matrix and maps Q1.14 back to bytes.
+
+## Ω correction
+
+The executable shift-exact residual memory update is:
+
+\[
+\Omega_{t+1}
+=
+\operatorname{sat}_{16}
+\left[
+\Omega_t-(\Omega_t\gg3)+(E_t\gg4)
+\right].
+\]
+
+The reference identity codec has zero reconstruction residual. Non-identity learned matrices can generate and accumulate bounded correction terms.
+
+## Inward self-encoding
+
+`DrMoagiEngine.self_encode()` routes an authorised six-byte self-state frame through the same encoder, quantiser, cell packer and 3D router as external data.
+
+Larger source, bytecode, trace or configuration states must first be deterministically framed, chunked or hashed. Self-state data is never granted commit authority merely because it was self-generated.
+
+## Λ verification and commit
+
+A candidate receives thirteen independent verification bits:
+
+```text
+parsed, shapes, memory bounds, opcode legality, deterministic replay,
+unit tests, integration tests, held-out tests, security tests,
+resource limits, semantic equivalence, no regression, authorised
+```
+
+The gate is:
+
+\[
+g_t=V_t\land H_t,
+\]
+
+where \(V_t\) means all required verification bits are set and \(H_t\) means the candidate loss beats the active loss by the required margin.
+
+The final update is literal bitwise selection:
+
+\[
+\Xi_{t+1}
+=
+(M_t\land\Xi'_t)
+\lor
+(\neg M_t\land\Xi_t),
+\]
+
+where \(M_t\) is 128 one-bits when `g_t=1`, otherwise 128 zero-bits.
+
+## Running the tests
+
+```bash
+pip install -e ".[test]"
+pytest -q tests/test_dr_moagi_3d.py
+```
+
+The tests validate:
+
+- 6400³ capacity arithmetic;
+- coordinate and address boundaries;
+- exact byte → Q1.14 → int8 → byte conversion;
+- 128-bit cell packing;
+- 128-bit instruction packing;
+- deterministic encode/decode;
+- transactional commit and rollback;
+- Ω shift arithmetic;
+- complete verification-mask enforcement.
+
+## Reference cycle
+
+```python
+from jarvisx.dr_moagi_3d import DrMoagiEngine, REQUIRED_VERIFICATION
+
+engine = DrMoagiEngine()
+decoded, committed, coordinate = engine.cycle(
+    b"ABCDEF",
+    REQUIRED_VERIFICATION,
+    candidate_loss=1,
+    active_loss=2,
+)
+
+assert decoded == b"ABCDEF"
+assert committed
+print(coordinate, engine.version)
+```

--- a/proto/jarvis_x_engine.py
+++ b/proto/jarvis_x_engine.py
@@ -1,1 +1,26 @@
-<CONTENT PLACEHOLDER>
+"""Runnable Dr Moagi M.M ROM Ω³ reference demonstration."""
+
+from jarvisx.dr_moagi_3d import DrMoagiEngine, REQUIRED_VERIFICATION
+
+
+def main() -> None:
+    engine = DrMoagiEngine()
+    source = b"JARVIS"
+    decoded, committed, coordinate = engine.cycle(
+        source,
+        REQUIRED_VERIFICATION,
+        candidate_loss=1,
+        active_loss=2,
+    )
+
+    print("input:", source)
+    print("decoded:", decoded)
+    print("coordinate:", coordinate)
+    print("cell address:", coordinate.cell_address)
+    print("cube/local:", coordinate.cube_id, coordinate.local_address)
+    print("committed:", committed)
+    print("version:", engine.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/__init__.py
+++ b/src/jarvisx/__init__.py
@@ -1,0 +1,5 @@
+"""Jarvis-X deterministic virtual machine primitives."""
+
+from .dr_moagi_3d import DrMoagiEngine, GeometricCodec
+
+__all__ = ["DrMoagiEngine", "GeometricCodec"]

--- a/src/jarvisx/dr_moagi_3d.py
+++ b/src/jarvisx/dr_moagi_3d.py
@@ -1,0 +1,488 @@
+"""Sparse, bit-accurate Dr Moagi M.M ROM Ω³ 6400³ reference runtime."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum, IntFlag
+from typing import Dict, List, Sequence, Tuple
+
+AXIS = 6400
+CUBE_EDGE = 64
+CUBES_PER_AXIS = 100
+CELL_BYTES = 16
+TOTAL_CELLS = AXIS**3
+TOTAL_BYTES = TOTAL_CELLS * CELL_BYTES
+CUBE_BYTES = CUBE_EDGE**3 * CELL_BYTES
+Q14_SHIFT = 14
+Q14_ONE = 1 << Q14_SHIFT
+I8_MIN, I8_MAX = -128, 127
+I16_MIN, I16_MAX = -32768, 32767
+U38_MASK = (1 << 38) - 1
+U48_MASK = (1 << 48) - 1
+U50_MASK = (1 << 50) - 1
+U128_MASK = (1 << 128) - 1
+
+
+def clamp(v: int, lo: int, hi: int) -> int:
+    return lo if v < lo else hi if v > hi else v
+
+
+def sat_i8(v: int) -> int:
+    return clamp(v, I8_MIN, I8_MAX)
+
+
+def sat_i16(v: int) -> int:
+    return clamp(v, I16_MIN, I16_MAX)
+
+
+def rounded_shift(v: int, shift: int) -> int:
+    if shift < 0:
+        raise ValueError("shift must be non-negative")
+    if shift == 0:
+        return v
+    half = 1 << (shift - 1)
+    return (v + half) >> shift if v >= 0 else -(((-v) + half) >> shift)
+
+
+def q14_from_byte(v: int) -> int:
+    if not 0 <= v <= 255:
+        raise ValueError("byte must be in [0, 255]")
+    return (v - 128) << 7
+
+
+def q14_to_byte(v: int) -> int:
+    return clamp((sat_i16(v) >> 7) + 128, 0, 255)
+
+
+def q14_mul(a: int, b: int) -> int:
+    return sat_i16(rounded_shift(a * b, Q14_SHIFT))
+
+
+def quantize_q14_to_i8(v: int) -> int:
+    return sat_i8(rounded_shift(sat_i16(v), 7))
+
+
+def dequantize_i8_to_q14(v: int) -> int:
+    if not I8_MIN <= v <= I8_MAX:
+        raise ValueError("value must fit signed int8")
+    return v << 7
+
+
+def _u8(v: int) -> int:
+    if not I8_MIN <= v <= I8_MAX:
+        raise ValueError("value must fit signed int8")
+    return v & 255
+
+
+def _i8(v: int) -> int:
+    return v - 256 if v & 128 else v
+
+
+@dataclass(frozen=True)
+class Coordinate3D:
+    x: int
+    y: int
+    z: int
+
+    def __post_init__(self) -> None:
+        if any(not 0 <= v < AXIS for v in (self.x, self.y, self.z)):
+            raise ValueError("coordinates must be in [0, 6399]")
+
+    @property
+    def cell_address(self) -> int:
+        return self.x + AXIS * (self.y + AXIS * self.z)
+
+    @property
+    def byte_address(self) -> int:
+        return self.cell_address << 4
+
+    @property
+    def cube_coordinate(self) -> Tuple[int, int, int]:
+        return self.x >> 6, self.y >> 6, self.z >> 6
+
+    @property
+    def local_coordinate(self) -> Tuple[int, int, int]:
+        return self.x & 63, self.y & 63, self.z & 63
+
+    @property
+    def cube_id(self) -> int:
+        cx, cy, cz = self.cube_coordinate
+        return cx + 100 * (cy + 100 * cz)
+
+    @property
+    def local_address(self) -> int:
+        lx, ly, lz = self.local_coordinate
+        return lx | (ly << 6) | (lz << 12)
+
+    @property
+    def sparse_key(self) -> int:
+        return (self.cube_id << 18) | self.local_address
+
+    @classmethod
+    def from_cell_address(cls, address: int) -> "Coordinate3D":
+        if not 0 <= address < TOTAL_CELLS:
+            raise ValueError("cell address out of range")
+        z, rem = divmod(address, AXIS * AXIS)
+        y, x = divmod(rem, AXIS)
+        return cls(x, y, z)
+
+
+class CellClass(IntEnum):
+    RAW_INPUT = 1
+    FEATURE = 2
+    LATENT = 3
+    BYTECODE = 4
+    OUTPUT = 5
+    RESIDUAL = 6
+    OMEGA = 7
+    TRACE = 8
+    CANDIDATE = 9
+    VERIFICATION = 10
+    JOURNAL = 11
+    INTEGRITY = 12
+
+
+class CellState(IntFlag):
+    VALID = 1 << 0
+    DIRTY = 1 << 1
+    CANDIDATE = 1 << 2
+    VERIFIED = 1 << 3
+    COMMITTED = 1 << 4
+    IMMUTABLE = 1 << 5
+    TOMBSTONE = 1 << 6
+
+
+def pack_i8x6(values: Sequence[int]) -> int:
+    if len(values) != 6:
+        raise ValueError("six signed int8 values required")
+    out = 0
+    for i, value in enumerate(values):
+        out |= _u8(value) << (8 * i)
+    return out
+
+
+def unpack_i8x6(payload: int) -> Tuple[int, int, int, int, int, int]:
+    if not 0 <= payload <= U48_MASK:
+        raise ValueError("payload must fit 48 bits")
+    values = [_i8((payload >> (8 * i)) & 255) for i in range(6)]
+    return tuple(values)  # type: ignore[return-value]
+
+
+@dataclass(frozen=True)
+class RomCell:
+    cell_class: CellClass
+    state: CellState
+    version: int
+    evidence: int
+    parent: int
+    payload: int
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.version <= 0xFFFF:
+            raise ValueError("version must fit 16 bits")
+        if not 0 <= self.evidence <= 0xFFFF:
+            raise ValueError("evidence must fit 16 bits")
+        if not 0 <= self.parent <= 0xFFFFFFFF:
+            raise ValueError("parent must fit 32 bits")
+        if not 0 <= self.payload <= U48_MASK:
+            raise ValueError("payload must fit 48 bits")
+
+    def pack(self) -> int:
+        return ((int(self.cell_class) << 120) | (int(self.state) << 112) |
+                (self.version << 96) | (self.evidence << 80) |
+                (self.parent << 48) | self.payload)
+
+    @classmethod
+    def unpack(cls, value: int) -> "RomCell":
+        if not 0 <= value <= U128_MASK:
+            raise ValueError("cell must fit 128 bits")
+        return cls(CellClass((value >> 120) & 255), CellState((value >> 112) & 255),
+                   (value >> 96) & 0xFFFF, (value >> 80) & 0xFFFF,
+                   (value >> 48) & 0xFFFFFFFF, value & U48_MASK)
+
+    @classmethod
+    def latent(cls, values: Sequence[int], version: int = 0, parent: int = 0) -> "RomCell":
+        return cls(CellClass.LATENT, CellState.VALID | CellState.CANDIDATE,
+                   version, 0, parent, pack_i8x6(values))
+
+
+class Opcode(IntEnum):
+    OBSERVE = 0x01
+    NORMALISE = 0x02
+    ENCODE = 0x03
+    QUANTISE = 0x04
+    ROUTE3D = 0x05
+    READROM = 0x06
+    WRITETX = 0x07
+    FUSE = 0x08
+    EXECUTE = 0x09
+    DECODE = 0x0A
+    COMPARE = 0x0B
+    OMEGA = 0x0C
+    VERIFY = 0x0D
+    COMMIT = 0x0E
+    ROLLBACK = 0x0F
+    SELF_SCAN = 0x20
+    SELF_ENCODE = 0x21
+    SELF_FORK = 0x22
+    SELF_MUTATE = 0x23
+    SELF_COMPILE = 0x24
+    SELF_TEST = 0x25
+    SELF_SCORE = 0x26
+    SELF_SEAL = 0x27
+
+
+@dataclass(frozen=True)
+class Instruction:
+    opcode: Opcode
+    mode: int = 0
+    dst: int = 0
+    src: int = 0
+    coordinate: int = 0
+    immediate: int = 0
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.mode <= 255:
+            raise ValueError("mode must fit 8 bits")
+        if not 0 <= self.dst <= 0xFFF or not 0 <= self.src <= 0xFFF:
+            raise ValueError("registers must fit 12 bits")
+        if not 0 <= self.coordinate < TOTAL_CELLS:
+            raise ValueError("coordinate out of range")
+        if not 0 <= self.immediate <= U50_MASK:
+            raise ValueError("immediate must fit 50 bits")
+
+    def pack(self) -> int:
+        return ((int(self.opcode) << 120) | (self.mode << 112) |
+                (self.dst << 100) | (self.src << 88) |
+                (self.coordinate << 50) | self.immediate)
+
+    @classmethod
+    def unpack(cls, value: int) -> "Instruction":
+        if not 0 <= value <= U128_MASK:
+            raise ValueError("instruction must fit 128 bits")
+        return cls(Opcode((value >> 120) & 255), (value >> 112) & 255,
+                   (value >> 100) & 0xFFF, (value >> 88) & 0xFFF,
+                   (value >> 50) & U38_MASK, value & U50_MASK)
+
+
+class VerificationBit(IntFlag):
+    PARSED = 1 << 0
+    SHAPES = 1 << 1
+    MEMORY_BOUNDS = 1 << 2
+    OPCODE_LEGALITY = 1 << 3
+    DETERMINISTIC_REPLAY = 1 << 4
+    UNIT_TESTS = 1 << 5
+    INTEGRATION_TESTS = 1 << 6
+    HELD_OUT_TESTS = 1 << 7
+    SECURITY_TESTS = 1 << 8
+    RESOURCE_LIMITS = 1 << 9
+    SEMANTIC_EQUIVALENCE = 1 << 10
+    NO_REGRESSION = 1 << 11
+    AUTHORISED = 1 << 12
+
+
+REQUIRED_VERIFICATION = VerificationBit((1 << 13) - 1)
+
+
+def bitwise_select_u128(active: int, candidate: int, commit: bool) -> int:
+    if any(not 0 <= v <= U128_MASK for v in (active, candidate)):
+        raise ValueError("states must fit 128 bits")
+    mask = U128_MASK if commit else 0
+    return (mask & candidate) | ((U128_MASK ^ mask) & active)
+
+
+def commit_gate(active: int, candidate: int, verification: VerificationBit, *,
+                candidate_loss: int, active_loss: int,
+                required_margin: int = 0) -> Tuple[int, bool]:
+    verified = (verification & REQUIRED_VERIFICATION) == REQUIRED_VERIFICATION
+    commit = bool(verified and candidate_loss + required_margin < active_loss)
+    return bitwise_select_u128(active, candidate, commit), commit
+
+
+@dataclass
+class SparseRom:
+    """Only touched cells are materialised; the logical lattice remains 6400³."""
+    cells: Dict[int, int] = field(default_factory=dict)
+    immutable: set = field(default_factory=set)
+
+    def read(self, coordinate: Coordinate3D) -> int:
+        return self.cells.get(coordinate.cell_address, 0)
+
+    def begin(self) -> "RomTransaction":
+        return RomTransaction(self)
+
+
+@dataclass
+class RomTransaction:
+    rom: SparseRom
+    staged: Dict[int, int] = field(default_factory=dict)
+    closed: bool = False
+
+    def write(self, coordinate: Coordinate3D, value: int) -> None:
+        if self.closed:
+            raise RuntimeError("transaction closed")
+        address = coordinate.cell_address
+        if address in self.rom.immutable:
+            raise PermissionError("immutable cell")
+        if not 0 <= value <= U128_MASK:
+            raise ValueError("cell must fit 128 bits")
+        self.staged[address] = value
+
+    def rollback(self) -> None:
+        self.staged.clear()
+        self.closed = True
+
+    def commit(self, verification: VerificationBit, *, candidate_loss: int,
+               active_loss: int, required_margin: int = 0,
+               make_immutable: bool = False) -> bool:
+        if self.closed:
+            raise RuntimeError("transaction closed")
+        accepted = ((verification & REQUIRED_VERIFICATION) == REQUIRED_VERIFICATION and
+                    candidate_loss + required_margin < active_loss)
+        if accepted:
+            self.rom.cells.update(self.staged)
+            if make_immutable:
+                self.rom.immutable.update(self.staged)
+        self.staged.clear()
+        self.closed = True
+        return bool(accepted)
+
+
+@dataclass(frozen=True)
+class FixedPointLinear:
+    weights: Tuple[Tuple[int, ...], ...]
+    bias: Tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.weights or not self.weights[0]:
+            raise ValueError("weights cannot be empty")
+        width = len(self.weights[0])
+        if any(len(row) != width for row in self.weights):
+            raise ValueError("ragged weight matrix")
+        if len(self.bias) != len(self.weights):
+            raise ValueError("bias/output mismatch")
+
+    @property
+    def input_width(self) -> int:
+        return len(self.weights[0])
+
+    @property
+    def output_width(self) -> int:
+        return len(self.weights)
+
+    def __call__(self, values: Sequence[int]) -> Tuple[int, ...]:
+        if len(values) != self.input_width:
+            raise ValueError("input width mismatch")
+        output: List[int] = []
+        for row, bias in zip(self.weights, self.bias):
+            acc = bias << Q14_SHIFT
+            for weight, value in zip(row, values):
+                acc += weight * value
+            output.append(sat_i16(rounded_shift(acc, Q14_SHIFT)))
+        return tuple(output)
+
+    @classmethod
+    def identity(cls, width: int) -> "FixedPointLinear":
+        rows = tuple(tuple(Q14_ONE if i == j else 0 for j in range(width))
+                     for i in range(width))
+        return cls(rows, tuple(0 for _ in range(width)))
+
+
+@dataclass(frozen=True)
+class EncodedBlock:
+    coordinate: Coordinate3D
+    latent_q14: Tuple[int, ...]
+    quantized: Tuple[int, int, int, int, int, int]
+    cell: RomCell
+
+
+@dataclass(frozen=True)
+class GeometricCodec:
+    encoder: FixedPointLinear
+    decoder: FixedPointLinear
+
+    def __post_init__(self) -> None:
+        if self.encoder.output_width != 6 or self.decoder.input_width != 6:
+            raise ValueError("one 128-bit cell requires six latent channels")
+        if self.decoder.output_width != self.encoder.input_width:
+            raise ValueError("encoder/decoder width mismatch")
+
+    @classmethod
+    def identity(cls, width: int = 6) -> "GeometricCodec":
+        if width != 6:
+            raise ValueError("reference cell width is six")
+        linear = FixedPointLinear.identity(width)
+        return cls(linear, linear)
+
+    @staticmethod
+    def _coordinate(latent: Sequence[int]) -> Coordinate3D:
+        def project(v: int) -> int:
+            return min(AXIS - 1, ((sat_i16(v) + 16384) * AXIS) >> 15)
+        return Coordinate3D(project(latent[0]), project(latent[1]), project(latent[2]))
+
+    def encode(self, data: bytes, *, version: int = 0, parent: int = 0) -> EncodedBlock:
+        if len(data) != self.encoder.input_width:
+            raise ValueError("input block width mismatch")
+        latent = self.encoder(tuple(q14_from_byte(v) for v in data))
+        quantized = tuple(quantize_q14_to_i8(v) for v in latent)
+        return EncodedBlock(self._coordinate(latent), latent, quantized,  # type: ignore[arg-type]
+                            RomCell.latent(quantized, version, parent))
+
+    def decode(self, cell_value: int) -> bytes:
+        cell = RomCell.unpack(cell_value)
+        if cell.cell_class != CellClass.LATENT:
+            raise ValueError("not a latent cell")
+        latent = tuple(dequantize_i8_to_q14(v) for v in unpack_i8x6(cell.payload))
+        return bytes(q14_to_byte(v) for v in self.decoder(latent))
+
+    def encode_into(self, tx: RomTransaction, data: bytes, *, version: int = 0) -> EncodedBlock:
+        block = self.encode(data, version=version)
+        tx.write(block.coordinate, block.cell.pack())
+        return block
+
+
+def omega_update(omega_q14: int, error_q14: int) -> int:
+    return sat_i16(omega_q14 - (omega_q14 >> 3) + (error_q14 >> 4))
+
+
+def reconstruction_error(actual: bytes, decoded: bytes) -> Tuple[int, ...]:
+    if len(actual) != len(decoded):
+        raise ValueError("length mismatch")
+    return tuple(sat_i16(q14_from_byte(a) - q14_from_byte(b))
+                 for a, b in zip(actual, decoded))
+
+
+@dataclass
+class DrMoagiEngine:
+    codec: GeometricCodec = field(default_factory=GeometricCodec.identity)
+    rom: SparseRom = field(default_factory=SparseRom)
+    omega: Tuple[int, ...] = (0, 0, 0, 0, 0, 0)
+    version: int = 0
+
+    def cycle(self, data: bytes, verification: VerificationBit, *,
+              candidate_loss: int, active_loss: int,
+              required_margin: int = 0) -> Tuple[bytes, bool, Coordinate3D]:
+        tx = self.rom.begin()
+        block = self.codec.encode_into(tx, data, version=self.version + 1)
+        decoded = self.codec.decode(block.cell.pack())
+        errors = reconstruction_error(data, decoded)
+        candidate_omega = tuple(omega_update(o, e) for o, e in zip(self.omega, errors))
+        committed = tx.commit(verification, candidate_loss=candidate_loss,
+                              active_loss=active_loss, required_margin=required_margin)
+        if committed:
+            self.version += 1
+            self.omega = candidate_omega
+        return decoded, committed, block.coordinate
+
+    def self_encode(self, authorised_state: bytes) -> EncodedBlock:
+        """Encode one authorised six-byte self-state frame through the same path."""
+        return self.codec.encode(authorised_state, version=self.version)
+
+
+__all__ = [
+    "AXIS", "CELL_BYTES", "CUBE_BYTES", "TOTAL_BYTES", "Coordinate3D",
+    "CellClass", "CellState", "RomCell", "Opcode", "Instruction",
+    "VerificationBit", "REQUIRED_VERIFICATION", "SparseRom", "RomTransaction",
+    "FixedPointLinear", "GeometricCodec", "EncodedBlock", "DrMoagiEngine",
+    "q14_from_byte", "q14_to_byte", "q14_mul", "quantize_q14_to_i8",
+    "dequantize_i8_to_q14", "omega_update", "commit_gate",
+]

--- a/tests/test_dr_moagi_3d.py
+++ b/tests/test_dr_moagi_3d.py
@@ -1,0 +1,140 @@
+import pytest
+
+from jarvisx.dr_moagi_3d import (
+    AXIS,
+    CUBE_BYTES,
+    REQUIRED_VERIFICATION,
+    TOTAL_BYTES,
+    CellClass,
+    Coordinate3D,
+    DrMoagiEngine,
+    GeometricCodec,
+    Instruction,
+    Opcode,
+    RomCell,
+    VerificationBit,
+    commit_gate,
+    dequantize_i8_to_q14,
+    omega_update,
+    q14_from_byte,
+    q14_to_byte,
+    quantize_q14_to_i8,
+)
+
+
+def test_capacity_and_cube_geometry() -> None:
+    assert AXIS == 6400
+    assert CUBE_BYTES == 4 * 1024 * 1024
+    assert TOTAL_BYTES == 4_194_304_000_000
+
+
+def test_coordinate_round_trip_and_bounds() -> None:
+    coordinate = Coordinate3D(6399, 6399, 6399)
+    assert Coordinate3D.from_cell_address(coordinate.cell_address) == coordinate
+    assert coordinate.cell_address == AXIS**3 - 1
+    assert coordinate.byte_address == TOTAL_BYTES - 16
+    assert coordinate.cube_coordinate == (99, 99, 99)
+    assert coordinate.local_coordinate == (63, 63, 63)
+
+    with pytest.raises(ValueError):
+        Coordinate3D(6400, 0, 0)
+
+
+def test_byte_q14_quantization_round_trip() -> None:
+    for value in range(256):
+        q14 = q14_from_byte(value)
+        quantized = quantize_q14_to_i8(q14)
+        restored = dequantize_i8_to_q14(quantized)
+        assert q14_to_byte(restored) == value
+
+
+def test_rom_cell_pack_round_trip() -> None:
+    block = GeometricCodec.identity().encode(b"ABCDEF", version=7, parent=11)
+    restored = RomCell.unpack(block.cell.pack())
+    assert restored == block.cell
+    assert restored.cell_class == CellClass.LATENT
+
+
+def test_instruction_pack_round_trip() -> None:
+    coordinate = Coordinate3D(123, 456, 789)
+    instruction = Instruction(
+        Opcode.SELF_ENCODE,
+        mode=2,
+        dst=31,
+        src=17,
+        coordinate=coordinate.cell_address,
+        immediate=0x12345,
+    )
+    assert Instruction.unpack(instruction.pack()) == instruction
+
+
+def test_identity_codec_is_bit_exact() -> None:
+    codec = GeometricCodec.identity()
+    encoded = codec.encode(b"ABCDEF")
+    assert codec.decode(encoded.cell.pack()) == b"ABCDEF"
+
+
+def test_commit_requires_all_verification_bits_and_improvement() -> None:
+    active = 0x1111
+    candidate = 0x2222
+
+    selected, committed = commit_gate(
+        active,
+        candidate,
+        REQUIRED_VERIFICATION,
+        candidate_loss=9,
+        active_loss=10,
+    )
+    assert committed is True
+    assert selected == candidate
+
+    selected, committed = commit_gate(
+        active,
+        candidate,
+        VerificationBit.PARSED,
+        candidate_loss=0,
+        active_loss=10,
+    )
+    assert committed is False
+    assert selected == active
+
+    selected, committed = commit_gate(
+        active,
+        candidate,
+        REQUIRED_VERIFICATION,
+        candidate_loss=10,
+        active_loss=10,
+    )
+    assert committed is False
+    assert selected == active
+
+
+def test_engine_commit_and_rollback() -> None:
+    engine = DrMoagiEngine()
+
+    decoded, committed, coordinate = engine.cycle(
+        b"ABCDEF",
+        REQUIRED_VERIFICATION,
+        candidate_loss=1,
+        active_loss=2,
+    )
+    assert decoded == b"ABCDEF"
+    assert committed is True
+    assert engine.rom.read(coordinate) != 0
+    assert engine.version == 1
+
+    decoded, committed, rejected_coordinate = engine.cycle(
+        b"UVWXYZ",
+        VerificationBit.PARSED,
+        candidate_loss=0,
+        active_loss=2,
+    )
+    assert decoded == b"UVWXYZ"
+    assert committed is False
+    assert engine.rom.read(rejected_coordinate) == 0
+    assert engine.version == 1
+
+
+def test_omega_shift_exact_update() -> None:
+    assert omega_update(0, 1600) == 100
+    assert omega_update(800, 0) == 700


### PR DESCRIPTION
## What changed

- adds a sparse 6400³ logical ROM runtime with 128-bit cells
- implements 38-bit 3D addressing and 4 MiB cloud-cube decomposition
- adds deterministic signed Q1.14 encoding, int8 quantisation and decoding
- packs and unpacks 128-bit ROM cells and bytecode instructions
- adds Ω residual-memory updates and a literal bitwise Λ commit selector
- turns authorised six-byte self-state frames inward through the same encoder
- replaces the prototype placeholder with a runnable demonstration
- documents the complete bitwise execution path
- adds focused unit tests for addressing, arithmetic, packing, commit and rollback

## Why

The repository already contains the canonical Dr Moagi 3D mathematical specifications, but the prototype was still a placeholder. This change establishes a small executable reference substrate that can be tested and evolved without pretending to allocate the complete 4.194304 TB logical lattice.

## Validation

Validated against the exact proposed module and tests with:

```text
9 passed in 0.06s
```

The tests cover all 256 byte values through byte → Q1.14 → int8 → byte conversion, address boundaries, cell/instruction round trips, transactional acceptance/rejection and Ω shift arithmetic.

## Design constraints

- sparse materialisation only
- deterministic integer arithmetic
- no candidate write reaches committed ROM without the full verification bitmap and an objective loss improvement
- immutable cells reject staged writes
- no claim of a physically deployed 4.194304 TB cloud runtime
