### PR TITLE
Add hierarchical 3D fractional smoothing engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,37 @@ At depth `D`, the deterministic invariants are:
 - active nodes: `(4 ** (D + 1) - 1) // 3`
 - retained volume: `2 ** (-D)` for a unit cube
 - similarity dimension: `2`
+
+## Hierarchical 3D Fractional Smoothing
+
+`jarvisx.fractional_smoothing_3d` implements a deterministic reference solver
+for periodic three-dimensional fractional diffusion, multiscale smoothing, and
+equilibrium search. It builds a 2×2×2 hierarchy, applies a separately configured
+fractional heat operator at each level, and fuses the coarse equilibrium back
+into the fine field.
+
+```python
+from jarvisx.fractional_smoothing_3d import (
+    FractionalHierarchyConfig,
+    Grid3D,
+    hierarchical_fractional_smooth,
+)
+
+field = Grid3D.impulse((8, 8, 8), (4, 4, 4), amplitude=1.0)
+result = hierarchical_fractional_smooth(
+    field,
+    FractionalHierarchyConfig(
+        alphas=(1.0, 0.75, 0.50),
+        taus=(0.05, 0.10, 0.20),
+        coarse_blends=(0.20, 0.35),
+    ),
+)
+
+assert abs(result.mass_drift) < 1.0e-9
+```
+
+The implementation emits a mechanistic instruction trace covering restriction,
+3D fractional heat evolution, prolongation, coarse/fine fusion, and invariant
+verification. See
+[`docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md`](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md)
+for the complete arithmetic derivation and engineering boundaries.

--- a/docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md
+++ b/docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md
@@ -1,0 +1,444 @@
+# Hierarchical 3D Fractional Geometric Smoothing
+
+## Scope
+
+This module operationalises a deterministic reference model for three-dimensional
+fractional diffusion, multiscale gradient smoothing, and equilibrium search.
+It works on a periodic scalar lattice and is designed as a correctness model for
+future FFT, sparse-octree, GPU, and latent-diffusion implementations.
+
+The word **fractional** refers to a non-integer power of the discrete Laplacian.
+It does not mean that voxel values are merely divided by 1000.
+
+## 1. Three-dimensional field memory
+
+A field is stored as
+
+\[
+u[x,y,z]\in\mathbb R,
+\qquad
+0\le x<N_x,\;0\le y<N_y,\;0\le z<N_z.
+\]
+
+The flat cell address is
+
+\[
+\boxed{a=x+N_x(y+N_yz)}.
+\]
+
+Every cell is therefore an explicit 3D state location. The current reference
+implementation stores one scalar per voxel, but the same mechanics can be
+applied independently to channels such as density, temperature, RGB, latent
+features, error, or an Ω correction field.
+
+## 2. Local 3D Laplacian
+
+For a six-neighbour periodic lattice, the positive discrete Laplacian is
+
+\[
+(Lu)_{x,y,z}
+=
+6u_{x,y,z}
+-u_{x+1,y,z}-u_{x-1,y,z}
+-u_{x,y+1,z}-u_{x,y-1,z}
+-u_{x,y,z+1}-u_{x,y,z-1}.
+\]
+
+Classical diffusion is
+
+\[
+\frac{\partial u}{\partial t}=-D Lu.
+\]
+
+Only the immediate six neighbours appear in the stencil, but repeated updates
+propagate information through the full volume.
+
+## 3. Fractional 3D operator
+
+The fractional model replaces `L` with
+
+\[
+L^\alpha,
+\qquad 0<\alpha\le 1.
+\]
+
+The evolution equation is
+
+\[
+\boxed{
+\frac{\partial u}{\partial t}
+=-D L^\alpha u+\Omega.
+}
+\]
+
+- `alpha = 1` gives classical lattice diffusion.
+- `alpha < 1` changes the spectral attenuation law and produces a nonlocal
+  operator in physical space.
+- `D` controls diffusion strength.
+- `Omega` is an optional persistent correction or forcing field.
+
+## 4. Arithmetic spectral execution
+
+The periodic discrete Fourier transform converts each spatial mode into an
+independent scalar update.
+
+### Forward transform
+
+\[
+\hat u_{p,q,r}
+=
+\sum_{z=0}^{N_z-1}
+\sum_{y=0}^{N_y-1}
+\sum_{x=0}^{N_x-1}
+u_{x,y,z}
+\exp\left[-2\pi i\left(
+\frac{px}{N_x}+\frac{qy}{N_y}+\frac{rz}{N_z}
+\right)\right].
+\]
+
+### Laplacian eigenvalue
+
+For mode `(p,q,r)`,
+
+\[
+\boxed{
+\lambda_{p,q,r}
+=
+6
+-2\cos\frac{2\pi p}{N_x}
+-2\cos\frac{2\pi q}{N_y}
+-2\cos\frac{2\pi r}{N_z}.
+}
+\]
+
+Therefore
+
+\[
+\widehat{L^\alpha u}_{p,q,r}
+=
+\lambda_{p,q,r}^{\alpha}\hat u_{p,q,r}.
+\]
+
+### Exact unforced diffusion step
+
+For a timestep `tau`,
+
+\[
+\boxed{
+\hat u'_{p,q,r}
+=
+\exp\left(-\tau D\lambda_{p,q,r}^{\alpha}\right)
+\hat u_{p,q,r}.
+}
+\]
+
+The zero-frequency eigenvalue is zero, so
+
+\[
+\hat u'_{0,0,0}=\hat u_{0,0,0}.
+\]
+
+Consequently the total mass is preserved in the unforced system.
+
+### Exact step with constant Ω forcing
+
+Let
+
+\[
+a=D\lambda^\alpha.
+\]
+
+For `a > 0`,
+
+\[
+\boxed{
+\hat u'
+=e^{-a\tau}\hat u
++\frac{1-e^{-a\tau}}{a}\hat\Omega.
+}
+\]
+
+For the constant mode `a = 0`,
+
+\[
+\hat u'_{0}=\hat u_0+\tau\hat\Omega_0.
+\]
+
+By default the implementation removes the mean of Ω, so Ω reshapes the field
+without changing its total mass.
+
+## 5. Hierarchical 3D geometry
+
+The fine field is level zero:
+
+\[
+G_0\in\mathbb R^{N_x\times N_y\times N_z}.
+\]
+
+A 2×2×2 restriction operator creates the next level:
+
+\[
+\boxed{
+G_{k+1}[i,j,l]
+=
+\frac{1}{8}
+\sum_{d_x,d_y,d_z\in\{0,1\}}
+G_k[2i+d_x,2j+d_y,2l+d_z].
+}
+\]
+
+Each restriction divides the voxel count by eight. A hierarchy with three
+levels has the form
+
+```text
+fine:   Nx × Ny × Nz
+middle: Nx/2 × Ny/2 × Nz/2
+coarse: Nx/4 × Ny/4 × Nz/4
+```
+
+Each level receives its own fractional order and smoothing time:
+
+\[
+G'_k
+=
+\exp(-\tau_kD L_k^{\alpha_k})G_k.
+\]
+
+A typical fine-to-coarse schedule is
+
+```text
+level 0: alpha = 1.00, tau = 0.05   local detail
+level 1: alpha = 0.75, tau = 0.10   regional structure
+level 2: alpha = 0.50, tau = 0.20   global structure
+```
+
+## 6. Coarse-to-fine reconstruction
+
+Constant prolongation copies each coarse voxel into a 2×2×2 block:
+
+\[
+(PG)[2i+d_x,2j+d_y,2l+d_z]=G[i,j,l].
+\]
+
+It satisfies
+
+\[
+\boxed{R(P(G))=G}
+\]
+
+up to floating-point roundoff.
+
+This is the operational meaning of the earlier reciprocal loop:
+
+```text
+1 coarse state -> 8 fine cells -> 1 reconstructed coarse state
+```
+
+or, at a larger symbolic scale,
+
+```text
+1/1000 compression <-> 1000/1 expansion.
+```
+
+The absolute scale changes, but normalising the complete round trip by itself
+returns the identity on the coarse subspace.
+
+At each fine level, the locally smoothed state is fused with the prolonged
+coarse state:
+
+\[
+\boxed{
+V_k=(1-\gamma_k)G'_k+\gamma_kP(V_{k+1}),
+\qquad 0\le\gamma_k\le 1.
+}
+\]
+
+`gamma` determines how strongly the global coarse equilibrium influences the
+local fine geometry.
+
+## 7. Complete mechanistic loop
+
+One transaction executes:
+
+```text
+LOAD_FINE_3D
+-> RESTRICT_2X2X2 until the coarsest level
+-> DFT3 each level
+-> compute lambda(p,q,r)
+-> multiply each mode by exp(-tau * D * lambda^alpha)
+-> inject exact Ω forcing when present
+-> inverse DFT3
+-> calculate variance, gradient energy, and equilibrium residual
+-> PROLONG_2X2X2 from coarse to fine
+-> FUSE_COARSE_FINE using gamma
+-> VERIFY mass drift and update magnitude
+-> COMMIT result
+```
+
+The Python result includes an explicit instruction trace with opcodes:
+
+```text
+RESTRICT_2X2X2
+FRACTIONAL_HEAT_3D
+PROLONG_2X2X2
+FUSE_COARSE_FINE
+VERIFY_MASS_AND_UPDATE
+```
+
+## 8. Gradient smoothing
+
+For a scalar energy functional `E(u)`, ordinary gradient flow is
+
+\[
+\frac{\partial u}{\partial t}
+=-\nabla_uE.
+\]
+
+A fractional preconditioned gradient flow can be written as
+
+\[
+\boxed{
+\frac{\partial u}{\partial t}
+=-L^\alpha\nabla_uE.
+}
+\]
+
+Alternatively, when `u` itself is the quantity being regularised,
+
+\[
+E_\alpha(u)=\frac{1}{2}\langle u,L^\alpha u\rangle
+\]
+
+has gradient
+
+\[
+\nabla_uE_\alpha=L^\alpha u,
+\]
+
+and its gradient flow is exactly fractional diffusion:
+
+\[
+\frac{\partial u}{\partial t}=-L^\alpha u.
+\]
+
+The hierarchy acts as a multiscale preconditioner:
+
+- the coarse levels remove global low-frequency imbalance;
+- the fine levels remove local high-frequency irregularity;
+- the fusion step coordinates the scales.
+
+## 9. Equilibrium arithmetic
+
+For the unforced system, equilibrium satisfies
+
+\[
+\boxed{L^\alpha u^*=0.}
+\]
+
+On a connected periodic lattice, the only scalar equilibria are spatially
+constant fields.
+
+For a zero-mean forcing field,
+
+\[
+\boxed{DL^\alpha u^*=\Omega.}
+\]
+
+The implementation measures the root-mean-square residual
+
+\[
+r(u)
+=
+\sqrt{
+\frac{1}{N}
+\sum_a
+\left[-D(L^\alpha u)_a+\Omega_a\right]^2
+}.
+\]
+
+Repeated cycles terminate when
+
+\[
+\sqrt{
+\frac{1}{N}
+\sum_a(u^{(t+1)}_a-u^{(t)}_a)^2
+}
+\le\varepsilon.
+\]
+
+This is numerical convergence, not a universal proof that every nonlinear
+extension will have a unique equilibrium.
+
+## 10. Applications
+
+### Latent diffusion and score fields
+
+A denoising score tensor can be smoothed spatially before the reverse update:
+
+\[
+\tilde s_\theta
+=
+\sum_k w_kP_kL_k^{\alpha_k}R_k s_\theta.
+\]
+
+This can suppress local score noise while retaining long-range structure.
+The method must be validated carefully because excessive smoothing can bias the
+learned score and reduce detail.
+
+### Geometry and signed-distance fields
+
+Fractional smoothing can regularise voxel occupancy, density, SDFs, point-cloud
+fields, or mesh-derived scalar quantities while allowing nonlocal propagation.
+
+### Physical equilibrium systems
+
+The solver can model anomalous or nonlocal transport, temperature-like fields,
+chemical concentration, or correction-driven steady states where distant
+regions interact through a fractional operator.
+
+### Optimization
+
+The hierarchy can be used as a gradient preconditioner. Coarse levels correct
+large-scale error modes that local descent removes slowly, while fine levels
+retain local resolution.
+
+## 11. Reference API
+
+```python
+from jarvisx.fractional_smoothing_3d import (
+    FractionalHierarchyConfig,
+    Grid3D,
+    hierarchical_fractional_smooth,
+    run_to_equilibrium,
+)
+
+field = Grid3D.impulse((8, 8, 8), (4, 4, 4), amplitude=1.0)
+config = FractionalHierarchyConfig(
+    alphas=(1.0, 0.75, 0.50),
+    taus=(0.05, 0.10, 0.20),
+    coarse_blends=(0.20, 0.35),
+)
+
+single_cycle = hierarchical_fractional_smooth(field, config)
+equilibrium = run_to_equilibrium(
+    field,
+    config,
+    tolerance=1.0e-6,
+    max_cycles=100,
+)
+```
+
+## 12. Engineering boundaries
+
+The current implementation intentionally uses a direct separable DFT and dense
+Python arrays. It is transparent and deterministic but not intended for large
+volumes. Production evolution should proceed in this order:
+
+1. validate the equations and invariants on small dense fields;
+2. replace the direct DFT with an FFT backend;
+3. introduce sparse bricks or an octree hierarchy;
+4. add vector-valued and batched tensors;
+5. port the spectral kernels to GPU;
+6. couple Ω to measured residuals or learned correction fields;
+7. benchmark convergence, energy, memory, and runtime against classical
+   diffusion, multigrid, and established fractional PDE solvers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --cov=src/jarvisx --cov-report=term-local --cov-report=html --tb=short"
+addopts = "-v --cov=src/jarvisx --cov-report=term-missing --cov-report=html --tb=short"
 
 [tool.coverage.run]
 source = ["src/jarvisx"]
@@ -74,14 +74,14 @@ omit = [
 [tool.black]
 line-length = 100
 target-version = ['py38']
-include = '\\.pyi?$'
+include = '\.pyi?$'
 extend-exclude = '''
 /(
-    \\.git
-  | \\.hg
-  | \\.mypy_cache
-  | \\.tox
-  | \\.venv
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
   | _build
   | buck-out
   | build

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,16 +1,17 @@
-from .registers import Registers
-from .memory import Memory
+from .debugger import Debugger
 from .decoder import Decoder
+from .ethics import LambdaShield
 from .executor import Executor
 from .ledger_store import PersistentLedger
-from .ethics import LambdaShield
+from .memory import Memory
 from .reflex import ReflexEngine
+from .registers import Registers
 from .sandbox import Sandbox
-from .debugger import Debugger
 from .tracer import Tracer
 
+
 class CodexVM:
-    def __init__(self):
+    def __init__(self, enable_reflex=False):
         self.regs = Registers()
         self.mem = Memory()
         self.decoder = Decoder()
@@ -18,6 +19,7 @@ class CodexVM:
         self.ledger = PersistentLedger()
         self.ethics = LambdaShield()
         self.reflex = ReflexEngine()
+        self.enable_reflex = enable_reflex
         self.sandbox = Sandbox()
         self.debugger = Debugger(self)
         self.tracer = Tracer()
@@ -39,7 +41,8 @@ class CodexVM:
         cont = self.executor.execute(instr)
         self.ledger.log(self.regs.snapshot(), instr.opcode)
         self.tracer.record(instr, self.regs.snapshot())
-        self.reflex.stabilize(self.regs)
+        if self.enable_reflex:
+            self.reflex.stabilize(self.regs)
 
         self.regs["IP"] += 1
         self.cycles += 1

--- a/src/jarvisx/fractional_smoothing_3d.py
+++ b/src/jarvisx/fractional_smoothing_3d.py
@@ -1,0 +1,625 @@
+"""Hierarchical three-dimensional fractional geometric smoothing.
+
+The module implements a deterministic reference solver for periodic 3D scalar
+fields.  It uses the exact eigenvalues of the six-neighbour discrete Laplacian
+and a separable discrete Fourier transform, so the fractional heat update is
+performed mode-by-mode without external numerical dependencies.
+
+This is a correctness-oriented CPU prototype.  It is not intended to replace
+FFT libraries or production sparse-grid solvers.
+"""
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+
+Shape3D = Tuple[int, int, int]
+
+
+def _index(x: int, y: int, z: int, shape: Shape3D) -> int:
+    nx, ny, _ = shape
+    return x + nx * (y + ny * z)
+
+
+def _rms(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return math.sqrt(sum(value * value for value in values) / len(values))
+
+
+@dataclass(frozen=True)
+class Grid3D:
+    """Dense scalar field stored with x as the fastest-moving coordinate."""
+
+    shape: Shape3D
+    values: Tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        nx, ny, nz = self.shape
+        if nx < 1 or ny < 1 or nz < 1:
+            raise ValueError("all grid dimensions must be positive")
+        if len(self.values) != nx * ny * nz:
+            raise ValueError("value count does not match grid shape")
+        if not all(math.isfinite(value) for value in self.values):
+            raise ValueError("grid values must be finite")
+
+    @classmethod
+    def constant(cls, shape: Shape3D, value: float) -> "Grid3D":
+        if not math.isfinite(value):
+            raise ValueError("constant value must be finite")
+        nx, ny, nz = shape
+        return cls(shape, (float(value),) * (nx * ny * nz))
+
+    @classmethod
+    def impulse(
+        cls,
+        shape: Shape3D,
+        coordinate: Tuple[int, int, int],
+        amplitude: float = 1.0,
+    ) -> "Grid3D":
+        nx, ny, nz = shape
+        x, y, z = coordinate
+        if not (0 <= x < nx and 0 <= y < ny and 0 <= z < nz):
+            raise ValueError("impulse coordinate lies outside the grid")
+        if not math.isfinite(amplitude):
+            raise ValueError("impulse amplitude must be finite")
+        values = [0.0] * (nx * ny * nz)
+        values[_index(x, y, z, shape)] = amplitude
+        return cls(shape, tuple(values))
+
+    def at(self, x: int, y: int, z: int) -> float:
+        nx, ny, nz = self.shape
+        if not (0 <= x < nx and 0 <= y < ny and 0 <= z < nz):
+            raise IndexError("grid coordinate out of range")
+        return self.values[_index(x, y, z, self.shape)]
+
+    @property
+    def mean(self) -> float:
+        return sum(self.values) / len(self.values)
+
+    @property
+    def mass(self) -> float:
+        return sum(self.values)
+
+    @property
+    def variance(self) -> float:
+        mean = self.mean
+        return sum((value - mean) ** 2 for value in self.values) / len(self.values)
+
+    @property
+    def l2_rms(self) -> float:
+        return _rms(self.values)
+
+
+def _transform_x(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> List[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / nx if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * x / nx) for x in range(nx)]
+        for k in range(nx)
+    ]
+    for z in range(nz):
+        for y in range(ny):
+            for k in range(nx):
+                total = 0j
+                for x in range(nx):
+                    total += values[_index(x, y, z, shape)] * roots[k][x]
+                output[_index(k, y, z, shape)] = total * scale
+    return output
+
+
+def _transform_y(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> List[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / ny if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * y / ny) for y in range(ny)]
+        for k in range(ny)
+    ]
+    for z in range(nz):
+        for x in range(nx):
+            for k in range(ny):
+                total = 0j
+                for y in range(ny):
+                    total += values[_index(x, y, z, shape)] * roots[k][y]
+                output[_index(x, k, z, shape)] = total * scale
+    return output
+
+
+def _transform_z(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> List[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / nz if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * z / nz) for z in range(nz)]
+        for k in range(nz)
+    ]
+    for y in range(ny):
+        for x in range(nx):
+            for k in range(nz):
+                total = 0j
+                for z in range(nz):
+                    total += values[_index(x, y, z, shape)] * roots[k][z]
+                output[_index(x, y, k, shape)] = total * scale
+    return output
+
+
+def _dft3(values: Sequence[float]) -> List[complex]:
+    raise RuntimeError("_dft3 requires a shape; use _forward_dft3")
+
+
+def _forward_dft3(grid: Grid3D) -> List[complex]:
+    values = [complex(value, 0.0) for value in grid.values]
+    return _transform_z(_transform_y(_transform_x(values, grid.shape, False), grid.shape, False), grid.shape, False)
+
+
+def _inverse_dft3(values: Sequence[complex], shape: Shape3D) -> Grid3D:
+    transformed = _transform_x(
+        _transform_y(_transform_z(values, shape, True), shape, True),
+        shape,
+        True,
+    )
+    return Grid3D(shape, tuple(value.real for value in transformed))
+
+
+def _laplacian_eigenvalue(kx: int, ky: int, kz: int, shape: Shape3D) -> float:
+    nx, ny, nz = shape
+    return (
+        6.0
+        - 2.0 * math.cos(2.0 * math.pi * kx / nx)
+        - 2.0 * math.cos(2.0 * math.pi * ky / ny)
+        - 2.0 * math.cos(2.0 * math.pi * kz / nz)
+    )
+
+
+def _prepare_omega(omega: Grid3D, zero_mean: bool) -> Grid3D:
+    if not zero_mean:
+        return omega
+    mean = omega.mean
+    return Grid3D(omega.shape, tuple(value - mean for value in omega.values))
+
+
+def fractional_laplacian(field: Grid3D, alpha: float) -> Grid3D:
+    """Return ``(-Delta)^alpha field`` on a periodic six-neighbour lattice."""
+
+    if not math.isfinite(alpha) or not 0.0 < alpha <= 1.0:
+        raise ValueError("alpha must be finite and in (0, 1]")
+    spectrum = _forward_dft3(field)
+    nx, ny, nz = field.shape
+    for kz in range(nz):
+        for ky in range(ny):
+            for kx in range(nx):
+                index = _index(kx, ky, kz, field.shape)
+                eigenvalue = _laplacian_eigenvalue(kx, ky, kz, field.shape)
+                spectrum[index] *= eigenvalue**alpha if eigenvalue > 0.0 else 0.0
+    return _inverse_dft3(spectrum, field.shape)
+
+
+def spectral_fractional_step(
+    field: Grid3D,
+    alpha: float,
+    tau: float,
+    diffusivity: float = 1.0,
+    omega: Optional[Grid3D] = None,
+    zero_mean_omega: bool = True,
+) -> Grid3D:
+    """Advance ``du/dt = -D(-Delta)^alpha u + omega`` exactly per mode.
+
+    The forcing field is treated as constant over the time interval ``tau``.
+    With no forcing, the constant Fourier mode is preserved exactly and every
+    non-constant mode is attenuated by ``exp(-tau * D * lambda**alpha)``.
+    """
+
+    if not math.isfinite(alpha) or not 0.0 < alpha <= 1.0:
+        raise ValueError("alpha must be finite and in (0, 1]")
+    if not math.isfinite(tau) or tau < 0.0:
+        raise ValueError("tau must be finite and non-negative")
+    if not math.isfinite(diffusivity) or diffusivity < 0.0:
+        raise ValueError("diffusivity must be finite and non-negative")
+    if omega is not None and omega.shape != field.shape:
+        raise ValueError("omega shape must match field shape")
+
+    spectrum = _forward_dft3(field)
+    omega_spectrum: Optional[List[complex]] = None
+    if omega is not None:
+        omega_spectrum = _forward_dft3(_prepare_omega(omega, zero_mean_omega))
+
+    nx, ny, nz = field.shape
+    for kz in range(nz):
+        for ky in range(ny):
+            for kx in range(nx):
+                index = _index(kx, ky, kz, field.shape)
+                eigenvalue = _laplacian_eigenvalue(kx, ky, kz, field.shape)
+                rate = diffusivity * (eigenvalue**alpha if eigenvalue > 0.0 else 0.0)
+                decay = math.exp(-tau * rate)
+                updated = decay * spectrum[index]
+                if omega_spectrum is not None:
+                    if rate > 0.0:
+                        updated += (1.0 - decay) * omega_spectrum[index] / rate
+                    else:
+                        updated += tau * omega_spectrum[index]
+                spectrum[index] = updated
+
+    return _inverse_dft3(spectrum, field.shape)
+
+
+def classical_gradient_energy(field: Grid3D) -> float:
+    """Mean squared forward difference over the three periodic axes."""
+
+    nx, ny, nz = field.shape
+    total = 0.0
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                center = field.at(x, y, z)
+                dx = field.at((x + 1) % nx, y, z) - center
+                dy = field.at(x, (y + 1) % ny, z) - center
+                dz = field.at(x, y, (z + 1) % nz) - center
+                total += dx * dx + dy * dy + dz * dz
+    return total / (3.0 * len(field.values))
+
+
+def equilibrium_residual(
+    field: Grid3D,
+    alpha: float,
+    diffusivity: float = 1.0,
+    omega: Optional[Grid3D] = None,
+    zero_mean_omega: bool = True,
+) -> float:
+    """RMS of ``-D(-Delta)^alpha u + omega``."""
+
+    operator = fractional_laplacian(field, alpha)
+    forcing = (0.0,) * len(field.values)
+    if omega is not None:
+        if omega.shape != field.shape:
+            raise ValueError("omega shape must match field shape")
+        forcing = _prepare_omega(omega, zero_mean_omega).values
+    return _rms(
+        tuple(
+            -diffusivity * operator_value + forcing_value
+            for operator_value, forcing_value in zip(operator.values, forcing)
+        )
+    )
+
+
+def restrict_half(field: Grid3D) -> Grid3D:
+    """Average every 2x2x2 block into one coarse voxel."""
+
+    nx, ny, nz = field.shape
+    if nx % 2 or ny % 2 or nz % 2:
+        raise ValueError("all dimensions must be even for half restriction")
+    coarse_shape = (nx // 2, ny // 2, nz // 2)
+    coarse = [0.0] * (coarse_shape[0] * coarse_shape[1] * coarse_shape[2])
+    for cz in range(coarse_shape[2]):
+        for cy in range(coarse_shape[1]):
+            for cx in range(coarse_shape[0]):
+                total = 0.0
+                for dz in range(2):
+                    for dy in range(2):
+                        for dx in range(2):
+                            total += field.at(2 * cx + dx, 2 * cy + dy, 2 * cz + dz)
+                coarse[_index(cx, cy, cz, coarse_shape)] = total / 8.0
+    return Grid3D(coarse_shape, tuple(coarse))
+
+
+def prolong_double(field: Grid3D) -> Grid3D:
+    """Replicate each coarse voxel into a 2x2x2 fine block.
+
+    This constant prolongation obeys ``restrict_half(prolong_double(u)) == u``
+    up to floating-point roundoff, making the coarse-to-fine-to-coarse loop an
+    identity on the coarse subspace.
+    """
+
+    nx, ny, nz = field.shape
+    fine_shape = (2 * nx, 2 * ny, 2 * nz)
+    fine = [0.0] * (fine_shape[0] * fine_shape[1] * fine_shape[2])
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                value = field.at(x, y, z)
+                for dz in range(2):
+                    for dy in range(2):
+                        for dx in range(2):
+                            fine[
+                                _index(2 * x + dx, 2 * y + dy, 2 * z + dz, fine_shape)
+                            ] = value
+    return Grid3D(fine_shape, tuple(fine))
+
+
+def round_trip_error(coarse: Grid3D) -> float:
+    reconstructed = restrict_half(prolong_double(coarse))
+    return _rms(
+        tuple(left - right for left, right in zip(reconstructed.values, coarse.values))
+    )
+
+
+@dataclass(frozen=True)
+class FractionalHierarchyConfig:
+    """Fine-to-coarse schedule for hierarchical fractional smoothing."""
+
+    alphas: Tuple[float, ...] = (1.0, 0.75, 0.50)
+    taus: Tuple[float, ...] = (0.05, 0.10, 0.20)
+    coarse_blends: Tuple[float, ...] = (0.20, 0.35)
+    diffusivity: float = 1.0
+    zero_mean_omega: bool = True
+
+    def validate(self) -> None:
+        if not self.alphas:
+            raise ValueError("at least one hierarchy level is required")
+        if len(self.taus) != len(self.alphas):
+            raise ValueError("taus must contain one value per hierarchy level")
+        if len(self.coarse_blends) != len(self.alphas) - 1:
+            raise ValueError("coarse_blends must contain one value per fusion boundary")
+        if not all(math.isfinite(alpha) and 0.0 < alpha <= 1.0 for alpha in self.alphas):
+            raise ValueError("all fractional orders must lie in (0, 1]")
+        if not all(math.isfinite(tau) and tau >= 0.0 for tau in self.taus):
+            raise ValueError("all smoothing times must be non-negative")
+        if not all(
+            math.isfinite(blend) and 0.0 <= blend <= 1.0
+            for blend in self.coarse_blends
+        ):
+            raise ValueError("all coarse blends must lie in [0, 1]")
+        if not math.isfinite(self.diffusivity) or self.diffusivity < 0.0:
+            raise ValueError("diffusivity must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class MechanisticInstruction:
+    sequence: int
+    opcode: str
+    level: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class LevelTrace:
+    level: int
+    shape: Shape3D
+    alpha: float
+    tau: float
+    mean_before: float
+    mean_after: float
+    variance_before: float
+    variance_after: float
+    gradient_energy_before: float
+    gradient_energy_after: float
+    equilibrium_residual_after: float
+
+
+@dataclass(frozen=True)
+class HierarchicalSmoothingResult:
+    field: Grid3D
+    traces: Tuple[LevelTrace, ...]
+    instructions: Tuple[MechanisticInstruction, ...]
+    mass_before: float
+    mass_after: float
+    mass_drift: float
+    update_rms: float
+
+
+@dataclass(frozen=True)
+class EquilibriumResult:
+    field: Grid3D
+    converged: bool
+    cycles: int
+    update_history: Tuple[float, ...]
+    residual_history: Tuple[float, ...]
+
+
+def _validate_hierarchy_shape(shape: Shape3D, levels: int) -> None:
+    nx, ny, nz = shape
+    divisor = 2 ** (levels - 1)
+    if nx % divisor or ny % divisor or nz % divisor:
+        raise ValueError(
+            "each dimension must be divisible by 2**(levels - 1)"
+        )
+
+
+def _blend_fields(local: Grid3D, coarse_projection: Grid3D, weight: float) -> Grid3D:
+    if local.shape != coarse_projection.shape:
+        raise ValueError("fields must share a shape before blending")
+    return Grid3D(
+        local.shape,
+        tuple(
+            (1.0 - weight) * left + weight * right
+            for left, right in zip(local.values, coarse_projection.values)
+        ),
+    )
+
+
+def hierarchical_fractional_smooth(
+    field: Grid3D,
+    config: Optional[FractionalHierarchyConfig] = None,
+    omega: Optional[Grid3D] = None,
+) -> HierarchicalSmoothingResult:
+    """Run one full fine-to-coarse-to-fine smoothing transaction."""
+
+    active_config = config or FractionalHierarchyConfig()
+    active_config.validate()
+    levels = len(active_config.alphas)
+    _validate_hierarchy_shape(field.shape, levels)
+    if omega is not None and omega.shape != field.shape:
+        raise ValueError("omega shape must match field shape")
+
+    grids = [field]
+    omega_grids: List[Optional[Grid3D]] = [omega]
+    instructions: List[MechanisticInstruction] = []
+    sequence = 0
+
+    for level in range(1, levels):
+        grids.append(restrict_half(grids[-1]))
+        omega_grids.append(
+            restrict_half(omega_grids[-1]) if omega_grids[-1] is not None else None
+        )
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "RESTRICT_2X2X2",
+                level,
+                "%s -> %s" % (grids[level - 1].shape, grids[level].shape),
+            )
+        )
+        sequence += 1
+
+    local_results: List[Grid3D] = []
+    traces: List[LevelTrace] = []
+    for level, source in enumerate(grids):
+        alpha = active_config.alphas[level]
+        tau = active_config.taus[level]
+        result = spectral_fractional_step(
+            source,
+            alpha,
+            tau,
+            active_config.diffusivity,
+            omega_grids[level],
+            active_config.zero_mean_omega,
+        )
+        local_results.append(result)
+        traces.append(
+            LevelTrace(
+                level,
+                source.shape,
+                alpha,
+                tau,
+                source.mean,
+                result.mean,
+                source.variance,
+                result.variance,
+                classical_gradient_energy(source),
+                classical_gradient_energy(result),
+                equilibrium_residual(
+                    result,
+                    alpha,
+                    active_config.diffusivity,
+                    omega_grids[level],
+                    active_config.zero_mean_omega,
+                ),
+            )
+        )
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "FRACTIONAL_HEAT_3D",
+                level,
+                "alpha=%.6f tau=%.6f shape=%s" % (alpha, tau, source.shape),
+            )
+        )
+        sequence += 1
+
+    fused = local_results[-1]
+    for level in range(levels - 2, -1, -1):
+        projected = prolong_double(fused)
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "PROLONG_2X2X2",
+                level,
+                "%s -> %s" % (fused.shape, projected.shape),
+            )
+        )
+        sequence += 1
+        weight = active_config.coarse_blends[level]
+        fused = _blend_fields(local_results[level], projected, weight)
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "FUSE_COARSE_FINE",
+                level,
+                "coarse_weight=%.6f" % weight,
+            )
+        )
+        sequence += 1
+
+    update_rms = _rms(
+        tuple(after - before for after, before in zip(fused.values, field.values))
+    )
+    mass_before = field.mass
+    mass_after = fused.mass
+    instructions.append(
+        MechanisticInstruction(
+            sequence,
+            "VERIFY_MASS_AND_UPDATE",
+            0,
+            "mass_drift=%.12e update_rms=%.12e"
+            % (mass_after - mass_before, update_rms),
+        )
+    )
+
+    return HierarchicalSmoothingResult(
+        fused,
+        tuple(traces),
+        tuple(instructions),
+        mass_before,
+        mass_after,
+        mass_after - mass_before,
+        update_rms,
+    )
+
+
+def run_to_equilibrium(
+    field: Grid3D,
+    config: Optional[FractionalHierarchyConfig] = None,
+    omega: Optional[Grid3D] = None,
+    tolerance: float = 1.0e-6,
+    max_cycles: int = 100,
+) -> EquilibriumResult:
+    """Repeat hierarchical smoothing until the field update becomes negligible."""
+
+    if not math.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("tolerance must be finite and positive")
+    if max_cycles < 1:
+        raise ValueError("max_cycles must be positive")
+    active_config = config or FractionalHierarchyConfig()
+    active_config.validate()
+
+    current = field
+    updates: List[float] = []
+    residuals: List[float] = []
+    for cycle in range(1, max_cycles + 1):
+        result = hierarchical_fractional_smooth(current, active_config, omega)
+        current = result.field
+        updates.append(result.update_rms)
+        residuals.append(
+            equilibrium_residual(
+                current,
+                active_config.alphas[0],
+                active_config.diffusivity,
+                omega,
+                active_config.zero_mean_omega,
+            )
+        )
+        if result.update_rms <= tolerance:
+            return EquilibriumResult(
+                current,
+                True,
+                cycle,
+                tuple(updates),
+                tuple(residuals),
+            )
+
+    return EquilibriumResult(
+        current,
+        False,
+        max_cycles,
+        tuple(updates),
+        tuple(residuals),
+    )
+
+
+def grid_from_values(shape: Shape3D, values: Iterable[float]) -> Grid3D:
+    """Convenience constructor that normalises an iterable to immutable storage."""
+
+    return Grid3D(shape, tuple(float(value) for value in values))

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -1,12 +1,13 @@
 import hashlib
 import time
 
+
 class OmegaLedger:
     def __init__(self):
         self.chain = []
 
     def log(self, state, opcode):
-        payload = f"{time.time()}|{state}|{opcode}".encode()
-        prev = self.chain[-1]["hash"].encode() if self.chain else b""
-        h = hashlib.sha256(prev + payload).hexdigest()
-        self.chain.append({"hash": h, "payload": payload})
+        payload = f"{time.time()}|{state}|{opcode}"
+        previous = self.chain[-1]["hash"].encode() if self.chain else b""
+        digest = hashlib.sha256(previous + payload.encode()).hexdigest()
+        self.chain.append({"hash": digest, "payload": payload})

--- a/tests/test_fractional_smoothing_3d.py
+++ b/tests/test_fractional_smoothing_3d.py
@@ -1,0 +1,132 @@
+import math
+
+import pytest
+
+from jarvisx.fractional_smoothing_3d import (
+    FractionalHierarchyConfig,
+    Grid3D,
+    classical_gradient_energy,
+    equilibrium_residual,
+    hierarchical_fractional_smooth,
+    prolong_double,
+    restrict_half,
+    round_trip_error,
+    run_to_equilibrium,
+    spectral_fractional_step,
+)
+
+
+def test_constant_field_is_a_fractional_equilibrium():
+    field = Grid3D.constant((4, 4, 4), 3.25)
+    result = spectral_fractional_step(field, alpha=0.6, tau=1.0)
+
+    assert result.values == pytest.approx(field.values, abs=1.0e-12)
+    assert equilibrium_residual(result, alpha=0.6) == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_fractional_step_preserves_mass_and_reduces_variance():
+    field = Grid3D.impulse((4, 4, 4), (1, 1, 1), amplitude=8.0)
+    result = spectral_fractional_step(field, alpha=0.7, tau=0.2)
+
+    assert result.mass == pytest.approx(field.mass, abs=1.0e-10)
+    assert result.variance < field.variance
+    assert max(result.values) < max(field.values)
+    assert min(result.values) > -1.0e-12
+
+
+def test_coarse_expansion_contraction_is_identity():
+    coarse = Grid3D(
+        (2, 2, 2),
+        tuple(float(index) for index in range(8)),
+    )
+
+    expanded = prolong_double(coarse)
+    reconstructed = restrict_half(expanded)
+
+    assert reconstructed.values == pytest.approx(coarse.values, abs=1.0e-12)
+    assert round_trip_error(coarse) == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_hierarchy_emits_mechanistic_3d_instruction_trace():
+    field = Grid3D.impulse((4, 4, 4), (0, 0, 0), amplitude=4.0)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.5),
+        taus=(0.05, 0.20),
+        coarse_blends=(0.30,),
+    )
+
+    result = hierarchical_fractional_smooth(field, config)
+    opcodes = tuple(instruction.opcode for instruction in result.instructions)
+
+    assert len(result.traces) == 2
+    assert result.traces[0].shape == (4, 4, 4)
+    assert result.traces[1].shape == (2, 2, 2)
+    assert "RESTRICT_2X2X2" in opcodes
+    assert opcodes.count("FRACTIONAL_HEAT_3D") == 2
+    assert "PROLONG_2X2X2" in opcodes
+    assert "FUSE_COARSE_FINE" in opcodes
+    assert opcodes[-1] == "VERIFY_MASS_AND_UPDATE"
+
+
+def test_hierarchy_preserves_mass_and_smooths_gradient():
+    values = tuple(
+        math.sin(2.0 * math.pi * x / 4.0)
+        + 0.5 * math.cos(2.0 * math.pi * y / 4.0)
+        + (1.0 if (x + y + z) % 2 else -1.0)
+        for z in range(4)
+        for y in range(4)
+        for x in range(4)
+    )
+    field = Grid3D((4, 4, 4), values)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.6),
+        taus=(0.08, 0.20),
+        coarse_blends=(0.25,),
+    )
+
+    result = hierarchical_fractional_smooth(field, config)
+
+    assert result.mass_after == pytest.approx(result.mass_before, abs=1.0e-9)
+    assert abs(result.mass_drift) < 1.0e-9
+    assert classical_gradient_energy(result.field) < classical_gradient_energy(field)
+    assert result.update_rms > 0.0
+
+
+def test_zero_mean_omega_preserves_total_mass():
+    field = Grid3D.constant((4, 4, 4), 1.0)
+    omega = Grid3D(
+        (4, 4, 4),
+        tuple(1.0 if index == 0 else -1.0 / 63.0 for index in range(64)),
+    )
+
+    result = spectral_fractional_step(
+        field,
+        alpha=0.75,
+        tau=0.1,
+        omega=omega,
+        zero_mean_omega=True,
+    )
+
+    assert result.mass == pytest.approx(field.mass, abs=1.0e-9)
+    assert result.values != pytest.approx(field.values, abs=1.0e-12)
+
+
+def test_repeated_smoothing_moves_toward_equilibrium():
+    field = Grid3D.impulse((4, 4, 4), (1, 2, 3), amplitude=1.0)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.65),
+        taus=(0.20, 0.35),
+        coarse_blends=(0.25,),
+    )
+
+    result = run_to_equilibrium(
+        field,
+        config,
+        tolerance=1.0e-5,
+        max_cycles=80,
+    )
+
+    assert result.converged
+    assert result.update_history[-1] <= 1.0e-5
+    assert result.residual_history[-1] < result.residual_history[0]
+    assert result.field.mass == pytest.approx(field.mass, abs=1.0e-8)


### PR DESCRIPTION
## Integration dependency

This PR depends on foundation PR #47. After #47 merges, rebase onto `main`, remove duplicate repository-wide pytest, ledger and reflex repairs, and keep this PR focused on the fractional-smoothing solver, tests and numerical documentation.

Required promotion sequence:

1. #47 green and merged;
2. rebase #46 and resolve duplicate prerequisites;
3. repository CI and CodeQL green;
4. compare the reference DFT against a trusted FFT-backed implementation on small fixtures;
5. add measured scaling data and mark ready for review.

## Purpose

Operationalise hierarchical 3D fractional geometric smoothing as a deterministic reference solver for diffusion gradients and equilibrium systems.

The implementation treats the 3D volume as an explicit periodic lattice, applies a non-integer power of the six-neighbour discrete Laplacian in Fourier space, builds a 2×2×2 multiresolution hierarchy, and fuses coarse equilibrium information back into the fine field.

## Core equation

```text
du/dt = -D (-Delta)^alpha u + Omega
```

For each periodic Fourier mode:

```text
lambda(kx,ky,kz)
  = 6
    - 2 cos(2 pi kx / Nx)
    - 2 cos(2 pi ky / Ny)
    - 2 cos(2 pi kz / Nz)

u_hat(t + tau)
  = exp(-tau D lambda^alpha) u_hat(t)
```

The Ω-forced mode update is integrated analytically over each timestep.

## What changed

- adds `src/jarvisx/fractional_smoothing_3d.py`
- adds a validated immutable `Grid3D` with flat addressing:
  - `a = x + Nx * (y + Ny * z)`
- adds a separable dependency-free 3D DFT reference implementation
- adds exact spectral fractional heat evolution for `0 < alpha <= 1`
- adds optional zero-mean Ω forcing with mass preservation
- adds 2×2×2 restriction and constant prolongation
- enforces the coarse identity:
  - `restrict_half(prolong_double(G)) == G`
- adds fine-to-coarse level schedules for alpha and tau
- adds coarse-to-fine weighted fusion
- exposes variance, gradient energy, mass drift, update RMS, and equilibrium residual
- emits an auditable instruction trace:
  - `RESTRICT_2X2X2`
  - `FRACTIONAL_HEAT_3D`
  - `PROLONG_2X2X2`
  - `FUSE_COARSE_FINE`
  - `VERIFY_MASS_AND_UPDATE`
- adds repeated convergence through `run_to_equilibrium`
- adds a full arithmetic and mechanistic derivation in `docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md`
- updates the README with a runnable example

## 1000/1 ↔ 1/1000 interpretation

The reciprocal idea is implemented as scale movement rather than scalar multiplication. Restriction compresses each 2×2×2 region into one coarse cell; prolongation expands one coarse cell into eight fine cells. Their composition is the identity on the coarse subspace. Repeated hierarchy levels generalise this expansion/compression symmetry.

## Tests

Focused tests cover:

- invariance of constant equilibrium fields
- mass preservation and variance reduction
- exact coarse prolongation/restriction round trip
- explicit mechanistic instruction emission
- hierarchical gradient-energy reduction
- zero-mean Ω forcing
- convergence toward equilibrium

## Engineering boundary

This is a transparent correctness-oriented CPU reference prototype. The direct separable DFT is intentionally not a production FFT. Large-volume deployment requires an FFT backend, sparse bricks or octrees, vector-valued tensors, GPU kernels and benchmarks against established fractional PDE and multigrid solvers. The solver does not establish physical-world validity without a calibrated model and empirical data.