### PR TITLE
Add self-evolutionary meta-volume architecture governor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,39 @@ At depth `D`, the deterministic invariants are:
 - active nodes: `(4 ** (D + 1) - 1) // 3`
 - retained volume: `2 ** (-D)` for a unit cube
 - similarity dimension: `2`
+
+## Self-Evolutionary Meta-Volume
+
+`jarvisx.meta_volume` implements a deterministic architecture-governor for a
+future adaptive neural renderer. It evolves bounded per-region depth, width,
+ray-sampling budgets, and pruning masks from scene error and hardware telemetry.
+Every accepted structural update emits auditable instructions and is committed
+through a SHA-256 journal; invalid or regressive candidates roll back.
+
+```python
+from jarvisx.meta_volume import (
+    FrameSignals,
+    HardwareTelemetry,
+    MetaVolumeConfig,
+    SelfEvolutionaryMetaVolume,
+)
+
+engine = SelfEvolutionaryMetaVolume(
+    MetaVolumeConfig(region_count=4, parameter_count=8)
+)
+result = engine.evolve(
+    FrameSignals(
+        error=(0.9, 0.1, 0.8, 0.05),
+        edge_density=(0.8, 0.1, 0.7, 0.0),
+        occupancy=(0.9, 0.0, 0.8, 0.0),
+    ),
+    HardwareTelemetry(frame_ms=12.0, flops=1.0e11, memory_mb=2048.0),
+)
+assert result.committed
+```
+
+The module is a tested control-plane prototype, not a claim of measured
+superiority over NeRF, Instant-NGP, or 3D Gaussian Splatting. See
+[`docs/SELF_EVOLUTIONARY_META_VOLUME.md`](docs/SELF_EVOLUTIONARY_META_VOLUME.md)
+for the equations, transaction protocol, structural bytecode, and benchmark
+requirements.

--- a/docs/SELF_EVOLUTIONARY_META_VOLUME.md
+++ b/docs/SELF_EVOLUTIONARY_META_VOLUME.md
@@ -1,0 +1,182 @@
+# Dr. Moagi Self-Evolutionary Meta-Volume
+
+## Status
+
+This document defines an executable **architecture-governor prototype** for a future neural renderer. It does not claim that Jarvis-X currently outperforms NeRF, Instant-NGP, or 3D Gaussian Splatting, and it does not claim 4K60 performance without measured benchmarks.
+
+The implemented contribution is the control plane that can change bounded structural parameters in response to scene error and hardware telemetry while preserving deterministic replay and transactional rollback.
+
+## Twelve-layer logical volume
+
+The renderer contract is represented as twelve logical layers:
+
+| Layer | Name | Logical content |
+|---:|---|---|
+| 0 | Input pixel buffer | Incoming RGB image |
+| 1 | Encoded latent volume | Compact scene representation |
+| 2 | Decoded pixel buffer | Reconstructed image |
+| 3 | Error volume | Per-pixel or regional reconstruction error |
+| 4 | Gradient volume | Weight and latent gradients |
+| 5 | Bytecode and weights | Executable renderer parameters |
+| 6 | Shader registers | Hardware execution state |
+| 7 | Rendered self-image | Visualised internal state |
+| 8 | Architecture DNA | Per-region depth, width, and kernel selection |
+| 9 | Step allocation map | Per-region ray-marching sample budget |
+| 10 | Sparsity mask | Active parameter or feature subset |
+| 11 | Meta-gradient accumulator | Structural update targets |
+
+Layers 0-7 are currently a logical interface. Layers 8-11 are operationalised by `jarvisx.meta_volume`.
+
+## Two-loop model
+
+The intended optimisation is bilevel:
+
+\[
+\theta^*(a)=\arg\min_\theta \mathcal L_{\mathrm{render}}(\theta,a)
+\]
+
+\[
+a_{t+1}=\Pi_{\mathcal A}\left[a_t-\eta_a\nabla_a\left(
+\mathcal L_{\mathrm{render}}
++\lambda_C\mathcal C_{\mathrm{compute}}
++\lambda_M\mathcal M_{\mathrm{memory}}
+\right)\right]
+\]
+
+where `a` contains depth, width, sample count, and pruning variables. The current prototype implements a deterministic projected surrogate update rather than full differentiable NAS.
+
+## Operational state
+
+\[
+S_t=(A_t,\;P_t,\;Q_t,\;M_t,\;G_t,\;J_t)
+\]
+
+- `A_t`: architecture DNA;
+- `P_t`: step allocation map;
+- `Q_t`: continuous pruning scores;
+- `M_t`: binary execution mask;
+- `G_t`: meta-gradient targets;
+- `J_t`: SHA-256 structural journal hash.
+
+The controller receives:
+
+\[
+X_t=(e_t,\;g_t,\;o_t,\;h_t)
+\]
+
+where `e` is normalised error, `g` is edge density, `o` is occupancy, and `h` is hardware telemetry.
+
+## Bounded structural instructions
+
+A committed meta-step emits auditable instructions:
+
+```text
+SET_DEPTH region depth
+SET_WIDTH region width
+SET_STEPS region samples
+SET_MASK parameter enabled
+```
+
+The implemented constraints are:
+
+```text
+4 <= depth <= 12
+32 <= width <= 256, aligned to 16
+4 <= samples <= 128
+kernel in {1, 3, 5}
+active mask ratio >= configured floor
+```
+
+The current prototype changes depth, width, steps, and pruning state. Kernel selection is represented and verified but remains fixed at `3` until a kernel-cost model is added.
+
+## Transaction protocol
+
+Each evolution cycle executes:
+
+```text
+observe scene signals and hardware telemetry
+-> evaluate current architecture
+-> compute structural targets
+-> project into legal architecture bounds
+-> evaluate candidate objective
+-> verify dimensions, bounds, and mask floor
+-> emit structural instructions
+-> commit and seal journal, or roll back atomically
+```
+
+The candidate commits only when its surrogate objective does not regress:
+
+\[
+J(a') \le J(a)+\varepsilon.
+\]
+
+A failed candidate leaves the architecture, cycle, and prior journal hash unchanged.
+
+## Hardware-aware objective
+
+The prototype uses:
+
+\[
+J=
+\mathcal L_{\mathrm{render}}
++\lambda_C\widehat{\mathcal C}
++\lambda_M\widehat{\mathcal M}.
+\]
+
+`render_loss` is a normalised regional proxy. Compute cost is estimated from depth, width, sample count, mask activity, frame time, FLOPs, and SM cycles. Memory cost uses active ratio, width, and measured VRAM usage.
+
+These proxies are deliberately separated from real benchmark claims. A CUDA renderer must replace them with measured kernel timings and allocator telemetry before performance comparisons are valid.
+
+## Pareto analysis
+
+`pareto_front()` computes non-dominated candidates under:
+
+- maximise PSNR;
+- minimise FLOPs;
+- minimise memory.
+
+A raw score such as `PSNR / (FLOPs * memory)` is not used as the sole decision rule because it is unit-dependent and can hide trade-offs. Scalarisation remains available through the weighted objective.
+
+## Example
+
+```python
+from jarvisx.meta_volume import (
+    FrameSignals,
+    HardwareTelemetry,
+    MetaVolumeConfig,
+    SelfEvolutionaryMetaVolume,
+)
+
+engine = SelfEvolutionaryMetaVolume(
+    MetaVolumeConfig(region_count=4, parameter_count=8)
+)
+
+signals = FrameSignals(
+    error=(0.9, 0.1, 0.8, 0.05),
+    edge_density=(0.8, 0.1, 0.7, 0.0),
+    occupancy=(0.9, 0.0, 0.8, 0.0),
+)
+telemetry = HardwareTelemetry(
+    frame_ms=12.0,
+    flops=1.0e11,
+    memory_mb=2048.0,
+)
+
+result = engine.evolve(signals, telemetry)
+assert result.committed
+assert engine.state.architecture.depth[0] > engine.state.architecture.depth[1]
+```
+
+## Research path to a real renderer
+
+The next implementation gates are:
+
+1. connect the controller to a concrete NeRF, hash-grid, or Gaussian renderer;
+2. replace regional quality proxies with MSE, SSIM, LPIPS, and measured PSNR;
+3. use differentiable gates or straight-through estimators for depth and pruning;
+4. profile actual CUDA kernels and memory allocation;
+5. train on public datasets with fixed evaluation protocols;
+6. compare quality, training time, render latency, energy, and VRAM against reproduced baselines;
+7. publish confidence intervals and ablation studies.
+
+“Beyond SOTA” remains a falsifiable research hypothesis until those measurements exist.

--- a/src/jarvisx/meta_volume.py
+++ b/src/jarvisx/meta_volume.py
@@ -1,0 +1,609 @@
+"""Deterministic architecture governor for the Jarvis-X meta-volume renderer.
+
+This is a control-plane prototype, not a NeRF/3DGS renderer or a benchmark claim.
+It evolves bounded depth, width, sample counts, and pruning masks, then commits
+only verified non-regressive structural changes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, replace
+from typing import Iterable, Optional, Sequence, Tuple
+
+
+def _mean(values: Sequence[float]) -> float:
+    return sum(values) / max(1, len(values))
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, value))
+
+
+@dataclass(frozen=True)
+class MetaVolumeConfig:
+    region_count: int = 64
+    parameter_count: int = 256
+    min_depth: int = 4
+    max_depth: int = 12
+    min_width: int = 32
+    max_width: int = 256
+    min_steps: int = 4
+    max_steps: int = 128
+    learning_rate: float = 0.22
+    lambda_compute: float = 0.035
+    lambda_memory: float = 0.025
+    minimum_active_ratio: float = 0.20
+    mask_threshold: float = 0.50
+    commit_tolerance: float = 1.0e-10
+    max_memory_mb: float = 24576.0
+    target_frame_ms: float = 16.667
+
+    def validate(self) -> None:
+        scalars = (
+            self.learning_rate,
+            self.lambda_compute,
+            self.lambda_memory,
+            self.minimum_active_ratio,
+            self.mask_threshold,
+            self.commit_tolerance,
+            self.max_memory_mb,
+            self.target_frame_ms,
+        )
+        if not all(math.isfinite(float(v)) for v in scalars):
+            raise ValueError("configuration must be finite")
+        if self.region_count < 1 or self.parameter_count < 1:
+            raise ValueError("region_count and parameter_count must be positive")
+        if not 1 <= self.min_depth <= self.max_depth:
+            raise ValueError("invalid depth bounds")
+        if (
+            not 1 <= self.min_width <= self.max_width
+            or self.min_width % 16
+            or self.max_width % 16
+        ):
+            raise ValueError("width bounds must be ordered multiples of 16")
+        if not 1 <= self.min_steps <= self.max_steps:
+            raise ValueError("invalid step bounds")
+        if not 0 < self.learning_rate <= 1:
+            raise ValueError("learning_rate must be in (0, 1]")
+        if self.lambda_compute < 0 or self.lambda_memory < 0:
+            raise ValueError("cost penalties must be non-negative")
+        if not 0 < self.minimum_active_ratio <= 1:
+            raise ValueError("minimum_active_ratio must be in (0, 1]")
+        if not 0 < self.mask_threshold < 1:
+            raise ValueError("mask_threshold must be in (0, 1)")
+        if (
+            self.commit_tolerance < 0
+            or self.max_memory_mb <= 0
+            or self.target_frame_ms <= 0
+        ):
+            raise ValueError("invalid transaction or hardware budget")
+
+
+@dataclass(frozen=True)
+class FrameSignals:
+    error: Tuple[float, ...]
+    edge_density: Tuple[float, ...]
+    occupancy: Tuple[float, ...]
+
+    def validate(self, count: int) -> None:
+        if not (
+            len(self.error)
+            == len(self.edge_density)
+            == len(self.occupancy)
+            == count
+        ):
+            raise ValueError("signal vectors must match region_count")
+        for vector in (self.error, self.edge_density, self.occupancy):
+            if not all(math.isfinite(v) and 0 <= v <= 1 for v in vector):
+                raise ValueError("signals must be finite values in [0, 1]")
+
+    def complexity(self) -> Tuple[float, ...]:
+        return tuple(
+            _clamp(0.55 * e + 0.25 * g + 0.20 * o, 0, 1)
+            for e, g, o in zip(self.error, self.edge_density, self.occupancy)
+        )
+
+
+@dataclass(frozen=True)
+class HardwareTelemetry:
+    frame_ms: float
+    flops: float
+    memory_mb: float
+    sm_cycles: float = 0.0
+
+    def validate(self) -> None:
+        if not all(math.isfinite(v) and v >= 0 for v in asdict(self).values()):
+            raise ValueError("hardware telemetry must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class ArchitectureDNA:
+    depth: Tuple[int, ...]
+    width: Tuple[int, ...]
+    kernel: Tuple[int, ...]
+    revision: int = 0
+
+
+@dataclass(frozen=True)
+class MetaGradients:
+    depth: Tuple[float, ...]
+    width: Tuple[float, ...]
+    steps: Tuple[float, ...]
+    mask: Tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class MetaEvaluation:
+    render_loss: float
+    compute_cost: float
+    memory_cost: float
+    objective: float
+    psnr_proxy_db: float
+    active_ratio: float
+    average_depth: float
+    average_width: float
+    average_steps: float
+
+
+@dataclass(frozen=True)
+class StructuralInstruction:
+    opcode: str
+    index: int
+    old_value: float
+    new_value: float
+
+
+@dataclass(frozen=True)
+class ParetoPoint:
+    name: str
+    psnr_db: float
+    flops: float
+    memory_mb: float
+
+
+@dataclass(frozen=True)
+class MetaVolumeState:
+    architecture: ArchitectureDNA
+    step_map: Tuple[int, ...]
+    mask_scores: Tuple[float, ...]
+    mask: Tuple[bool, ...]
+    meta_gradients: MetaGradients
+    cycle: int
+    journal_hash: str
+    last_committed: bool
+    rollback_reason: Optional[str] = None
+
+    def layer_manifest(self) -> Tuple[dict, ...]:
+        fixed = (
+            (0, "input_pixel_buffer", [512, 512, 3]),
+            (1, "encoded_latent_volume", [64, 64, 256]),
+            (2, "decoded_pixel_buffer", [512, 512, 3]),
+            (3, "error_volume", [512, 512, 3]),
+            (4, "gradient_volume", [512, 512, 256]),
+            (5, "bytecode_and_weights", [128, 128, 64]),
+            (6, "shader_registers", [256, 256, 16]),
+            (7, "rendered_self_image", [512, 512, 4]),
+        )
+        layers = [
+            {"layer": i, "name": name, "shape": shape}
+            for i, name, shape in fixed
+        ]
+        layers.extend(
+            [
+                {
+                    "layer": 8,
+                    "name": "architecture_dna",
+                    "logical_entries": len(self.architecture.depth),
+                },
+                {
+                    "layer": 9,
+                    "name": "step_allocation_map",
+                    "logical_entries": len(self.step_map),
+                },
+                {
+                    "layer": 10,
+                    "name": "sparsity_mask",
+                    "logical_entries": len(self.mask),
+                },
+                {
+                    "layer": 11,
+                    "name": "meta_gradient_accumulator",
+                    "logical_entries": sum(
+                        len(v)
+                        for v in (
+                            self.meta_gradients.depth,
+                            self.meta_gradients.width,
+                            self.meta_gradients.steps,
+                            self.meta_gradients.mask,
+                        )
+                    ),
+                },
+            ]
+        )
+        return tuple(layers)
+
+
+@dataclass(frozen=True)
+class EvolutionResult:
+    committed: bool
+    state: MetaVolumeState
+    baseline: MetaEvaluation
+    candidate: MetaEvaluation
+    instructions: Tuple[StructuralInstruction, ...]
+
+
+class SelfEvolutionaryMetaVolume:
+    """Projected meta-update with deterministic transaction semantics."""
+
+    def __init__(self, config: Optional[MetaVolumeConfig] = None) -> None:
+        self.config = config or MetaVolumeConfig()
+        self.config.validate()
+        rc, pc = self.config.region_count, self.config.parameter_count
+        zeros_r, zeros_m = (0.0,) * rc, (0.0,) * pc
+        scores = (0.75,) * pc
+        self.state = MetaVolumeState(
+            ArchitectureDNA((8,) * rc, (128,) * rc, (3,) * rc),
+            (96,) * rc,
+            scores,
+            tuple(v >= self.config.mask_threshold for v in scores),
+            MetaGradients(zeros_r, zeros_r, zeros_r, zeros_m),
+            0,
+            "0" * 64,
+            True,
+        )
+
+    @staticmethod
+    def _active_ratio(mask: Sequence[bool]) -> float:
+        return sum(mask) / len(mask)
+
+    def evaluate(
+        self,
+        state: MetaVolumeState,
+        signals: FrameSignals,
+        hw: HardwareTelemetry,
+    ) -> MetaEvaluation:
+        signals.validate(self.config.region_count)
+        hw.validate()
+        c, active = self.config, self._active_ratio(state.mask)
+        capacity = []
+        for d, w, s in zip(
+            state.architecture.depth,
+            state.architecture.width,
+            state.step_map,
+        ):
+            dn = (d - c.min_depth) / max(1, c.max_depth - c.min_depth)
+            wn = (w - c.min_width) / max(1, c.max_width - c.min_width)
+            sn = (s - c.min_steps) / max(1, c.max_steps - c.min_steps)
+            capacity.append(
+                _clamp(
+                    0.30 * dn + 0.20 * wn + 0.35 * sn + 0.15 * active,
+                    0,
+                    1,
+                )
+            )
+        residual = tuple(
+            e * (1 - 0.78 * cap)
+            + 0.08 * g * (1 - cap)
+            + 0.04 * o * (1 - cap)
+            for e, g, o, cap in zip(
+                signals.error,
+                signals.edge_density,
+                signals.occupancy,
+                capacity,
+            )
+        )
+        loss = _mean(tuple(v * v for v in residual))
+        architecture_compute = _mean(
+            tuple(
+                (d / c.max_depth)
+                * (w / c.max_width)
+                * (s / c.max_steps)
+                * active
+                for d, w, s in zip(
+                    state.architecture.depth,
+                    state.architecture.width,
+                    state.step_map,
+                )
+            )
+        )
+        compute = (
+            architecture_compute
+            + 0.05 * hw.frame_ms / c.target_frame_ms
+            + 0.01 * hw.flops / 1e12
+            + 0.005 * hw.sm_cycles / 1e9
+        )
+        memory = (
+            active
+            * _mean(tuple(float(w) for w in state.architecture.width))
+            / c.max_width
+            + 0.05 * hw.memory_mb / c.max_memory_mb
+        )
+        objective = loss + c.lambda_compute * compute + c.lambda_memory * memory
+        return MetaEvaluation(
+            loss,
+            compute,
+            memory,
+            objective,
+            -10 * math.log10(max(loss, 1e-12)),
+            active,
+            _mean(tuple(float(v) for v in state.architecture.depth)),
+            _mean(tuple(float(v) for v in state.architecture.width)),
+            _mean(tuple(float(v) for v in state.step_map)),
+        )
+
+    def _targets(
+        self,
+        signals: FrameSignals,
+        hw: HardwareTelemetry,
+    ) -> MetaGradients:
+        c, complexity = self.config, signals.complexity()
+        frame_pressure = max(0.0, hw.frame_ms / c.target_frame_ms - 1.0)
+        memory_pressure = max(0.0, hw.memory_mb / c.max_memory_mb - 0.75)
+        depth = tuple(
+            c.min_depth
+            + x * (c.max_depth - c.min_depth)
+            - 2 * frame_pressure
+            for x in complexity
+        )
+        width = tuple(
+            c.min_width
+            + x * (c.max_width - c.min_width)
+            - 32 * memory_pressure
+            - 16 * frame_pressure
+            for x in complexity
+        )
+        steps = tuple(
+            c.min_steps
+            + x * (c.max_steps - c.min_steps)
+            - 24 * frame_pressure
+            for x in complexity
+        )
+        avg = _mean(complexity)
+        mask = tuple(
+            max(
+                c.minimum_active_ratio,
+                0.15 + 0.55 * complexity[i % c.region_count] + 0.30 * avg,
+            )
+            - 0.35 * memory_pressure
+            for i in range(c.parameter_count)
+        )
+        return MetaGradients(depth, width, steps, mask)
+
+    def _propose(self, targets: MetaGradients) -> MetaVolumeState:
+        c, old, lr = self.config, self.state, self.config.learning_rate
+        depth = tuple(
+            int(round(_clamp(v + lr * (t - v), c.min_depth, c.max_depth)))
+            for v, t in zip(old.architecture.depth, targets.depth)
+        )
+        width = tuple(
+            max(
+                c.min_width,
+                min(
+                    c.max_width,
+                    int(round((v + lr * (t - v)) / 16) * 16),
+                ),
+            )
+            for v, t in zip(old.architecture.width, targets.width)
+        )
+        steps = tuple(
+            int(round(_clamp(v + lr * (t - v), c.min_steps, c.max_steps)))
+            for v, t in zip(old.step_map, targets.steps)
+        )
+        scores = tuple(
+            _clamp(v + lr * (t - v), 0, 1)
+            for v, t in zip(old.mask_scores, targets.mask)
+        )
+        mask = [v >= c.mask_threshold for v in scores]
+        floor = max(1, math.ceil(c.minimum_active_ratio * len(mask)))
+        if sum(mask) < floor:
+            for i in sorted(
+                range(len(scores)), key=lambda j: (-scores[j], j)
+            )[:floor]:
+                mask[i] = True
+        return MetaVolumeState(
+            ArchitectureDNA(
+                depth,
+                width,
+                old.architecture.kernel,
+                old.architecture.revision + 1,
+            ),
+            steps,
+            scores,
+            tuple(mask),
+            targets,
+            old.cycle + 1,
+            old.journal_hash,
+            False,
+        )
+
+    def _verify(self, state: MetaVolumeState) -> Optional[str]:
+        c = self.config
+        if (
+            len(state.architecture.depth) != c.region_count
+            or len(state.architecture.width) != c.region_count
+            or len(state.architecture.kernel) != c.region_count
+            or len(state.step_map) != c.region_count
+        ):
+            return "regional map size mismatch"
+        if (
+            len(state.mask) != c.parameter_count
+            or len(state.mask_scores) != c.parameter_count
+        ):
+            return "mask size mismatch"
+        if not all(
+            c.min_depth <= v <= c.max_depth for v in state.architecture.depth
+        ):
+            return "depth bound exceeded"
+        if not all(
+            c.min_width <= v <= c.max_width and v % 16 == 0
+            for v in state.architecture.width
+        ):
+            return "width bound exceeded"
+        if not all(c.min_steps <= v <= c.max_steps for v in state.step_map):
+            return "step bound exceeded"
+        if not all(v in (1, 3, 5) for v in state.architecture.kernel):
+            return "unsupported kernel size"
+        if not all(
+            math.isfinite(v) and 0 <= v <= 1 for v in state.mask_scores
+        ):
+            return "invalid mask score"
+        if self._active_ratio(state.mask) < c.minimum_active_ratio:
+            return "minimum active ratio violated"
+        return None
+
+    @staticmethod
+    def _instructions(
+        before: MetaVolumeState,
+        after: MetaVolumeState,
+    ) -> Tuple[StructuralInstruction, ...]:
+        out = []
+        groups = (
+            (
+                "SET_DEPTH",
+                before.architecture.depth,
+                after.architecture.depth,
+            ),
+            (
+                "SET_WIDTH",
+                before.architecture.width,
+                after.architecture.width,
+            ),
+            ("SET_STEPS", before.step_map, after.step_map),
+            ("SET_MASK", before.mask, after.mask),
+        )
+        for opcode, left, right in groups:
+            for i, (old, new) in enumerate(zip(left, right)):
+                if old != new:
+                    out.append(
+                        StructuralInstruction(
+                            opcode,
+                            i,
+                            float(old),
+                            float(new),
+                        )
+                    )
+        return tuple(out)
+
+    def _seal(
+        self,
+        state: MetaVolumeState,
+        evaluation: MetaEvaluation,
+        instructions: Sequence[StructuralInstruction],
+    ) -> str:
+        payload = {
+            "cycle": state.cycle,
+            "architecture": asdict(state.architecture),
+            "step_map": state.step_map,
+            "mask_scores": tuple(round(v, 15) for v in state.mask_scores),
+            "mask": state.mask,
+            "evaluation": asdict(evaluation),
+            "instructions": [asdict(v) for v in instructions],
+        }
+        canonical = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode()
+        return hashlib.sha256(
+            bytes.fromhex(self.state.journal_hash) + canonical
+        ).hexdigest()
+
+    def evolve(
+        self,
+        signals: FrameSignals,
+        hw: HardwareTelemetry,
+    ) -> EvolutionResult:
+        signals.validate(self.config.region_count)
+        hw.validate()
+        baseline = self.evaluate(self.state, signals, hw)
+        candidate_state = self._propose(self._targets(signals, hw))
+        reason = self._verify(candidate_state)
+        if reason:
+            self.state = replace(
+                self.state,
+                last_committed=False,
+                rollback_reason=reason,
+            )
+            return EvolutionResult(False, self.state, baseline, baseline, ())
+        candidate = self.evaluate(candidate_state, signals, hw)
+        if candidate.objective > baseline.objective + self.config.commit_tolerance:
+            self.state = replace(
+                self.state,
+                last_committed=False,
+                rollback_reason="candidate objective did not improve",
+            )
+            return EvolutionResult(False, self.state, baseline, candidate, ())
+        instructions = self._instructions(self.state, candidate_state)
+        self.state = replace(
+            candidate_state,
+            journal_hash=self._seal(candidate_state, candidate, instructions),
+            last_committed=True,
+            rollback_reason=None,
+        )
+        return EvolutionResult(
+            True,
+            self.state,
+            baseline,
+            candidate,
+            instructions,
+        )
+
+    def snapshot(self) -> dict:
+        return {
+            "cycle": self.state.cycle,
+            "journal_hash": self.state.journal_hash,
+            "last_committed": self.state.last_committed,
+            "rollback_reason": self.state.rollback_reason,
+            "architecture_revision": self.state.architecture.revision,
+            "average_depth": _mean(
+                tuple(float(v) for v in self.state.architecture.depth)
+            ),
+            "average_width": _mean(
+                tuple(float(v) for v in self.state.architecture.width)
+            ),
+            "average_steps": _mean(
+                tuple(float(v) for v in self.state.step_map)
+            ),
+            "active_ratio": self._active_ratio(self.state.mask),
+            "layers": self.state.layer_manifest(),
+        }
+
+
+def pareto_front(points: Iterable[ParetoPoint]) -> Tuple[ParetoPoint, ...]:
+    values = tuple(points)
+    for point in values:
+        if (
+            not all(
+                math.isfinite(v)
+                for v in (point.psnr_db, point.flops, point.memory_mb)
+            )
+            or point.flops < 0
+            or point.memory_mb < 0
+        ):
+            raise ValueError(
+                "Pareto values must be finite and costs non-negative"
+            )
+    front = []
+    for candidate in values:
+        dominated = any(
+            other != candidate
+            and other.psnr_db >= candidate.psnr_db
+            and other.flops <= candidate.flops
+            and other.memory_mb <= candidate.memory_mb
+            and (
+                other.psnr_db > candidate.psnr_db
+                or other.flops < candidate.flops
+                or other.memory_mb < candidate.memory_mb
+            )
+            for other in values
+        )
+        if not dominated:
+            front.append(candidate)
+    return tuple(
+        sorted(
+            front,
+            key=lambda v: (-v.psnr_db, v.flops, v.memory_mb, v.name),
+        )
+    )

--- a/tests/test_meta_volume.py
+++ b/tests/test_meta_volume.py
@@ -1,0 +1,159 @@
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.meta_volume import (
+    FrameSignals,
+    HardwareTelemetry,
+    MetaVolumeConfig,
+    ParetoPoint,
+    SelfEvolutionaryMetaVolume,
+    pareto_front,
+)
+
+
+def make_signals():
+    return FrameSignals(
+        error=(0.90, 0.10, 0.80, 0.05),
+        edge_density=(0.80, 0.10, 0.70, 0.00),
+        occupancy=(0.90, 0.00, 0.80, 0.00),
+    )
+
+
+def make_engine(**overrides):
+    values = dict(
+        region_count=4,
+        parameter_count=8,
+        learning_rate=0.50,
+        lambda_compute=0.02,
+        lambda_memory=0.01,
+        minimum_active_ratio=0.25,
+    )
+    values.update(overrides)
+    return SelfEvolutionaryMetaVolume(MetaVolumeConfig(**values))
+
+
+def test_layer_manifest_exposes_twelve_logical_layers():
+    engine = make_engine()
+    manifest = engine.state.layer_manifest()
+    assert len(manifest) == 12
+    assert manifest[8]["name"] == "architecture_dna"
+    assert manifest[9]["name"] == "step_allocation_map"
+    assert manifest[10]["name"] == "sparsity_mask"
+    assert manifest[11]["name"] == "meta_gradient_accumulator"
+
+
+def test_complex_regions_receive_more_depth_and_samples():
+    engine = make_engine()
+    result = engine.evolve(
+        make_signals(),
+        HardwareTelemetry(frame_ms=12.0, flops=1.0e11, memory_mb=2048.0),
+    )
+    assert result.committed
+    assert engine.state.architecture.depth[0] > engine.state.architecture.depth[1]
+    assert engine.state.step_map[0] > engine.state.step_map[1]
+    assert engine.state.architecture.depth[2] > engine.state.architecture.depth[3]
+    assert engine.state.step_map[2] > engine.state.step_map[3]
+    assert any(item.opcode == "SET_DEPTH" for item in result.instructions)
+    assert any(item.opcode == "SET_STEPS" for item in result.instructions)
+
+
+def test_high_hardware_pressure_reduces_allocations():
+    low_pressure = make_engine()
+    high_pressure = make_engine(lambda_compute=0.50, lambda_memory=0.50)
+    signals = make_signals()
+
+    low = low_pressure.evolve(
+        signals,
+        HardwareTelemetry(frame_ms=12.0, flops=1.0e11, memory_mb=2048.0),
+    )
+    high = high_pressure.evolve(
+        signals,
+        HardwareTelemetry(
+            frame_ms=40.0,
+            flops=1.0e12,
+            memory_mb=23000.0,
+            sm_cycles=1.0e9,
+        ),
+    )
+
+    assert low.committed and high.committed
+    assert sum(high.state.architecture.depth) <= sum(low.state.architecture.depth)
+    assert sum(high.state.step_map) < sum(low.state.step_map)
+
+
+def test_empty_scene_prunes_to_declared_floor():
+    engine = make_engine(
+        learning_rate=0.60,
+        lambda_compute=0.20,
+        lambda_memory=0.20,
+    )
+    empty = FrameSignals(
+        error=(0.0, 0.0, 0.0, 0.0),
+        edge_density=(0.0, 0.0, 0.0, 0.0),
+        occupancy=(0.0, 0.0, 0.0, 0.0),
+    )
+    telemetry = HardwareTelemetry(
+        frame_ms=40.0,
+        flops=2.0e12,
+        memory_mb=23000.0,
+        sm_cycles=1.0e9,
+    )
+
+    result = engine.evolve(empty, telemetry)
+    assert result.committed
+    assert engine.snapshot()["active_ratio"] == pytest.approx(0.25)
+    assert set(engine.state.architecture.depth) == {engine.config.min_depth}
+
+
+def test_invalid_candidate_rolls_back_atomically(monkeypatch):
+    engine = make_engine()
+    before = engine.state
+    original = engine._propose
+
+    def invalid(gradients):
+        candidate = original(gradients)
+        architecture = replace(
+            candidate.architecture,
+            depth=(99,) + candidate.architecture.depth[1:],
+        )
+        return replace(candidate, architecture=architecture)
+
+    monkeypatch.setattr(engine, "_propose", invalid)
+    result = engine.evolve(
+        make_signals(),
+        HardwareTelemetry(frame_ms=12.0, flops=1.0e11, memory_mb=2048.0),
+    )
+
+    assert not result.committed
+    assert engine.state.cycle == before.cycle
+    assert engine.state.journal_hash == before.journal_hash
+    assert engine.state.architecture == before.architecture
+    assert engine.state.rollback_reason == "depth bound exceeded"
+
+
+def test_replay_is_deterministic():
+    left = make_engine()
+    right = make_engine()
+    signals = make_signals()
+    telemetry = HardwareTelemetry(
+        frame_ms=12.0,
+        flops=1.0e11,
+        memory_mb=2048.0,
+    )
+
+    for _ in range(3):
+        assert left.evolve(signals, telemetry) == right.evolve(signals, telemetry)
+
+    assert left.state == right.state
+    assert left.state.journal_hash == right.state.journal_hash
+
+
+def test_pareto_front_removes_dominated_candidates():
+    points = (
+        ParetoPoint("fixed-small", 29.0, 100.0, 10.0),
+        ParetoPoint("dominated", 28.0, 120.0, 12.0),
+        ParetoPoint("quality", 31.0, 150.0, 8.0),
+    )
+    front = pareto_front(points)
+    assert {point.name for point in front} == {"fixed-small", "quality"}


### PR DESCRIPTION
## Purpose

Operationalise the proposed 12-layer Dr. Moagi meta-volume as a bounded, deterministic architecture-control plane rather than committing unverified “beyond SOTA” performance claims.

This PR is intentionally isolated from PR #29. It targets `main` from `agent/self-evolutionary-meta-volume` and remains draft until repository CI and review are complete.

## What changed

- adds `src/jarvisx/meta_volume.py`
- models the 12-layer logical volume contract
- operationalises Layers 8–11:
  - architecture DNA: per-region depth, width, and kernel metadata
  - adaptive step allocation: 4–128 samples per region
  - continuous pruning scores plus a bounded binary execution mask
  - meta-gradient/structural-target accumulator
- consumes normalised error, edge-density, occupancy, and hardware telemetry
- evaluates a hardware-aware objective:

  `render_loss + lambda_compute * compute_cost + lambda_memory * memory_cost`

- projects all structural proposals into explicit legal bounds
- emits auditable structural instructions:
  - `SET_DEPTH`
  - `SET_WIDTH`
  - `SET_STEPS`
  - `SET_MASK`
- atomically commits only verified, non-regressive candidates
- SHA-256 seals every committed structural transition
- restores architecture, cycle, and prior journal state on rejection
- adds non-dominated Pareto-front selection for PSNR/FLOPs/memory experiments
- adds full architecture and research-boundary documentation
- updates the README with a runnable example

## Mechanistic cycle

```text
scene signals + hardware telemetry
→ evaluate current structure
→ derive bounded structural targets
→ project depth/width/steps/mask
→ evaluate candidate objective
→ verify invariants
→ emit structural bytecode
→ commit and seal, or roll back
```

## Correctness boundaries

This is a control-plane prototype. It does **not** yet implement a NeRF, Instant-NGP, 3D Gaussian Splatting renderer, differentiable NAS, CUDA kernels, LPIPS, or measured 4K60 performance.

“Beyond SOTA” is retained only as a falsifiable research hypothesis. The documentation requires reproduced baselines, public datasets, measured GPU timing, VRAM telemetry, ablations, and confidence intervals before comparative claims are accepted.

## Validation

Focused tests cover:

- all twelve logical layers
- increased depth and sampling for complex regions
- reduced allocation under hardware pressure
- pruning to the configured active floor
- invalid-candidate atomic rollback
- deterministic replay and journal equality
- Pareto filtering of dominated candidates

Local focused result: `7 passed`.

## Follow-on gates

1. connect the controller to a concrete renderer backend;
2. replace quality/cost proxies with measured MSE, SSIM, LPIPS, PSNR, kernel time, energy, and VRAM;
3. add differentiable gates or straight-through estimators;
4. implement real kernel and architecture mutation safely;
5. benchmark against reproduced NeRF, Instant-NGP, and 3DGS baselines.
