### PR TITLE
Operationalize Dr Moagi spatial world loop

### DIFF
--- a/.github/workflows/spatial-runtime-ci.yml
+++ b/.github/workflows/spatial-runtime-ci.yml
@@ -1,0 +1,47 @@
+name: Dr Moagi Spatial Runtime CI
+
+on:
+  push:
+    branches: [agent/dr-moagi-spatial-runtime]
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "src/jarvisx/spatial/**"
+      - "tests/test_spatial_runtime.py"
+      - "examples/dr_moagi_spatial_echo.py"
+      - "docs/DR_MOAGI_SPATIAL_RUNTIME.md"
+      - ".github/workflows/spatial-runtime-ci.yml"
+
+jobs:
+  spatial-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e ".[test]"
+
+      - name: Run repository test suite with retained transcript
+        id: pytest
+        shell: bash
+        run: |
+          set +e
+          pytest -v --tb=long 2>&1 | tee pytest.log
+          status=${PIPESTATUS[0]}
+          echo "exit_code=${status}" >> "$GITHUB_OUTPUT"
+          exit "$status"
+
+      - name: Upload pytest transcript
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spatial-runtime-pytest-log
+          path: pytest.log
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -4,12 +4,76 @@ Jarvis-X is a deterministic, auditable virtual machine with a reflex
 control layer and policy gate.
 
 ## Install
+
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
 cd Jarvis-X
 pip install -r requirements.txt
 pip install .
 ```
+
+## Dr Moagi Operational Spatial Runtime
+
+`jarvisx.spatial` is the first executable architectural-spatial intelligence
+kernel. It provides:
+
+- a canonical hierarchical world-state contract;
+- typed architectural entities and relations;
+- deterministic 3D predicates for support, containment, intersection, and
+  relative height;
+- a multi-term objective over geometry, semantics, relations, hierarchy,
+  architecture, physics, uncertainty, and description length;
+- a bounded propose-shadow-verify-commit echo controller;
+- rollback, journaling, canonical serialization, and real SHA-256 world-state
+  fingerprints.
+
+```python
+from jarvisx.spatial import (
+    AABB,
+    ArchitecturalWorldModel,
+    EchoController,
+    Entity,
+    EntityKind,
+    Relation,
+    RelationKind,
+    Vector3,
+)
+
+world = ArchitecturalWorldModel()
+world.add_entity(
+    Entity(
+        "table",
+        EntityKind.OBJECT,
+        AABB(Vector3(-1, -0.5, 0), Vector3(1, 0.5, 1)),
+        semantic_label="table",
+    )
+)
+world.add_entity(
+    Entity(
+        "lamp",
+        EntityKind.OBJECT,
+        AABB(Vector3(-0.2, -0.2, 1.2), Vector3(0.2, 0.2, 2.2)),
+        semantic_label="lamp",
+    )
+)
+world.add_relation(Relation("table", "lamp", RelationKind.SUPPORTS))
+
+controller = EchoController(world)
+reports = controller.auto_repair_supports()
+
+assert reports[0].accepted
+assert controller.world.revision == 1
+assert len(controller.world.fingerprint()) == 64
+```
+
+Run the complete example with:
+
+```bash
+python examples/dr_moagi_spatial_echo.py
+```
+
+The formal operational boundary and integration roadmap are documented in
+[`docs/DR_MOAGI_SPATIAL_RUNTIME.md`](docs/DR_MOAGI_SPATIAL_RUNTIME.md).
 
 ## Sparse Fractal Octree
 

--- a/docs/DR_MOAGI_SPATIAL_RUNTIME.md
+++ b/docs/DR_MOAGI_SPATIAL_RUNTIME.md
@@ -1,0 +1,252 @@
+# Dr Moagi Operational Spatial Runtime
+
+## Status
+
+This document defines the first executable boundary of the Dr Moagi
+architectural-spatial intelligence framework inside Jarvis-X.
+
+The implementation in `jarvisx.spatial` is a deterministic world-state,
+geometry, verification, provenance, and rollback kernel. It does **not** claim
+that image perception, neural 3D reconstruction, rendering, BIM export, or
+language-conditioned planning are complete. Those systems must compile their
+outputs into the world-state contract defined here.
+
+## 1. System boundary
+
+Jarvis-X is divided into two planes:
+
+1. **Spatial intelligence plane** — perception, geometry, entities, relations,
+   architectural constraints, uncertainty, and reasoning.
+2. **Control plane** — policy, transactions, verification, journaling,
+   deterministic execution, commit, and rollback.
+
+The spatial plane produces candidate worlds. The control plane decides whether
+a candidate is admissible.
+
+```text
+observation -> world hypothesis -> shadow correction -> verification
+      ^                                                |
+      |                                                v
+      +------------- committed world <- commit/rollback
+```
+
+## 2. Canonical world state
+
+The operational state is:
+
+\[
+\mathcal W_t=(\mathcal G_t,\mathcal F_t,\mathcal K_t,\mathcal U_t,\mathcal M_t),
+\]
+
+where:
+
+- `G`: hierarchical entity and relation graph;
+- `F`: future continuous geometric or renderable field;
+- `K`: geometric, physical, architectural, and policy constraints;
+- `U`: uncertainty and confidence;
+- `M`: temporal identity and revision history.
+
+The current executable milestone implements the discrete, auditable subset:
+
+\[
+\mathcal W_t^{(0)}=(V_t,E_t,K_t,U_t,J_t).
+\]
+
+## 3. Entity hierarchy
+
+The implemented entity kinds are:
+
+```text
+surface -> part -> object -> opening/boundary -> room -> zone -> building
+```
+
+Every entity contains:
+
+- stable identifier;
+- entity kind;
+- axis-aligned 3D bounds;
+- semantic label;
+- confidence;
+- uncertainty;
+- optional parent identifier;
+- typed metadata.
+
+Axis-aligned boxes are intentionally the first geometry contract. They make
+spatial predicates deterministic and testable. Future mesh, Gaussian, SDF,
+point-map, or `SE(3)` pose representations can be attached without changing
+entity identity or relation semantics.
+
+## 4. Relation ontology
+
+The runtime declares geometric, constructive, spatial, and functional
+relations, including:
+
+- `above`, `below`, `inside`, `intersects`;
+- `aligned`, `parallel`, `orthogonal`;
+- `supports`, `attached_to`, `embedded_in`, `spans`, `encloses`;
+- `adjacent`, `connected_through`, `visible_from`, `accessible_from`;
+- `used_for`, `serves`, `controls`, `permits`, `obstructs`.
+
+Relations are directed and confidence-bearing. The present verification kernel
+has hard geometric validators for `supports` and `inside`. Other predicates are
+part of the stable ontology and will acquire validators incrementally.
+
+## 5. Geometric predicates
+
+For a supporter box `A` and supported box `B`, support requires:
+
+\[
+|z_{B,\min}-z_{A,\max}|\leq\varepsilon
+\]
+
+and:
+
+\[
+\frac{\operatorname{area}(A_{xy}\cap B_{xy})}
+{\operatorname{area}(B_{xy})}\geq\tau.
+\]
+
+The denominator is the supported object's footprint. A large floor can
+therefore completely support a small object.
+
+Containment requires both corners of an inner box to lie inside the outer box,
+within the declared tolerance.
+
+## 6. Operational objective
+
+The executable objective is decomposed as:
+
+\[
+\mathcal F=
+\lambda_gL_g+
+\lambda_sL_s+
+\lambda_rL_r+
+\lambda_hL_h+
+\lambda_aL_a+
+\lambda_pL_p+
+\lambda_uL_u+
+\lambda_mL_{MDL}.
+\]
+
+The current terms measure:
+
+- invalid or degenerate geometry;
+- semantic confidence error;
+- relation confidence error;
+- parent-child containment error;
+- architectural containment error;
+- physical support error;
+- entity uncertainty;
+- description length relative to a declared budget.
+
+Observation, rendering, and query terms are present in the objective contract
+but remain zero until their corresponding subsystems are connected.
+
+## 7. Verified echo loop
+
+A correction is never committed directly.
+
+```text
+PROPOSE -> SHADOW -> SCORE -> VALIDATE -> COMMIT or REJECT
+```
+
+For candidate `W'` and committed world `W`, acceptance requires:
+
+\[
+\mathcal F(\mathcal W')
+\leq
+\mathcal F(\mathcal W)-\delta
+\]
+
+and:
+
+\[
+\operatorname{Violations}(\mathcal W')=\varnothing.
+\]
+
+A successful commit:
+
+1. increments the revision;
+2. records the previous fingerprint;
+3. records the operation and rationale;
+4. appends the score change to the journal;
+5. stores a rollback snapshot.
+
+A failed proposal cannot mutate the committed world.
+
+## 8. Bounded auto-repair
+
+`EchoController.auto_repair_supports()` is the first complete automatic
+operation. It:
+
+1. finds the first declared support relation that fails geometric validation;
+2. computes the exact vertical correction required to close the support gap;
+3. creates a shadow world;
+4. evaluates the candidate;
+5. validates all hard constraints;
+6. commits only when the objective improves;
+7. fingerprints and journals the revision;
+8. stops at a declared maximum number of steps.
+
+This is bounded self-correction, not unrestricted self-rewriting.
+
+## 9. Cryptographic anchoring
+
+Every world has a canonical JSON serialization. Entity and relation ordering is
+normalized before serialization. The operational fingerprint is:
+
+\[
+h_t=\operatorname{SHA256}(\operatorname{CanonicalJSON}(\mathcal W_t)).
+\]
+
+The digest is computed by the runtime; it is not a conceptual placeholder.
+
+## 10. Running the milestone
+
+```bash
+python examples/dr_moagi_spatial_echo.py
+pytest -q tests/test_spatial_runtime.py
+```
+
+The demonstration begins with a lamp floating above a table while a `supports`
+relation is declared. The echo controller closes the vertical gap, verifies the
+new state, commits revision 1, and emits a SHA-256 fingerprint and journal.
+
+## 11. Integration contract for perception models
+
+A future image or multi-view encoder must produce:
+
+```python
+ArchitecturalWorldModel(
+    entities={...},
+    relations=[...],
+    metadata={
+        "observation_ids": [...],
+        "camera_model": "...",
+        "model_version": "...",
+        "calibration": {...},
+    },
+)
+```
+
+It must not bypass verification by directly mutating committed state.
+
+## 12. Next operational increments
+
+1. Add oriented boxes and `SE(3)` poses.
+2. Add room, opening, adjacency, and circulation validators.
+3. Add probabilistic multi-hypothesis worlds.
+4. Add observation and differentiable-rendering residuals.
+5. Add a geometry compiler for images, video, depth, or point clouds.
+6. Add open-vocabulary object and relation compilation.
+7. Add BIM/IFC and glTF projections.
+8. Bind spatial commits into the existing persistent Jarvis-X ledger.
+9. Add benchmark gates for geometry, relation recall, architectural reasoning,
+   uncertainty calibration, and rollback integrity.
+
+## 13. Non-claims
+
+This milestone is not a trained architectural vision model and is not evidence
+of general intelligence. It is the deterministic operational substrate needed
+for such models to produce auditable, geometrically testable, reversible world
+states.

--- a/examples/dr_moagi_spatial_echo.py
+++ b/examples/dr_moagi_spatial_echo.py
@@ -1,0 +1,53 @@
+"""Minimal executable Dr Moagi spatial echo demonstration."""
+
+from jarvisx.spatial import (
+    AABB,
+    ArchitecturalWorldModel,
+    EchoController,
+    Entity,
+    EntityKind,
+    Relation,
+    RelationKind,
+    Vector3,
+)
+
+
+def main() -> None:
+    world = ArchitecturalWorldModel(metadata={"source": "synthetic-demo"})
+    world.add_entity(
+        Entity(
+            "table",
+            EntityKind.OBJECT,
+            AABB(Vector3(-1.0, -0.5, 0.0), Vector3(1.0, 0.5, 1.0)),
+            semantic_label="table",
+        )
+    )
+    world.add_entity(
+        Entity(
+            "lamp",
+            EntityKind.OBJECT,
+            AABB(Vector3(-0.2, -0.2, 1.2), Vector3(0.2, 0.2, 2.2)),
+            semantic_label="lamp",
+        )
+    )
+    world.add_relation(Relation("table", "lamp", RelationKind.SUPPORTS))
+
+    controller = EchoController(world)
+    print("baseline score:", controller.score(controller.world))
+    print("baseline fingerprint:", controller.world.fingerprint())
+
+    reports = controller.auto_repair_supports()
+    for report in reports:
+        print("operation:", report.operation)
+        print("accepted:", report.accepted)
+        print("improvement:", report.improvement)
+        print("violations:", report.violations)
+
+    print("committed revision:", controller.world.revision)
+    print("committed score:", controller.score(controller.world))
+    print("committed fingerprint:", controller.world.fingerprint())
+    print("journal:", controller.journal)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,16 @@
 import hashlib
 import time
 
+
 class OmegaLedger:
     def __init__(self):
         self.chain = []
 
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        """Append a JSON-serializable hash-linked ledger entry."""
+
+        payload = "{}|{}|{}".format(time.time(), state, opcode)
+        previous_hash = self.chain[-1]["hash"] if self.chain else ""
+        digest_input = (previous_hash + payload).encode("utf-8")
+        entry_hash = hashlib.sha256(digest_input).hexdigest()
+        self.chain.append({"hash": entry_hash, "payload": payload})

--- a/src/jarvisx/reflex.py
+++ b/src/jarvisx/reflex.py
@@ -1,6 +1,23 @@
 class ReflexEngine:
+    """Optional bounded proportional correction for the dedicated state pair.
+
+    Reflex correction is disabled by default so ordinary VM instructions retain
+    exact register semantics. Systems that intentionally use the Ψ/Φ feedback
+    pair must opt in explicitly.
+    """
+
+    def __init__(self, gain=0.1, enabled=False):
+        if gain < 0.0:
+            raise ValueError("gain must be non-negative")
+        self.gain = gain
+        self.enabled = enabled
+
     def stabilize(self, regs):
+        if not self.enabled:
+            return 0
+
         psi = regs["Ψ"]
         phi = regs["Φ"]
-        delta = int(0.1 * (psi - phi))
-        regs["Φ"] += delta
+        correction = int(self.gain * (psi - phi))
+        regs["Φ"] += correction
+        return correction

--- a/src/jarvisx/spatial/__init__.py
+++ b/src/jarvisx/spatial/__init__.py
@@ -1,0 +1,34 @@
+"""Operational spatial-world kernel for the Dr Moagi framework.
+
+The package keeps perception models separate from the auditable world state.
+External encoders can populate :class:`ArchitecturalWorldModel`; the geometry,
+verification, echo, and provenance layers remain deterministic and testable.
+"""
+
+from .echo import EchoCandidate, EchoController, ObjectiveTerms, VerificationReport
+from .geometry import AABB, Vector3, above, inside, intersects, supports
+from .world import (
+    ArchitecturalWorldModel,
+    Entity,
+    EntityKind,
+    Relation,
+    RelationKind,
+)
+
+__all__ = [
+    "AABB",
+    "ArchitecturalWorldModel",
+    "EchoCandidate",
+    "EchoController",
+    "Entity",
+    "EntityKind",
+    "ObjectiveTerms",
+    "Relation",
+    "RelationKind",
+    "Vector3",
+    "VerificationReport",
+    "above",
+    "inside",
+    "intersects",
+    "supports",
+]

--- a/src/jarvisx/spatial/echo.py
+++ b/src/jarvisx/spatial/echo.py
@@ -1,0 +1,334 @@
+"""Verified propose-shadow-commit loop for architectural world states."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Mapping, Optional, Tuple
+
+from .geometry import Vector3, inside, supports
+from .world import ArchitecturalWorldModel, Relation, RelationKind
+
+
+DEFAULT_WEIGHTS = {
+    "observation": 0.00,
+    "geometry": 0.10,
+    "semantics": 0.10,
+    "relations": 0.10,
+    "hierarchy": 0.15,
+    "architecture": 0.20,
+    "physics": 0.30,
+    "uncertainty": 0.10,
+    "mdl": 0.05,
+    "query": 0.00,
+}
+
+
+@dataclass(frozen=True)
+class ObjectiveTerms:
+    """Normalized components of the operational Dr Moagi objective."""
+
+    observation: float = 0.0
+    geometry: float = 0.0
+    semantics: float = 0.0
+    relations: float = 0.0
+    hierarchy: float = 0.0
+    architecture: float = 0.0
+    physics: float = 0.0
+    uncertainty: float = 0.0
+    mdl: float = 0.0
+    query: float = 0.0
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "observation": self.observation,
+            "geometry": self.geometry,
+            "semantics": self.semantics,
+            "relations": self.relations,
+            "hierarchy": self.hierarchy,
+            "architecture": self.architecture,
+            "physics": self.physics,
+            "uncertainty": self.uncertainty,
+            "mdl": self.mdl,
+            "query": self.query,
+        }
+
+    def total(self, weights: Optional[Mapping[str, float]] = None) -> float:
+        active_weights = DEFAULT_WEIGHTS if weights is None else weights
+        values = self.as_dict()
+        unknown = set(active_weights) - set(values)
+        if unknown:
+            raise ValueError("unknown objective terms: {}".format(sorted(unknown)))
+        return sum(values[name] * weight for name, weight in active_weights.items())
+
+
+@dataclass(frozen=True)
+class EchoCandidate:
+    """A shadow world-state proposal that has not yet been committed."""
+
+    world: ArchitecturalWorldModel
+    operation: str
+    rationale: str = ""
+
+
+@dataclass(frozen=True)
+class VerificationReport:
+    """Complete decision record for one candidate world state."""
+
+    accepted: bool
+    baseline_score: float
+    candidate_score: float
+    violations: Tuple[str, ...]
+    baseline_fingerprint: str
+    candidate_fingerprint: str
+    operation: str
+
+    @property
+    def improvement(self) -> float:
+        return self.baseline_score - self.candidate_score
+
+
+@dataclass
+class EchoController:
+    """Deterministic world-state optimizer with shadow verification and rollback."""
+
+    initial_world: ArchitecturalWorldModel
+    description_budget: int = 100
+    minimum_improvement: float = 1e-9
+    support_tolerance: float = 0.05
+    weights: Mapping[str, float] = field(default_factory=lambda: dict(DEFAULT_WEIGHTS))
+
+    def __post_init__(self) -> None:
+        if self.description_budget <= 0:
+            raise ValueError("description_budget must be positive")
+        if self.minimum_improvement < 0.0:
+            raise ValueError("minimum_improvement must be non-negative")
+        self._world = self.initial_world.clone()
+        self._history = [self._world.clone()]
+        self.journal = []
+
+    @property
+    def world(self) -> ArchitecturalWorldModel:
+        return self._world.clone()
+
+    def evaluate(self, world: ArchitecturalWorldModel) -> ObjectiveTerms:
+        entities = list(world.entities.values())
+        relations = list(world.relations)
+
+        entity_count = max(1, len(entities))
+        relation_count = max(1, len(relations))
+
+        geometry_errors = sum(
+            1 for entity in entities if entity.bounds.volume <= 0.0
+        ) / float(entity_count)
+        semantic_error = sum(1.0 - entity.confidence for entity in entities) / float(
+            entity_count
+        )
+        relation_error = sum(
+            1.0 - relation.confidence for relation in relations
+        ) / float(relation_count)
+        uncertainty_error = sum(entity.uncertainty for entity in entities) / float(
+            entity_count
+        )
+
+        parented = [entity for entity in entities if entity.parent_id is not None]
+        hierarchy_errors = 0
+        for entity in parented:
+            parent = world.entities.get(entity.parent_id)
+            if parent is None or not inside(
+                entity.bounds, parent.bounds, tolerance=self.support_tolerance
+            ):
+                hierarchy_errors += 1
+        hierarchy_error = hierarchy_errors / float(max(1, len(parented)))
+
+        support_relations = [
+            relation
+            for relation in relations
+            if relation.kind == RelationKind.SUPPORTS
+        ]
+        support_errors = 0
+        for relation in support_relations:
+            source = world.entities[relation.source_id]
+            target = world.entities[relation.target_id]
+            if not supports(
+                source.bounds,
+                target.bounds,
+                tolerance=self.support_tolerance,
+            ):
+                support_errors += 1
+        physics_error = support_errors / float(max(1, len(support_relations)))
+
+        inside_relations = [
+            relation for relation in relations if relation.kind == RelationKind.INSIDE
+        ]
+        inside_errors = 0
+        for relation in inside_relations:
+            source = world.entities[relation.source_id]
+            target = world.entities[relation.target_id]
+            if not inside(
+                source.bounds,
+                target.bounds,
+                tolerance=self.support_tolerance,
+            ):
+                inside_errors += 1
+        architecture_error = inside_errors / float(max(1, len(inside_relations)))
+
+        mdl = (len(entities) + len(relations)) / float(self.description_budget)
+
+        return ObjectiveTerms(
+            geometry=geometry_errors,
+            semantics=semantic_error,
+            relations=relation_error,
+            hierarchy=hierarchy_error,
+            architecture=architecture_error,
+            physics=physics_error,
+            uncertainty=uncertainty_error,
+            mdl=mdl,
+        )
+
+    def score(self, world: ArchitecturalWorldModel) -> float:
+        return self.evaluate(world).total(self.weights)
+
+    def propose_move(
+        self,
+        identifier: str,
+        delta: Vector3,
+        rationale: str = "",
+    ) -> EchoCandidate:
+        shadow = self._world.clone()
+        shadow.move_entity(identifier, delta)
+        return EchoCandidate(
+            world=shadow,
+            operation="move:{}:{},{},{}".format(
+                identifier, delta.x, delta.y, delta.z
+            ),
+            rationale=rationale,
+        )
+
+    def propose_relation(
+        self,
+        relation: Relation,
+        rationale: str = "",
+    ) -> EchoCandidate:
+        shadow = self._world.clone()
+        shadow.add_relation(relation)
+        return EchoCandidate(
+            world=shadow,
+            operation="relate:{}:{}:{}".format(
+                relation.source_id,
+                relation.kind.value,
+                relation.target_id,
+            ),
+            rationale=rationale,
+        )
+
+    def verify(self, candidate: EchoCandidate) -> VerificationReport:
+        baseline_score = self.score(self._world)
+        candidate_score = self.score(candidate.world)
+        violations = tuple(
+            candidate.world.validate(support_tolerance=self.support_tolerance)
+        )
+        accepted = (
+            not violations
+            and candidate_score
+            <= baseline_score - self.minimum_improvement
+        )
+        return VerificationReport(
+            accepted=accepted,
+            baseline_score=baseline_score,
+            candidate_score=candidate_score,
+            violations=violations,
+            baseline_fingerprint=self._world.fingerprint(),
+            candidate_fingerprint=candidate.world.fingerprint(),
+            operation=candidate.operation,
+        )
+
+    def commit(
+        self,
+        candidate: EchoCandidate,
+        report: Optional[VerificationReport] = None,
+    ) -> ArchitecturalWorldModel:
+        active_report = self.verify(candidate) if report is None else report
+        if not active_report.accepted:
+            raise ValueError("candidate failed verification")
+        if active_report.candidate_fingerprint != candidate.world.fingerprint():
+            raise ValueError("candidate changed after verification")
+
+        committed = candidate.world.clone()
+        committed.revision = self._world.revision + 1
+        committed.metadata["previous_fingerprint"] = self._world.fingerprint()
+        committed.metadata["operation"] = candidate.operation
+        committed.metadata["rationale"] = candidate.rationale
+
+        self._world = committed
+        self._history.append(committed.clone())
+        self.journal.append(
+            {
+                "event": "commit",
+                "revision": committed.revision,
+                "operation": candidate.operation,
+                "baseline_score": active_report.baseline_score,
+                "candidate_score": active_report.candidate_score,
+                "improvement": active_report.improvement,
+                "fingerprint": committed.fingerprint(),
+            }
+        )
+        return committed.clone()
+
+    def rollback(self) -> ArchitecturalWorldModel:
+        if len(self._history) <= 1:
+            raise RuntimeError("no committed revision available for rollback")
+        removed = self._history.pop()
+        self._world = self._history[-1].clone()
+        self.journal.append(
+            {
+                "event": "rollback",
+                "removed_revision": removed.revision,
+                "restored_revision": self._world.revision,
+                "fingerprint": self._world.fingerprint(),
+            }
+        )
+        return self._world.clone()
+
+    def auto_repair_supports(self, max_steps: int = 16) -> List[VerificationReport]:
+        """Repair vertical support gaps using verified, reversible moves.
+
+        This is intentionally bounded. It performs no unconstrained source-code
+        rewriting and no opaque neural mutation; every candidate is evaluated,
+        verified, fingerprinted, and journaled.
+        """
+
+        if max_steps < 1:
+            raise ValueError("max_steps must be at least 1")
+
+        reports = []
+        for _ in range(max_steps):
+            invalid_relation = None
+            for relation in self._world.iter_relations(RelationKind.SUPPORTS):
+                supporter = self._world.entities[relation.source_id]
+                supported = self._world.entities[relation.target_id]
+                if not supports(
+                    supporter.bounds,
+                    supported.bounds,
+                    tolerance=self.support_tolerance,
+                ):
+                    invalid_relation = relation
+                    break
+
+            if invalid_relation is None:
+                break
+
+            supporter = self._world.entities[invalid_relation.source_id]
+            supported = self._world.entities[invalid_relation.target_id]
+            delta_z = supporter.bounds.maximum.z - supported.bounds.minimum.z
+            candidate = self.propose_move(
+                supported.identifier,
+                Vector3(0.0, 0.0, delta_z),
+                rationale="close support gap declared by {}->{}".format(
+                    supporter.identifier, supported.identifier
+                ),
+            )
+            report = self.verify(candidate)
+            reports.append(report)
+            if not report.accepted:
+                break
+            self.commit(candidate, report)
+
+        return reports

--- a/src/jarvisx/spatial/geometry.py
+++ b/src/jarvisx/spatial/geometry.py
@@ -1,0 +1,150 @@
+"""Deterministic geometric primitives and architectural predicates."""
+
+from dataclasses import dataclass
+from math import sqrt
+
+
+@dataclass(frozen=True)
+class Vector3:
+    """Three-dimensional Euclidean vector."""
+
+    x: float
+    y: float
+    z: float
+
+    def __add__(self, other: "Vector3") -> "Vector3":
+        return Vector3(self.x + other.x, self.y + other.y, self.z + other.z)
+
+    def __sub__(self, other: "Vector3") -> "Vector3":
+        return Vector3(self.x - other.x, self.y - other.y, self.z - other.z)
+
+    def scale(self, factor: float) -> "Vector3":
+        return Vector3(self.x * factor, self.y * factor, self.z * factor)
+
+    def norm(self) -> float:
+        return sqrt(self.x ** 2 + self.y ** 2 + self.z ** 2)
+
+    def as_tuple(self):
+        return (self.x, self.y, self.z)
+
+
+@dataclass(frozen=True)
+class AABB:
+    """Axis-aligned bounding box used by the deterministic spatial kernel."""
+
+    minimum: Vector3
+    maximum: Vector3
+
+    def __post_init__(self) -> None:
+        if (
+            self.minimum.x > self.maximum.x
+            or self.minimum.y > self.maximum.y
+            or self.minimum.z > self.maximum.z
+        ):
+            raise ValueError("minimum corner must not exceed maximum corner")
+
+    @property
+    def center(self) -> Vector3:
+        return Vector3(
+            (self.minimum.x + self.maximum.x) / 2.0,
+            (self.minimum.y + self.maximum.y) / 2.0,
+            (self.minimum.z + self.maximum.z) / 2.0,
+        )
+
+    @property
+    def size(self) -> Vector3:
+        return self.maximum - self.minimum
+
+    @property
+    def volume(self) -> float:
+        size = self.size
+        return size.x * size.y * size.z
+
+    @property
+    def footprint_area(self) -> float:
+        size = self.size
+        return size.x * size.y
+
+    def translated(self, delta: Vector3) -> "AABB":
+        return AABB(self.minimum + delta, self.maximum + delta)
+
+    def contains_point(self, point: Vector3, tolerance: float = 0.0) -> bool:
+        return (
+            self.minimum.x - tolerance <= point.x <= self.maximum.x + tolerance
+            and self.minimum.y - tolerance <= point.y <= self.maximum.y + tolerance
+            and self.minimum.z - tolerance <= point.z <= self.maximum.z + tolerance
+        )
+
+    def contains_box(self, other: "AABB", tolerance: float = 0.0) -> bool:
+        return self.contains_point(other.minimum, tolerance) and self.contains_point(
+            other.maximum, tolerance
+        )
+
+    def horizontal_overlap_area(self, other: "AABB") -> float:
+        x_overlap = max(
+            0.0,
+            min(self.maximum.x, other.maximum.x)
+            - max(self.minimum.x, other.minimum.x),
+        )
+        y_overlap = max(
+            0.0,
+            min(self.maximum.y, other.maximum.y)
+            - max(self.minimum.y, other.minimum.y),
+        )
+        return x_overlap * y_overlap
+
+
+def distance(first: AABB, second: AABB) -> float:
+    """Euclidean center-to-center distance."""
+
+    return (first.center - second.center).norm()
+
+
+def intersects(first: AABB, second: AABB, tolerance: float = 0.0) -> bool:
+    """Return whether two boxes overlap or touch within a tolerance."""
+
+    return not (
+        first.maximum.x < second.minimum.x - tolerance
+        or second.maximum.x < first.minimum.x - tolerance
+        or first.maximum.y < second.minimum.y - tolerance
+        or second.maximum.y < first.minimum.y - tolerance
+        or first.maximum.z < second.minimum.z - tolerance
+        or second.maximum.z < first.minimum.z - tolerance
+    )
+
+
+def inside(inner: AABB, outer: AABB, tolerance: float = 0.0) -> bool:
+    """Return whether ``inner`` is contained by ``outer``."""
+
+    return outer.contains_box(inner, tolerance=tolerance)
+
+
+def above(upper: AABB, lower: AABB, tolerance: float = 0.0) -> bool:
+    """Return whether the upper object's bottom is above the lower object's top."""
+
+    return upper.minimum.z >= lower.maximum.z - tolerance
+
+
+def supports(
+    supporter: AABB,
+    supported: AABB,
+    tolerance: float = 0.05,
+    minimum_overlap_ratio: float = 0.2,
+) -> bool:
+    """Test contact and horizontal overlap for a support relationship.
+
+    The overlap ratio is measured against the supported object's footprint,
+    because a large floor supporting a small object should score as complete
+    support rather than as a tiny fraction of the floor.
+    """
+
+    if not 0.0 <= minimum_overlap_ratio <= 1.0:
+        raise ValueError("minimum_overlap_ratio must be in [0, 1]")
+
+    vertical_gap = abs(supported.minimum.z - supporter.maximum.z)
+    footprint = supported.footprint_area
+    if footprint <= 0.0:
+        return False
+
+    overlap_ratio = supporter.horizontal_overlap_area(supported) / footprint
+    return vertical_gap <= tolerance and overlap_ratio >= minimum_overlap_ratio

--- a/src/jarvisx/spatial/world.py
+++ b/src/jarvisx/spatial/world.py
@@ -1,0 +1,241 @@
+"""Canonical hierarchical world state for Dr Moagi spatial intelligence."""
+
+import copy
+import hashlib
+import json
+from dataclasses import dataclass, field, replace
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from .geometry import AABB, Vector3, inside, supports
+
+
+class EntityKind(str, Enum):
+    """Architectural entity hierarchy from local geometry to whole systems."""
+
+    SURFACE = "surface"
+    PART = "part"
+    OBJECT = "object"
+    OPENING = "opening"
+    BOUNDARY = "boundary"
+    ROOM = "room"
+    ZONE = "zone"
+    BUILDING = "building"
+
+
+class RelationKind(str, Enum):
+    """Geometric, constructive, spatial, and functional predicates."""
+
+    ABOVE = "above"
+    BELOW = "below"
+    INSIDE = "inside"
+    INTERSECTS = "intersects"
+    ALIGNED = "aligned"
+    PARALLEL = "parallel"
+    ORTHOGONAL = "orthogonal"
+    SUPPORTS = "supports"
+    ATTACHED_TO = "attached_to"
+    EMBEDDED_IN = "embedded_in"
+    SPANS = "spans"
+    ENCLOSES = "encloses"
+    ADJACENT = "adjacent"
+    CONNECTED_THROUGH = "connected_through"
+    VISIBLE_FROM = "visible_from"
+    ACCESSIBLE_FROM = "accessible_from"
+    USED_FOR = "used_for"
+    SERVES = "serves"
+    CONTROLS = "controls"
+    PERMITS = "permits"
+    OBSTRUCTS = "obstructs"
+
+
+@dataclass(frozen=True)
+class Entity:
+    """One identified architectural or scene entity."""
+
+    identifier: str
+    kind: EntityKind
+    bounds: AABB
+    semantic_label: str = "unknown"
+    confidence: float = 1.0
+    uncertainty: float = 0.0
+    parent_id: Optional[str] = None
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.identifier:
+            raise ValueError("entity identifier must not be empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("entity confidence must be in [0, 1]")
+        if not 0.0 <= self.uncertainty <= 1.0:
+            raise ValueError("entity uncertainty must be in [0, 1]")
+
+    def translated(self, delta: Vector3) -> "Entity":
+        return replace(self, bounds=self.bounds.translated(delta))
+
+
+@dataclass(frozen=True)
+class Relation:
+    """Directed typed relation between two world entities."""
+
+    source_id: str
+    target_id: str
+    kind: RelationKind
+    confidence: float = 1.0
+    attributes: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.source_id or not self.target_id:
+            raise ValueError("relation endpoints must not be empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("relation confidence must be in [0, 1]")
+
+
+@dataclass
+class ArchitecturalWorldModel:
+    """Auditable world hypothesis shared by rendering and reasoning layers."""
+
+    entities: Dict[str, Entity] = field(default_factory=dict)
+    relations: List[Relation] = field(default_factory=list)
+    revision: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def clone(self) -> "ArchitecturalWorldModel":
+        return copy.deepcopy(self)
+
+    def add_entity(self, entity: Entity) -> None:
+        if entity.identifier in self.entities:
+            raise ValueError("duplicate entity identifier: {}".format(entity.identifier))
+        if entity.parent_id is not None and entity.parent_id not in self.entities:
+            raise ValueError("unknown parent entity: {}".format(entity.parent_id))
+        self.entities[entity.identifier] = entity
+
+    def replace_entity(self, entity: Entity) -> None:
+        if entity.identifier not in self.entities:
+            raise KeyError(entity.identifier)
+        if entity.parent_id is not None and entity.parent_id not in self.entities:
+            raise ValueError("unknown parent entity: {}".format(entity.parent_id))
+        self.entities[entity.identifier] = entity
+
+    def move_entity(self, identifier: str, delta: Vector3) -> None:
+        self.replace_entity(self.entities[identifier].translated(delta))
+
+    def add_relation(self, relation: Relation) -> None:
+        if relation.source_id not in self.entities:
+            raise ValueError("unknown relation source: {}".format(relation.source_id))
+        if relation.target_id not in self.entities:
+            raise ValueError("unknown relation target: {}".format(relation.target_id))
+        if relation in self.relations:
+            raise ValueError("duplicate relation")
+        self.relations.append(relation)
+
+    def iter_relations(self, kind: Optional[RelationKind] = None) -> Iterable[Relation]:
+        for relation in self.relations:
+            if kind is None or relation.kind == kind:
+                yield relation
+
+    def validate(self, support_tolerance: float = 0.05) -> List[str]:
+        """Return deterministic hard-constraint violations."""
+
+        violations = []
+        for entity in self.entities.values():
+            if entity.parent_id is not None and entity.parent_id not in self.entities:
+                violations.append(
+                    "entity {} references missing parent {}".format(
+                        entity.identifier, entity.parent_id
+                    )
+                )
+
+        for relation in self.relations:
+            source = self.entities.get(relation.source_id)
+            target = self.entities.get(relation.target_id)
+            if source is None or target is None:
+                violations.append(
+                    "relation {}->{} has missing endpoint".format(
+                        relation.source_id, relation.target_id
+                    )
+                )
+                continue
+
+            if relation.kind == RelationKind.SUPPORTS and not supports(
+                source.bounds,
+                target.bounds,
+                tolerance=support_tolerance,
+            ):
+                violations.append(
+                    "{} does not geometrically support {}".format(
+                        relation.source_id, relation.target_id
+                    )
+                )
+
+            if relation.kind == RelationKind.INSIDE and not inside(
+                source.bounds, target.bounds, tolerance=support_tolerance
+            ):
+                violations.append(
+                    "{} is not geometrically inside {}".format(
+                        relation.source_id, relation.target_id
+                    )
+                )
+
+        return violations
+
+    def canonical_dict(self) -> Dict[str, Any]:
+        """Return a stable, serialization-ready representation."""
+
+        entities = []
+        for identifier in sorted(self.entities):
+            entity = self.entities[identifier]
+            entities.append(
+                {
+                    "identifier": entity.identifier,
+                    "kind": entity.kind.value,
+                    "semantic_label": entity.semantic_label,
+                    "confidence": entity.confidence,
+                    "uncertainty": entity.uncertainty,
+                    "parent_id": entity.parent_id,
+                    "bounds": {
+                        "minimum": entity.bounds.minimum.as_tuple(),
+                        "maximum": entity.bounds.maximum.as_tuple(),
+                    },
+                    "attributes": dict(sorted(entity.attributes.items())),
+                }
+            )
+
+        relations = []
+        for relation in sorted(
+            self.relations,
+            key=lambda value: (
+                value.source_id,
+                value.kind.value,
+                value.target_id,
+            ),
+        ):
+            relations.append(
+                {
+                    "source_id": relation.source_id,
+                    "target_id": relation.target_id,
+                    "kind": relation.kind.value,
+                    "confidence": relation.confidence,
+                    "attributes": dict(sorted(relation.attributes.items())),
+                }
+            )
+
+        return {
+            "revision": self.revision,
+            "entities": entities,
+            "relations": relations,
+            "metadata": dict(sorted(self.metadata.items())),
+        }
+
+    def canonical_json(self) -> str:
+        return json.dumps(
+            self.canonical_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+    def fingerprint(self) -> str:
+        """Compute a real SHA-256 digest over the canonical world state."""
+
+        return hashlib.sha256(self.canonical_json().encode("utf-8")).hexdigest()

--- a/tests/test_ledger_store.py
+++ b/tests/test_ledger_store.py
@@ -1,0 +1,32 @@
+import hashlib
+import json
+
+from jarvisx.ledger_store import PersistentLedger
+
+
+def test_persistent_ledger_is_json_serializable_and_hash_linked(tmp_path):
+    path = tmp_path / "omega_ledger.json"
+    ledger = PersistentLedger(path=str(path))
+
+    ledger.log({"A": 1}, 0x01)
+    ledger.log({"A": 2}, 0x03)
+
+    with path.open(encoding="utf-8") as handle:
+        persisted = json.load(handle)
+
+    assert len(persisted) == 2
+    assert isinstance(persisted[0]["payload"], str)
+    assert isinstance(persisted[1]["payload"], str)
+
+    first_expected = hashlib.sha256(
+        persisted[0]["payload"].encode("utf-8")
+    ).hexdigest()
+    second_expected = hashlib.sha256(
+        (persisted[0]["hash"] + persisted[1]["payload"]).encode("utf-8")
+    ).hexdigest()
+
+    assert persisted[0]["hash"] == first_expected
+    assert persisted[1]["hash"] == second_expected
+
+    reloaded = PersistentLedger(path=str(path))
+    assert reloaded.chain == persisted

--- a/tests/test_reflex.py
+++ b/tests/test_reflex.py
@@ -1,0 +1,31 @@
+import pytest
+
+from jarvisx.reflex import ReflexEngine
+from jarvisx.registers import Registers
+
+
+def test_reflex_is_non_mutating_by_default():
+    registers = Registers()
+    registers["Ψ"] = 10
+    registers["Φ"] = 20
+
+    correction = ReflexEngine().stabilize(registers)
+
+    assert correction == 0
+    assert registers["Φ"] == 20
+
+
+def test_reflex_can_be_enabled_explicitly():
+    registers = Registers()
+    registers["Ψ"] = 10
+    registers["Φ"] = 20
+
+    correction = ReflexEngine(gain=0.1, enabled=True).stabilize(registers)
+
+    assert correction == -1
+    assert registers["Φ"] == 19
+
+
+def test_reflex_rejects_negative_gain():
+    with pytest.raises(ValueError):
+        ReflexEngine(gain=-0.1)

--- a/tests/test_spatial_runtime.py
+++ b/tests/test_spatial_runtime.py
@@ -1,0 +1,135 @@
+from jarvisx.spatial import (
+    AABB,
+    ArchitecturalWorldModel,
+    EchoController,
+    Entity,
+    EntityKind,
+    Relation,
+    RelationKind,
+    Vector3,
+    supports,
+)
+
+
+def box(x0, y0, z0, x1, y1, z1):
+    return AABB(Vector3(x0, y0, z0), Vector3(x1, y1, z1))
+
+
+def floating_lamp_world():
+    world = ArchitecturalWorldModel()
+    world.add_entity(
+        Entity(
+            identifier="table",
+            kind=EntityKind.OBJECT,
+            semantic_label="table",
+            bounds=box(-1.0, -0.5, 0.0, 1.0, 0.5, 1.0),
+        )
+    )
+    world.add_entity(
+        Entity(
+            identifier="lamp",
+            kind=EntityKind.OBJECT,
+            semantic_label="lamp",
+            bounds=box(-0.2, -0.2, 1.2, 0.2, 0.2, 2.2),
+        )
+    )
+    world.add_relation(
+        Relation(
+            source_id="table",
+            target_id="lamp",
+            kind=RelationKind.SUPPORTS,
+        )
+    )
+    return world
+
+
+def test_support_predicate_detects_gap_and_contact():
+    table = box(-1.0, -0.5, 0.0, 1.0, 0.5, 1.0)
+    floating = box(-0.2, -0.2, 1.2, 0.2, 0.2, 2.2)
+    resting = box(-0.2, -0.2, 1.0, 0.2, 0.2, 2.0)
+
+    assert not supports(table, floating)
+    assert supports(table, resting)
+
+
+def test_auto_repair_closes_loop_and_records_provenance():
+    controller = EchoController(floating_lamp_world())
+    baseline_score = controller.score(controller.world)
+
+    reports = controller.auto_repair_supports()
+
+    assert len(reports) == 1
+    assert reports[0].accepted
+    assert reports[0].candidate_score < reports[0].baseline_score
+
+    committed = controller.world
+    assert committed.revision == 1
+    assert committed.metadata["operation"].startswith("move:lamp")
+    assert len(committed.fingerprint()) == 64
+    assert supports(
+        committed.entities["table"].bounds,
+        committed.entities["lamp"].bounds,
+    )
+    assert controller.score(committed) < baseline_score
+    assert controller.journal[-1]["event"] == "commit"
+
+
+def test_failed_candidate_does_not_mutate_committed_world():
+    controller = EchoController(floating_lamp_world())
+    baseline_fingerprint = controller.world.fingerprint()
+
+    candidate = controller.propose_move(
+        "lamp",
+        Vector3(0.0, 0.0, 1.0),
+        rationale="intentionally worsen the support gap",
+    )
+    report = controller.verify(candidate)
+
+    assert not report.accepted
+    assert report.violations
+    assert controller.world.fingerprint() == baseline_fingerprint
+
+
+def test_rollback_restores_previous_verified_revision():
+    controller = EchoController(floating_lamp_world())
+    reports = controller.auto_repair_supports()
+    assert reports[0].accepted
+
+    restored = controller.rollback()
+
+    assert restored.revision == 0
+    assert not supports(
+        restored.entities["table"].bounds,
+        restored.entities["lamp"].bounds,
+    )
+    assert controller.journal[-1]["event"] == "rollback"
+
+
+def test_fingerprint_is_independent_of_insertion_order():
+    first = ArchitecturalWorldModel()
+    second = ArchitecturalWorldModel()
+
+    table = Entity(
+        identifier="table",
+        kind=EntityKind.OBJECT,
+        semantic_label="table",
+        bounds=box(-1.0, -0.5, 0.0, 1.0, 0.5, 1.0),
+    )
+    lamp = Entity(
+        identifier="lamp",
+        kind=EntityKind.OBJECT,
+        semantic_label="lamp",
+        bounds=box(-0.2, -0.2, 1.0, 0.2, 0.2, 2.0),
+    )
+
+    first.add_entity(table)
+    first.add_entity(lamp)
+    second.add_entity(lamp)
+    second.add_entity(table)
+
+    relation = Relation("table", "lamp", RelationKind.SUPPORTS)
+    first.add_relation(relation)
+    second.add_relation(relation)
+
+    assert first.canonical_json() == second.canonical_json()
+    assert first.fingerprint() == second.fingerprint()


### PR DESCRIPTION
## What changed

### Dr Moagi spatial kernel

- add `jarvisx.spatial`, a deterministic architectural world-state kernel
- define typed entity and relation ontologies across surfaces, parts, objects, rooms, zones, and buildings
- add 3D AABB geometry and support, containment, intersection, and height predicates
- implement a weighted objective over geometry, semantics, relations, hierarchy, architecture, physics, uncertainty, and description length
- implement a bounded propose-shadow-verify-commit echo controller with rollback and journaling
- compute real SHA-256 fingerprints over canonical world-state JSON
- add an automatic support-gap repair demonstration
- add README integration and the formal operational runtime specification

### Integration hardening

Repository-wide validation exposed and fixed three inherited blockers:

1. `pyproject.toml` requested the unsupported pytest-cov reporter `term-local`; it now uses `term-missing`.
2. `OmegaLedger` stored byte payloads that `PersistentLedger` could not JSON-serialize; entries now use hash-linked UTF-8 text payloads.
3. `ReflexEngine` mutated the program-visible `Φ` register after every VM instruction, corrupting exact instruction semantics; reflex correction is now explicit and opt-in.

### Tests and diagnostics

- add focused spatial echo, provenance, rejection, rollback, and canonical-fingerprint tests
- add persistent-ledger serialization and hash-chain tests
- add reflex default-safety and opt-in behavior tests
- add a dedicated spatial runtime workflow that retains the complete pytest transcript as an artifact

## Why

The existing project had a strong systems specification and a neural autoencoder prototype, but no stable executable contract between future image/3D perception models and the Jarvis-X control plane. This PR creates that boundary without overstating perception capabilities.

## Operational behavior

The included demo starts from a declared but geometrically invalid `table supports lamp` relation. The controller computes a bounded vertical correction, evaluates it in a shadow world, rejects hard-constraint violations, commits only if the objective improves, fingerprints the committed revision, journals the operation, and supports rollback.

## Developer impact

Future geometry, scene-graph, rendering, language, BIM, and multimodal components can compile into `ArchitecturalWorldModel` rather than mutating opaque latent state directly.

## Validation

All current checks pass on head `6e0474b3ec07fdcc94eabbd97f835d313e2b4918`:

- dedicated Dr Moagi Spatial Runtime CI: passed
- pytest matrix: Python 3.8, 3.9, 3.10, 3.11, and 3.12 passed
- coverage generation and Codecov upload passed across the matrix
- mypy type-check passed
- black and isort code-quality jobs passed

## Follow-on roadmap

Tracked in:

- #34 — `SE(3)` poses and oriented geometry
- #35 — image and multi-view observation compiler
- #36 — rooms, openings, circulation, and access reasoning
- #37 — probabilistic hypotheses and calibrated uncertainty
- #38 — rendering, persistent ledger integration, BIM export, and benchmark gates