### PR TITLE
Operationalize sparse 3D virtual computer

### DIFF
--- a/.github/workflows/virtual3d-ci.yml
+++ b/.github/workflows/virtual3d-ci.yml
@@ -1,0 +1,45 @@
+name: Jarvis-X 3D Virtual Computer CI
+
+on:
+  push:
+    branches: [agent/3d-virtual-computer]
+    paths:
+      - "src/jarvisx/virtual3d/**"
+      - "tests/test_virtual3d.py"
+      - "examples/virtual3d_rom_demo.py"
+      - "docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md"
+      - ".github/workflows/virtual3d-ci.yml"
+  pull_request:
+    branches: [agent/dr-moagi-spatial-runtime, main]
+    paths:
+      - "src/jarvisx/virtual3d/**"
+      - "tests/test_virtual3d.py"
+      - "examples/virtual3d_rom_demo.py"
+      - "docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md"
+      - ".github/workflows/virtual3d-ci.yml"
+
+jobs:
+  virtual3d:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project and test dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install -e ".[test]"
+
+      - name: Run 3D virtual computer tests
+        run: pytest -v tests/test_virtual3d.py
+
+      - name: Run ROM demonstration
+        run: python examples/virtual3d_rom_demo.py

--- a/README.md
+++ b/README.md
@@ -75,6 +75,51 @@ python examples/dr_moagi_spatial_echo.py
 The formal operational boundary and integration roadmap are documented in
 [`docs/DR_MOAGI_SPATIAL_RUNTIME.md`](docs/DR_MOAGI_SPATIAL_RUNTIME.md).
 
+## Sparse 3D Virtual Computer
+
+`jarvisx.virtual3d` provides a sparse logical 3D memory volume with:
+
+- exact coordinate-to-block and local-offset translation;
+- clipped boundary blocks;
+- lazy allocation at both block and cell level;
+- deterministic per-block compression with checksum verification;
+- exact global reblocking across candidate block shapes;
+- online, offline, and adaptive modes;
+- canonical ROM snapshots with SHA-256 state fingerprints.
+
+```python
+from jarvisx.virtual3d import OperationalMode, Virtual3DComputer, VolumeGeometry
+
+geometry = VolumeGeometry(
+    extent=(6400, 6400, 6400),
+    block_shape=(1024, 1024, 1024),
+    cell_bytes=1_000_000_000,
+)
+computer = Virtual3DComputer(geometry, mode=OperationalMode.ADAPTIVE)
+
+computer.write((10, 20, 30), b"Jarvis-X")
+assert computer.read((10, 20, 30)) == b"Jarvis-X"
+
+report = computer.optimize_layout(
+    [(256, 256, 256), (512, 512, 512), (1024, 1024, 1024)]
+)
+fingerprint = computer.save_rom("jarvisx-state.jxrom")
+```
+
+The capacity is explicit: `6400^3` one-byte cells represent 262.144 GB decimal;
+`6400^3` one-gigabyte cells represent 262.144 EB decimal. The runtime never
+allocates the logical capacity densely.
+
+Run the complete ROM demonstration with:
+
+```bash
+python examples/virtual3d_rom_demo.py
+```
+
+The geometry, compression, layout, persistence, and current implementation
+boundary are documented in
+[`docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md`](docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md).
+
 ## Sparse Fractal Octree
 
 The concrete recursive spatial substrate is available as

--- a/docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md
+++ b/docs/DR_MOAGI_3D_VIRTUAL_COMPUTER.md
@@ -1,0 +1,268 @@
+# Dr Moagi Sparse 3D Virtual Computer
+
+## Status
+
+Operational reference implementation for a sparse, block-addressed 3D logical
+memory volume with deterministic compression, adaptive reblocking, exact ROM
+restoration, and cryptographic integrity checks.
+
+This module is a storage and address-space runtime. It does not claim that a
+neural volumetric autoencoder is already trained or deployed. The initial codec
+is a deterministic lossless zlib reference implementation behind a replaceable
+block-codec boundary.
+
+## 1. Correct capacity semantics
+
+The original phrase `6400 x 6400 x 6400 GB` mixes spatial coordinates and data
+units. The runtime separates them:
+
+```text
+extent      = number of logical cells on x, y, and z
+cell_bytes  = maximum payload represented by one logical cell
+block_shape = number of logical cells per block on x, y, and z
+```
+
+The logical capacity is:
+
+\[
+C = D H W c,
+\]
+
+where \(c\) is `cell_bytes`.
+
+For an extent of `6400^3`:
+
+- `cell_bytes = 1` gives `262,144,000,000` bytes, or 262.144 GB decimal;
+- `cell_bytes = 1,000,000,000` gives
+  `262,144,000,000,000,000,000` bytes, or 262.144 EB decimal.
+
+The 262.144 EB interpretation therefore means **6400 logical cells per axis,
+with each cell representing up to one gigabyte**. It is not byte-addressable at
+the outer coordinate level. Byte-addressable operation uses `cell_bytes = 1`.
+
+## 2. Block mapping
+
+For a block shape \(B_x,B_y,B_z\), coordinate \((x,y,z)\) maps to:
+
+\[
+(i,j,k)=
+\left(
+\left\lfloor\frac{x}{B_x}\right\rfloor,
+\left\lfloor\frac{y}{B_y}\right\rfloor,
+\left\lfloor\frac{z}{B_z}\right\rfloor
+\right),
+\]
+
+with local offset:
+
+\[
+(o_x,o_y,o_z)=
+(x\bmod B_x,y\bmod B_y,z\bmod B_z).
+\]
+
+With an extent of 6400 and a block side of 1024, the block grid is:
+
+\[
+\left\lceil\frac{6400}{1024}\right\rceil^3=7^3=343.
+\]
+
+Boundary blocks are clipped. The final block on each axis has an effective side
+of 256 cells rather than being padded to 1024 cells.
+
+## 3. Two-level sparsity
+
+The runtime never constructs a dense `B^3` array merely because a block has a
+large logical shape.
+
+```text
+volume
+  -> sparse dictionary of allocated block indices
+      -> sparse dictionary of written local cell offsets
+```
+
+An unwritten read returns the empty byte string and does not allocate memory. A
+non-empty write allocates exactly one block record and one cell payload. Writing
+an empty payload deletes the cell and releases the block if it becomes empty.
+
+Physical storage is therefore proportional to written content and metadata, not
+to the logical capacity.
+
+## 4. Block encoding
+
+Each allocated block is serialized canonically:
+
+```text
+block index
+block shape
+cell capacity
+sorted local offsets
+base64 cell payloads
+read/write counters
+```
+
+The canonical bytes are compressed independently at zlib levels 1 through 9.
+The reference optimizer selects:
+
+\[
+C_b^\star=\arg\min_{C_b\in\{1,\ldots,9\}} S_b(C_b),
+\]
+
+with deterministic tie-breaking toward the lower compression level.
+
+Because this reference codec is lossless:
+
+\[
+D_b=0,
+\]
+
+and its current block objective reduces to encoded size. A future learned codec
+can expose a rate-distortion objective:
+
+\[
+J_b=\alpha R_b+\beta D_b,
+\]
+
+where \(R_b\) is the encoded byte rate and \(D_b\) is a declared geometric or
+numeric distortion measure. PSNR is appropriate only for bounded numeric voxel
+fields; it is not used for arbitrary byte payloads.
+
+## 5. Adaptive layout optimization
+
+`optimize_layout` evaluates the current block shape together with supplied
+candidate shapes. Each candidate is rebuilt from the sparse written cells,
+compressed, and scored as:
+
+\[
+J_{layout}=S_{encoded}+n_b S_{entry},
+\]
+
+where \(n_b\) is the number of allocated blocks and \(S_{entry}\) is the
+configured layout-metadata cost.
+
+The selected layout is the minimum-cost candidate with deterministic
+ tie-breaking. Reblocking preserves all coordinates and values exactly.
+
+This is global reblocking. Per-region octree split, merge, and heterogeneous
+block shapes remain a follow-on subsystem.
+
+## 6. Operational modes
+
+### Online
+
+Blocks remain materialized after access. Reads and writes are serviced directly
+from sparse in-memory block state.
+
+### Offline
+
+Compacted blocks are retained as compressed bytecode and materialized only when
+read or modified.
+
+### Adaptive
+
+Compaction behaves like offline mode, and the caller may periodically run layout
+optimization against candidate block shapes.
+
+The runtime does not create a hidden background optimizer. Optimization is an
+explicit, auditable operation.
+
+## 7. ROM format
+
+A ROM envelope contains:
+
+```text
+schema version
+volume geometry
+operational mode
+read/write counters
+encoded block records
+SHA-256 fingerprint of canonical state JSON
+```
+
+Saving uses a temporary file followed by atomic replacement. Loading verifies
+the state fingerprint before accepting the ROM. Each block also carries a
+checksum over its uncompressed canonical representation.
+
+The two integrity layers are:
+
+\[
+h_b=\operatorname{SHA256}(\operatorname{decode}(b)),
+\]
+
+and:
+
+\[
+h_{ROM}=\operatorname{SHA256}(\operatorname{CanonicalJSON}(state)).
+\]
+
+These hashes establish deterministic integrity, not secrecy. Encryption and
+signatures are separate concerns.
+
+## 8. Python API
+
+```python
+from jarvisx.virtual3d import OperationalMode, Virtual3DComputer, VolumeGeometry
+
+geometry = VolumeGeometry(
+    extent=(6400, 6400, 6400),
+    block_shape=(1024, 1024, 1024),
+    cell_bytes=1_000_000_000,
+)
+computer = Virtual3DComputer(geometry, mode=OperationalMode.ADAPTIVE)
+
+computer.write((10, 20, 30), b"Jarvis-X")
+assert computer.read((10, 20, 30)) == b"Jarvis-X"
+
+report = computer.optimize_layout(
+    [(256, 256, 256), (512, 512, 512), (1024, 1024, 1024)]
+)
+fingerprint = computer.save_rom("jarvisx-state.jxrom")
+restored = Virtual3DComputer.load_rom("jarvisx-state.jxrom")
+```
+
+## 9. Operational flow
+
+```mermaid
+flowchart TB
+    A[Logical coordinate and bytes] --> B[Validate extent]
+    B --> C[Map to block index and local offset]
+    C --> D{Block present?}
+    D -->|No read| E[Return empty value]
+    D -->|No write| F[Allocate sparse block]
+    D -->|Encoded| G[Verify and decompress block]
+    F --> H[Write sparse cell]
+    G --> H
+    H --> I[Mark block materialized]
+    I --> J{Compact requested?}
+    J -->|Yes| K[Canonical encode]
+    K --> L[Evaluate zlib levels]
+    L --> M[Store smallest verified block bytecode]
+    M --> N[ROM canonical state and SHA-256]
+```
+
+## 10. Current boundary
+
+Implemented now:
+
+- exact 3D coordinate mapping;
+- clipped boundary blocks;
+- block- and cell-level lazy allocation;
+- deterministic lossless per-block encoding;
+- compression-level optimization;
+- global exact reblocking;
+- online, offline, and adaptive modes;
+- ROM save/load;
+- block checksums and ROM fingerprints;
+- capacity, mapping, persistence, tamper, and reblocking tests.
+
+Not yet implemented:
+
+- neural 3D convolutional codecs;
+- lossy quantization and domain-specific distortion metrics;
+- heterogeneous block sizes within one active layout;
+- octree split/merge policies driven by heat or entropy;
+- memory-mapped or distributed backing stores;
+- transaction isolation for concurrent writers;
+- encryption, signatures, or erasure coding.
+
+Those capabilities can now be added against a stable address, codec, layout,
+and ROM contract rather than an undefined dense tensor.

--- a/examples/virtual3d_rom_demo.py
+++ b/examples/virtual3d_rom_demo.py
@@ -1,0 +1,46 @@
+"""Demonstrate sparse writes, adaptive reblocking, and ROM restoration."""
+
+from pathlib import Path
+
+from jarvisx.virtual3d import OperationalMode, Virtual3DComputer, VolumeGeometry
+
+
+def main() -> None:
+    geometry = VolumeGeometry(
+        extent=(6400, 6400, 6400),
+        block_shape=(1024, 1024, 1024),
+        cell_bytes=1_000_000_000,
+    )
+    computer = Virtual3DComputer(
+        geometry=geometry,
+        mode=OperationalMode.ADAPTIVE,
+    )
+
+    computer.write((10, 20, 30), b"architectural-state")
+    computer.write((6399, 6399, 6399), b"boundary-state")
+
+    before = computer.statistics()
+    report = computer.optimize_layout(
+        [
+            (256, 256, 256),
+            (512, 512, 512),
+            (1024, 1024, 1024),
+        ]
+    )
+
+    destination = Path("virtual3d-demo.jxrom")
+    fingerprint = computer.save_rom(str(destination))
+    restored = Virtual3DComputer.load_rom(str(destination))
+
+    assert restored.read((10, 20, 30)) == b"architectural-state"
+    assert restored.read((6399, 6399, 6399)) == b"boundary-state"
+
+    print("Logical capacity (bytes):", before.logical_capacity_bytes)
+    print("Allocated cells:", before.allocated_cells)
+    print("Selected block shape:", report.selected.block_shape)
+    print("ROM fingerprint:", fingerprint)
+    print("ROM path:", destination.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/virtual3d/__init__.py
+++ b/src/jarvisx/virtual3d/__init__.py
@@ -1,0 +1,25 @@
+"""Sparse 3D virtual-computer primitives."""
+
+from .codec import EncodedBlock, SparseBlock, ZlibSparseBlockCodec
+from .geometry import BlockAddress, Coordinate3D, VolumeGeometry
+from .volume import (
+    OperationalMode,
+    OptimizationCandidate,
+    OptimizationReport,
+    Virtual3DComputer,
+    VolumeStatistics,
+)
+
+__all__ = [
+    "BlockAddress",
+    "Coordinate3D",
+    "EncodedBlock",
+    "OperationalMode",
+    "OptimizationCandidate",
+    "OptimizationReport",
+    "SparseBlock",
+    "Virtual3DComputer",
+    "VolumeGeometry",
+    "VolumeStatistics",
+    "ZlibSparseBlockCodec",
+]

--- a/src/jarvisx/virtual3d/codec.py
+++ b/src/jarvisx/virtual3d/codec.py
@@ -1,0 +1,191 @@
+"""Deterministic sparse-block encoding and compression."""
+
+import base64
+import hashlib
+import json
+import zlib
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Iterator, Tuple
+
+from .geometry import Coordinate3D
+
+
+@dataclass
+class SparseBlock:
+    """A block whose logical cells are allocated only when written."""
+
+    index: Coordinate3D
+    shape: Coordinate3D
+    cell_bytes: int
+    cells: Dict[Coordinate3D, bytes] = field(default_factory=dict)
+    reads: int = 0
+    writes: int = 0
+
+    def _validate_offset(self, offset: Coordinate3D) -> None:
+        if len(offset) != 3:
+            raise ValueError("offset must contain exactly three values")
+        for axis, limit in zip(offset, self.shape):
+            if axis < 0 or axis >= limit:
+                raise IndexError(
+                    "offset {} lies outside block shape {}".format(
+                        offset, self.shape
+                    )
+                )
+
+    def read(self, offset: Coordinate3D) -> bytes:
+        self._validate_offset(offset)
+        self.reads += 1
+        return self.cells.get(offset, b"")
+
+    def write(self, offset: Coordinate3D, value: bytes) -> None:
+        self._validate_offset(offset)
+        if not isinstance(value, bytes):
+            raise TypeError("value must be bytes")
+        if len(value) > self.cell_bytes:
+            raise ValueError(
+                "payload has {} bytes but cell capacity is {}".format(
+                    len(value), self.cell_bytes
+                )
+            )
+        self.writes += 1
+        if value:
+            self.cells[offset] = value
+        else:
+            self.cells.pop(offset, None)
+
+    @property
+    def allocated_cells(self) -> int:
+        return len(self.cells)
+
+    @property
+    def physical_payload_bytes(self) -> int:
+        return sum(len(value) for value in self.cells.values())
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.cells
+
+    def iter_cells(self) -> Iterator[Tuple[Coordinate3D, bytes]]:
+        for offset in sorted(self.cells):
+            yield offset, self.cells[offset]
+
+    def canonical_document(self) -> Dict[str, object]:
+        return {
+            "cell_bytes": self.cell_bytes,
+            "cells": [
+                {
+                    "offset": list(offset),
+                    "payload": base64.b64encode(value).decode("ascii"),
+                }
+                for offset, value in self.iter_cells()
+            ],
+            "index": list(self.index),
+            "reads": self.reads,
+            "shape": list(self.shape),
+            "writes": self.writes,
+        }
+
+    def canonical_bytes(self) -> bytes:
+        return json.dumps(
+            self.canonical_document(), sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+
+    @classmethod
+    def from_canonical_bytes(cls, payload: bytes) -> "SparseBlock":
+        document = json.loads(payload.decode("utf-8"))
+        block = cls(
+            index=tuple(document["index"]),
+            shape=tuple(document["shape"]),
+            cell_bytes=int(document["cell_bytes"]),
+            reads=int(document.get("reads", 0)),
+            writes=int(document.get("writes", 0)),
+        )
+        for cell in document["cells"]:
+            offset = tuple(cell["offset"])
+            value = base64.b64decode(cell["payload"].encode("ascii"))
+            block.cells[offset] = value
+        return block
+
+
+@dataclass(frozen=True)
+class EncodedBlock:
+    """One compressed block with enough metadata for verified restoration."""
+
+    index: Coordinate3D
+    level: int
+    raw_bytes: int
+    compressed_bytes: int
+    checksum: str
+    payload: bytes
+    codec: str = "zlib-sparse-v1"
+
+    def to_document(self) -> Dict[str, object]:
+        return {
+            "checksum": self.checksum,
+            "codec": self.codec,
+            "compressed_bytes": self.compressed_bytes,
+            "index": list(self.index),
+            "level": self.level,
+            "payload": base64.b64encode(self.payload).decode("ascii"),
+            "raw_bytes": self.raw_bytes,
+        }
+
+    @classmethod
+    def from_document(cls, document: Dict[str, object]) -> "EncodedBlock":
+        return cls(
+            index=tuple(document["index"]),  # type: ignore[arg-type]
+            level=int(document["level"]),
+            raw_bytes=int(document["raw_bytes"]),
+            compressed_bytes=int(document["compressed_bytes"]),
+            checksum=str(document["checksum"]),
+            codec=str(document["codec"]),
+            payload=base64.b64decode(
+                str(document["payload"]).encode("ascii")
+            ),
+        )
+
+
+class ZlibSparseBlockCodec:
+    """Lossless reference codec used until learned 3D codecs are attached."""
+
+    name = "zlib-sparse-v1"
+
+    @staticmethod
+    def encode(block: SparseBlock, level: int = 6) -> EncodedBlock:
+        if level < 1 or level > 9:
+            raise ValueError("zlib compression level must be in [1, 9]")
+        raw = block.canonical_bytes()
+        payload = zlib.compress(raw, level)
+        return EncodedBlock(
+            index=block.index,
+            level=level,
+            raw_bytes=len(raw),
+            compressed_bytes=len(payload),
+            checksum=hashlib.sha256(raw).hexdigest(),
+            payload=payload,
+        )
+
+    @staticmethod
+    def decode(encoded: EncodedBlock) -> SparseBlock:
+        if encoded.codec != ZlibSparseBlockCodec.name:
+            raise ValueError("unsupported codec: {}".format(encoded.codec))
+        raw = zlib.decompress(encoded.payload)
+        checksum = hashlib.sha256(raw).hexdigest()
+        if checksum != encoded.checksum:
+            raise ValueError("block checksum mismatch")
+        block = SparseBlock.from_canonical_bytes(raw)
+        if block.index != encoded.index:
+            raise ValueError("encoded block index does not match decoded block")
+        return block
+
+    @classmethod
+    def optimize(
+        cls, block: SparseBlock, levels: Iterable[int] = range(1, 10)
+    ) -> EncodedBlock:
+        candidates = [cls.encode(block, level) for level in levels]
+        if not candidates:
+            raise ValueError("at least one compression level is required")
+        return min(
+            candidates,
+            key=lambda item: (item.compressed_bytes, item.level),
+        )

--- a/src/jarvisx/virtual3d/geometry.py
+++ b/src/jarvisx/virtual3d/geometry.py
@@ -1,0 +1,106 @@
+"""Geometry and address translation for the sparse 3D virtual computer."""
+
+from dataclasses import dataclass
+from math import ceil
+from typing import Tuple
+
+Coordinate3D = Tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class BlockAddress:
+    """Resolved block index and local offset for one logical coordinate."""
+
+    block: Coordinate3D
+    offset: Coordinate3D
+
+
+@dataclass(frozen=True)
+class VolumeGeometry:
+    """Immutable geometry contract for a sparse logical 3D volume.
+
+    ``extent`` and ``block_shape`` are measured in logical cells. ``cell_bytes``
+    defines the maximum payload represented by one cell. Setting ``cell_bytes``
+    to one gives byte-addressable semantics. Setting it to one billion models
+    the 6400^3 one-gigabyte-cell design without allocating that capacity.
+    """
+
+    extent: Coordinate3D = (6400, 6400, 6400)
+    block_shape: Coordinate3D = (1024, 1024, 1024)
+    cell_bytes: int = 1
+
+    def __post_init__(self) -> None:
+        if any(value <= 0 for value in self.extent):
+            raise ValueError("extent dimensions must be positive")
+        if any(value <= 0 for value in self.block_shape):
+            raise ValueError("block dimensions must be positive")
+        if self.cell_bytes <= 0:
+            raise ValueError("cell_bytes must be positive")
+
+    @property
+    def logical_cells(self) -> int:
+        x, y, z = self.extent
+        return x * y * z
+
+    @property
+    def logical_capacity_bytes(self) -> int:
+        return self.logical_cells * self.cell_bytes
+
+    @property
+    def block_grid_shape(self) -> Coordinate3D:
+        return tuple(
+            int(ceil(axis / block))
+            for axis, block in zip(self.extent, self.block_shape)
+        )  # type: ignore[return-value]
+
+    @property
+    def maximum_block_count(self) -> int:
+        x, y, z = self.block_grid_shape
+        return x * y * z
+
+    def validate_coordinate(self, coordinate: Coordinate3D) -> None:
+        if len(coordinate) != 3:
+            raise ValueError("coordinate must contain exactly three values")
+        for axis, limit in zip(coordinate, self.extent):
+            if axis < 0 or axis >= limit:
+                raise IndexError(
+                    "coordinate {} lies outside extent {}".format(
+                        coordinate, self.extent
+                    )
+                )
+
+    def map_coordinate(self, coordinate: Coordinate3D) -> BlockAddress:
+        self.validate_coordinate(coordinate)
+        block = tuple(
+            axis // block_axis
+            for axis, block_axis in zip(coordinate, self.block_shape)
+        )
+        offset = tuple(
+            axis % block_axis
+            for axis, block_axis in zip(coordinate, self.block_shape)
+        )
+        return BlockAddress(block=block, offset=offset)  # type: ignore[arg-type]
+
+    def global_coordinate(
+        self, block: Coordinate3D, offset: Coordinate3D
+    ) -> Coordinate3D:
+        coordinate = tuple(
+            block_axis * block_size + local_axis
+            for block_axis, block_size, local_axis in zip(
+                block, self.block_shape, offset
+            )
+        )
+        self.validate_coordinate(coordinate)  # type: ignore[arg-type]
+        return coordinate  # type: ignore[return-value]
+
+    def effective_block_shape(self, block: Coordinate3D) -> Coordinate3D:
+        grid = self.block_grid_shape
+        if any(axis < 0 or axis >= limit for axis, limit in zip(block, grid)):
+            raise IndexError("block {} lies outside grid {}".format(block, grid))
+        shape = []
+        for block_axis, block_size, extent_axis in zip(
+            block, self.block_shape, self.extent
+        ):
+            start = block_axis * block_size
+            shape.append(min(block_size, extent_axis - start))
+        return tuple(shape)  # type: ignore[return-value]

--- a/src/jarvisx/virtual3d/volume.py
+++ b/src/jarvisx/virtual3d/volume.py
@@ -1,0 +1,308 @@
+"""Sparse 3D virtual computer, adaptive layout optimizer, and ROM format."""
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Optional, Tuple
+
+from .codec import EncodedBlock, SparseBlock, ZlibSparseBlockCodec
+from .geometry import Coordinate3D, VolumeGeometry
+
+
+class OperationalMode(str, Enum):
+    ONLINE = "online"
+    OFFLINE = "offline"
+    ADAPTIVE = "adaptive"
+
+
+@dataclass(frozen=True)
+class VolumeStatistics:
+    logical_capacity_bytes: int
+    maximum_blocks: int
+    allocated_blocks: int
+    allocated_cells: int
+    physical_payload_bytes: int
+    encoded_bytes: int
+    reads: int
+    writes: int
+
+
+@dataclass(frozen=True)
+class OptimizationCandidate:
+    block_shape: Coordinate3D
+    allocated_blocks: int
+    encoded_bytes: int
+    layout_bytes: int
+    objective: float
+
+
+@dataclass(frozen=True)
+class OptimizationReport:
+    previous_block_shape: Coordinate3D
+    selected: OptimizationCandidate
+    candidates: Tuple[OptimizationCandidate, ...]
+
+
+class Virtual3DComputer:
+    """Sparse logical 3D address space with verified block persistence.
+
+    The implementation is sparse at two levels: blocks are allocated lazily,
+    and cells inside a block are allocated lazily. It therefore never creates a
+    dense ``B^3`` array merely because the logical block shape is large.
+    """
+
+    schema_version = "jarvisx.virtual3d.rom.v1"
+
+    def __init__(
+        self,
+        geometry: Optional[VolumeGeometry] = None,
+        mode: OperationalMode = OperationalMode.ONLINE,
+    ) -> None:
+        self.geometry = geometry or VolumeGeometry()
+        self.mode = OperationalMode(mode)
+        self.blocks: Dict[Coordinate3D, SparseBlock] = {}
+        self.encoded_blocks: Dict[Coordinate3D, EncodedBlock] = {}
+        self.reads = 0
+        self.writes = 0
+
+    def _allocate_block(self, index: Coordinate3D) -> SparseBlock:
+        block = SparseBlock(
+            index=index,
+            shape=self.geometry.effective_block_shape(index),
+            cell_bytes=self.geometry.cell_bytes,
+        )
+        self.blocks[index] = block
+        return block
+
+    def _materialize_block(self, index: Coordinate3D) -> Optional[SparseBlock]:
+        block = self.blocks.get(index)
+        if block is not None:
+            return block
+        encoded = self.encoded_blocks.get(index)
+        if encoded is None:
+            return None
+        block = ZlibSparseBlockCodec.decode(encoded)
+        self.blocks[index] = block
+        return block
+
+    def read(self, coordinate: Coordinate3D) -> bytes:
+        address = self.geometry.map_coordinate(coordinate)
+        self.reads += 1
+        block = self._materialize_block(address.block)
+        if block is None:
+            return b""
+        return block.read(address.offset)
+
+    def write(self, coordinate: Coordinate3D, value: bytes) -> None:
+        address = self.geometry.map_coordinate(coordinate)
+        self.writes += 1
+        block = self._materialize_block(address.block)
+        if block is None:
+            if not value:
+                return
+            block = self._allocate_block(address.block)
+        block.write(address.offset, value)
+        self.encoded_blocks.pop(address.block, None)
+        if block.is_empty:
+            self.blocks.pop(address.block, None)
+
+    def iter_allocated_cells(self) -> Iterator[Tuple[Coordinate3D, bytes]]:
+        indexes = sorted(set(self.blocks) | set(self.encoded_blocks))
+        for index in indexes:
+            block = self._materialize_block(index)
+            if block is None:
+                continue
+            for offset, value in block.iter_cells():
+                yield self.geometry.global_coordinate(index, offset), value
+
+    def compact_block(self, index: Coordinate3D) -> Optional[EncodedBlock]:
+        block = self._materialize_block(index)
+        if block is None:
+            return None
+        if block.is_empty:
+            self.blocks.pop(index, None)
+            self.encoded_blocks.pop(index, None)
+            return None
+        encoded = ZlibSparseBlockCodec.optimize(block)
+        self.encoded_blocks[index] = encoded
+        if self.mode in (OperationalMode.OFFLINE, OperationalMode.ADAPTIVE):
+            self.blocks.pop(index, None)
+        return encoded
+
+    def compact_all(self) -> Tuple[EncodedBlock, ...]:
+        indexes = sorted(set(self.blocks) | set(self.encoded_blocks))
+        encoded = []
+        for index in indexes:
+            result = self.compact_block(index)
+            if result is not None:
+                encoded.append(result)
+        return tuple(encoded)
+
+    def reblocked(self, block_shape: Coordinate3D) -> "Virtual3DComputer":
+        geometry = VolumeGeometry(
+            extent=self.geometry.extent,
+            block_shape=block_shape,
+            cell_bytes=self.geometry.cell_bytes,
+        )
+        rebuilt = Virtual3DComputer(geometry=geometry, mode=self.mode)
+        for coordinate, value in self.iter_allocated_cells():
+            rebuilt.write(coordinate, value)
+        rebuilt.reads = self.reads
+        rebuilt.writes = self.writes
+        return rebuilt
+
+    def _candidate_score(
+        self, block_shape: Coordinate3D, layout_entry_bytes: int
+    ) -> Tuple[OptimizationCandidate, "Virtual3DComputer"]:
+        candidate = self.reblocked(block_shape)
+        encoded = candidate.compact_all()
+        encoded_bytes = sum(item.compressed_bytes for item in encoded)
+        layout_bytes = len(encoded) * layout_entry_bytes
+        score = float(encoded_bytes + layout_bytes)
+        return (
+            OptimizationCandidate(
+                block_shape=block_shape,
+                allocated_blocks=len(encoded),
+                encoded_bytes=encoded_bytes,
+                layout_bytes=layout_bytes,
+                objective=score,
+            ),
+            candidate,
+        )
+
+    def optimize_layout(
+        self,
+        candidate_block_shapes: Iterable[Coordinate3D],
+        layout_entry_bytes: int = 64,
+    ) -> OptimizationReport:
+        if layout_entry_bytes < 0:
+            raise ValueError("layout_entry_bytes must be non-negative")
+        shapes = [self.geometry.block_shape]
+        for shape in candidate_block_shapes:
+            if shape not in shapes:
+                shapes.append(shape)
+        evaluations = [
+            self._candidate_score(shape, layout_entry_bytes) for shape in shapes
+        ]
+        selected_score, selected_volume = min(
+            evaluations,
+            key=lambda item: (
+                item[0].objective,
+                item[0].allocated_blocks,
+                item[0].block_shape,
+            ),
+        )
+        previous = self.geometry.block_shape
+        self.geometry = selected_volume.geometry
+        self.blocks = selected_volume.blocks
+        self.encoded_blocks = selected_volume.encoded_blocks
+        return OptimizationReport(
+            previous_block_shape=previous,
+            selected=selected_score,
+            candidates=tuple(item[0] for item in evaluations),
+        )
+
+    def statistics(self) -> VolumeStatistics:
+        materialized = list(self.blocks.values())
+        encoded_only = set(self.encoded_blocks) - set(self.blocks)
+        allocated_cells = sum(block.allocated_cells for block in materialized)
+        physical_payload = sum(
+            block.physical_payload_bytes for block in materialized
+        )
+        for index in encoded_only:
+            block = ZlibSparseBlockCodec.decode(self.encoded_blocks[index])
+            allocated_cells += block.allocated_cells
+            physical_payload += block.physical_payload_bytes
+        return VolumeStatistics(
+            logical_capacity_bytes=self.geometry.logical_capacity_bytes,
+            maximum_blocks=self.geometry.maximum_block_count,
+            allocated_blocks=len(set(self.blocks) | set(self.encoded_blocks)),
+            allocated_cells=allocated_cells,
+            physical_payload_bytes=physical_payload,
+            encoded_bytes=sum(
+                item.compressed_bytes for item in self.encoded_blocks.values()
+            ),
+            reads=self.reads,
+            writes=self.writes,
+        )
+
+    def _rom_document(self) -> Dict[str, object]:
+        encoded = self.compact_all()
+        return {
+            "blocks": [
+                item.to_document()
+                for item in sorted(encoded, key=lambda block: block.index)
+            ],
+            "geometry": {
+                "block_shape": list(self.geometry.block_shape),
+                "cell_bytes": self.geometry.cell_bytes,
+                "extent": list(self.geometry.extent),
+            },
+            "mode": self.mode.value,
+            "reads": self.reads,
+            "schema": self.schema_version,
+            "writes": self.writes,
+        }
+
+    def to_rom_bytes(self) -> bytes:
+        document = self._rom_document()
+        canonical = json.dumps(
+            document, sort_keys=True, separators=(",", ":")
+        )
+        envelope = {
+            "fingerprint": hashlib.sha256(
+                canonical.encode("utf-8")
+            ).hexdigest(),
+            "state": document,
+        }
+        return json.dumps(
+            envelope, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+
+    @classmethod
+    def from_rom_bytes(cls, payload: bytes) -> "Virtual3DComputer":
+        envelope = json.loads(payload.decode("utf-8"))
+        document = envelope["state"]
+        canonical = json.dumps(
+            document, sort_keys=True, separators=(",", ":")
+        )
+        fingerprint = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        if fingerprint != envelope["fingerprint"]:
+            raise ValueError("ROM fingerprint mismatch")
+        if document["schema"] != cls.schema_version:
+            raise ValueError(
+                "unsupported ROM schema: {}".format(document["schema"])
+            )
+        geometry_document = document["geometry"]
+        geometry = VolumeGeometry(
+            extent=tuple(geometry_document["extent"]),
+            block_shape=tuple(geometry_document["block_shape"]),
+            cell_bytes=int(geometry_document["cell_bytes"]),
+        )
+        computer = cls(
+            geometry=geometry,
+            mode=OperationalMode(document["mode"]),
+        )
+        computer.reads = int(document["reads"])
+        computer.writes = int(document["writes"])
+        for item in document["blocks"]:
+            encoded = EncodedBlock.from_document(item)
+            computer.encoded_blocks[encoded.index] = encoded
+        return computer
+
+    def save_rom(self, path: str) -> str:
+        payload = self.to_rom_bytes()
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_suffix(destination.suffix + ".tmp")
+        temporary.write_bytes(payload)
+        os.replace(str(temporary), str(destination))
+        envelope = json.loads(payload.decode("utf-8"))
+        return str(envelope["fingerprint"])
+
+    @classmethod
+    def load_rom(cls, path: str) -> "Virtual3DComputer":
+        return cls.from_rom_bytes(Path(path).read_bytes())

--- a/tests/test_virtual3d.py
+++ b/tests/test_virtual3d.py
@@ -1,0 +1,151 @@
+import json
+
+import pytest
+
+from jarvisx.virtual3d import OperationalMode, Virtual3DComputer, VolumeGeometry
+
+
+def test_6400_cubed_gigabyte_cells_equal_262_144_exabytes_decimal():
+    geometry = VolumeGeometry(
+        extent=(6400, 6400, 6400),
+        block_shape=(1024, 1024, 1024),
+        cell_bytes=1_000_000_000,
+    )
+
+    assert geometry.logical_cells == 262_144_000_000
+    assert geometry.logical_capacity_bytes == 262_144_000_000_000_000_000
+    assert geometry.block_grid_shape == (7, 7, 7)
+    assert geometry.maximum_block_count == 343
+
+
+def test_byte_addressable_interpretation_is_262_144_gigabytes_decimal():
+    geometry = VolumeGeometry(
+        extent=(6400, 6400, 6400),
+        block_shape=(1024, 1024, 1024),
+        cell_bytes=1,
+    )
+
+    assert geometry.logical_capacity_bytes == 262_144_000_000
+
+
+def test_mapping_handles_regular_and_boundary_blocks():
+    geometry = VolumeGeometry(
+        extent=(6400, 6400, 6400),
+        block_shape=(1024, 1024, 1024),
+    )
+
+    address = geometry.map_coordinate((6399, 1024, 2047))
+
+    assert address.block == (6, 1, 1)
+    assert address.offset == (255, 0, 1023)
+    assert geometry.effective_block_shape((6, 6, 6)) == (256, 256, 256)
+
+
+def test_reads_do_not_allocate_and_writes_allocate_lazily():
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(16, 16, 16),
+            block_shape=(4, 4, 4),
+            cell_bytes=8,
+        )
+    )
+
+    assert computer.read((5, 5, 5)) == b""
+    assert computer.statistics().allocated_blocks == 0
+
+    computer.write((5, 5, 5), b"Jarvis")
+
+    assert computer.read((5, 5, 5)) == b"Jarvis"
+    assert computer.statistics().allocated_blocks == 1
+    assert computer.statistics().allocated_cells == 1
+
+
+def test_empty_write_releases_the_last_cell_and_block():
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(8, 8, 8),
+            block_shape=(4, 4, 4),
+            cell_bytes=4,
+        )
+    )
+    computer.write((1, 1, 1), b"data")
+    computer.write((1, 1, 1), b"")
+
+    assert computer.statistics().allocated_blocks == 0
+
+
+def test_payload_cannot_exceed_cell_capacity():
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(2, 2, 2),
+            block_shape=(1, 1, 1),
+            cell_bytes=2,
+        )
+    )
+
+    with pytest.raises(ValueError):
+        computer.write((0, 0, 0), b"abc")
+
+
+def test_rom_round_trip_restores_geometry_values_and_fingerprint(tmp_path):
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(32, 32, 32),
+            block_shape=(8, 8, 8),
+            cell_bytes=16,
+        ),
+        mode=OperationalMode.OFFLINE,
+    )
+    computer.write((1, 2, 3), b"alpha")
+    computer.write((31, 31, 31), b"omega")
+
+    path = tmp_path / "state.jxrom"
+    fingerprint = computer.save_rom(str(path))
+    restored = Virtual3DComputer.load_rom(str(path))
+
+    envelope = json.loads(path.read_text())
+    assert envelope["fingerprint"] == fingerprint
+    assert restored.geometry == computer.geometry
+    assert restored.read((1, 2, 3)) == b"alpha"
+    assert restored.read((31, 31, 31)) == b"omega"
+
+
+def test_rom_tampering_is_detected():
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(4, 4, 4),
+            block_shape=(2, 2, 2),
+            cell_bytes=8,
+        )
+    )
+    computer.write((0, 0, 0), b"safe")
+    envelope = json.loads(computer.to_rom_bytes().decode("utf-8"))
+    envelope["state"]["writes"] = 999
+
+    with pytest.raises(ValueError, match="fingerprint"):
+        Virtual3DComputer.from_rom_bytes(
+            json.dumps(envelope).encode("utf-8")
+        )
+
+
+def test_layout_optimizer_can_reblock_without_changing_values():
+    computer = Virtual3DComputer(
+        VolumeGeometry(
+            extent=(16, 16, 16),
+            block_shape=(8, 8, 8),
+            cell_bytes=8,
+        ),
+        mode=OperationalMode.ADAPTIVE,
+    )
+    computer.write((0, 0, 0), b"a")
+    computer.write((15, 15, 15), b"b")
+
+    report = computer.optimize_layout([(4, 4, 4), (16, 16, 16)])
+
+    assert report.selected.block_shape in {
+        (4, 4, 4),
+        (8, 8, 8),
+        (16, 16, 16),
+    }
+    assert computer.read((0, 0, 0)) == b"a"
+    assert computer.read((15, 15, 15)) == b"b"


### PR DESCRIPTION
## What changed

- add `jarvisx.virtual3d`, a sparse logical 3D address-space runtime
- separate spatial extent, block shape, and per-cell byte capacity
- implement exact coordinate-to-block and local-offset mapping
- clip boundary blocks instead of padding them to the nominal block shape
- allocate blocks and cells lazily
- add deterministic canonical block serialization and zlib compression-level optimization
- add global exact reblocking across candidate block shapes
- add online, offline, and adaptive operational modes
- add canonical ROM save/load with atomic replacement, per-block checksums, and a full-state SHA-256 fingerprint
- add a runnable ROM demonstration, formal systems specification, README integration, tests, and a dedicated Python 3.8/3.10/3.12 workflow

## Capacity correction

The design now distinguishes logical coordinates from storage units:

- `extent=(6400,6400,6400), cell_bytes=1` represents 262.144 GB decimal
- `extent=(6400,6400,6400), cell_bytes=1_000_000_000` represents 262.144 EB decimal

The 262.144 EB interpretation means 6400 logical cells per axis with each coordinate representing up to one gigabyte. The runtime never allocates this capacity densely.

## Operational behavior

1. validate a logical coordinate
2. map it to a block index and local offset
3. materialize a compressed block only when required
4. allocate a new sparse block only for a non-empty write
5. encode allocated blocks canonically
6. evaluate zlib levels 1–9 and retain the smallest deterministic representation
7. optionally evaluate alternate global block shapes and reblock without changing coordinates or values
8. persist a canonical ROM envelope and verify its fingerprint before restoration

## Deliberate implementation boundary

The current codec is a deterministic lossless reference codec. It does not claim that a trained 3D convolutional autoencoder exists. The codec boundary is designed so learned rate-distortion codecs can be introduced later without changing addressing, layout, ROM, or integrity semantics.

Per-region heterogeneous blocks, octree split/merge, learned volumetric codecs, distributed backing stores, concurrent transactions, encryption, and signatures remain follow-on work.

## Validation

All dedicated checks pass on head `d71883c20b0e7e83c1bc71401813741ed75b65e1`:

- Python 3.8: unit tests and ROM demonstration passed
- Python 3.10: unit tests and ROM demonstration passed
- Python 3.12: unit tests and ROM demonstration passed

Focused tests cover capacity semantics, block mapping, clipped boundary blocks, lazy allocation, deletion, cell-capacity enforcement, ROM round trips, tamper detection, and exact reblocking.

## Follow-on roadmap

- #40 — learned volumetric rate-distortion codecs
- #41 — heterogeneous octree blocks and hot-cold adaptation
- #42 — durable backing stores and transactional concurrency

## Stack

This PR is intentionally based on `agent/dr-moagi-spatial-runtime` and should be reviewed after draft PR #33.