### PR TITLE
Add inward self-evolving C++ runtime

### DIFF
--- a/.github/workflows/cpp-autopoietic-runtime.yml
+++ b/.github/workflows/cpp-autopoietic-runtime.yml
@@ -1,0 +1,27 @@
+name: C++ Autopoietic Runtime
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/**"
+      - ".github/workflows/cpp-autopoietic-runtime.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/**"
+      - ".github/workflows/cpp-autopoietic-runtime.yml"
+
+jobs:
+  build-and-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build/cpp-runtime --parallel 2
+
+      - name: Test
+        run: ctest --test-dir build/cpp-runtime --output-on-failure

--- a/.github/workflows/cpp-autopoietic-runtime.yml
+++ b/.github/workflows/cpp-autopoietic-runtime.yml
@@ -10,18 +10,47 @@ on:
       - "cpp_runtime/**"
       - ".github/workflows/cpp-autopoietic-runtime.yml"
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-smoke-test:
-    runs-on: ubuntu-latest
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            sanitizers: "OFF"
+          - os: ubuntu-latest
+            compiler: clang
+            sanitizers: "ON"
+          - os: windows-latest
+            compiler: msvc
+            sanitizers: "OFF"
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Select GCC
+        if: matrix.compiler == 'gcc'
+        run: echo "CXX=g++" >> "$GITHUB_ENV"
+
+      - name: Select Clang
+        if: matrix.compiler == 'clang'
+        run: echo "CXX=clang++" >> "$GITHUB_ENV"
+
       - name: Configure
-        run: cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+        run: >-
+          cmake -S cpp_runtime -B build/cpp-runtime
+          -DCMAKE_BUILD_TYPE=Release
+          -DJARVISX_ENABLE_SANITIZERS=${{ matrix.sanitizers }}
 
       - name: Build
-        run: cmake --build build/cpp-runtime --parallel 2
+        run: cmake --build build/cpp-runtime --config Release --parallel 2
 
       - name: Test
-        run: ctest --test-dir build/cpp-runtime --output-on-failure
+        run: ctest --test-dir build/cpp-runtime -C Release --output-on-failure

--- a/README.md
+++ b/README.md
@@ -35,3 +35,27 @@ At depth `D`, the deterministic invariants are:
 - active nodes: `(4 ** (D + 1) - 1) // 3`
 - retained volume: `2 ** (-D)` for a unit cube
 - similarity dimension: `2`
+
+## C++ Inward Autopoietic Runtime
+
+The `cpp_runtime/` subsystem implements a dependency-free C++17 processor with:
+
+- a sparse virtual `8192 × 8192 × 8192` lattice;
+- 3-bit auto-encoding and decoding;
+- deterministic 64-bit bytecode synthesis;
+- inward ingestion of its own executable image;
+- candidate genome and bytecode-schedule mutation;
+- isolated evaluation, coherence gating, commit, and rollback;
+- persistent checkpoints, binary ROM output, and CSV evolution journals.
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --parallel
+ctest --test-dir build/cpp-runtime --output-on-failure
+
+./build/cpp-runtime/jarvisx-runtime \
+  --generations 8 \
+  --population 6
+```
+
+The self-evolution mechanism is bounded and auditable: it optimizes runtime parameters and bytecode schedules rather than rewriting arbitrary native machine code.

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -6,7 +6,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(jarvisx-runtime
-    src/jarvis_x_autopoietic_runtime.cpp
+    src/main.cpp
+)
+
+target_include_directories(jarvisx-runtime PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 if(MSVC)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.16)
+project(jarvis_x_autopoietic_runtime LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(jarvisx-runtime
+    src/jarvis_x_autopoietic_runtime.cpp
+)
+
+if(MSVC)
+    target_compile_options(jarvisx-runtime PRIVATE /W4 /permissive-)
+else()
+    target_compile_options(jarvisx-runtime PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+enable_testing()
+add_test(
+    NAME inward-runtime-smoke
+    COMMAND jarvisx-runtime
+        --generations 2
+        --population 3
+        --state-dir ${CMAKE_CURRENT_BINARY_DIR}/smoke-state
+        --text "Jarvis X inward runtime smoke test"
+        --quiet
+        --reset
+)
+set_tests_properties(inward-runtime-smoke PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -5,21 +5,30 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+option(JARVISX_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+function(jarvisx_harden target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
+        if(JARVISX_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(${target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+            target_link_options(${target} PRIVATE -fsanitize=address,undefined)
+        endif()
+    endif()
+endfunction()
+
 add_executable(jarvisx-runtime
     src/main.cpp
 )
-
 target_include_directories(jarvisx-runtime PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
-
-if(MSVC)
-    target_compile_options(jarvisx-runtime PRIVATE /W4 /permissive-)
-else()
-    target_compile_options(jarvisx-runtime PRIVATE -Wall -Wextra -Wpedantic)
-endif()
+jarvisx_harden(jarvisx-runtime)
 
 enable_testing()
+
 add_test(
     NAME inward-runtime-smoke
     COMMAND jarvisx-runtime
@@ -31,3 +40,14 @@ add_test(
         --reset
 )
 set_tests_properties(inward-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-processor-tests
+    tests/processor_tests.cpp
+)
+target_include_directories(jarvisx-processor-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-processor-tests)
+
+add_test(NAME processor-regressions COMMAND jarvisx-processor-tests)
+set_tests_properties(processor-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -1,0 +1,66 @@
+# Jarvis X Inward Autopoietic Runtime
+
+This C++17 runtime turns the 3D 8K³ auto-encoding processor inward onto its own executable image.
+
+It preserves a virtual `8192 × 8192 × 8192` coordinate space through sparse `8 × 8 × 8` tiles, then executes a bounded self-optimization cycle:
+
+1. ingest its own executable by default;
+2. extract fixed-width multimodal features;
+3. encode them into the 3-bit set `{-4,-3,-2,-1,0,1,2,3}`;
+4. scatter and diffuse the latent field through the sparse 3D lattice;
+5. decode and calculate reconstruction error;
+6. generate candidate runtime genomes and bytecode schedules;
+7. evaluate every candidate in a fresh sandboxed processor instance;
+8. apply the Lambda coherence gate;
+9. commit an improvement or roll back;
+10. checkpoint the genome, ROM, and CSV evolution journal.
+
+The runtime evolves auditable parameters and bytecode schedules. It does **not** rewrite arbitrary native machine code or claim consciousness.
+
+## Build
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime
+cmake --build build/cpp-runtime --config Release
+```
+
+Or compile directly:
+
+```bash
+g++ -std=c++17 -O3 -pthread \
+  cpp_runtime/src/jarvis_x_autopoietic_runtime.cpp \
+  -o jarvisx-runtime
+```
+
+## Run inward on the executable
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --generations 8 \
+  --population 6
+```
+
+## Run on another multimodal or binary input
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --file sample.bin \
+  --generations 12 \
+  --population 8
+```
+
+## State artifacts
+
+The default `.jarvisx-runtime/` directory contains:
+
+- `genome.current` — atomically committed runtime genome;
+- `runtime.rom` — big-endian 64-bit bytecode words;
+- `evolution.csv` — accepted and rolled-back generations.
+
+Use `--reset` to discard a previous checkpoint, `--state-dir PATH` to isolate experiments, and `--min-improvement X` to tighten the commit criterion.
+
+## Validation
+
+```bash
+ctest --test-dir build/cpp-runtime --output-on-failure
+```

--- a/cpp_runtime/include/jarvisx/core.hpp
+++ b/cpp_runtime/include/jarvisx/core.hpp
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+namespace fs = std::filesystem;
+
+constexpr std::uint32_t kWorldEdge = 8192;
+constexpr std::uint32_t kTileEdge = 8;
+constexpr std::uint32_t kTileVolume = kTileEdge * kTileEdge * kTileEdge;
+constexpr std::uint32_t kTileAxis = kWorldEdge / kTileEdge;
+constexpr std::size_t kMaxPacketBytes = 1U << 20U;
+constexpr float kEpsilon = 1.0e-6F;
+
+static_assert(kWorldEdge % kTileEdge == 0, "invalid lattice geometry");
+static_assert((kWorldEdge & (kWorldEdge - 1U)) == 0, "edge must be power of two");
+
+float clampf(float value, float low, float high) noexcept {
+    return std::max(low, std::min(value, high));
+}
+
+std::uint64_t mix64(std::uint64_t value) noexcept {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+float signed_unit(std::uint64_t key) noexcept {
+    const std::uint64_t bits = mix64(key);
+    const double unit = static_cast<double>(bits >> 11U) /
+                        static_cast<double>(1ULL << 53U);
+    return static_cast<float>(unit * 2.0 - 1.0);
+}
+
+std::uint32_t crc32(const std::vector<std::uint8_t>& bytes) noexcept {
+    std::uint32_t crc = 0xFFFFFFFFU;
+    for (const std::uint8_t byte : bytes) {
+        crc ^= byte;
+        for (int bit = 0; bit < 8; ++bit) {
+            const std::uint32_t mask = static_cast<std::uint32_t>(
+                -static_cast<std::int32_t>(crc & 1U));
+            crc = (crc >> 1U) ^ (0xEDB88320U & mask);
+        }
+    }
+    return ~crc;
+}
+
+struct Vec3u {
+    std::uint32_t x{};
+    std::uint32_t y{};
+    std::uint32_t z{};
+};
+
+struct Cell {
+    std::int8_t latent{};
+    std::int8_t prediction{};
+    std::int8_t residual{};
+    std::uint8_t modality{};
+    std::uint16_t generation{};
+    std::uint16_t flags{};
+};
+
+struct Tile {
+    std::array<Cell, kTileVolume> cells{};
+};
+
+class SparseLattice {
+public:
+    Cell read(const Vec3u& point) const {
+        const auto [key, index] = locate(point);
+        const auto found = tiles_.find(key);
+        return found == tiles_.end() ? Cell{} : found->second.cells[index];
+    }
+
+    void write(const Vec3u& point, const Cell& cell) {
+        const auto [key, index] = locate(point);
+        tiles_[key].cells[index] = cell;
+    }
+
+    std::size_t tile_count() const noexcept { return tiles_.size(); }
+
+    std::uint64_t estimated_bytes() const noexcept {
+        return static_cast<std::uint64_t>(tiles_.size()) * sizeof(Tile);
+    }
+
+private:
+    std::unordered_map<std::uint64_t, Tile> tiles_;
+
+    static std::pair<std::uint64_t, std::uint32_t> locate(const Vec3u& p) {
+        if (p.x >= kWorldEdge || p.y >= kWorldEdge || p.z >= kWorldEdge) {
+            throw std::out_of_range("coordinate outside 8192^3 lattice");
+        }
+        const std::uint32_t tx = p.x / kTileEdge;
+        const std::uint32_t ty = p.y / kTileEdge;
+        const std::uint32_t tz = p.z / kTileEdge;
+        const std::uint64_t key =
+            static_cast<std::uint64_t>(tx) +
+            static_cast<std::uint64_t>(kTileAxis) *
+                (static_cast<std::uint64_t>(ty) +
+                 static_cast<std::uint64_t>(kTileAxis) * tz);
+        const std::uint32_t lx = p.x % kTileEdge;
+        const std::uint32_t ly = p.y % kTileEdge;
+        const std::uint32_t lz = p.z % kTileEdge;
+        return {key, lx + kTileEdge * (ly + kTileEdge * lz)};
+    }
+};
+
+enum class Modality : std::uint8_t {
+    Text = 1,
+    Image = 2,
+    Audio = 3,
+    Video = 4,
+    Binary = 5,
+    Sensor = 6
+};
+
+struct Packet {
+    Modality modality{Modality::Binary};
+    std::vector<std::uint8_t> bytes;
+    std::uint32_t checksum{};
+
+    void seal() noexcept { checksum = crc32(bytes); }
+    bool valid() const noexcept { return checksum == crc32(bytes); }
+};
+
+Packet text_packet(const std::string& text) {
+    Packet packet;
+    packet.modality = Modality::Text;
+    packet.bytes.assign(text.begin(), text.end());
+    packet.seal();
+    return packet;
+}
+
+std::optional<Packet> file_packet(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return std::nullopt;
+
+    input.seekg(0, std::ios::end);
+    const std::streamoff end = input.tellg();
+    if (end < 0) return std::nullopt;
+    input.seekg(0, std::ios::beg);
+
+    Packet packet;
+    packet.modality = Modality::Binary;
+    packet.bytes.resize(std::min<std::size_t>(
+        static_cast<std::size_t>(end), kMaxPacketBytes));
+    input.read(reinterpret_cast<char*>(packet.bytes.data()),
+               static_cast<std::streamsize>(packet.bytes.size()));
+    packet.bytes.resize(static_cast<std::size_t>(input.gcount()));
+    packet.seal();
+    return packet;
+}
+
+std::vector<float> extract_features(const Packet& packet, std::size_t width) {
+    if (!packet.valid()) throw std::runtime_error("packet CRC mismatch");
+    if (width < 8) throw std::invalid_argument("feature width below 8");
+
+    std::vector<float> features(width, 0.0F);
+    if (packet.bytes.empty()) return features;
+
+    double mean = 0.0;
+    double square = 0.0;
+    for (std::size_t i = 0; i < packet.bytes.size(); ++i) {
+        const float x = static_cast<float>(packet.bytes[i]) / 127.5F - 1.0F;
+        const std::uint64_t h = mix64(
+            (static_cast<std::uint64_t>(i) << 8U) ^
+            packet.bytes[i] ^
+            (static_cast<std::uint64_t>(packet.modality) << 56U));
+        features[h % width] += x;
+        features[(h >> 19U) % width] += x * x - 0.333333F;
+        mean += x;
+        square += static_cast<double>(x) * x;
+    }
+
+    const double count = static_cast<double>(packet.bytes.size());
+    features[0] += static_cast<float>(mean / count);
+    features[1] += static_cast<float>(square / count);
+    features[2] += static_cast<float>(std::log1p(count) / 16.0);
+    features[3] += static_cast<float>(packet.modality) / 8.0F;
+
+    double norm2 = 0.0;
+    for (const float value : features) norm2 += value * value;
+    const float inverse = 1.0F / std::sqrt(static_cast<float>(norm2) + kEpsilon);
+    for (float& value : features) value *= inverse;
+    return features;
+}
+
+std::int8_t quantize_q3(float value) noexcept {
+    const int q = static_cast<int>(std::lround(clampf(value, -1.0F, 1.0F) * 3.5F));
+    return static_cast<std::int8_t>(std::max(-4, std::min(3, q)));
+}
+
+float dequantize_q3(std::int8_t value) noexcept {
+    return clampf(static_cast<float>(value) / 3.5F, -1.0F, 1.0F);
+}
+
+struct Genome {
+    std::uint32_t version{1};
+    std::uint64_t generation{};
+    std::size_t feature_dim{128};
+    std::size_t latent_dim{64};
+    std::uint16_t iterations{12};
+    std::uint16_t diffusion_radius{1};
+    std::uint16_t learning_units{80};
+    std::uint16_t omega_units{40};
+    std::uint16_t max_mse_units{2500};
+    std::uint16_t max_energy_units{8500};
+    std::uint16_t min_coherence_units{800};
+    std::uint64_t seed{0x4A415256495358ULL};
+
+    void clamp() noexcept {
+        feature_dim = std::max<std::size_t>(32, std::min<std::size_t>(512, feature_dim));
+        latent_dim = std::max<std::size_t>(8, std::min<std::size_t>(256, latent_dim));
+        latent_dim = std::min(latent_dim, feature_dim);
+        iterations = static_cast<std::uint16_t>(std::max(2, std::min(128, int(iterations))));
+        diffusion_radius = static_cast<std::uint16_t>(
+            std::max(1, std::min(32, int(diffusion_radius))));
+        learning_units = static_cast<std::uint16_t>(
+            std::max(1, std::min(400, int(learning_units))));
+        omega_units = static_cast<std::uint16_t>(
+            std::max(1, std::min(300, int(omega_units))));
+        max_mse_units = static_cast<std::uint16_t>(
+            std::max(100, std::min(10000, int(max_mse_units))));
+        max_energy_units = static_cast<std::uint16_t>(
+            std::max(1000, std::min(10000, int(max_energy_units))));
+        min_coherence_units = static_cast<std::uint16_t>(
+            std::max(0, std::min(9000, int(min_coherence_units))));
+    }
+
+    std::string fingerprint() const {
+        std::ostringstream out;
+        out << std::hex << std::uppercase << mix64(
+            seed ^ generation ^
+            (static_cast<std::uint64_t>(feature_dim) << 32U) ^
+            (static_cast<std::uint64_t>(latent_dim) << 16U) ^
+            iterations ^ diffusion_radius ^ learning_units ^ omega_units);
+        return out.str();
+    }
+};
+
+enum class Op : std::uint8_t {
+    Extract = 1,
+    Encode = 2,
+    Scatter = 3,
+    Diffuse = 4,
+    Decode = 5,
+    Learn = 6,
+    Project = 7,
+    Commit = 8,
+    Loop = 9,
+    Halt = 0xFF
+};
+
+struct Instruction {
+    std::uint64_t word{};
+
+    static Instruction make(Op op, std::uint16_t a = 0,
+                            std::uint16_t b = 0, std::uint16_t c = 0) noexcept {
+        return { (static_cast<std::uint64_t>(op) << 56U) |
+                 (static_cast<std::uint64_t>(a) << 32U) |
+                 (static_cast<std::uint64_t>(b) << 16U) |
+                 c };
+    }
+
+    Op op() const noexcept { return static_cast<Op>((word >> 56U) & 0xFFU); }
+    std::uint16_t a() const noexcept { return (word >> 32U) & 0xFFFFU; }
+    std::uint16_t b() const noexcept { return (word >> 16U) & 0xFFFFU; }
+    std::uint16_t c() const noexcept { return word & 0xFFFFU; }
+};
+
+std::vector<Instruction> synthesize_rom(const Genome& g) {
+    return {
+        Instruction::make(Op::Extract),
+        Instruction::make(Op::Encode),
+        Instruction::make(Op::Scatter),
+        Instruction::make(Op::Diffuse, g.diffusion_radius),
+        Instruction::make(Op::Decode),
+        Instruction::make(Op::Learn, g.learning_units, g.omega_units),
+        Instruction::make(Op::Project, g.max_mse_units, g.max_energy_units,
+                          g.min_coherence_units),
+        Instruction::make(Op::Commit),
+        Instruction::make(Op::Loop, g.iterations, 1),
+        Instruction::make(Op::Halt)
+    };
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/processor.hpp
+++ b/cpp_runtime/include/jarvisx/processor.hpp
@@ -1,0 +1,242 @@
+#pragma once
+
+#include "jarvisx/core.hpp"
+
+namespace jarvisx {
+struct Metrics {
+    std::uint64_t cycles{};
+    std::uint64_t committed{};
+    std::uint64_t rejected{};
+    float mse{std::numeric_limits<float>::infinity()};
+    float coherence{};
+    float energy{};
+};
+
+class Processor {
+public:
+    Processor(Genome genome, Packet packet)
+        : genome_(std::move(genome)), packet_(std::move(packet)),
+          omega_(genome_.feature_dim, 0.0F), rom_(synthesize_rom(genome_)) {
+        genome_.clamp();
+        if (!packet_.valid()) throw std::runtime_error("invalid packet");
+    }
+
+    void run() {
+        while (!halted_ && metrics_.cycles < 32ULL + genome_.iterations * 16ULL) {
+            if (pc_ >= rom_.size()) throw std::runtime_error("ROM PC overflow");
+            execute(rom_[pc_]);
+            ++metrics_.cycles;
+        }
+        if (!halted_) throw std::runtime_error("processor cycle limit reached");
+    }
+
+    const Metrics& metrics() const noexcept { return metrics_; }
+    const SparseLattice& lattice() const noexcept { return lattice_; }
+
+private:
+    Genome genome_;
+    Packet packet_;
+    SparseLattice lattice_;
+    std::vector<float> features_;
+    std::vector<std::int8_t> latent_;
+    std::vector<float> reconstruction_;
+    std::vector<float> omega_;
+    std::vector<Instruction> rom_;
+    Metrics metrics_{};
+    std::size_t pc_{};
+    std::uint64_t iteration_{};
+    bool halted_{};
+    bool admissible_{};
+
+    Vec3u coordinate(std::size_t index) const noexcept {
+        const std::uint64_t a = mix64(index ^ (iteration_ << 32U) ^ genome_.seed);
+        const std::uint64_t b = mix64(a);
+        const std::uint64_t c = mix64(b);
+        return {static_cast<std::uint32_t>(a & (kWorldEdge - 1U)),
+                static_cast<std::uint32_t>(b & (kWorldEdge - 1U)),
+                static_cast<std::uint32_t>(c & (kWorldEdge - 1U))};
+    }
+
+    void execute(const Instruction& instruction) {
+        switch (instruction.op()) {
+        case Op::Extract:
+            features_ = extract_features(packet_, genome_.feature_dim);
+            ++pc_;
+            break;
+        case Op::Encode:
+            encode();
+            ++pc_;
+            break;
+        case Op::Scatter:
+            scatter();
+            ++pc_;
+            break;
+        case Op::Diffuse:
+            diffuse(std::max<std::uint16_t>(1, instruction.a()));
+            ++pc_;
+            break;
+        case Op::Decode:
+            decode();
+            ++pc_;
+            break;
+        case Op::Learn:
+            learn(instruction.a(), instruction.b());
+            ++pc_;
+            break;
+        case Op::Project:
+            project(instruction.a(), instruction.b(), instruction.c());
+            ++pc_;
+            break;
+        case Op::Commit:
+            admissible_ ? ++metrics_.committed : ++metrics_.rejected;
+            ++pc_;
+            break;
+        case Op::Loop:
+            ++iteration_;
+            pc_ = iteration_ < instruction.a() ? instruction.b() : pc_ + 1;
+            break;
+        case Op::Halt:
+            halted_ = true;
+            break;
+        }
+    }
+
+    void encode() {
+        latent_.assign(genome_.latent_dim, 0);
+        double energy = 0.0;
+        for (std::size_t j = 0; j < latent_.size(); ++j) {
+            float sum = 0.0F;
+            for (std::size_t i = 0; i < features_.size(); ++i) {
+                const float weight = 0.125F * signed_unit(
+                    genome_.seed ^ (j * 0x9E3779B97F4A7C15ULL + i));
+                sum += weight * features_[i];
+            }
+            latent_[j] = quantize_q3(std::tanh(sum));
+            const double x = dequantize_q3(latent_[j]);
+            energy += x * x;
+        }
+        metrics_.energy = static_cast<float>(energy / latent_.size());
+    }
+
+    void scatter() {
+        for (std::size_t i = 0; i < latent_.size(); ++i) {
+            Cell cell;
+            cell.latent = latent_[i];
+            cell.prediction = latent_[i];
+            cell.modality = static_cast<std::uint8_t>(packet_.modality);
+            cell.generation = static_cast<std::uint16_t>(
+                genome_.generation & 0xFFFFU);
+            cell.flags = 1U;
+            lattice_.write(coordinate(i), cell);
+        }
+    }
+
+    void diffuse(std::uint16_t radius) {
+        std::vector<std::int8_t> evolved(latent_.size());
+        for (std::size_t i = 0; i < latent_.size(); ++i) {
+            const std::size_t left =
+                (i + latent_.size() - radius % latent_.size()) % latent_.size();
+            const std::size_t right = (i + radius) % latent_.size();
+            const int value = latent_[left] + 2 * latent_[i] + latent_[right];
+            evolved[i] = static_cast<std::int8_t>(
+                std::max(-4, std::min(3, int(std::lround(value / 4.0)))));
+            Cell cell = lattice_.read(coordinate(i));
+            cell.prediction = evolved[i];
+            cell.residual = static_cast<std::int8_t>(
+                std::max(-4, std::min(3, int(cell.latent) - int(evolved[i]))));
+            cell.flags |= 2U;
+            lattice_.write(coordinate(i), cell);
+        }
+        latent_.swap(evolved);
+    }
+
+    void decode() {
+        reconstruction_.assign(genome_.feature_dim, 0.0F);
+        for (std::size_t i = 0; i < reconstruction_.size(); ++i) {
+            float sum = 0.0F;
+            for (std::size_t j = 0; j < latent_.size(); ++j) {
+                const float weight = 0.125F * signed_unit(
+                    (genome_.seed ^ 0xC0DEC0DEC0DEULL) ^
+                    (i * 0xD1B54A32D192ED03ULL + j));
+                sum += weight * dequantize_q3(latent_[j]);
+            }
+            reconstruction_[i] = clampf(std::tanh(sum) + omega_[i], -1.0F, 1.0F);
+        }
+    }
+
+    void learn(std::uint16_t learning_units, std::uint16_t omega_units) {
+        const float learning = learning_units / 100000.0F;
+        const float omega_rate = omega_units / 100000.0F;
+        double error2 = 0.0;
+        for (std::size_t i = 0; i < features_.size(); ++i) {
+            const float error = features_[i] - reconstruction_[i];
+            error2 += error * error;
+            omega_[i] = clampf(omega_[i] + (learning + omega_rate) * error,
+                               -0.25F, 0.25F);
+        }
+        metrics_.mse = static_cast<float>(error2 / features_.size());
+    }
+
+    void project(std::uint16_t mse_units, std::uint16_t energy_units,
+                 std::uint16_t coherence_units) {
+        const float mse_limit = std::max(kEpsilon, mse_units / 10000.0F);
+        const float energy_limit = std::max(kEpsilon, energy_units / 10000.0F);
+        const float mse_score = 1.0F - clampf(metrics_.mse / mse_limit, 0.0F, 1.0F);
+        const float energy_score =
+            1.0F - clampf(metrics_.energy / energy_limit, 0.0F, 1.0F);
+        metrics_.coherence = 0.7F * mse_score + 0.3F * energy_score;
+        admissible_ = std::isfinite(metrics_.mse) &&
+            metrics_.coherence >= coherence_units / 10000.0F;
+        if (!admissible_) {
+            for (std::int8_t& q : latent_) q = static_cast<std::int8_t>(q / 2);
+        }
+    }
+};
+
+struct Evaluation {
+    Genome genome;
+    Metrics metrics;
+    std::size_t tiles{};
+    std::uint64_t memory_bytes{};
+    double elapsed_ms{};
+    double fitness{-std::numeric_limits<double>::infinity()};
+    bool valid{};
+    std::string error;
+};
+
+double fitness(const Evaluation& e) noexcept {
+    if (!e.valid || !std::isfinite(e.metrics.mse)) {
+        return -std::numeric_limits<double>::infinity();
+    }
+    return 8.0 * clampf(e.metrics.coherence, 0.0F, 1.0F)
+         - 2.0 * std::log1p(1000.0 * std::max(0.0F, e.metrics.mse))
+         - 0.25 * e.metrics.energy
+         - 0.15 * e.metrics.rejected
+         - 0.0005 * e.elapsed_ms
+         - 0.00000001 * static_cast<double>(e.memory_bytes);
+}
+
+Evaluation evaluate(Genome genome, const Packet& packet) {
+    Evaluation result;
+    result.genome = genome;
+    result.genome.clamp();
+    try {
+        const auto start = std::chrono::steady_clock::now();
+        Processor processor(result.genome, packet);
+        processor.run();
+        const auto stop = std::chrono::steady_clock::now();
+        result.elapsed_ms =
+            std::chrono::duration<double, std::milli>(stop - start).count();
+        result.metrics = processor.metrics();
+        result.tiles = processor.lattice().tile_count();
+        result.memory_bytes = processor.lattice().estimated_bytes();
+        result.valid = result.metrics.committed + result.metrics.rejected >=
+                       result.genome.iterations;
+        result.fitness = fitness(result);
+    } catch (const std::exception& error) {
+        result.error = error.what();
+    }
+    return result;
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/processor.hpp
+++ b/cpp_runtime/include/jarvisx/processor.hpp
@@ -15,14 +15,17 @@ struct Metrics {
 class Processor {
 public:
     Processor(Genome genome, Packet packet)
-        : genome_(std::move(genome)), packet_(std::move(packet)),
-          omega_(genome_.feature_dim, 0.0F), rom_(synthesize_rom(genome_)) {
-        genome_.clamp();
+        : genome_(normalize_genome(std::move(genome))),
+          packet_(std::move(packet)),
+          omega_(genome_.feature_dim, 0.0F),
+          rom_(synthesize_rom(genome_)) {
         if (!packet_.valid()) throw std::runtime_error("invalid packet");
     }
 
     void run() {
-        while (!halted_ && metrics_.cycles < 32ULL + genome_.iterations * 16ULL) {
+        const std::uint64_t cycle_limit =
+            32ULL + static_cast<std::uint64_t>(genome_.iterations) * 16ULL;
+        while (!halted_ && metrics_.cycles < cycle_limit) {
             if (pc_ >= rom_.size()) throw std::runtime_error("ROM PC overflow");
             execute(rom_[pc_]);
             ++metrics_.cycles;
@@ -32,8 +35,14 @@ public:
 
     const Metrics& metrics() const noexcept { return metrics_; }
     const SparseLattice& lattice() const noexcept { return lattice_; }
+    const Genome& genome() const noexcept { return genome_; }
 
 private:
+    static Genome normalize_genome(Genome genome) noexcept {
+        genome.clamp();
+        return genome;
+    }
+
     Genome genome_;
     Packet packet_;
     SparseLattice lattice_;
@@ -98,6 +107,8 @@ private:
         case Op::Halt:
             halted_ = true;
             break;
+        default:
+            throw std::runtime_error("invalid ROM opcode");
         }
     }
 
@@ -132,11 +143,12 @@ private:
     }
 
     void diffuse(std::uint16_t radius) {
+        if (latent_.empty()) throw std::runtime_error("diffusion before encoding");
         std::vector<std::int8_t> evolved(latent_.size());
+        const std::size_t offset = radius % latent_.size();
         for (std::size_t i = 0; i < latent_.size(); ++i) {
-            const std::size_t left =
-                (i + latent_.size() - radius % latent_.size()) % latent_.size();
-            const std::size_t right = (i + radius) % latent_.size();
+            const std::size_t left = (i + latent_.size() - offset) % latent_.size();
+            const std::size_t right = (i + offset) % latent_.size();
             const int value = latent_[left] + 2 * latent_[i] + latent_[right];
             evolved[i] = static_cast<std::int8_t>(
                 std::max(-4, std::min(3, int(std::lround(value / 4.0)))));
@@ -151,6 +163,7 @@ private:
     }
 
     void decode() {
+        if (latent_.empty()) throw std::runtime_error("decode before encoding");
         reconstruction_.assign(genome_.feature_dim, 0.0F);
         for (std::size_t i = 0; i < reconstruction_.size(); ++i) {
             float sum = 0.0F;
@@ -165,6 +178,9 @@ private:
     }
 
     void learn(std::uint16_t learning_units, std::uint16_t omega_units) {
+        if (features_.size() != reconstruction_.size()) {
+            throw std::runtime_error("learning state dimension mismatch");
+        }
         const float learning = learning_units / 100000.0F;
         const float omega_rate = omega_units / 100000.0F;
         double error2 = 0.0;
@@ -186,6 +202,8 @@ private:
             1.0F - clampf(metrics_.energy / energy_limit, 0.0F, 1.0F);
         metrics_.coherence = 0.7F * mse_score + 0.3F * energy_score;
         admissible_ = std::isfinite(metrics_.mse) &&
+            std::isfinite(metrics_.energy) &&
+            std::isfinite(metrics_.coherence) &&
             metrics_.coherence >= coherence_units / 10000.0F;
         if (!admissible_) {
             for (std::int8_t& q : latent_) q = static_cast<std::int8_t>(q / 2);
@@ -205,14 +223,16 @@ struct Evaluation {
 };
 
 double fitness(const Evaluation& e) noexcept {
-    if (!e.valid || !std::isfinite(e.metrics.mse)) {
+    if (!e.valid || !std::isfinite(e.metrics.mse) ||
+        !std::isfinite(e.metrics.coherence) || !std::isfinite(e.metrics.energy)) {
         return -std::numeric_limits<double>::infinity();
     }
+    // Fitness is intentionally independent of wall-clock time. Latency remains
+    // telemetry, but excluding it keeps replay and candidate selection deterministic.
     return 8.0 * clampf(e.metrics.coherence, 0.0F, 1.0F)
          - 2.0 * std::log1p(1000.0 * std::max(0.0F, e.metrics.mse))
          - 0.25 * e.metrics.energy
-         - 0.15 * e.metrics.rejected
-         - 0.0005 * e.elapsed_ms
+         - 0.15 * static_cast<double>(e.metrics.rejected)
          - 0.00000001 * static_cast<double>(e.memory_bytes);
 }
 
@@ -227,12 +247,19 @@ Evaluation evaluate(Genome genome, const Packet& packet) {
         const auto stop = std::chrono::steady_clock::now();
         result.elapsed_ms =
             std::chrono::duration<double, std::milli>(stop - start).count();
+        result.genome = processor.genome();
         result.metrics = processor.metrics();
         result.tiles = processor.lattice().tile_count();
         result.memory_bytes = processor.lattice().estimated_bytes();
-        result.valid = result.metrics.committed + result.metrics.rejected >=
-                       result.genome.iterations;
+        const std::uint64_t decisions =
+            result.metrics.committed + result.metrics.rejected;
+        result.valid = decisions == result.genome.iterations &&
+                       result.metrics.cycles > 0 &&
+                       std::isfinite(result.metrics.mse) &&
+                       std::isfinite(result.metrics.coherence) &&
+                       std::isfinite(result.metrics.energy);
         result.fitness = fitness(result);
+        if (!result.valid) result.error = "incomplete or non-finite evaluation";
     } catch (const std::exception& error) {
         result.error = error.what();
     }

--- a/cpp_runtime/include/jarvisx/runtime.hpp
+++ b/cpp_runtime/include/jarvisx/runtime.hpp
@@ -1,0 +1,396 @@
+#pragma once
+
+#include "jarvisx/processor.hpp"
+
+namespace jarvisx {
+class Rng {
+public:
+    explicit Rng(std::uint64_t seed) : state_(seed ? seed : 1ULL) {}
+    std::uint64_t next() noexcept {
+        state_ ^= state_ << 13U;
+        state_ ^= state_ >> 7U;
+        state_ ^= state_ << 17U;
+        return state_;
+    }
+    int step(int radius) noexcept {
+        return static_cast<int>(next() % (2ULL * radius + 1ULL)) - radius;
+    }
+private:
+    std::uint64_t state_;
+};
+
+Genome mutate(const Genome& parent, std::uint64_t generation,
+              std::size_t candidate, const Evaluation& telemetry) {
+    Genome child = parent;
+    child.generation = generation;
+    child.seed = mix64(parent.seed ^ generation ^
+                       (candidate * 0xD1B54A32D192ED03ULL));
+    Rng rng(child.seed);
+
+    switch (rng.next() % 9ULL) {
+    case 0: child.feature_dim = std::size_t(std::max<long long>(
+                32, static_cast<long long>(child.feature_dim) + 16LL * rng.step(2))); break;
+    case 1: child.latent_dim = std::size_t(std::max<long long>(
+                8, static_cast<long long>(child.latent_dim) + 8LL * rng.step(2))); break;
+    case 2: child.iterations = std::uint16_t(int(child.iterations) + rng.step(4)); break;
+    case 3: child.diffusion_radius =
+                std::uint16_t(int(child.diffusion_radius) + rng.step(2)); break;
+    case 4: child.learning_units =
+                std::uint16_t(int(child.learning_units) + 10 * rng.step(3)); break;
+    case 5: child.omega_units =
+                std::uint16_t(int(child.omega_units) + 8 * rng.step(3)); break;
+    case 6: child.max_mse_units =
+                std::uint16_t(int(child.max_mse_units) + 200 * rng.step(3)); break;
+    case 7: child.max_energy_units =
+                std::uint16_t(int(child.max_energy_units) + 250 * rng.step(2)); break;
+    default: child.min_coherence_units =
+                std::uint16_t(int(child.min_coherence_units) + 100 * rng.step(3)); break;
+    }
+
+    if (telemetry.valid && telemetry.metrics.mse > 0.05F) {
+        child.feature_dim += 16;
+        child.learning_units = std::uint16_t(child.learning_units + 4);
+    }
+    if (telemetry.valid && telemetry.metrics.coherence < 0.35F) {
+        child.omega_units = std::uint16_t(child.omega_units + 3);
+        child.min_coherence_units = std::uint16_t(
+            std::max(0, int(child.min_coherence_units) - 50));
+    }
+    child.clamp();
+    return child;
+}
+
+std::string serialize(const Genome& g) {
+    std::ostringstream out;
+    out << "version=" << g.version << '\n'
+        << "generation=" << g.generation << '\n'
+        << "feature_dim=" << g.feature_dim << '\n'
+        << "latent_dim=" << g.latent_dim << '\n'
+        << "iterations=" << g.iterations << '\n'
+        << "diffusion_radius=" << g.diffusion_radius << '\n'
+        << "learning_units=" << g.learning_units << '\n'
+        << "omega_units=" << g.omega_units << '\n'
+        << "max_mse_units=" << g.max_mse_units << '\n'
+        << "max_energy_units=" << g.max_energy_units << '\n'
+        << "min_coherence_units=" << g.min_coherence_units << '\n'
+        << "seed=" << g.seed << '\n'
+        << "fingerprint=" << g.fingerprint() << '\n';
+    return out.str();
+}
+
+Genome deserialize(const std::string& text) {
+    Genome g;
+    std::istringstream input(text);
+    std::string line;
+    while (std::getline(input, line)) {
+        const auto split = line.find('=');
+        if (split == std::string::npos) continue;
+        const std::string key = line.substr(0, split);
+        const std::string value = line.substr(split + 1);
+        if (key == "version") g.version = std::stoul(value);
+        else if (key == "generation") g.generation = std::stoull(value);
+        else if (key == "feature_dim") g.feature_dim = std::stoull(value);
+        else if (key == "latent_dim") g.latent_dim = std::stoull(value);
+        else if (key == "iterations") g.iterations = std::stoul(value);
+        else if (key == "diffusion_radius") g.diffusion_radius = std::stoul(value);
+        else if (key == "learning_units") g.learning_units = std::stoul(value);
+        else if (key == "omega_units") g.omega_units = std::stoul(value);
+        else if (key == "max_mse_units") g.max_mse_units = std::stoul(value);
+        else if (key == "max_energy_units") g.max_energy_units = std::stoul(value);
+        else if (key == "min_coherence_units") g.min_coherence_units = std::stoul(value);
+        else if (key == "seed") g.seed = std::stoull(value);
+    }
+    if (g.version != 1) throw std::runtime_error("unsupported genome version");
+    g.clamp();
+    return g;
+}
+
+void atomic_write(const fs::path& path, const std::string& text) {
+    fs::create_directories(path.parent_path());
+    const fs::path temp = path.string() + ".tmp";
+    {
+        std::ofstream output(temp, std::ios::binary | std::ios::trunc);
+        if (!output) throw std::runtime_error("cannot write " + temp.string());
+        output << text;
+        output.flush();
+        if (!output) throw std::runtime_error("cannot flush " + temp.string());
+    }
+    std::error_code error;
+    fs::rename(temp, path, error);
+    if (error) {
+        fs::remove(path, error);
+        error.clear();
+        fs::rename(temp, path, error);
+    }
+    if (error) throw std::runtime_error("cannot commit " + path.string());
+}
+
+std::optional<Genome> load_genome(const fs::path& path) {
+    std::ifstream input(path);
+    if (!input) return std::nullopt;
+    std::ostringstream text;
+    text << input.rdbuf();
+    return deserialize(text.str());
+}
+
+void write_rom(const fs::path& path, const std::vector<Instruction>& rom) {
+    fs::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output) throw std::runtime_error("cannot write bytecode ROM");
+    for (const Instruction& instruction : rom) {
+        for (int byte = 7; byte >= 0; --byte) {
+            output.put(static_cast<char>(
+                (instruction.word >> unsigned(byte * 8)) & 0xFFULL));
+        }
+    }
+}
+
+struct Options {
+    std::uint64_t generations{4};
+    std::size_t population{5};
+    fs::path state_dir{".jarvisx-runtime"};
+    std::string file;
+    std::string text;
+    double min_improvement{1.0e-5};
+    bool reset{};
+    bool quiet{};
+};
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& i, const std::string& flag) {
+        if (i + 1 >= argc) throw std::invalid_argument("missing value after " + flag);
+        return std::string(argv[++i]);
+    };
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--generations") options.generations =
+            std::max<std::uint64_t>(1, std::stoull(value(i, arg)));
+        else if (arg == "--population") options.population =
+            std::max<std::size_t>(2, std::min<std::size_t>(
+                32, std::stoull(value(i, arg))));
+        else if (arg == "--state-dir") options.state_dir = value(i, arg);
+        else if (arg == "--file") options.file = value(i, arg);
+        else if (arg == "--text") options.text = value(i, arg);
+        else if (arg == "--min-improvement") options.min_improvement =
+            std::max(0.0, std::stod(value(i, arg)));
+        else if (arg == "--reset") options.reset = true;
+        else if (arg == "--quiet") options.quiet = true;
+        else if (arg == "--help" || arg == "-h") {
+            std::cout
+                << "Usage: jarvisx-runtime [options]\n"
+                << "  --generations N       evolution generations\n"
+                << "  --population N        candidates per generation (2..32)\n"
+                << "  --state-dir PATH      checkpoint directory\n"
+                << "  --file PATH           external multimodal/binary input\n"
+                << "  --text TEXT           text input\n"
+                << "  --min-improvement X   minimum fitness delta\n"
+                << "  --reset               discard prior checkpoint\n"
+                << "  --quiet               hide candidate rows\n"
+                << "\nDefault input: this executable's own binary image.\n";
+            std::exit(0);
+        } else throw std::invalid_argument("unknown option: " + arg);
+    }
+    return options;
+}
+
+enum class MetaOp : std::uint8_t {
+    Observe = 1, Spawn = 2, Evaluate = 3, Select = 4,
+    Gate = 5, Checkpoint = 6, Loop = 7, Halt = 0xFF
+};
+
+class Runtime {
+public:
+    Runtime(Options options, Packet packet)
+        : options_(std::move(options)), packet_(std::move(packet)) {
+        fs::create_directories(options_.state_dir);
+        genome_path_ = options_.state_dir / "genome.current";
+        journal_path_ = options_.state_dir / "evolution.csv";
+        rom_path_ = options_.state_dir / "runtime.rom";
+        if (!options_.reset) {
+            if (const auto loaded = load_genome(genome_path_)) genome_ = *loaded;
+        }
+        meta_rom_ = {MetaOp::Observe, MetaOp::Spawn, MetaOp::Evaluate,
+                     MetaOp::Select, MetaOp::Gate, MetaOp::Checkpoint,
+                     MetaOp::Loop, MetaOp::Halt};
+    }
+
+    int run() {
+        incumbent_ = evaluate(genome_, packet_);
+        if (!incumbent_.valid) throw std::runtime_error(
+            "incumbent self-evaluation failed: " + incumbent_.error);
+
+        std::cout
+            << "Jarvis X Inward Runtime\n"
+            << "  lattice: 8192 x 8192 x 8192 virtual cells\n"
+            << "  mode: sandboxed bytecode/genome evolution\n"
+            << "  starting generation: " << genome_.generation << '\n'
+            << "  starting fingerprint: " << genome_.fingerprint() << '\n'
+            << "  population: " << options_.population << '\n'
+            << "  generations: " << options_.generations << "\n\n";
+
+        while (!halted_) execute(meta_rom_.at(meta_pc_));
+
+        std::cout << "\nFinal genome\n" << serialize(genome_)
+                  << "fitness=" << std::setprecision(10) << incumbent_.fitness << '\n'
+                  << "mse=" << incumbent_.metrics.mse << '\n'
+                  << "coherence=" << incumbent_.metrics.coherence << '\n'
+                  << "checkpoint=" << genome_path_.string() << '\n'
+                  << "rom=" << rom_path_.string() << '\n'
+                  << "journal=" << journal_path_.string() << '\n';
+        return 0;
+    }
+
+private:
+    Options options_;
+    Packet packet_;
+    Genome genome_;
+    Evaluation incumbent_;
+    std::vector<Genome> candidates_;
+    std::vector<Evaluation> evaluations_;
+    Evaluation champion_;
+    std::vector<MetaOp> meta_rom_;
+    std::size_t meta_pc_{};
+    std::uint64_t completed_{};
+    bool halted_{};
+    bool accepted_{};
+    fs::path genome_path_, journal_path_, rom_path_;
+
+    void execute(MetaOp op) {
+        switch (op) {
+        case MetaOp::Observe:
+            std::cout << "[Observe] generation=" << genome_.generation + 1
+                      << " fitness=" << std::fixed << std::setprecision(7)
+                      << incumbent_.fitness << " mse=" << incumbent_.metrics.mse
+                      << " coherence=" << incumbent_.metrics.coherence << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Spawn:
+            candidates_.clear();
+            {
+                Genome anchor = genome_;
+                anchor.generation = genome_.generation + 1;
+                candidates_.push_back(anchor);
+            }
+            for (std::size_t i = 1; i < options_.population; ++i) {
+                candidates_.push_back(mutate(
+                    genome_, genome_.generation + 1, i, incumbent_));
+            }
+            std::cout << "[Spawn] candidates=" << candidates_.size() << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Evaluate:
+            evaluations_.clear();
+            for (std::size_t i = 0; i < candidates_.size(); ++i) {
+                Evaluation result = evaluate(candidates_[i], packet_);
+                if (!options_.quiet) {
+                    std::cout << "  candidate=" << i
+                              << " fp=" << result.genome.fingerprint()
+                              << " valid=" << (result.valid ? "yes" : "no")
+                              << " fitness=" << result.fitness
+                              << " mse=" << result.metrics.mse
+                              << " coherence=" << result.metrics.coherence
+                              << " ms=" << result.elapsed_ms << '\n';
+                }
+                evaluations_.push_back(std::move(result));
+            }
+            ++meta_pc_;
+            break;
+        case MetaOp::Select:
+            champion_ = *std::max_element(
+                evaluations_.begin(), evaluations_.end(),
+                [](const Evaluation& left, const Evaluation& right) {
+                    if (left.fitness == right.fitness)
+                        return left.elapsed_ms > right.elapsed_ms;
+                    return left.fitness < right.fitness;
+                });
+            std::cout << "[Select] champion=" << champion_.genome.fingerprint()
+                      << " fitness=" << champion_.fitness << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Gate: {
+            const bool coherent = champion_.valid &&
+                champion_.metrics.coherence >=
+                champion_.genome.min_coherence_units / 10000.0F;
+            const bool improved = champion_.fitness >
+                incumbent_.fitness + options_.min_improvement;
+            accepted_ = coherent && improved;
+            if (accepted_) {
+                genome_ = champion_.genome;
+                incumbent_ = champion_;
+                std::cout << "[Lambda] COMMIT\n";
+            } else {
+                ++genome_.generation;
+                incumbent_.genome = genome_;
+                std::cout << "[Lambda] ROLLBACK\n";
+            }
+            ++meta_pc_;
+            break;
+        }
+        case MetaOp::Checkpoint:
+            atomic_write(genome_path_, serialize(genome_));
+            write_rom(rom_path_, synthesize_rom(genome_));
+            append_journal();
+            std::cout << "[Checkpoint] generation=" << genome_.generation
+                      << " status=" << (accepted_ ? "accepted" : "rolled-back")
+                      << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Loop:
+            ++completed_;
+            meta_pc_ = completed_ < options_.generations ? 0 : meta_pc_ + 1;
+            break;
+        case MetaOp::Halt:
+            halted_ = true;
+            break;
+        }
+    }
+
+    void append_journal() {
+        const bool exists = fs::exists(journal_path_);
+        std::ofstream output(journal_path_, std::ios::app);
+        if (!output) throw std::runtime_error("cannot append journal");
+        if (!exists) {
+            output << "generation,status,fingerprint,fitness,mse,coherence,"
+                      "energy,features,latent,iterations,radius,learning,omega,"
+                      "tiles,memory_bytes,elapsed_ms\n";
+        }
+        output << genome_.generation << ','
+               << (accepted_ ? "accepted" : "rolled-back") << ','
+               << genome_.fingerprint() << ','
+               << std::setprecision(12) << incumbent_.fitness << ','
+               << incumbent_.metrics.mse << ','
+               << incumbent_.metrics.coherence << ','
+               << incumbent_.metrics.energy << ','
+               << genome_.feature_dim << ',' << genome_.latent_dim << ','
+               << genome_.iterations << ',' << genome_.diffusion_radius << ','
+               << genome_.learning_units << ',' << genome_.omega_units << ','
+               << incumbent_.tiles << ',' << incumbent_.memory_bytes << ','
+               << incumbent_.elapsed_ms << '\n';
+    }
+};
+
+Packet resolve_packet(int argc, char** argv, const Options& options) {
+    if (!options.file.empty()) {
+        auto packet = file_packet(options.file);
+        if (!packet) throw std::runtime_error("cannot read " + options.file);
+        std::cout << "[Input] external packet: " << options.file << '\n';
+        return *packet;
+    }
+    if (!options.text.empty()) {
+        std::cout << "[Input] text packet\n";
+        return text_packet(options.text);
+    }
+    if (argc > 0 && argv[0]) {
+        auto packet = file_packet(argv[0]);
+        if (packet && !packet->bytes.empty()) {
+            std::cout << "[Input] inward executable image: " << argv[0]
+                      << " (" << packet->bytes.size() << " bytes)\n";
+            return *packet;
+        }
+    }
+    std::cout << "[Input] fallback inward identity packet\n";
+    return text_packet("Jarvis X reconstructs its own runtime state.");
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/src/main.cpp
+++ b/cpp_runtime/src/main.cpp
@@ -1,0 +1,13 @@
+#include "jarvisx/runtime.hpp"
+
+int main(int argc, char** argv) {
+    try {
+        jarvisx::Options options = jarvisx::parse_options(argc, argv);
+        jarvisx::Packet packet = jarvisx::resolve_packet(argc, argv, options);
+        jarvisx::Runtime runtime(std::move(options), std::move(packet));
+        return runtime.run();
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis X runtime failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/processor_tests.cpp
+++ b/cpp_runtime/tests/processor_tests.cpp
@@ -1,0 +1,82 @@
+#include "jarvisx/processor.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void test_constructor_normalizes_before_allocation() {
+    jarvisx::Genome genome;
+    genome.feature_dim = 1;
+    genome.latent_dim = 1024;
+    genome.iterations = 0;
+
+    jarvisx::Processor processor(genome, jarvisx::text_packet("normalization"));
+    const auto& normalized = processor.genome();
+
+    require(normalized.feature_dim == 32, "feature_dim was not normalized");
+    require(normalized.latent_dim == 32, "latent_dim was not normalized");
+    require(normalized.iterations == 2, "iterations were not normalized");
+
+    processor.run();
+    require(processor.metrics().committed + processor.metrics().rejected == 2,
+            "normalized iteration count was not executed");
+}
+
+void test_evaluation_is_deterministic() {
+    jarvisx::Genome genome;
+    const auto packet = jarvisx::text_packet("Jarvis X deterministic replay");
+
+    const auto first = jarvisx::evaluate(genome, packet);
+    const auto second = jarvisx::evaluate(genome, packet);
+
+    require(first.valid && second.valid, "evaluation was invalid");
+    require(first.metrics.cycles == second.metrics.cycles, "cycle count drifted");
+    require(first.metrics.committed == second.metrics.committed,
+            "commit count drifted");
+    require(first.metrics.rejected == second.metrics.rejected,
+            "reject count drifted");
+    require(first.metrics.mse == second.metrics.mse, "MSE drifted");
+    require(first.metrics.coherence == second.metrics.coherence,
+            "coherence drifted");
+    require(first.metrics.energy == second.metrics.energy, "energy drifted");
+    require(first.tiles == second.tiles, "tile count drifted");
+    require(first.memory_bytes == second.memory_bytes, "memory estimate drifted");
+    require(first.fitness == second.fitness, "fitness drifted");
+}
+
+void test_latency_is_telemetry_not_fitness() {
+    jarvisx::Evaluation fast;
+    fast.valid = true;
+    fast.metrics.mse = 0.01F;
+    fast.metrics.coherence = 0.8F;
+    fast.metrics.energy = 0.2F;
+    fast.memory_bytes = 4096;
+    fast.elapsed_ms = 1.0;
+
+    jarvisx::Evaluation slow = fast;
+    slow.elapsed_ms = 100000.0;
+
+    require(jarvisx::fitness(fast) == jarvisx::fitness(slow),
+            "wall-clock latency changed deterministic fitness");
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_constructor_normalizes_before_allocation();
+        test_evaluation_is_deterministic();
+        test_latency_is_telemetry_not_fitness();
+        std::cout << "processor regression tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "processor regression test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]


### PR DESCRIPTION
## Integration dependency

This PR depends on foundation PR #47. After #47 merges, rebase this branch onto `main`, remove duplicate repository-wide CI and pytest configuration repairs, and preserve the C++ runtime as an isolated subsystem change.

Required promotion sequence:

1. #47 green and merged;
2. rebase #45;
3. C++ matrix, repository CI and CodeQL green on the rebased head;
4. review the bytecode, checkpoint and deterministic replay contracts;
5. mark ready for review.

## What changed

- adds a dependency-free C++17 runtime under `cpp_runtime/`
- preserves a sparse virtual `8192 × 8192 × 8192` lattice with `8³` tiles
- implements multimodal byte ingestion, fixed-width feature extraction, 3-bit latent encoding, spatial scatter/diffusion, decoding, residual learning, and coherence projection
- adds a deterministic 64-bit processor bytecode ROM
- turns the processor inward by ingesting its own executable image by default
- adds a meta-runtime that spawns candidate genomes and bytecode schedules, evaluates each candidate in a fresh processor sandbox, selects a champion, and applies commit/rollback gating
- persists `genome.current`, `runtime.rom`, and `evolution.csv`
- adds CMake, CTest regression coverage, documentation, and a path-scoped GitHub Actions workflow

## Why

The original standalone processor performed a fixed auto-encoding loop. This change closes the loop around the runtime itself so that its execution parameters and bytecode schedule can improve from measured reconstruction, coherence, energy, latency, and memory telemetry.

Self-evolution is intentionally bounded and auditable. The runtime does not rewrite arbitrary native instructions; it mutates constrained genomes and synthesized bytecode, preserves a rollback anchor, and journals every accepted or rejected generation.

## Determinism and safety hardening

- normalizes every genome before allocating Ω memory or synthesizing its ROM
- rejects invalid opcodes and inconsistent execution states explicitly
- validates exact iteration completion and finite telemetry
- keeps elapsed time as telemetry but removes wall-clock time from evolutionary fitness, preserving deterministic replay and selection
- adds regression tests for constructor normalization, repeatable evaluation, and latency-independent fitness
- enables stricter compiler diagnostics
- adds optional AddressSanitizer and UndefinedBehaviorSanitizer support
- tests GCC, Clang with sanitizers, and MSVC in CI

## Validation

```bash
cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
cmake --build build/cpp-runtime --parallel
ctest --test-dir build/cpp-runtime --output-on-failure
```

Sanitizer validation:

```bash
cmake -S cpp_runtime -B build/cpp-runtime-san \
  -DCMAKE_BUILD_TYPE=Release \
  -DJARVISX_ENABLE_SANITIZERS=ON
cmake --build build/cpp-runtime-san --parallel
ctest --test-dir build/cpp-runtime-san --output-on-failure
```

## Developer impact

The existing Python package remains unchanged by the intended final scope. The C++ runtime is isolated under `cpp_runtime/` and is built or tested only when explicitly selected or when its path-scoped workflow runs.

## Capability boundary

This is a bounded parameter and schedule search runtime. It does not claim consciousness, AGI, unrestricted native-code self-rewriting, production isolation or physical realization of the full virtual lattice.