### PR TITLE
Integrate bounded deterministic C++ processor laboratory

### DIFF
--- a/.github/workflows/cpp-autopoietic-runtime.yml
+++ b/.github/workflows/cpp-autopoietic-runtime.yml
@@ -1,0 +1,60 @@
+name: C++ Autopoietic Runtime
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/**"
+      - ".github/workflows/cpp-autopoietic-runtime.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/**"
+      - ".github/workflows/cpp-autopoietic-runtime.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cpp-runtime-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            sanitizers: "OFF"
+          - os: ubuntu-latest
+            compiler: clang
+            sanitizers: "ON"
+          - os: windows-latest
+            compiler: msvc
+            sanitizers: "OFF"
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Select GCC
+        if: matrix.compiler == 'gcc'
+        run: echo "CXX=g++" >> "$GITHUB_ENV"
+
+      - name: Select Clang
+        if: matrix.compiler == 'clang'
+        run: echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name: Configure
+        run: >-
+          cmake -S cpp_runtime -B build/cpp-runtime
+          -DCMAKE_BUILD_TYPE=Release
+          -DJARVISX_ENABLE_SANITIZERS=${{ matrix.sanitizers }}
+
+      - name: Build
+        run: cmake --build build/cpp-runtime --config Release --parallel 2
+
+      - name: Test
+        run: ctest --test-dir build/cpp-runtime -C Release --output-on-failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ The project follows semantic versioning where practical during alpha development
 - expanded VM and ledger regression tests;
 - enforced CI quality, test and dependency-audit jobs;
 - architecture, project-status, roadmap, governance, security and contribution documents;
-- repository templates, ownership, dependency automation and citation metadata.
+- repository templates, ownership, dependency automation and citation metadata;
+- dependency-free C++17 processor laboratory with a sparse virtual `8192³` lattice;
+- signed 3-bit feature encoding, sparse scatter/diffusion, decoding and residual correction;
+- bounded deterministic genome and bytecode-schedule candidate evaluation;
+- atomic genome, ROM and evolution-journal checkpoints;
+- cross-platform GCC, Clang sanitizer and MSVC validation.
 
 ### Changed
 
@@ -24,7 +29,9 @@ The project follows semantic versioning where practical during alpha development
 - packaging metadata is authoritative in `pyproject.toml`;
 - supported Python versions begin at Python 3.10;
 - CI uses current Node 24-compatible major versions of core actions;
-- project documentation distinguishes stable code, integration candidates, demonstrations and specifications.
+- project documentation distinguishes stable code, reference laboratories, integration candidates, demonstrations and specifications;
+- C++ candidate selection excludes wall-clock latency from both fitness and equal-fitness tie handling;
+- C++ checkpoint loading requires all versioned fields and a matching deterministic fingerprint.
 
 ### Fixed
 
@@ -32,7 +39,10 @@ The project follows semantic versioning where practical during alpha development
 - pytest used the invalid coverage reporter `term-local`;
 - tests could create or mutate an `omega_ledger.json` file in the working directory;
 - VM loading accepted empty and non-64-bit programs;
-- invalid instruction-pointer states were not rejected explicitly.
+- invalid instruction-pointer states were not rejected explicitly;
+- negative C++ genome mutations could wrap unsigned fields to their maximum bounds;
+- the earlier C++ direct-build documentation referenced a nonexistent source file;
+- C++ ROM and CSV state writes could leave partial output after interruption.
 
 ## [0.1.0] — Initial alpha
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jarvis-X
 
 [![Jarvis-X CI](https://github.com/Lord-Xido/Jarvis-X/actions/workflows/ci.yml/badge.svg)](https://github.com/Lord-Xido/Jarvis-X/actions/workflows/ci.yml)
+[![C++ Runtime](https://github.com/Lord-Xido/Jarvis-X/actions/workflows/cpp-autopoietic-runtime.yml/badge.svg)](https://github.com/Lord-Xido/Jarvis-X/actions/workflows/cpp-autopoietic-runtime.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](pyproject.toml)
 [![Status: Alpha](https://img.shields.io/badge/status-alpha-orange.svg)](docs/PROJECT_STATUS.md)
@@ -9,7 +10,7 @@
 
 The project investigates how large virtual state spaces, geometric representations, residual memory and bounded adaptation can be implemented as reproducible software without confusing virtual extent with physical allocation or simulation with deployed intelligence.
 
-> **Current status:** alpha research software. The repository contains a small stable VM core, validated reference components and multiple experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
+> **Current status:** alpha research software. The repository contains a stable reference VM foundation, validated sparse and packaging components, a bounded C++ processor laboratory and experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
 
 ## Why Jarvis-X exists
 
@@ -33,13 +34,14 @@ The symbolic vocabulary used in the research documents maps to ordinary engineer
 | Π | projection into a valid state set |
 | Ξ | integrated runtime state |
 
-## Stable capabilities on `main`
+## Capabilities on `main`
 
 | Area | Implemented capability | Maturity |
 |---|---|---|
 | Bytecode VM | parser, assembler, decoder, registers and minimal 64-bit instruction execution | Alpha |
 | Core ISA | `SET`, `ADD`, `SUB`, `HALT` | Alpha |
-| Runtime controls | policy check, cycle sandbox, tracing and ledger integration | Alpha |
+| Runtime controls | policy check, cycle sandbox, tracing and verifiable ledger integration | Reference foundation |
+| C++ processor laboratory | sparse virtual `8192³` lattice, signed 3-bit latent cycle, deterministic bounded genome/schedule search | Reference laboratory |
 | Sparse geometry | deterministic inward-folding fractal octree with closed-form invariants | Reference |
 | Model packaging | Hugging Face-compatible configuration, model and safetensors exporter | Reference |
 | Research specifications | reality-grounded observer dynamics, spatial bytecode and bounded optimization documents | Proposed / reference |
@@ -48,7 +50,7 @@ Experimental engines remain in draft pull requests until their tests, interfaces
 
 ## Quick start
 
-### Install for development
+### Install the Python package for development
 
 ```bash
 git clone https://github.com/Lord-Xido/Jarvis-X.git
@@ -95,6 +97,24 @@ Adaptive reflex correction is also explicit and disabled by default:
 vm = CodexVM(enable_reflex=True)
 ```
 
+### Build the C++ processor laboratory
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --config Release --parallel
+ctest --test-dir build/cpp-runtime -C Release --output-on-failure
+```
+
+Run a bounded inward experiment:
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --generations 8 \
+  --population 6
+```
+
+See [`cpp_runtime/README.md`](cpp_runtime/README.md) for its state artifacts, determinism contract, sanitizer build and capability limits.
+
 ## Architecture
 
 ```text
@@ -113,8 +133,8 @@ Parser → Assembler → 64-bit bytecode
                          │
               ┌──────────┴──────────┐
               ▼                     ▼
-      authoritative state    optional research layers
-      registers / memory     spatial / adaptive / visual
+      authoritative state    isolated research layers
+      registers / memory     C++ / spatial / visual
 ```
 
 The canonical design rules are documented in [Architecture](docs/ARCHITECTURE.md).
@@ -143,9 +163,10 @@ At depth `D`:
 
 | Track | Purpose | Status |
 |---|---|---|
-| C++ inward runtime | sparse `8192³` virtual processor with bounded genome and bytecode search | Draft PR #45 |
-| Fractional smoothing | deterministic hierarchical 3D fractional-diffusion reference solver | Draft PR #46 |
-| Platform foundation | canonical VM repair, CI enforcement and contributor-ready governance | Draft PR #47 |
+| Fractional smoothing | deterministic hierarchical 3D fractional-diffusion reference solver | Draft PR #46; rebase required |
+| Backlog consolidation | select canonical implementations and close superseded research branches | Issue #48 |
+| Repository protection | required checks, secret scanning and private vulnerability reporting | Issue #49 |
+| Public profile | account-level profile README and pinned-project cleanup | Issue #50 |
 | Browser engines | bounded interactive 3D visual-computing demonstrations | Separate repository |
 
 Draft status is intentional: experimental subsystems are not represented as canonical until CI, review and integration boundaries are satisfied.
@@ -159,11 +180,11 @@ docs/              specifications and architecture records
 scripts/           packaging and export utilities
 examples/          runnable demonstrations
 cuda/              accelerator reference work
-cpp_runtime/       C++ runtime integration track
+cpp_runtime/       bounded C++ processor laboratory
 .github/           CI, templates and repository automation
 ```
 
-Some paths exist only on active branches. [Project Status](docs/PROJECT_STATUS.md) identifies what is present on the default branch.
+[Project Status](docs/PROJECT_STATUS.md) identifies what is implemented, experimental or proposed.
 
 ## Engineering standards
 
@@ -198,7 +219,7 @@ Large architectural proposals should begin as an issue or specification. Product
 
 Jarvis-X is an experimental software and mathematical research project. It does not claim consciousness, unrestricted autonomous self-modification, lossless compression of arbitrary high-dimensional inputs into smaller states, or production safety merely because a policy layer is present.
 
-Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility.
+Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility. The C++ processor mutates bounded parameters and schedules; it does not rewrite arbitrary native code.
 
 ## Citation
 

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.16)
+project(jarvis_x_autopoietic_runtime LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(JARVISX_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+function(jarvisx_harden target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
+        if(JARVISX_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(${target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+            target_link_options(${target} PRIVATE -fsanitize=address,undefined)
+        endif()
+    endif()
+endfunction()
+
+add_executable(jarvisx-runtime
+    src/main.cpp
+)
+target_include_directories(jarvisx-runtime PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-runtime)
+
+enable_testing()
+
+add_test(
+    NAME inward-runtime-smoke
+    COMMAND jarvisx-runtime
+        --generations 2
+        --population 3
+        --state-dir ${CMAKE_CURRENT_BINARY_DIR}/smoke-state
+        --text "Jarvis X inward runtime smoke test"
+        --quiet
+        --reset
+)
+set_tests_properties(inward-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-processor-tests
+    tests/processor_tests.cpp
+)
+target_include_directories(jarvisx-processor-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-processor-tests)
+
+add_test(NAME processor-regressions COMMAND jarvisx-processor-tests)
+set_tests_properties(processor-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -1,0 +1,96 @@
+# Jarvis-X Inward C++ Runtime
+
+This dependency-free C++17 subsystem implements a bounded sparse auto-encoding processor and deterministic parameter/schedule search loop.
+
+It exposes a virtual `8192 × 8192 × 8192` coordinate domain through lazily materialized `8 × 8 × 8` tiles. The virtual extent is an addressing contract, not a dense allocation.
+
+## Operational cycle
+
+1. ingest the executable image by default, or accept explicit text/binary input;
+2. extract a fixed-width deterministic feature vector;
+3. encode into the signed 3-bit set `{-4,-3,-2,-1,0,1,2,3}`;
+4. scatter and diffuse the latent field through sparse coordinates;
+5. decode and calculate reconstruction error;
+6. generate bounded genome and bytecode-schedule candidates;
+7. evaluate each candidate in a fresh processor instance;
+8. apply the Lambda coherence and improvement gates;
+9. commit the champion or retain the rollback anchor;
+10. persist the genome, ROM and evolution journal.
+
+The runtime mutates constrained parameters and synthesized bytecode schedules. It does **not** rewrite arbitrary native instructions, establish consciousness, provide hostile-code isolation or physically allocate the full virtual lattice.
+
+## Build
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --config Release --parallel
+ctest --test-dir build/cpp-runtime -C Release --output-on-failure
+```
+
+Direct GCC/Clang build:
+
+```bash
+g++ -std=c++17 -O3 -Wall -Wextra -Wpedantic \
+  -Icpp_runtime/include \
+  cpp_runtime/src/main.cpp \
+  -o jarvisx-runtime
+```
+
+## Run inward on the executable
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --generations 8 \
+  --population 6
+```
+
+## Run on explicit input
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --file sample.bin \
+  --generations 12 \
+  --population 8
+```
+
+Text input is also supported:
+
+```bash
+./build/cpp-runtime/jarvisx-runtime \
+  --text "deterministic replay fixture" \
+  --generations 4 \
+  --population 5
+```
+
+## State artifacts
+
+The default `.jarvisx-runtime/` directory contains:
+
+- `genome.current` — atomically committed runtime genome;
+- `runtime.rom` — big-endian 64-bit bytecode words;
+- `evolution.csv` — accepted and rolled-back generations with telemetry.
+
+Use `--reset` to discard an earlier checkpoint, `--state-dir PATH` to isolate an experiment and `--min-improvement X` to tighten the commit threshold.
+
+## Determinism contract
+
+Candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. Wall-clock latency is recorded as telemetry but excluded from fitness. Platform floating-point implementations may still produce small cross-architecture differences; bit-exact portability is not claimed.
+
+## Validation
+
+The CTest suite includes:
+
+- inward executable/text smoke execution;
+- genome normalization before allocation;
+- repeatable processor evaluation;
+- proof that wall-clock latency does not alter deterministic fitness.
+
+Optional sanitizer build:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime-san \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DJARVISX_ENABLE_SANITIZERS=ON
+cmake --build build/cpp-runtime-san --parallel
+ctest --test-dir build/cpp-runtime-san --output-on-failure
+```

--- a/cpp_runtime/include/jarvisx/core.hpp
+++ b/cpp_runtime/include/jarvisx/core.hpp
@@ -1,0 +1,305 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+namespace fs = std::filesystem;
+
+constexpr std::uint32_t kWorldEdge = 8192;
+constexpr std::uint32_t kTileEdge = 8;
+constexpr std::uint32_t kTileVolume = kTileEdge * kTileEdge * kTileEdge;
+constexpr std::uint32_t kTileAxis = kWorldEdge / kTileEdge;
+constexpr std::size_t kMaxPacketBytes = 1U << 20U;
+constexpr float kEpsilon = 1.0e-6F;
+
+static_assert(kWorldEdge % kTileEdge == 0, "invalid lattice geometry");
+static_assert((kWorldEdge & (kWorldEdge - 1U)) == 0, "edge must be power of two");
+
+float clampf(float value, float low, float high) noexcept {
+    return std::max(low, std::min(value, high));
+}
+
+std::uint64_t mix64(std::uint64_t value) noexcept {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+float signed_unit(std::uint64_t key) noexcept {
+    const std::uint64_t bits = mix64(key);
+    const double unit = static_cast<double>(bits >> 11U) /
+                        static_cast<double>(1ULL << 53U);
+    return static_cast<float>(unit * 2.0 - 1.0);
+}
+
+std::uint32_t crc32(const std::vector<std::uint8_t>& bytes) noexcept {
+    std::uint32_t crc = 0xFFFFFFFFU;
+    for (const std::uint8_t byte : bytes) {
+        crc ^= byte;
+        for (int bit = 0; bit < 8; ++bit) {
+            const std::uint32_t mask = static_cast<std::uint32_t>(
+                -static_cast<std::int32_t>(crc & 1U));
+            crc = (crc >> 1U) ^ (0xEDB88320U & mask);
+        }
+    }
+    return ~crc;
+}
+
+struct Vec3u {
+    std::uint32_t x{};
+    std::uint32_t y{};
+    std::uint32_t z{};
+};
+
+struct Cell {
+    std::int8_t latent{};
+    std::int8_t prediction{};
+    std::int8_t residual{};
+    std::uint8_t modality{};
+    std::uint16_t generation{};
+    std::uint16_t flags{};
+};
+
+struct Tile {
+    std::array<Cell, kTileVolume> cells{};
+};
+
+class SparseLattice {
+public:
+    Cell read(const Vec3u& point) const {
+        const auto [key, index] = locate(point);
+        const auto found = tiles_.find(key);
+        return found == tiles_.end() ? Cell{} : found->second.cells[index];
+    }
+
+    void write(const Vec3u& point, const Cell& cell) {
+        const auto [key, index] = locate(point);
+        tiles_[key].cells[index] = cell;
+    }
+
+    std::size_t tile_count() const noexcept { return tiles_.size(); }
+
+    std::uint64_t estimated_bytes() const noexcept {
+        return static_cast<std::uint64_t>(tiles_.size()) * sizeof(Tile);
+    }
+
+private:
+    std::unordered_map<std::uint64_t, Tile> tiles_;
+
+    static std::pair<std::uint64_t, std::uint32_t> locate(const Vec3u& p) {
+        if (p.x >= kWorldEdge || p.y >= kWorldEdge || p.z >= kWorldEdge) {
+            throw std::out_of_range("coordinate outside 8192^3 lattice");
+        }
+        const std::uint32_t tx = p.x / kTileEdge;
+        const std::uint32_t ty = p.y / kTileEdge;
+        const std::uint32_t tz = p.z / kTileEdge;
+        const std::uint64_t key =
+            static_cast<std::uint64_t>(tx) +
+            static_cast<std::uint64_t>(kTileAxis) *
+                (static_cast<std::uint64_t>(ty) +
+                 static_cast<std::uint64_t>(kTileAxis) * tz);
+        const std::uint32_t lx = p.x % kTileEdge;
+        const std::uint32_t ly = p.y % kTileEdge;
+        const std::uint32_t lz = p.z % kTileEdge;
+        return {key, lx + kTileEdge * (ly + kTileEdge * lz)};
+    }
+};
+
+enum class Modality : std::uint8_t {
+    Text = 1,
+    Image = 2,
+    Audio = 3,
+    Video = 4,
+    Binary = 5,
+    Sensor = 6
+};
+
+struct Packet {
+    Modality modality{Modality::Binary};
+    std::vector<std::uint8_t> bytes;
+    std::uint32_t checksum{};
+
+    void seal() noexcept { checksum = crc32(bytes); }
+    bool valid() const noexcept { return checksum == crc32(bytes); }
+};
+
+Packet text_packet(const std::string& text) {
+    Packet packet;
+    packet.modality = Modality::Text;
+    packet.bytes.assign(text.begin(), text.end());
+    packet.seal();
+    return packet;
+}
+
+std::optional<Packet> file_packet(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return std::nullopt;
+
+    input.seekg(0, std::ios::end);
+    const std::streamoff end = input.tellg();
+    if (end < 0) return std::nullopt;
+    input.seekg(0, std::ios::beg);
+
+    Packet packet;
+    packet.modality = Modality::Binary;
+    packet.bytes.resize(std::min<std::size_t>(
+        static_cast<std::size_t>(end), kMaxPacketBytes));
+    input.read(reinterpret_cast<char*>(packet.bytes.data()),
+               static_cast<std::streamsize>(packet.bytes.size()));
+    packet.bytes.resize(static_cast<std::size_t>(input.gcount()));
+    packet.seal();
+    return packet;
+}
+
+std::vector<float> extract_features(const Packet& packet, std::size_t width) {
+    if (!packet.valid()) throw std::runtime_error("packet CRC mismatch");
+    if (width < 8) throw std::invalid_argument("feature width below 8");
+
+    std::vector<float> features(width, 0.0F);
+    if (packet.bytes.empty()) return features;
+
+    double mean = 0.0;
+    double square = 0.0;
+    for (std::size_t i = 0; i < packet.bytes.size(); ++i) {
+        const float x = static_cast<float>(packet.bytes[i]) / 127.5F - 1.0F;
+        const std::uint64_t h = mix64(
+            (static_cast<std::uint64_t>(i) << 8U) ^
+            packet.bytes[i] ^
+            (static_cast<std::uint64_t>(packet.modality) << 56U));
+        features[h % width] += x;
+        features[(h >> 19U) % width] += x * x - 0.333333F;
+        mean += x;
+        square += static_cast<double>(x) * x;
+    }
+
+    const double count = static_cast<double>(packet.bytes.size());
+    features[0] += static_cast<float>(mean / count);
+    features[1] += static_cast<float>(square / count);
+    features[2] += static_cast<float>(std::log1p(count) / 16.0);
+    features[3] += static_cast<float>(packet.modality) / 8.0F;
+
+    double norm2 = 0.0;
+    for (const float value : features) norm2 += value * value;
+    const float inverse = 1.0F / std::sqrt(static_cast<float>(norm2) + kEpsilon);
+    for (float& value : features) value *= inverse;
+    return features;
+}
+
+std::int8_t quantize_q3(float value) noexcept {
+    const int q = static_cast<int>(std::lround(clampf(value, -1.0F, 1.0F) * 3.5F));
+    return static_cast<std::int8_t>(std::max(-4, std::min(3, q)));
+}
+
+float dequantize_q3(std::int8_t value) noexcept {
+    return clampf(static_cast<float>(value) / 3.5F, -1.0F, 1.0F);
+}
+
+struct Genome {
+    std::uint32_t version{1};
+    std::uint64_t generation{};
+    std::size_t feature_dim{128};
+    std::size_t latent_dim{64};
+    std::uint16_t iterations{12};
+    std::uint16_t diffusion_radius{1};
+    std::uint16_t learning_units{80};
+    std::uint16_t omega_units{40};
+    std::uint16_t max_mse_units{2500};
+    std::uint16_t max_energy_units{8500};
+    std::uint16_t min_coherence_units{800};
+    std::uint64_t seed{0x4A415256495358ULL};
+
+    void clamp() noexcept {
+        feature_dim = std::max<std::size_t>(32, std::min<std::size_t>(512, feature_dim));
+        latent_dim = std::max<std::size_t>(8, std::min<std::size_t>(256, latent_dim));
+        latent_dim = std::min(latent_dim, feature_dim);
+        iterations = static_cast<std::uint16_t>(std::max(2, std::min(128, int(iterations))));
+        diffusion_radius = static_cast<std::uint16_t>(
+            std::max(1, std::min(32, int(diffusion_radius))));
+        learning_units = static_cast<std::uint16_t>(
+            std::max(1, std::min(400, int(learning_units))));
+        omega_units = static_cast<std::uint16_t>(
+            std::max(1, std::min(300, int(omega_units))));
+        max_mse_units = static_cast<std::uint16_t>(
+            std::max(100, std::min(10000, int(max_mse_units))));
+        max_energy_units = static_cast<std::uint16_t>(
+            std::max(1000, std::min(10000, int(max_energy_units))));
+        min_coherence_units = static_cast<std::uint16_t>(
+            std::max(0, std::min(9000, int(min_coherence_units))));
+    }
+
+    std::string fingerprint() const {
+        std::ostringstream out;
+        out << std::hex << std::uppercase << mix64(
+            seed ^ generation ^
+            (static_cast<std::uint64_t>(feature_dim) << 32U) ^
+            (static_cast<std::uint64_t>(latent_dim) << 16U) ^
+            iterations ^ diffusion_radius ^ learning_units ^ omega_units);
+        return out.str();
+    }
+};
+
+enum class Op : std::uint8_t {
+    Extract = 1,
+    Encode = 2,
+    Scatter = 3,
+    Diffuse = 4,
+    Decode = 5,
+    Learn = 6,
+    Project = 7,
+    Commit = 8,
+    Loop = 9,
+    Halt = 0xFF
+};
+
+struct Instruction {
+    std::uint64_t word{};
+
+    static Instruction make(Op op, std::uint16_t a = 0,
+                            std::uint16_t b = 0, std::uint16_t c = 0) noexcept {
+        return { (static_cast<std::uint64_t>(op) << 56U) |
+                 (static_cast<std::uint64_t>(a) << 32U) |
+                 (static_cast<std::uint64_t>(b) << 16U) |
+                 c };
+    }
+
+    Op op() const noexcept { return static_cast<Op>((word >> 56U) & 0xFFU); }
+    std::uint16_t a() const noexcept { return (word >> 32U) & 0xFFFFU; }
+    std::uint16_t b() const noexcept { return (word >> 16U) & 0xFFFFU; }
+    std::uint16_t c() const noexcept { return word & 0xFFFFU; }
+};
+
+std::vector<Instruction> synthesize_rom(const Genome& g) {
+    return {
+        Instruction::make(Op::Extract),
+        Instruction::make(Op::Encode),
+        Instruction::make(Op::Scatter),
+        Instruction::make(Op::Diffuse, g.diffusion_radius),
+        Instruction::make(Op::Decode),
+        Instruction::make(Op::Learn, g.learning_units, g.omega_units),
+        Instruction::make(Op::Project, g.max_mse_units, g.max_energy_units,
+                          g.min_coherence_units),
+        Instruction::make(Op::Commit),
+        Instruction::make(Op::Loop, g.iterations, 1),
+        Instruction::make(Op::Halt)
+    };
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/processor.hpp
+++ b/cpp_runtime/include/jarvisx/processor.hpp
@@ -1,0 +1,269 @@
+#pragma once
+
+#include "jarvisx/core.hpp"
+
+namespace jarvisx {
+struct Metrics {
+    std::uint64_t cycles{};
+    std::uint64_t committed{};
+    std::uint64_t rejected{};
+    float mse{std::numeric_limits<float>::infinity()};
+    float coherence{};
+    float energy{};
+};
+
+class Processor {
+public:
+    Processor(Genome genome, Packet packet)
+        : genome_(normalize_genome(std::move(genome))),
+          packet_(std::move(packet)),
+          omega_(genome_.feature_dim, 0.0F),
+          rom_(synthesize_rom(genome_)) {
+        if (!packet_.valid()) throw std::runtime_error("invalid packet");
+    }
+
+    void run() {
+        const std::uint64_t cycle_limit =
+            32ULL + static_cast<std::uint64_t>(genome_.iterations) * 16ULL;
+        while (!halted_ && metrics_.cycles < cycle_limit) {
+            if (pc_ >= rom_.size()) throw std::runtime_error("ROM PC overflow");
+            execute(rom_[pc_]);
+            ++metrics_.cycles;
+        }
+        if (!halted_) throw std::runtime_error("processor cycle limit reached");
+    }
+
+    const Metrics& metrics() const noexcept { return metrics_; }
+    const SparseLattice& lattice() const noexcept { return lattice_; }
+    const Genome& genome() const noexcept { return genome_; }
+
+private:
+    static Genome normalize_genome(Genome genome) noexcept {
+        genome.clamp();
+        return genome;
+    }
+
+    Genome genome_;
+    Packet packet_;
+    SparseLattice lattice_;
+    std::vector<float> features_;
+    std::vector<std::int8_t> latent_;
+    std::vector<float> reconstruction_;
+    std::vector<float> omega_;
+    std::vector<Instruction> rom_;
+    Metrics metrics_{};
+    std::size_t pc_{};
+    std::uint64_t iteration_{};
+    bool halted_{};
+    bool admissible_{};
+
+    Vec3u coordinate(std::size_t index) const noexcept {
+        const std::uint64_t a = mix64(index ^ (iteration_ << 32U) ^ genome_.seed);
+        const std::uint64_t b = mix64(a);
+        const std::uint64_t c = mix64(b);
+        return {static_cast<std::uint32_t>(a & (kWorldEdge - 1U)),
+                static_cast<std::uint32_t>(b & (kWorldEdge - 1U)),
+                static_cast<std::uint32_t>(c & (kWorldEdge - 1U))};
+    }
+
+    void execute(const Instruction& instruction) {
+        switch (instruction.op()) {
+        case Op::Extract:
+            features_ = extract_features(packet_, genome_.feature_dim);
+            ++pc_;
+            break;
+        case Op::Encode:
+            encode();
+            ++pc_;
+            break;
+        case Op::Scatter:
+            scatter();
+            ++pc_;
+            break;
+        case Op::Diffuse:
+            diffuse(std::max<std::uint16_t>(1, instruction.a()));
+            ++pc_;
+            break;
+        case Op::Decode:
+            decode();
+            ++pc_;
+            break;
+        case Op::Learn:
+            learn(instruction.a(), instruction.b());
+            ++pc_;
+            break;
+        case Op::Project:
+            project(instruction.a(), instruction.b(), instruction.c());
+            ++pc_;
+            break;
+        case Op::Commit:
+            admissible_ ? ++metrics_.committed : ++metrics_.rejected;
+            ++pc_;
+            break;
+        case Op::Loop:
+            ++iteration_;
+            pc_ = iteration_ < instruction.a() ? instruction.b() : pc_ + 1;
+            break;
+        case Op::Halt:
+            halted_ = true;
+            break;
+        default:
+            throw std::runtime_error("invalid ROM opcode");
+        }
+    }
+
+    void encode() {
+        latent_.assign(genome_.latent_dim, 0);
+        double energy = 0.0;
+        for (std::size_t j = 0; j < latent_.size(); ++j) {
+            float sum = 0.0F;
+            for (std::size_t i = 0; i < features_.size(); ++i) {
+                const float weight = 0.125F * signed_unit(
+                    genome_.seed ^ (j * 0x9E3779B97F4A7C15ULL + i));
+                sum += weight * features_[i];
+            }
+            latent_[j] = quantize_q3(std::tanh(sum));
+            const double x = dequantize_q3(latent_[j]);
+            energy += x * x;
+        }
+        metrics_.energy = static_cast<float>(energy / latent_.size());
+    }
+
+    void scatter() {
+        for (std::size_t i = 0; i < latent_.size(); ++i) {
+            Cell cell;
+            cell.latent = latent_[i];
+            cell.prediction = latent_[i];
+            cell.modality = static_cast<std::uint8_t>(packet_.modality);
+            cell.generation = static_cast<std::uint16_t>(
+                genome_.generation & 0xFFFFU);
+            cell.flags = 1U;
+            lattice_.write(coordinate(i), cell);
+        }
+    }
+
+    void diffuse(std::uint16_t radius) {
+        if (latent_.empty()) throw std::runtime_error("diffusion before encoding");
+        std::vector<std::int8_t> evolved(latent_.size());
+        const std::size_t offset = radius % latent_.size();
+        for (std::size_t i = 0; i < latent_.size(); ++i) {
+            const std::size_t left = (i + latent_.size() - offset) % latent_.size();
+            const std::size_t right = (i + offset) % latent_.size();
+            const int value = latent_[left] + 2 * latent_[i] + latent_[right];
+            evolved[i] = static_cast<std::int8_t>(
+                std::max(-4, std::min(3, int(std::lround(value / 4.0)))));
+            Cell cell = lattice_.read(coordinate(i));
+            cell.prediction = evolved[i];
+            cell.residual = static_cast<std::int8_t>(
+                std::max(-4, std::min(3, int(cell.latent) - int(evolved[i]))));
+            cell.flags |= 2U;
+            lattice_.write(coordinate(i), cell);
+        }
+        latent_.swap(evolved);
+    }
+
+    void decode() {
+        if (latent_.empty()) throw std::runtime_error("decode before encoding");
+        reconstruction_.assign(genome_.feature_dim, 0.0F);
+        for (std::size_t i = 0; i < reconstruction_.size(); ++i) {
+            float sum = 0.0F;
+            for (std::size_t j = 0; j < latent_.size(); ++j) {
+                const float weight = 0.125F * signed_unit(
+                    (genome_.seed ^ 0xC0DEC0DEC0DEULL) ^
+                    (i * 0xD1B54A32D192ED03ULL + j));
+                sum += weight * dequantize_q3(latent_[j]);
+            }
+            reconstruction_[i] = clampf(std::tanh(sum) + omega_[i], -1.0F, 1.0F);
+        }
+    }
+
+    void learn(std::uint16_t learning_units, std::uint16_t omega_units) {
+        if (features_.size() != reconstruction_.size()) {
+            throw std::runtime_error("learning state dimension mismatch");
+        }
+        const float learning = learning_units / 100000.0F;
+        const float omega_rate = omega_units / 100000.0F;
+        double error2 = 0.0;
+        for (std::size_t i = 0; i < features_.size(); ++i) {
+            const float error = features_[i] - reconstruction_[i];
+            error2 += error * error;
+            omega_[i] = clampf(omega_[i] + (learning + omega_rate) * error,
+                               -0.25F, 0.25F);
+        }
+        metrics_.mse = static_cast<float>(error2 / features_.size());
+    }
+
+    void project(std::uint16_t mse_units, std::uint16_t energy_units,
+                 std::uint16_t coherence_units) {
+        const float mse_limit = std::max(kEpsilon, mse_units / 10000.0F);
+        const float energy_limit = std::max(kEpsilon, energy_units / 10000.0F);
+        const float mse_score = 1.0F - clampf(metrics_.mse / mse_limit, 0.0F, 1.0F);
+        const float energy_score =
+            1.0F - clampf(metrics_.energy / energy_limit, 0.0F, 1.0F);
+        metrics_.coherence = 0.7F * mse_score + 0.3F * energy_score;
+        admissible_ = std::isfinite(metrics_.mse) &&
+            std::isfinite(metrics_.energy) &&
+            std::isfinite(metrics_.coherence) &&
+            metrics_.coherence >= coherence_units / 10000.0F;
+        if (!admissible_) {
+            for (std::int8_t& q : latent_) q = static_cast<std::int8_t>(q / 2);
+        }
+    }
+};
+
+struct Evaluation {
+    Genome genome;
+    Metrics metrics;
+    std::size_t tiles{};
+    std::uint64_t memory_bytes{};
+    double elapsed_ms{};
+    double fitness{-std::numeric_limits<double>::infinity()};
+    bool valid{};
+    std::string error;
+};
+
+double fitness(const Evaluation& e) noexcept {
+    if (!e.valid || !std::isfinite(e.metrics.mse) ||
+        !std::isfinite(e.metrics.coherence) || !std::isfinite(e.metrics.energy)) {
+        return -std::numeric_limits<double>::infinity();
+    }
+    // Fitness is intentionally independent of wall-clock time. Latency remains
+    // telemetry, but excluding it keeps replay and candidate selection deterministic.
+    return 8.0 * clampf(e.metrics.coherence, 0.0F, 1.0F)
+         - 2.0 * std::log1p(1000.0 * std::max(0.0F, e.metrics.mse))
+         - 0.25 * e.metrics.energy
+         - 0.15 * static_cast<double>(e.metrics.rejected)
+         - 0.00000001 * static_cast<double>(e.memory_bytes);
+}
+
+Evaluation evaluate(Genome genome, const Packet& packet) {
+    Evaluation result;
+    result.genome = genome;
+    result.genome.clamp();
+    try {
+        const auto start = std::chrono::steady_clock::now();
+        Processor processor(result.genome, packet);
+        processor.run();
+        const auto stop = std::chrono::steady_clock::now();
+        result.elapsed_ms =
+            std::chrono::duration<double, std::milli>(stop - start).count();
+        result.genome = processor.genome();
+        result.metrics = processor.metrics();
+        result.tiles = processor.lattice().tile_count();
+        result.memory_bytes = processor.lattice().estimated_bytes();
+        const std::uint64_t decisions =
+            result.metrics.committed + result.metrics.rejected;
+        result.valid = decisions == result.genome.iterations &&
+                       result.metrics.cycles > 0 &&
+                       std::isfinite(result.metrics.mse) &&
+                       std::isfinite(result.metrics.coherence) &&
+                       std::isfinite(result.metrics.energy);
+        result.fitness = fitness(result);
+        if (!result.valid) result.error = "incomplete or non-finite evaluation";
+    } catch (const std::exception& error) {
+        result.error = error.what();
+    }
+    return result;
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/runtime.hpp
+++ b/cpp_runtime/include/jarvisx/runtime.hpp
@@ -1,0 +1,567 @@
+#pragma once
+
+#include "jarvisx/processor.hpp"
+
+#include <cstdlib>
+
+namespace jarvisx {
+
+class Rng {
+public:
+    explicit Rng(std::uint64_t seed) : state_(seed ? seed : 1ULL) {}
+
+    std::uint64_t next() noexcept {
+        state_ ^= state_ << 13U;
+        state_ ^= state_ >> 7U;
+        state_ ^= state_ << 17U;
+        return state_;
+    }
+
+    int step(int radius) noexcept {
+        if (radius <= 0) return 0;
+        const auto span = 2ULL * static_cast<std::uint64_t>(radius) + 1ULL;
+        return static_cast<int>(next() % span) - radius;
+    }
+
+private:
+    std::uint64_t state_;
+};
+
+std::uint16_t bounded_u16(std::uint16_t value, int delta,
+                          int low, int high) noexcept {
+    const int adjusted = std::clamp(static_cast<int>(value) + delta, low, high);
+    return static_cast<std::uint16_t>(adjusted);
+}
+
+std::size_t bounded_size(std::size_t value, long long delta,
+                         std::size_t low, std::size_t high) noexcept {
+    const auto signed_value = static_cast<long long>(value);
+    const auto signed_low = static_cast<long long>(low);
+    const auto signed_high = static_cast<long long>(high);
+    return static_cast<std::size_t>(
+        std::clamp(signed_value + delta, signed_low, signed_high));
+}
+
+Genome mutate(const Genome& parent, std::uint64_t generation,
+              std::size_t candidate, const Evaluation& telemetry) {
+    Genome child = parent;
+    child.generation = generation;
+    child.seed = mix64(
+        parent.seed ^ generation ^
+        (static_cast<std::uint64_t>(candidate) * 0xD1B54A32D192ED03ULL));
+    Rng rng(child.seed);
+
+    switch (rng.next() % 9ULL) {
+    case 0:
+        child.feature_dim = bounded_size(
+            child.feature_dim, 16LL * rng.step(2), 32U, 512U);
+        break;
+    case 1:
+        child.latent_dim = bounded_size(
+            child.latent_dim, 8LL * rng.step(2), 8U, 256U);
+        break;
+    case 2:
+        child.iterations = bounded_u16(
+            child.iterations, rng.step(4), 2, 128);
+        break;
+    case 3:
+        child.diffusion_radius = bounded_u16(
+            child.diffusion_radius, rng.step(2), 1, 32);
+        break;
+    case 4:
+        child.learning_units = bounded_u16(
+            child.learning_units, 10 * rng.step(3), 1, 400);
+        break;
+    case 5:
+        child.omega_units = bounded_u16(
+            child.omega_units, 8 * rng.step(3), 1, 300);
+        break;
+    case 6:
+        child.max_mse_units = bounded_u16(
+            child.max_mse_units, 200 * rng.step(3), 100, 10000);
+        break;
+    case 7:
+        child.max_energy_units = bounded_u16(
+            child.max_energy_units, 250 * rng.step(2), 1000, 10000);
+        break;
+    default:
+        child.min_coherence_units = bounded_u16(
+            child.min_coherence_units, 100 * rng.step(3), 0, 9000);
+        break;
+    }
+
+    if (telemetry.valid && telemetry.metrics.mse > 0.05F) {
+        child.feature_dim = bounded_size(child.feature_dim, 16, 32U, 512U);
+        child.learning_units = bounded_u16(child.learning_units, 4, 1, 400);
+    }
+    if (telemetry.valid && telemetry.metrics.coherence < 0.35F) {
+        child.omega_units = bounded_u16(child.omega_units, 3, 1, 300);
+        child.min_coherence_units = bounded_u16(
+            child.min_coherence_units, -50, 0, 9000);
+    }
+    child.clamp();
+    return child;
+}
+
+std::string serialize(const Genome& genome) {
+    std::ostringstream output;
+    output << "version=" << genome.version << '\n'
+           << "generation=" << genome.generation << '\n'
+           << "feature_dim=" << genome.feature_dim << '\n'
+           << "latent_dim=" << genome.latent_dim << '\n'
+           << "iterations=" << genome.iterations << '\n'
+           << "diffusion_radius=" << genome.diffusion_radius << '\n'
+           << "learning_units=" << genome.learning_units << '\n'
+           << "omega_units=" << genome.omega_units << '\n'
+           << "max_mse_units=" << genome.max_mse_units << '\n'
+           << "max_energy_units=" << genome.max_energy_units << '\n'
+           << "min_coherence_units=" << genome.min_coherence_units << '\n'
+           << "seed=" << genome.seed << '\n'
+           << "fingerprint=" << genome.fingerprint() << '\n';
+    return output.str();
+}
+
+std::uint64_t parse_u64(const std::string& value, const std::string& key) {
+    std::size_t consumed = 0;
+    const auto parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::runtime_error("invalid numeric genome field: " + key);
+    }
+    return static_cast<std::uint64_t>(parsed);
+}
+
+std::uint16_t parse_u16(const std::string& value, const std::string& key) {
+    const std::uint64_t parsed = parse_u64(value, key);
+    if (parsed > std::numeric_limits<std::uint16_t>::max()) {
+        throw std::runtime_error("genome field outside uint16 range: " + key);
+    }
+    return static_cast<std::uint16_t>(parsed);
+}
+
+Genome deserialize(const std::string& text) {
+    constexpr std::uint32_t kRequiredFields = (1U << 12U) - 1U;
+    Genome genome;
+    std::uint32_t seen = 0;
+    std::optional<std::string> stored_fingerprint;
+    std::istringstream input(text);
+    std::string line;
+
+    while (std::getline(input, line)) {
+        const auto split = line.find('=');
+        if (split == std::string::npos) continue;
+        const std::string key = line.substr(0, split);
+        const std::string value = line.substr(split + 1);
+
+        if (key == "version") {
+            genome.version = static_cast<std::uint32_t>(parse_u64(value, key));
+            seen |= 1U << 0U;
+        } else if (key == "generation") {
+            genome.generation = parse_u64(value, key);
+            seen |= 1U << 1U;
+        } else if (key == "feature_dim") {
+            const std::uint64_t parsed = parse_u64(value, key);
+            if (parsed > std::numeric_limits<std::size_t>::max()) {
+                throw std::runtime_error("genome field outside size_t range: " + key);
+            }
+            genome.feature_dim = static_cast<std::size_t>(parsed);
+            seen |= 1U << 2U;
+        } else if (key == "latent_dim") {
+            const std::uint64_t parsed = parse_u64(value, key);
+            if (parsed > std::numeric_limits<std::size_t>::max()) {
+                throw std::runtime_error("genome field outside size_t range: " + key);
+            }
+            genome.latent_dim = static_cast<std::size_t>(parsed);
+            seen |= 1U << 3U;
+        } else if (key == "iterations") {
+            genome.iterations = parse_u16(value, key);
+            seen |= 1U << 4U;
+        } else if (key == "diffusion_radius") {
+            genome.diffusion_radius = parse_u16(value, key);
+            seen |= 1U << 5U;
+        } else if (key == "learning_units") {
+            genome.learning_units = parse_u16(value, key);
+            seen |= 1U << 6U;
+        } else if (key == "omega_units") {
+            genome.omega_units = parse_u16(value, key);
+            seen |= 1U << 7U;
+        } else if (key == "max_mse_units") {
+            genome.max_mse_units = parse_u16(value, key);
+            seen |= 1U << 8U;
+        } else if (key == "max_energy_units") {
+            genome.max_energy_units = parse_u16(value, key);
+            seen |= 1U << 9U;
+        } else if (key == "min_coherence_units") {
+            genome.min_coherence_units = parse_u16(value, key);
+            seen |= 1U << 10U;
+        } else if (key == "seed") {
+            genome.seed = parse_u64(value, key);
+            seen |= 1U << 11U;
+        } else if (key == "fingerprint") {
+            stored_fingerprint = value;
+        }
+    }
+
+    if (seen != kRequiredFields) {
+        throw std::runtime_error("genome checkpoint is missing required fields");
+    }
+    if (genome.version != 1U) {
+        throw std::runtime_error("unsupported genome version");
+    }
+
+    genome.clamp();
+    if (!stored_fingerprint || *stored_fingerprint != genome.fingerprint()) {
+        throw std::runtime_error("genome checkpoint fingerprint mismatch");
+    }
+    return genome;
+}
+
+void atomic_write(const fs::path& path, const std::string& bytes) {
+    fs::create_directories(path.parent_path());
+    const fs::path temporary = path.string() + ".tmp";
+    {
+        std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+        if (!output) {
+            throw std::runtime_error("cannot write " + temporary.string());
+        }
+        output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+        output.flush();
+        if (!output) {
+            throw std::runtime_error("cannot flush " + temporary.string());
+        }
+    }
+
+    std::error_code error;
+    fs::rename(temporary, path, error);
+    if (error) {
+        fs::remove(path, error);
+        error.clear();
+        fs::rename(temporary, path, error);
+    }
+    if (error) {
+        throw std::runtime_error("cannot commit " + path.string());
+    }
+}
+
+std::optional<Genome> load_genome(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return std::nullopt;
+    std::ostringstream text;
+    text << input.rdbuf();
+    if (!input.eof() && input.fail()) {
+        throw std::runtime_error("cannot read genome checkpoint");
+    }
+    return deserialize(text.str());
+}
+
+void write_rom(const fs::path& path, const std::vector<Instruction>& rom) {
+    std::string bytes;
+    bytes.reserve(rom.size() * sizeof(std::uint64_t));
+    for (const Instruction& instruction : rom) {
+        for (int byte = 7; byte >= 0; --byte) {
+            const auto shift = static_cast<unsigned>(byte * 8);
+            bytes.push_back(static_cast<char>((instruction.word >> shift) & 0xFFULL));
+        }
+    }
+    atomic_write(path, bytes);
+}
+
+struct Options {
+    std::uint64_t generations{4};
+    std::size_t population{5};
+    fs::path state_dir{".jarvisx-runtime"};
+    std::string file;
+    std::string text;
+    double min_improvement{1.0e-5};
+    bool reset{};
+    bool quiet{};
+};
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& index, const std::string& flag) {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("missing value after " + flag);
+        }
+        return std::string(argv[++index]);
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--generations") {
+            options.generations = std::max<std::uint64_t>(
+                1, parse_u64(value(index, argument), argument));
+        } else if (argument == "--population") {
+            const auto parsed = parse_u64(value(index, argument), argument);
+            options.population = static_cast<std::size_t>(
+                std::clamp<std::uint64_t>(parsed, 2, 32));
+        } else if (argument == "--state-dir") {
+            options.state_dir = value(index, argument);
+        } else if (argument == "--file") {
+            options.file = value(index, argument);
+        } else if (argument == "--text") {
+            options.text = value(index, argument);
+        } else if (argument == "--min-improvement") {
+            std::size_t consumed = 0;
+            const std::string raw = value(index, argument);
+            const double parsed = std::stod(raw, &consumed);
+            if (consumed != raw.size() || !std::isfinite(parsed)) {
+                throw std::invalid_argument("invalid minimum improvement");
+            }
+            options.min_improvement = std::max(0.0, parsed);
+        } else if (argument == "--reset") {
+            options.reset = true;
+        } else if (argument == "--quiet") {
+            options.quiet = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: jarvisx-runtime [options]\n"
+                << "  --generations N       evolution generations\n"
+                << "  --population N        candidates per generation (2..32)\n"
+                << "  --state-dir PATH      checkpoint directory\n"
+                << "  --file PATH           external multimodal/binary input\n"
+                << "  --text TEXT           text input\n"
+                << "  --min-improvement X   minimum fitness delta\n"
+                << "  --reset               discard prior checkpoint\n"
+                << "  --quiet               hide candidate rows\n"
+                << "\nDefault input: this executable's own binary image.\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+enum class MetaOp : std::uint8_t {
+    Observe = 1,
+    Spawn = 2,
+    Evaluate = 3,
+    Select = 4,
+    Gate = 5,
+    Checkpoint = 6,
+    Loop = 7,
+    Halt = 0xFF
+};
+
+bool evaluation_less(const Evaluation& left, const Evaluation& right) noexcept {
+    return left.fitness < right.fitness;
+}
+
+class Runtime {
+public:
+    Runtime(Options options, Packet packet)
+        : options_(std::move(options)), packet_(std::move(packet)) {
+        fs::create_directories(options_.state_dir);
+        genome_path_ = options_.state_dir / "genome.current";
+        journal_path_ = options_.state_dir / "evolution.csv";
+        rom_path_ = options_.state_dir / "runtime.rom";
+        if (!options_.reset) {
+            if (const auto loaded = load_genome(genome_path_)) genome_ = *loaded;
+        }
+        meta_rom_ = {
+            MetaOp::Observe,
+            MetaOp::Spawn,
+            MetaOp::Evaluate,
+            MetaOp::Select,
+            MetaOp::Gate,
+            MetaOp::Checkpoint,
+            MetaOp::Loop,
+            MetaOp::Halt
+        };
+    }
+
+    int run() {
+        incumbent_ = evaluate(genome_, packet_);
+        if (!incumbent_.valid) {
+            throw std::runtime_error(
+                "incumbent self-evaluation failed: " + incumbent_.error);
+        }
+
+        std::cout
+            << "Jarvis X Inward Runtime\n"
+            << "  lattice: 8192 x 8192 x 8192 virtual cells\n"
+            << "  mode: sandboxed bytecode/genome evolution\n"
+            << "  starting generation: " << genome_.generation << '\n'
+            << "  starting fingerprint: " << genome_.fingerprint() << '\n'
+            << "  population: " << options_.population << '\n'
+            << "  generations: " << options_.generations << "\n\n";
+
+        while (!halted_) execute(meta_rom_.at(meta_pc_));
+
+        std::cout << "\nFinal genome\n" << serialize(genome_)
+                  << "fitness=" << std::setprecision(10) << incumbent_.fitness << '\n'
+                  << "mse=" << incumbent_.metrics.mse << '\n'
+                  << "coherence=" << incumbent_.metrics.coherence << '\n'
+                  << "checkpoint=" << genome_path_.string() << '\n'
+                  << "rom=" << rom_path_.string() << '\n'
+                  << "journal=" << journal_path_.string() << '\n';
+        return 0;
+    }
+
+private:
+    Options options_;
+    Packet packet_;
+    Genome genome_;
+    Evaluation incumbent_;
+    std::vector<Genome> candidates_;
+    std::vector<Evaluation> evaluations_;
+    Evaluation champion_;
+    std::vector<MetaOp> meta_rom_;
+    std::size_t meta_pc_{};
+    std::uint64_t completed_{};
+    bool halted_{};
+    bool accepted_{};
+    fs::path genome_path_;
+    fs::path journal_path_;
+    fs::path rom_path_;
+
+    void execute(MetaOp operation) {
+        switch (operation) {
+        case MetaOp::Observe:
+            std::cout << "[Observe] generation=" << genome_.generation + 1
+                      << " fitness=" << std::fixed << std::setprecision(7)
+                      << incumbent_.fitness << " mse=" << incumbent_.metrics.mse
+                      << " coherence=" << incumbent_.metrics.coherence << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Spawn:
+            candidates_.clear();
+            {
+                Genome anchor = genome_;
+                anchor.generation = genome_.generation + 1;
+                candidates_.push_back(anchor);
+            }
+            for (std::size_t index = 1; index < options_.population; ++index) {
+                candidates_.push_back(mutate(
+                    genome_, genome_.generation + 1, index, incumbent_));
+            }
+            std::cout << "[Spawn] candidates=" << candidates_.size() << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Evaluate:
+            evaluations_.clear();
+            for (std::size_t index = 0; index < candidates_.size(); ++index) {
+                Evaluation result = evaluate(candidates_[index], packet_);
+                if (!options_.quiet) {
+                    std::cout << "  candidate=" << index
+                              << " fp=" << result.genome.fingerprint()
+                              << " valid=" << (result.valid ? "yes" : "no")
+                              << " fitness=" << result.fitness
+                              << " mse=" << result.metrics.mse
+                              << " coherence=" << result.metrics.coherence
+                              << " ms=" << result.elapsed_ms << '\n';
+                }
+                evaluations_.push_back(std::move(result));
+            }
+            ++meta_pc_;
+            break;
+        case MetaOp::Select:
+            if (evaluations_.empty()) {
+                throw std::runtime_error("cannot select from an empty population");
+            }
+            champion_ = *std::max_element(
+                evaluations_.begin(), evaluations_.end(), evaluation_less);
+            std::cout << "[Select] champion=" << champion_.genome.fingerprint()
+                      << " fitness=" << champion_.fitness << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Gate: {
+            const bool coherent = champion_.valid &&
+                champion_.metrics.coherence >=
+                champion_.genome.min_coherence_units / 10000.0F;
+            const bool improved = champion_.fitness >
+                incumbent_.fitness + options_.min_improvement;
+            accepted_ = coherent && improved;
+            if (accepted_) {
+                genome_ = champion_.genome;
+                incumbent_ = champion_;
+                std::cout << "[Lambda] COMMIT\n";
+            } else {
+                ++genome_.generation;
+                incumbent_.genome = genome_;
+                std::cout << "[Lambda] ROLLBACK\n";
+            }
+            ++meta_pc_;
+            break;
+        }
+        case MetaOp::Checkpoint:
+            atomic_write(genome_path_, serialize(genome_));
+            write_rom(rom_path_, synthesize_rom(genome_));
+            append_journal();
+            std::cout << "[Checkpoint] generation=" << genome_.generation
+                      << " status=" << (accepted_ ? "accepted" : "rolled-back")
+                      << '\n';
+            ++meta_pc_;
+            break;
+        case MetaOp::Loop:
+            ++completed_;
+            meta_pc_ = completed_ < options_.generations ? 0 : meta_pc_ + 1;
+            break;
+        case MetaOp::Halt:
+            halted_ = true;
+            break;
+        default:
+            throw std::runtime_error("invalid meta-runtime opcode");
+        }
+    }
+
+    void append_journal() {
+        std::string existing;
+        if (fs::exists(journal_path_)) {
+            std::ifstream input(journal_path_, std::ios::binary);
+            if (!input) throw std::runtime_error("cannot read evolution journal");
+            std::ostringstream buffer;
+            buffer << input.rdbuf();
+            if (!input.eof() && input.fail()) {
+                throw std::runtime_error("cannot read evolution journal");
+            }
+            existing = buffer.str();
+        }
+
+        std::ostringstream row;
+        if (existing.empty()) {
+            row << "generation,status,fingerprint,fitness,mse,coherence,"
+                   "energy,features,latent,iterations,radius,learning,omega,"
+                   "tiles,memory_bytes,elapsed_ms\n";
+        }
+        row << genome_.generation << ','
+            << (accepted_ ? "accepted" : "rolled-back") << ','
+            << genome_.fingerprint() << ','
+            << std::setprecision(12) << incumbent_.fitness << ','
+            << incumbent_.metrics.mse << ','
+            << incumbent_.metrics.coherence << ','
+            << incumbent_.metrics.energy << ','
+            << genome_.feature_dim << ',' << genome_.latent_dim << ','
+            << genome_.iterations << ',' << genome_.diffusion_radius << ','
+            << genome_.learning_units << ',' << genome_.omega_units << ','
+            << incumbent_.tiles << ',' << incumbent_.memory_bytes << ','
+            << incumbent_.elapsed_ms << '\n';
+
+        atomic_write(journal_path_, existing + row.str());
+    }
+};
+
+Packet resolve_packet(int argc, char** argv, const Options& options) {
+    if (!options.file.empty()) {
+        auto packet = file_packet(options.file);
+        if (!packet) throw std::runtime_error("cannot read " + options.file);
+        std::cout << "[Input] external packet: " << options.file << '\n';
+        return *packet;
+    }
+    if (!options.text.empty()) {
+        std::cout << "[Input] text packet\n";
+        return text_packet(options.text);
+    }
+    if (argc > 0 && argv[0]) {
+        auto packet = file_packet(argv[0]);
+        if (packet && !packet->bytes.empty()) {
+            std::cout << "[Input] inward executable image: " << argv[0]
+                      << " (" << packet->bytes.size() << " bytes)\n";
+            return *packet;
+        }
+    }
+    std::cout << "[Input] fallback inward identity packet\n";
+    return text_packet("Jarvis X reconstructs its own runtime state.");
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/src/main.cpp
+++ b/cpp_runtime/src/main.cpp
@@ -1,0 +1,13 @@
+#include "jarvisx/runtime.hpp"
+
+int main(int argc, char** argv) {
+    try {
+        jarvisx::Options options = jarvisx::parse_options(argc, argv);
+        jarvisx::Packet packet = jarvisx::resolve_packet(argc, argv, options);
+        jarvisx::Runtime runtime(std::move(options), std::move(packet));
+        return runtime.run();
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis X runtime failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/processor_tests.cpp
+++ b/cpp_runtime/tests/processor_tests.cpp
@@ -1,13 +1,23 @@
-#include "jarvisx/processor.hpp"
+#include "jarvisx/runtime.hpp"
 
-#include <cmath>
 #include <iostream>
 #include <stdexcept>
+#include <string>
 
 namespace {
 
 void require(bool condition, const char* message) {
     if (!condition) throw std::runtime_error(message);
+}
+
+template <typename Function>
+void require_throws(Function function, const char* message) {
+    try {
+        function();
+    } catch (const std::exception&) {
+        return;
+    }
+    throw std::runtime_error(message);
 }
 
 void test_constructor_normalizes_before_allocation() {
@@ -50,7 +60,7 @@ void test_evaluation_is_deterministic() {
     require(first.fitness == second.fitness, "fitness drifted");
 }
 
-void test_latency_is_telemetry_not_fitness() {
+void test_latency_is_telemetry_not_selection() {
     jarvisx::Evaluation fast;
     fast.valid = true;
     fast.metrics.mse = 0.01F;
@@ -58,12 +68,61 @@ void test_latency_is_telemetry_not_fitness() {
     fast.metrics.energy = 0.2F;
     fast.memory_bytes = 4096;
     fast.elapsed_ms = 1.0;
+    fast.fitness = jarvisx::fitness(fast);
 
     jarvisx::Evaluation slow = fast;
     slow.elapsed_ms = 100000.0;
 
     require(jarvisx::fitness(fast) == jarvisx::fitness(slow),
             "wall-clock latency changed deterministic fitness");
+    require(!jarvisx::evaluation_less(fast, slow) &&
+                !jarvisx::evaluation_less(slow, fast),
+            "wall-clock latency changed equal-fitness selection order");
+}
+
+void test_bounded_unsigned_mutation_does_not_wrap() {
+    require(jarvisx::bounded_u16(2, -4, 2, 128) == 2,
+            "iteration mutation wrapped below its lower bound");
+    require(jarvisx::bounded_u16(1, -30, 1, 400) == 1,
+            "learning mutation wrapped below its lower bound");
+    require(jarvisx::bounded_u16(9000, 500, 0, 9000) == 9000,
+            "coherence mutation exceeded its upper bound");
+    require(jarvisx::bounded_size(32, -64, 32, 512) == 32,
+            "feature mutation wrapped below its lower bound");
+}
+
+void test_checkpoint_round_trip_and_tamper_detection() {
+    jarvisx::Genome genome;
+    genome.generation = 7;
+    genome.seed = 123456789ULL;
+    genome.clamp();
+
+    const std::string encoded = jarvisx::serialize(genome);
+    const jarvisx::Genome restored = jarvisx::deserialize(encoded);
+
+    require(restored.generation == genome.generation,
+            "checkpoint generation did not round trip");
+    require(restored.seed == genome.seed, "checkpoint seed did not round trip");
+    require(restored.fingerprint() == genome.fingerprint(),
+            "checkpoint fingerprint did not round trip");
+
+    std::string corrupted = encoded;
+    const auto fingerprint = corrupted.find("fingerprint=");
+    require(fingerprint != std::string::npos, "checkpoint fingerprint was absent");
+    corrupted.replace(fingerprint + 12, genome.fingerprint().size(), "CORRUPTED");
+
+    require_throws(
+        [&corrupted]() { static_cast<void>(jarvisx::deserialize(corrupted)); },
+        "corrupt checkpoint fingerprint was accepted");
+
+    const auto required_field = corrupted.find("iterations=");
+    require(required_field != std::string::npos, "checkpoint field was absent");
+    const auto required_end = corrupted.find('\n', required_field);
+    corrupted.erase(required_field, required_end - required_field + 1);
+
+    require_throws(
+        [&corrupted]() { static_cast<void>(jarvisx::deserialize(corrupted)); },
+        "checkpoint with a missing required field was accepted");
 }
 
 } // namespace
@@ -72,7 +131,9 @@ int main() {
     try {
         test_constructor_normalizes_before_allocation();
         test_evaluation_is_deterministic();
-        test_latency_is_telemetry_not_fitness();
+        test_latency_is_telemetry_not_selection();
+        test_bounded_unsigned_mutation_does_not_wrap();
+        test_checkpoint_round_trip_and_tamper_detection();
         std::cout << "processor regression tests passed\n";
         return 0;
     } catch (const std::exception& error) {

--- a/cpp_runtime/tests/processor_tests.cpp
+++ b/cpp_runtime/tests/processor_tests.cpp
@@ -1,0 +1,82 @@
+#include "jarvisx/processor.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void test_constructor_normalizes_before_allocation() {
+    jarvisx::Genome genome;
+    genome.feature_dim = 1;
+    genome.latent_dim = 1024;
+    genome.iterations = 0;
+
+    jarvisx::Processor processor(genome, jarvisx::text_packet("normalization"));
+    const auto& normalized = processor.genome();
+
+    require(normalized.feature_dim == 32, "feature_dim was not normalized");
+    require(normalized.latent_dim == 32, "latent_dim was not normalized");
+    require(normalized.iterations == 2, "iterations were not normalized");
+
+    processor.run();
+    require(processor.metrics().committed + processor.metrics().rejected == 2,
+            "normalized iteration count was not executed");
+}
+
+void test_evaluation_is_deterministic() {
+    jarvisx::Genome genome;
+    const auto packet = jarvisx::text_packet("Jarvis X deterministic replay");
+
+    const auto first = jarvisx::evaluate(genome, packet);
+    const auto second = jarvisx::evaluate(genome, packet);
+
+    require(first.valid && second.valid, "evaluation was invalid");
+    require(first.metrics.cycles == second.metrics.cycles, "cycle count drifted");
+    require(first.metrics.committed == second.metrics.committed,
+            "commit count drifted");
+    require(first.metrics.rejected == second.metrics.rejected,
+            "reject count drifted");
+    require(first.metrics.mse == second.metrics.mse, "MSE drifted");
+    require(first.metrics.coherence == second.metrics.coherence,
+            "coherence drifted");
+    require(first.metrics.energy == second.metrics.energy, "energy drifted");
+    require(first.tiles == second.tiles, "tile count drifted");
+    require(first.memory_bytes == second.memory_bytes, "memory estimate drifted");
+    require(first.fitness == second.fitness, "fitness drifted");
+}
+
+void test_latency_is_telemetry_not_fitness() {
+    jarvisx::Evaluation fast;
+    fast.valid = true;
+    fast.metrics.mse = 0.01F;
+    fast.metrics.coherence = 0.8F;
+    fast.metrics.energy = 0.2F;
+    fast.memory_bytes = 4096;
+    fast.elapsed_ms = 1.0;
+
+    jarvisx::Evaluation slow = fast;
+    slow.elapsed_ms = 100000.0;
+
+    require(jarvisx::fitness(fast) == jarvisx::fitness(slow),
+            "wall-clock latency changed deterministic fitness");
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_constructor_normalizes_before_allocation();
+        test_evaluation_is_deterministic();
+        test_latency_is_telemetry_not_fitness();
+        std::cout << "processor regression tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "processor regression test failed: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -11,6 +11,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 |---|---|
 | Stable reference | deterministic implementation with focused tests; API may still change before `1.0` |
 | Alpha | executable on `main`, but incomplete or lightly tested |
+| Reference laboratory | bounded executable research subsystem with explicit limits and isolated authority |
 | Integration candidate | implemented on a branch or pull request and awaiting canonical integration |
 | Demonstration | runnable visualization or example that is not an authoritative runtime |
 | Specification | documented mathematical or architectural proposal |
@@ -25,7 +26,8 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Register VM | Alpha | `core.py`, `executor.py` | canonical ISA currently has a small instruction surface |
 | Lambda instruction policy | Alpha | `ethics.py` | application-level guard, not a security sandbox |
 | Cycle sandbox | Stable reference | `sandbox.py` | cycle bound only; no process isolation |
-| Trace and Omega journal | Stable reference after PR #47 | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
+| Trace and Omega journal | Stable reference | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
+| C++ inward processor | Reference laboratory | `cpp_runtime/`, CTest, cross-platform workflow | sparse virtual `8192³` domain; bounded parameter/schedule search; floating-point bit identity across platforms is not claimed |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
@@ -33,11 +35,12 @@ This document is the authoritative implemented-versus-experimental capability ma
 
 ## Active integration candidates
 
-| Pull request | Capability | Current classification | Required before merge |
+| Pull request or issue | Capability | Current classification | Required before merge or completion |
 |---|---|---|---|
-| #45 | dependency-free C++17 sparse inward runtime | Integration candidate | repository-wide CI green, review, canonical API boundary |
-| #46 | hierarchical fractional 3D smoothing solver | Integration candidate | review numerical limits, benchmark reference, merge sequencing |
-| #47 | VM, CI, documentation and governance foundation | Integration candidate | all required checks green and final review |
+| #46 | hierarchical fractional 3D smoothing solver | Integration candidate | rebase, numerical reference comparison, measured scaling data and green CI |
+| #48 | pull-request backlog consolidation | Governance work | classify overlaps, preserve unique evidence and reduce active drafts below ten |
+| #49 | branch protection and security settings | Repository administration | enable required checks, scanning and private reporting in GitHub settings |
+| #50 | public GitHub profile README | Profile administration | create `Lord-Xido/Lord-Xido`, pin active repositories and review public metadata |
 
 Other long-lived draft pull requests are research branches until explicitly classified, rebased and validated.
 
@@ -58,7 +61,8 @@ Jarvis-X does not currently claim:
 - lossless compression of arbitrary data into a smaller state without side information;
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
-- safety certification from the presence of a policy or coherence gate.
+- safety certification from the presence of a policy or coherence gate;
+- bit-exact cross-platform floating-point results from the C++ research processor.
 
 ## Canonical promotion checklist
 
@@ -83,7 +87,8 @@ A capability moves to `main` only when all applicable items are satisfied:
 - JSON-native verifiable journal;
 - versioned bytecode container;
 - expanded ISA tests;
-- enforced CI and contributor documentation.
+- enforced CI and contributor documentation;
+- isolated C++ processor laboratory with cross-platform validation.
 
 ### `0.3.0` — Sparse spatial runtime
 


### PR DESCRIPTION
## Purpose

Replace draft PR #45 with a clean feature-only integration based on the canonical foundation merged in #47.

This PR carries only the C++ processor laboratory, its dedicated workflow, additive documentation and status updates. It does not replace `pyproject.toml`, duplicate repository-wide repairs or overwrite the canonical project foundation.

## Classification

- [x] Reference laboratory
- [x] Native runtime integration
- [x] Deterministic regression and persistence hardening

## What changed

- add a dependency-free C++17 subsystem under `cpp_runtime/`
- represent a virtual `8192 × 8192 × 8192` coordinate domain through sparse `8³` tiles
- ingest the executable image by default, or accept explicit text and binary packets
- extract deterministic fixed-width features
- encode and decode the signed 3-bit set `{-4,-3,-2,-1,0,1,2,3}`
- scatter and diffuse latent values through sparse coordinates
- calculate reconstruction MSE, energy and coherence
- generate bounded genome and bytecode-schedule candidates
- evaluate candidates in fresh processor instances
- commit improvements or retain the rollback anchor
- persist `genome.current`, `runtime.rom` and `evolution.csv`

## Hardening beyond PR #45

- remove wall-clock latency from equal-fitness candidate selection, not only from fitness
- prevent negative signed mutation steps from wrapping unsigned fields to upper bounds
- require complete versioned checkpoint fields
- verify checkpoint fingerprints before accepting persisted state
- write genome, ROM and CSV journal state through atomic replacement
- reject invalid meta-runtime opcodes and empty populations explicitly
- validate numeric CLI arguments and finite improvement thresholds
- fix the direct compiler command to use the actual `cpp_runtime/src/main.cpp`
- document that cross-platform floating-point bit identity is not claimed

## Determinism and authority boundary

Candidate generation, feature extraction, quantization, schedule synthesis and objective selection are deterministic for the same input and genome. Elapsed time remains telemetry only.

This subsystem is isolated from the canonical Python VM. It mutates bounded parameters and bytecode schedules; it does not rewrite arbitrary native code, provide hostile-code isolation, establish consciousness or physically allocate the full virtual lattice.

## Validation completed

- GCC Release build and CTest: passed
- Clang Release build with AddressSanitizer and UndefinedBehaviorSanitizer: passed
- MSVC Release build and CTest: passed
- Python 3.10, 3.11, 3.12 and 3.13 tests: passed
- Black, isort, flake8 and mypy quality gates: passed
- dependency audit: passed
- source distribution and wheel build: passed
- package metadata and installed-wheel smoke test: passed
- CodeQL: passed

CTest covers:

- inward runtime smoke execution;
- normalization before allocation;
- repeatable processor metrics and fitness;
- latency-independent equal-fitness selection;
- mutation underflow and overflow bounds;
- checkpoint round trip, missing-field rejection and fingerprint tamper rejection.

```bash
cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
cmake --build build/cpp-runtime --config Release --parallel
ctest --test-dir build/cpp-runtime -C Release --output-on-failure
```

## Supersession

This PR supersedes #45. After merge, #45 should close as superseded rather than be rebased with duplicated foundation changes.