### PR TITLE
Add independently validated fractional 3D smoothing reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,25 +41,29 @@ jobs:
       - name: Reject syntax errors and undefined names
         run: flake8 src/jarvisx tests --select=E9,F63,F7,F82 --show-source --statistics
 
-      - name: Check foundation formatting
+      - name: Check canonical formatting
         run: >-
           black --check --diff
           setup.py
           src/jarvisx/core.py
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
+          src/jarvisx/fractional_smoothing_3d.py
           tests/test_vm.py
           tests/test_ledger.py
+          tests/test_fractional_smoothing_3d.py
 
-      - name: Check foundation import order
+      - name: Check canonical import order
         run: >-
           isort --check-only --diff
           setup.py
           src/jarvisx/core.py
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
+          src/jarvisx/fractional_smoothing_3d.py
           tests/test_vm.py
           tests/test_ledger.py
+          tests/test_fractional_smoothing_3d.py
 
       - name: Type-check package
         run: mypy src/jarvisx --ignore-missing-imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ The project follows semantic versioning where practical during alpha development
 - signed 3-bit feature encoding, sparse scatter/diffusion, decoding and residual correction;
 - bounded deterministic genome and bytecode-schedule candidate evaluation;
 - atomic genome, ROM and evolution-journal checkpoints;
-- cross-platform GCC, Clang sanitizer and MSVC validation.
+- cross-platform GCC, Clang sanitizer and MSVC validation;
+- dependency-free periodic fractional 3D smoothing reference;
+- public forward/inverse 3D DFT and periodic Laplacian spectral primitives;
+- analytic constant-forcing updates for `du/dt = -D(-Delta)^alpha u + Omega`;
+- `2×2×2` restriction, prolongation and coarse-to-fine fusion;
+- ordered mechanistic traces, mass drift, gradient energy, residual and convergence telemetry;
+- independent direct-DFT, spatial-stencil and semigroup validation tests.
 
 ### Changed
 
@@ -29,9 +35,10 @@ The project follows semantic versioning where practical during alpha development
 - packaging metadata is authoritative in `pyproject.toml`;
 - supported Python versions begin at Python 3.10;
 - CI uses current Node 24-compatible major versions of core actions;
-- project documentation distinguishes stable code, reference laboratories, integration candidates, demonstrations and specifications;
+- project documentation distinguishes stable code, reference laboratories, numerical references, integration candidates, demonstrations and specifications;
 - C++ candidate selection excludes wall-clock latency from both fitness and equal-fitness tie handling;
-- C++ checkpoint loading requires all versioned fields and a matching deterministic fingerprint.
+- C++ checkpoint loading requires all versioned fields and a matching deterministic fingerprint;
+- fractional smoothing documentation states dense storage and separable `O(N⁴)` cost for cubic grids explicitly.
 
 ### Fixed
 
@@ -42,7 +49,8 @@ The project follows semantic versioning where practical during alpha development
 - invalid instruction-pointer states were not rejected explicitly;
 - negative C++ genome mutations could wrap unsigned fields to their maximum bounds;
 - the earlier C++ direct-build documentation referenced a nonexistent source file;
-- C++ ROM and CSV state writes could leave partial output after interruption.
+- C++ ROM and CSV state writes could leave partial output after interruption;
+- the earlier fractional branch exposed a dead `_dft3` helper that always raised instead of a testable spectral API.
 
 ## [0.1.0] — Initial alpha
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 The project investigates how large virtual state spaces, geometric representations, residual memory and bounded adaptation can be implemented as reproducible software without confusing virtual extent with physical allocation or simulation with deployed intelligence.
 
-> **Current status:** alpha research software. The repository contains a stable reference VM foundation, validated sparse and packaging components, a bounded C++ processor laboratory and experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
+> **Current status:** alpha research software. The repository contains a stable reference VM foundation, validated sparse and numerical components, a bounded C++ processor laboratory and experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
 
 ## Why Jarvis-X exists
 
@@ -42,6 +42,7 @@ The symbolic vocabulary used in the research documents maps to ordinary engineer
 | Core ISA | `SET`, `ADD`, `SUB`, `HALT` | Alpha |
 | Runtime controls | policy check, cycle sandbox, tracing and verifiable ledger integration | Reference foundation |
 | C++ processor laboratory | sparse virtual `8192³` lattice, signed 3-bit latent cycle, deterministic bounded genome/schedule search | Reference laboratory |
+| Fractional 3D smoothing | periodic spectral fractional diffusion, analytic forcing and multiresolution fusion | Numerical reference |
 | Sparse geometry | deterministic inward-folding fractal octree with closed-form invariants | Reference |
 | Model packaging | Hugging Face-compatible configuration, model and safetensors exporter | Reference |
 | Research specifications | reality-grounded observer dynamics, spatial bytecode and bounded optimization documents | Proposed / reference |
@@ -97,6 +98,29 @@ Adaptive reflex correction is also explicit and disabled by default:
 vm = CodexVM(enable_reflex=True)
 ```
 
+### Run fractional 3D smoothing
+
+```python
+from jarvisx.fractional_smoothing_3d import (
+    FractionalHierarchyConfig,
+    Grid3D,
+    hierarchical_fractional_smooth,
+)
+
+field = Grid3D.impulse((4, 4, 4), (1, 1, 1), amplitude=8.0)
+config = FractionalHierarchyConfig(
+    alphas=(1.0, 0.65),
+    taus=(0.08, 0.20),
+    coarse_blends=(0.25,),
+)
+result = hierarchical_fractional_smooth(field, config)
+
+assert abs(result.mass_drift) < 1.0e-9
+assert result.field.variance < field.variance
+```
+
+The solver uses a dependency-free separable direct DFT for small correctness fixtures. See [Hierarchical 3D Fractional Smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md) for the equations, complexity and production boundary.
+
 ### Build the C++ processor laboratory
 
 ```bash
@@ -134,7 +158,7 @@ Parser → Assembler → 64-bit bytecode
               ┌──────────┴──────────┐
               ▼                     ▼
       authoritative state    isolated research layers
-      registers / memory     C++ / spatial / visual
+      registers / memory     C++ / numerical / visual
 ```
 
 The canonical design rules are documented in [Architecture](docs/ARCHITECTURE.md).
@@ -163,7 +187,6 @@ At depth `D`:
 
 | Track | Purpose | Status |
 |---|---|---|
-| Fractional smoothing | deterministic hierarchical 3D fractional-diffusion reference solver | Draft PR #46; rebase required |
 | Backlog consolidation | select canonical implementations and close superseded research branches | Issue #48 |
 | Repository protection | required checks, secret scanning and private vulnerability reporting | Issue #49 |
 | Public profile | account-level profile README and pinned-project cleanup | Issue #50 |
@@ -174,7 +197,7 @@ Draft status is intentional: experimental subsystems are not represented as cano
 ## Repository structure
 
 ```text
-src/jarvisx/       canonical Python package
+src/jarvisx/       canonical Python package and numerical references
 tests/             regression and invariant tests
 docs/              specifications and architecture records
 scripts/           packaging and export utilities
@@ -203,6 +226,7 @@ Every canonical subsystem should provide:
 
 - [Architecture](docs/ARCHITECTURE.md)
 - [Project status](docs/PROJECT_STATUS.md)
+- [Hierarchical 3D fractional smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md)
 - [Roadmap](ROADMAP.md)
 - [Governance](GOVERNANCE.md)
 - [Security policy](SECURITY.md)
@@ -219,7 +243,7 @@ Large architectural proposals should begin as an issue or specification. Product
 
 Jarvis-X is an experimental software and mathematical research project. It does not claim consciousness, unrestricted autonomous self-modification, lossless compression of arbitrary high-dimensional inputs into smaller states, or production safety merely because a policy layer is present.
 
-Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility. The C++ processor mutates bounded parameters and schedules; it does not rewrite arbitrary native code.
+Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility. The C++ processor mutates bounded parameters and schedules; it does not rewrite arbitrary native code. The fractional solver is a small-grid CPU reference, not a calibrated physical model or production FFT implementation.
 
 ## Citation
 

--- a/docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md
+++ b/docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md
@@ -1,0 +1,253 @@
+# Hierarchical 3D Fractional Smoothing
+
+## Classification
+
+This subsystem is a deterministic, dependency-free **numerical reference kernel** for small periodic scalar grids. It is intended for equation-level verification, fixtures and auditable experiments.
+
+It is not a production FFT, sparse-volume solver, calibrated physical model or performance claim for large three-dimensional fields.
+
+## 1. State and addressing
+
+A scalar grid has shape
+
+```text
+(Nx, Ny, Nz)
+```
+
+and immutable values stored with `x` as the fastest-moving coordinate:
+
+```text
+a(x,y,z) = x + Nx (y + Ny z)
+```
+
+All dimensions are positive. Every stored value must be finite.
+
+The current reference implementation materializes the complete grid and complete complex spectrum. Therefore resident storage is proportional to
+
+```text
+O(Nx Ny Nz)
+```
+
+for each field or spectrum, despite any broader virtual-space research context in Jarvis-X.
+
+## 2. Periodic six-neighbour operator
+
+For a periodic lattice, define
+
+```text
+(-Delta u)[x,y,z]
+  = 6 u[x,y,z]
+    - u[x-1,y,z] - u[x+1,y,z]
+    - u[x,y-1,z] - u[x,y+1,z]
+    - u[x,y,z-1] - u[x,y,z+1]
+```
+
+with every coordinate wrapped modulo its axis length.
+
+The corresponding Fourier eigenvalue is
+
+```text
+lambda(kx,ky,kz)
+  = 6
+    - 2 cos(2 pi kx / Nx)
+    - 2 cos(2 pi ky / Ny)
+    - 2 cos(2 pi kz / Nz)
+```
+
+where
+
+```text
+0 <= lambda <= 12.
+```
+
+The zero mode has `lambda = 0`, so unforced diffusion preserves the field mean and total mass.
+
+## 3. Fractional operator
+
+For
+
+```text
+0 < alpha <= 1,
+```
+
+the fractional operator is defined spectrally:
+
+```text
+F[(-Delta)^alpha u](k)
+  = lambda(k)^alpha F[u](k).
+```
+
+At `alpha = 1`, this is exactly the periodic six-neighbour stencil above, up to floating-point roundoff.
+
+The implementation uses a separable direct DFT rather than an FFT dependency:
+
+```text
+DFT_x -> DFT_y -> DFT_z
+```
+
+and the inverse applies one `1/N` normalization factor per axis.
+
+For a cubic `N × N × N` grid, the separable arithmetic cost is
+
+```text
+O(N^4),
+```
+
+not the `O(N^3 log N)` cost expected from a production 3D FFT.
+
+## 4. Exact mode update
+
+The governing equation is
+
+```text
+du/dt = -D (-Delta)^alpha u + Omega,
+```
+
+where:
+
+- `D >= 0` is diffusivity;
+- `Omega` is constant over one timestep;
+- `tau >= 0` is the timestep.
+
+For one mode with
+
+```text
+r(k) = D lambda(k)^alpha,
+```
+
+the exact update is
+
+```text
+u_hat(t + tau)
+  = exp(-tau r) u_hat(t)
+    + (1 - exp(-tau r)) Omega_hat / r,  r > 0
+```
+
+and for the zero-rate mode:
+
+```text
+u_hat(t + tau)
+  = u_hat(t) + tau Omega_hat.
+```
+
+When `zero_mean_omega=True`, the forcing mean is removed before transformation. This prevents forcing from changing total mass, up to floating-point roundoff.
+
+Special cases are explicit:
+
+- `tau = 0` returns the authoritative input field unchanged;
+- `D = 0` performs the exact physical-space update `u + tau Omega`;
+- no forcing and a constant field produce equilibrium.
+
+## 5. Multiresolution hierarchy
+
+Restriction averages every `2 × 2 × 2` block:
+
+```text
+R(u)[i,j,k]
+  = (1/8) sum u[2i+dx, 2j+dy, 2k+dz].
+```
+
+Constant prolongation replicates one coarse value into eight fine cells:
+
+```text
+P(v)[2i+dx, 2j+dy, 2k+dz] = v[i,j,k].
+```
+
+Therefore
+
+```text
+R(P(v)) = v
+```
+
+on the coarse subspace, up to floating-point roundoff.
+
+A hierarchy with `L` levels requires every original dimension to be divisible by
+
+```text
+2^(L-1).
+```
+
+Each level receives its own fractional order `alpha_l` and smoothing time `tau_l`.
+
+After local smoothing, coarse information returns to the next finer level through
+
+```text
+u_fused
+  = (1 - beta_l) u_local + beta_l P(u_coarse),
+```
+
+where
+
+```text
+0 <= beta_l <= 1.
+```
+
+Because local unforced steps preserve mean, restriction preserves mean, prolongation restores the corresponding fine-grid mass and blending is affine, the complete unforced hierarchy preserves total mass up to numerical roundoff.
+
+## 6. Mechanistic trace
+
+One hierarchy transaction emits an ordered trace containing:
+
+```text
+RESTRICT_2X2X2
+FRACTIONAL_HEAT_3D
+PROLONG_2X2X2
+FUSE_COARSE_FINE
+VERIFY_MASS_AND_UPDATE
+```
+
+Each instruction records its sequence number, hierarchy level and numerical detail. The trace is explanatory telemetry, not executable Jarvis-X bytecode.
+
+## 7. Metrics
+
+The solver exposes:
+
+- field mean and mass;
+- variance;
+- classical periodic gradient energy;
+- fractional equilibrium residual;
+- hierarchy mass drift;
+- update RMS;
+- per-level before/after traces;
+- repeated-cycle update and residual histories.
+
+Classical gradient energy is
+
+```text
+G(u) = mean((dx u)^2 + (dy u)^2 + (dz u)^2) / 3.
+```
+
+The equilibrium residual is
+
+```text
+R(u) = RMS(-D (-Delta)^alpha u + Omega).
+```
+
+`run_to_equilibrium` stops when update RMS is less than or equal to the requested positive tolerance, or reports non-convergence after `max_cycles`.
+
+## 8. Independent validation
+
+Tests do not rely only on internal consistency. They compare:
+
+1. the separable transform against the literal direct 3D DFT definition;
+2. `alpha = 1` against the spatial periodic stencil;
+3. split timesteps against the exact semigroup identity;
+4. coarse prolongation/restriction against the exact coarse identity;
+5. mass and gradient behavior across hierarchy transactions;
+6. malformed geometry, spectra, parameters and convergence bounds.
+
+## 9. Production path
+
+A production solver would require separate engineering decisions:
+
+- NumPy, FFTW, MKL, cuFFT or another verified FFT backend;
+- real-to-complex symmetry and plan reuse;
+- sparse bricks, octrees or domain decomposition;
+- boundary conditions beyond periodicity;
+- vector and tensor fields;
+- calibrated units and physical constitutive models;
+- precision and stability studies;
+- benchmark comparison with established fractional PDE and multigrid solvers;
+- CPU/GPU memory, throughput and scaling measurements.
+
+Those capabilities are not implied by the reference implementation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -12,6 +12,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Stable reference | deterministic implementation with focused tests; API may still change before `1.0` |
 | Alpha | executable on `main`, but incomplete or lightly tested |
 | Reference laboratory | bounded executable research subsystem with explicit limits and isolated authority |
+| Numerical reference | correctness-oriented solver with independent mathematical tests and explicit scaling limits |
 | Integration candidate | implemented on a branch or pull request and awaiting canonical integration |
 | Demonstration | runnable visualization or example that is not an authoritative runtime |
 | Specification | documented mathematical or architectural proposal |
@@ -28,16 +29,16 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Cycle sandbox | Stable reference | `sandbox.py` | cycle bound only; no process isolation |
 | Trace and Omega journal | Stable reference | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
 | C++ inward processor | Reference laboratory | `cpp_runtime/`, CTest, cross-platform workflow | sparse virtual `8192³` domain; bounded parameter/schedule search; floating-point bit identity across platforms is not claimed |
+| Fractional 3D smoothing | Numerical reference | `fractional_smoothing_3d.py`, independent DFT/stencil/semigroup tests | dense periodic scalar grids and separable `O(N⁴)` cubic DFT; not a production FFT or calibrated physical model |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
 
-## Active integration candidates
+## Active integration and administration work
 
-| Pull request or issue | Capability | Current classification | Required before merge or completion |
+| Issue | Capability | Current classification | Required before completion |
 |---|---|---|---|
-| #46 | hierarchical fractional 3D smoothing solver | Integration candidate | rebase, numerical reference comparison, measured scaling data and green CI |
 | #48 | pull-request backlog consolidation | Governance work | classify overlaps, preserve unique evidence and reduce active drafts below ten |
 | #49 | branch protection and security settings | Repository administration | enable required checks, scanning and private reporting in GitHub settings |
 | #50 | public GitHub profile README | Profile administration | create `Lord-Xido/Lord-Xido`, pin active repositories and review public metadata |
@@ -62,7 +63,8 @@ Jarvis-X does not currently claim:
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
 - safety certification from the presence of a policy or coherence gate;
-- bit-exact cross-platform floating-point results from the C++ research processor.
+- bit-exact cross-platform floating-point results from the C++ research processor;
+- production-scale fractional PDE performance or physical validity from the numerical reference solver.
 
 ## Canonical promotion checklist
 
@@ -88,7 +90,8 @@ A capability moves to `main` only when all applicable items are satisfied:
 - versioned bytecode container;
 - expanded ISA tests;
 - enforced CI and contributor documentation;
-- isolated C++ processor laboratory with cross-platform validation.
+- isolated C++ processor laboratory with cross-platform validation;
+- independently validated fractional smoothing reference for small periodic grids.
 
 ### `0.3.0` — Sparse spatial runtime
 

--- a/src/jarvisx/fractional_smoothing_3d.py
+++ b/src/jarvisx/fractional_smoothing_3d.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 
 import cmath
 import math
-from dataclasses import dataclass
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 
 Shape3D = tuple[int, int, int]
 Coordinate3D = tuple[int, int, int]
@@ -96,68 +96,44 @@ def grid_from_values(shape: Shape3D, values: Iterable[float]) -> Grid3D:
     return Grid3D(shape, tuple(float(value) for value in values))
 
 
-def _transform_x(
-    values: Sequence[complex], shape: Shape3D, inverse: bool
-) -> list[complex]:
+def _transform_x(values: Sequence[complex], shape: Shape3D, inverse: bool) -> list[complex]:
     nx, ny, nz = shape
     output = [0j] * len(values)
     sign = 1.0 if inverse else -1.0
     scale = 1.0 / nx if inverse else 1.0
-    roots = [
-        [cmath.exp(sign * 2j * math.pi * k * x / nx) for x in range(nx)]
-        for k in range(nx)
-    ]
+    roots = [[cmath.exp(sign * 2j * math.pi * k * x / nx) for x in range(nx)] for k in range(nx)]
     for z in range(nz):
         for y in range(ny):
             for k in range(nx):
-                total = sum(
-                    values[_index(x, y, z, shape)] * roots[k][x]
-                    for x in range(nx)
-                )
+                total = sum(values[_index(x, y, z, shape)] * roots[k][x] for x in range(nx))
                 output[_index(k, y, z, shape)] = total * scale
     return output
 
 
-def _transform_y(
-    values: Sequence[complex], shape: Shape3D, inverse: bool
-) -> list[complex]:
+def _transform_y(values: Sequence[complex], shape: Shape3D, inverse: bool) -> list[complex]:
     nx, ny, nz = shape
     output = [0j] * len(values)
     sign = 1.0 if inverse else -1.0
     scale = 1.0 / ny if inverse else 1.0
-    roots = [
-        [cmath.exp(sign * 2j * math.pi * k * y / ny) for y in range(ny)]
-        for k in range(ny)
-    ]
+    roots = [[cmath.exp(sign * 2j * math.pi * k * y / ny) for y in range(ny)] for k in range(ny)]
     for z in range(nz):
         for x in range(nx):
             for k in range(ny):
-                total = sum(
-                    values[_index(x, y, z, shape)] * roots[k][y]
-                    for y in range(ny)
-                )
+                total = sum(values[_index(x, y, z, shape)] * roots[k][y] for y in range(ny))
                 output[_index(x, k, z, shape)] = total * scale
     return output
 
 
-def _transform_z(
-    values: Sequence[complex], shape: Shape3D, inverse: bool
-) -> list[complex]:
+def _transform_z(values: Sequence[complex], shape: Shape3D, inverse: bool) -> list[complex]:
     nx, ny, nz = shape
     output = [0j] * len(values)
     sign = 1.0 if inverse else -1.0
     scale = 1.0 / nz if inverse else 1.0
-    roots = [
-        [cmath.exp(sign * 2j * math.pi * k * z / nz) for z in range(nz)]
-        for k in range(nz)
-    ]
+    roots = [[cmath.exp(sign * 2j * math.pi * k * z / nz) for z in range(nz)] for k in range(nz)]
     for y in range(ny):
         for x in range(nx):
             for k in range(nz):
-                total = sum(
-                    values[_index(x, y, z, shape)] * roots[k][z]
-                    for z in range(nz)
-                )
+                total = sum(values[_index(x, y, z, shape)] * roots[k][z] for z in range(nz))
                 output[_index(x, y, k, shape)] = total * scale
     return output
 
@@ -354,9 +330,7 @@ def prolong_double(field: Grid3D) -> Grid3D:
 
 def round_trip_error(coarse: Grid3D) -> float:
     reconstructed = restrict_half(prolong_double(coarse))
-    return _rms(
-        tuple(left - right for left, right in zip(reconstructed.values, coarse.values))
-    )
+    return _rms(tuple(left - right for left, right in zip(reconstructed.values, coarse.values)))
 
 
 @dataclass(frozen=True)
@@ -378,10 +352,7 @@ class FractionalHierarchyConfig:
             _validate_alpha(alpha)
         if not all(math.isfinite(tau) and tau >= 0.0 for tau in self.taus):
             raise ValueError("all smoothing times must be finite and non-negative")
-        if not all(
-            math.isfinite(weight) and 0.0 <= weight <= 1.0
-            for weight in self.coarse_blends
-        ):
+        if not all(math.isfinite(weight) and 0.0 <= weight <= 1.0 for weight in self.coarse_blends):
             raise ValueError("all coarse blends must lie in [0, 1]")
         if not math.isfinite(self.diffusivity) or self.diffusivity < 0.0:
             raise ValueError("diffusivity must be finite and non-negative")
@@ -548,9 +519,7 @@ def hierarchical_fractional_smooth(
         )
         sequence += 1
 
-    update_rms = _rms(
-        tuple(after - before for after, before in zip(fused.values, field.values))
-    )
+    update_rms = _rms(tuple(after - before for after, before in zip(fused.values, field.values)))
     mass_before = field.mass
     mass_after = fused.mass
     instructions.append(
@@ -558,8 +527,7 @@ def hierarchical_fractional_smooth(
             sequence,
             "VERIFY_MASS_AND_UPDATE",
             0,
-            f"mass_drift={mass_after - mass_before:.12e} "
-            f"update_rms={update_rms:.12e}",
+            f"mass_drift={mass_after - mass_before:.12e} update_rms={update_rms:.12e}",
         )
     )
     return HierarchicalSmoothingResult(
@@ -606,9 +574,5 @@ def run_to_equilibrium(
             )
         )
         if result.update_rms <= tolerance:
-            return EquilibriumResult(
-                current, True, cycle, tuple(updates), tuple(residuals)
-            )
-    return EquilibriumResult(
-        current, False, max_cycles, tuple(updates), tuple(residuals)
-    )
+            return EquilibriumResult(current, True, cycle, tuple(updates), tuple(residuals))
+    return EquilibriumResult(current, False, max_cycles, tuple(updates), tuple(residuals))

--- a/src/jarvisx/fractional_smoothing_3d.py
+++ b/src/jarvisx/fractional_smoothing_3d.py
@@ -1,0 +1,614 @@
+"""Deterministic reference solver for periodic fractional diffusion in 3D.
+
+The implementation uses the exact spectrum of the six-neighbour discrete
+Laplacian and a dependency-free separable DFT. It is designed for correctness,
+small fixtures and auditable experiments, not production-scale FFT workloads.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from collections.abc import Iterable, Sequence
+
+Shape3D = tuple[int, int, int]
+Coordinate3D = tuple[int, int, int]
+
+
+def _index(x: int, y: int, z: int, shape: Shape3D) -> int:
+    nx, ny, _ = shape
+    return x + nx * (y + ny * z)
+
+
+def _rms(values: Sequence[float]) -> float:
+    if not values:
+        return 0.0
+    return math.sqrt(sum(value * value for value in values) / len(values))
+
+
+def _validate_alpha(alpha: float) -> None:
+    if not math.isfinite(alpha) or not 0.0 < alpha <= 1.0:
+        raise ValueError("alpha must be finite and in (0, 1]")
+
+
+@dataclass(frozen=True)
+class Grid3D:
+    """Immutable scalar field with x as the fastest-moving coordinate."""
+
+    shape: Shape3D
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        nx, ny, nz = self.shape
+        if nx < 1 or ny < 1 or nz < 1:
+            raise ValueError("all grid dimensions must be positive")
+        if len(self.values) != nx * ny * nz:
+            raise ValueError("value count does not match grid shape")
+        if not all(math.isfinite(value) for value in self.values):
+            raise ValueError("grid values must be finite")
+
+    @classmethod
+    def constant(cls, shape: Shape3D, value: float) -> "Grid3D":
+        if not math.isfinite(value):
+            raise ValueError("constant value must be finite")
+        nx, ny, nz = shape
+        return cls(shape, (float(value),) * (nx * ny * nz))
+
+    @classmethod
+    def impulse(
+        cls,
+        shape: Shape3D,
+        coordinate: Coordinate3D,
+        amplitude: float = 1.0,
+    ) -> "Grid3D":
+        nx, ny, nz = shape
+        x, y, z = coordinate
+        if not (0 <= x < nx and 0 <= y < ny and 0 <= z < nz):
+            raise ValueError("impulse coordinate lies outside the grid")
+        if not math.isfinite(amplitude):
+            raise ValueError("impulse amplitude must be finite")
+        values = [0.0] * (nx * ny * nz)
+        values[_index(x, y, z, shape)] = float(amplitude)
+        return cls(shape, tuple(values))
+
+    def at(self, x: int, y: int, z: int) -> float:
+        nx, ny, nz = self.shape
+        if not (0 <= x < nx and 0 <= y < ny and 0 <= z < nz):
+            raise IndexError("grid coordinate out of range")
+        return self.values[_index(x, y, z, self.shape)]
+
+    @property
+    def mean(self) -> float:
+        return sum(self.values) / len(self.values)
+
+    @property
+    def mass(self) -> float:
+        return sum(self.values)
+
+    @property
+    def variance(self) -> float:
+        mean = self.mean
+        return sum((value - mean) ** 2 for value in self.values) / len(self.values)
+
+
+def grid_from_values(shape: Shape3D, values: Iterable[float]) -> Grid3D:
+    return Grid3D(shape, tuple(float(value) for value in values))
+
+
+def _transform_x(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> list[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / nx if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * x / nx) for x in range(nx)]
+        for k in range(nx)
+    ]
+    for z in range(nz):
+        for y in range(ny):
+            for k in range(nx):
+                total = sum(
+                    values[_index(x, y, z, shape)] * roots[k][x]
+                    for x in range(nx)
+                )
+                output[_index(k, y, z, shape)] = total * scale
+    return output
+
+
+def _transform_y(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> list[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / ny if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * y / ny) for y in range(ny)]
+        for k in range(ny)
+    ]
+    for z in range(nz):
+        for x in range(nx):
+            for k in range(ny):
+                total = sum(
+                    values[_index(x, y, z, shape)] * roots[k][y]
+                    for y in range(ny)
+                )
+                output[_index(x, k, z, shape)] = total * scale
+    return output
+
+
+def _transform_z(
+    values: Sequence[complex], shape: Shape3D, inverse: bool
+) -> list[complex]:
+    nx, ny, nz = shape
+    output = [0j] * len(values)
+    sign = 1.0 if inverse else -1.0
+    scale = 1.0 / nz if inverse else 1.0
+    roots = [
+        [cmath.exp(sign * 2j * math.pi * k * z / nz) for z in range(nz)]
+        for k in range(nz)
+    ]
+    for y in range(ny):
+        for x in range(nx):
+            for k in range(nz):
+                total = sum(
+                    values[_index(x, y, z, shape)] * roots[k][z]
+                    for z in range(nz)
+                )
+                output[_index(x, y, k, shape)] = total * scale
+    return output
+
+
+def forward_dft3(field: Grid3D) -> tuple[complex, ...]:
+    """Return the unnormalised separable 3D DFT of ``field``."""
+
+    values = [complex(value, 0.0) for value in field.values]
+    transformed = _transform_x(values, field.shape, False)
+    transformed = _transform_y(transformed, field.shape, False)
+    transformed = _transform_z(transformed, field.shape, False)
+    return tuple(transformed)
+
+
+def inverse_dft3(values: Sequence[complex], shape: Shape3D) -> Grid3D:
+    """Invert a spectrum using one ``1/N`` factor per transformed axis."""
+
+    nx, ny, nz = shape
+    if len(values) != nx * ny * nz:
+        raise ValueError("spectrum size does not match shape")
+    transformed = _transform_z(values, shape, True)
+    transformed = _transform_y(transformed, shape, True)
+    transformed = _transform_x(transformed, shape, True)
+    return Grid3D(shape, tuple(value.real for value in transformed))
+
+
+def laplacian_eigenvalue(kx: int, ky: int, kz: int, shape: Shape3D) -> float:
+    """Eigenvalue of the periodic six-neighbour operator ``(-Delta)``."""
+
+    nx, ny, nz = shape
+    if not (0 <= kx < nx and 0 <= ky < ny and 0 <= kz < nz):
+        raise ValueError("mode coordinate lies outside the spectrum")
+    return (
+        6.0
+        - 2.0 * math.cos(2.0 * math.pi * kx / nx)
+        - 2.0 * math.cos(2.0 * math.pi * ky / ny)
+        - 2.0 * math.cos(2.0 * math.pi * kz / nz)
+    )
+
+
+def _zero_mean(field: Grid3D) -> Grid3D:
+    mean = field.mean
+    return Grid3D(field.shape, tuple(value - mean for value in field.values))
+
+
+def fractional_laplacian(field: Grid3D, alpha: float) -> Grid3D:
+    """Return ``(-Delta)^alpha field`` on the periodic lattice."""
+
+    _validate_alpha(alpha)
+    spectrum = list(forward_dft3(field))
+    nx, ny, nz = field.shape
+    for kz in range(nz):
+        for ky in range(ny):
+            for kx in range(nx):
+                index = _index(kx, ky, kz, field.shape)
+                eigenvalue = laplacian_eigenvalue(kx, ky, kz, field.shape)
+                multiplier = eigenvalue**alpha if eigenvalue > 0.0 else 0.0
+                spectrum[index] *= multiplier
+    return inverse_dft3(spectrum, field.shape)
+
+
+def spectral_fractional_step(
+    field: Grid3D,
+    alpha: float,
+    tau: float,
+    diffusivity: float = 1.0,
+    omega: Grid3D | None = None,
+    zero_mean_omega: bool = True,
+) -> Grid3D:
+    """Advance ``du/dt = -D(-Delta)^alpha u + omega`` exactly per mode."""
+
+    _validate_alpha(alpha)
+    if not math.isfinite(tau) or tau < 0.0:
+        raise ValueError("tau must be finite and non-negative")
+    if not math.isfinite(diffusivity) or diffusivity < 0.0:
+        raise ValueError("diffusivity must be finite and non-negative")
+    if omega is not None and omega.shape != field.shape:
+        raise ValueError("omega shape must match field shape")
+    if tau == 0.0:
+        return field
+
+    forcing = omega
+    if forcing is not None and zero_mean_omega:
+        forcing = _zero_mean(forcing)
+    if diffusivity == 0.0:
+        forcing_values = forcing.values if forcing is not None else (0.0,) * len(field.values)
+        return Grid3D(
+            field.shape,
+            tuple(
+                value + tau * forcing_value
+                for value, forcing_value in zip(field.values, forcing_values)
+            ),
+        )
+
+    spectrum = list(forward_dft3(field))
+    forcing_spectrum = list(forward_dft3(forcing)) if forcing is not None else None
+    nx, ny, nz = field.shape
+    for kz in range(nz):
+        for ky in range(ny):
+            for kx in range(nx):
+                index = _index(kx, ky, kz, field.shape)
+                eigenvalue = laplacian_eigenvalue(kx, ky, kz, field.shape)
+                rate = diffusivity * (eigenvalue**alpha if eigenvalue > 0.0 else 0.0)
+                decay = math.exp(-tau * rate)
+                updated = decay * spectrum[index]
+                if forcing_spectrum is not None:
+                    if rate > 0.0:
+                        updated += (1.0 - decay) * forcing_spectrum[index] / rate
+                    else:
+                        updated += tau * forcing_spectrum[index]
+                spectrum[index] = updated
+    return inverse_dft3(spectrum, field.shape)
+
+
+def classical_gradient_energy(field: Grid3D) -> float:
+    """Mean squared forward difference over the three periodic axes."""
+
+    nx, ny, nz = field.shape
+    total = 0.0
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                center = field.at(x, y, z)
+                dx = field.at((x + 1) % nx, y, z) - center
+                dy = field.at(x, (y + 1) % ny, z) - center
+                dz = field.at(x, y, (z + 1) % nz) - center
+                total += dx * dx + dy * dy + dz * dz
+    return total / (3.0 * len(field.values))
+
+
+def equilibrium_residual(
+    field: Grid3D,
+    alpha: float,
+    diffusivity: float = 1.0,
+    omega: Grid3D | None = None,
+    zero_mean_omega: bool = True,
+) -> float:
+    """Return the RMS residual of ``-D(-Delta)^alpha u + omega``."""
+
+    if not math.isfinite(diffusivity) or diffusivity < 0.0:
+        raise ValueError("diffusivity must be finite and non-negative")
+    if omega is not None and omega.shape != field.shape:
+        raise ValueError("omega shape must match field shape")
+    operator = fractional_laplacian(field, alpha)
+    forcing = omega
+    if forcing is not None and zero_mean_omega:
+        forcing = _zero_mean(forcing)
+    forcing_values = forcing.values if forcing is not None else (0.0,) * len(field.values)
+    return _rms(
+        tuple(
+            -diffusivity * operator_value + forcing_value
+            for operator_value, forcing_value in zip(operator.values, forcing_values)
+        )
+    )
+
+
+def restrict_half(field: Grid3D) -> Grid3D:
+    """Average each ``2×2×2`` block into one coarse cell."""
+
+    nx, ny, nz = field.shape
+    if nx % 2 or ny % 2 or nz % 2:
+        raise ValueError("all dimensions must be even for half restriction")
+    coarse_shape = (nx // 2, ny // 2, nz // 2)
+    values: list[float] = []
+    for cz in range(coarse_shape[2]):
+        for cy in range(coarse_shape[1]):
+            for cx in range(coarse_shape[0]):
+                total = sum(
+                    field.at(2 * cx + dx, 2 * cy + dy, 2 * cz + dz)
+                    for dz in range(2)
+                    for dy in range(2)
+                    for dx in range(2)
+                )
+                values.append(total / 8.0)
+    return Grid3D(coarse_shape, tuple(values))
+
+
+def prolong_double(field: Grid3D) -> Grid3D:
+    """Replicate each coarse cell across one ``2×2×2`` fine block."""
+
+    nx, ny, nz = field.shape
+    fine_shape = (2 * nx, 2 * ny, 2 * nz)
+    fine = [0.0] * (fine_shape[0] * fine_shape[1] * fine_shape[2])
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                value = field.at(x, y, z)
+                for dz in range(2):
+                    for dy in range(2):
+                        for dx in range(2):
+                            fine[_index(2 * x + dx, 2 * y + dy, 2 * z + dz, fine_shape)] = value
+    return Grid3D(fine_shape, tuple(fine))
+
+
+def round_trip_error(coarse: Grid3D) -> float:
+    reconstructed = restrict_half(prolong_double(coarse))
+    return _rms(
+        tuple(left - right for left, right in zip(reconstructed.values, coarse.values))
+    )
+
+
+@dataclass(frozen=True)
+class FractionalHierarchyConfig:
+    alphas: tuple[float, ...] = (1.0, 0.75, 0.5)
+    taus: tuple[float, ...] = (0.05, 0.1, 0.2)
+    coarse_blends: tuple[float, ...] = (0.2, 0.35)
+    diffusivity: float = 1.0
+    zero_mean_omega: bool = True
+
+    def validate(self) -> None:
+        if not self.alphas:
+            raise ValueError("at least one hierarchy level is required")
+        if len(self.taus) != len(self.alphas):
+            raise ValueError("taus must contain one value per hierarchy level")
+        if len(self.coarse_blends) != len(self.alphas) - 1:
+            raise ValueError("coarse_blends must contain one value per fusion boundary")
+        for alpha in self.alphas:
+            _validate_alpha(alpha)
+        if not all(math.isfinite(tau) and tau >= 0.0 for tau in self.taus):
+            raise ValueError("all smoothing times must be finite and non-negative")
+        if not all(
+            math.isfinite(weight) and 0.0 <= weight <= 1.0
+            for weight in self.coarse_blends
+        ):
+            raise ValueError("all coarse blends must lie in [0, 1]")
+        if not math.isfinite(self.diffusivity) or self.diffusivity < 0.0:
+            raise ValueError("diffusivity must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class MechanisticInstruction:
+    sequence: int
+    opcode: str
+    level: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class LevelTrace:
+    level: int
+    shape: Shape3D
+    alpha: float
+    tau: float
+    mean_before: float
+    mean_after: float
+    variance_before: float
+    variance_after: float
+    gradient_energy_before: float
+    gradient_energy_after: float
+    equilibrium_residual_after: float
+
+
+@dataclass(frozen=True)
+class HierarchicalSmoothingResult:
+    field: Grid3D
+    traces: tuple[LevelTrace, ...]
+    instructions: tuple[MechanisticInstruction, ...]
+    mass_before: float
+    mass_after: float
+    mass_drift: float
+    update_rms: float
+
+
+@dataclass(frozen=True)
+class EquilibriumResult:
+    field: Grid3D
+    converged: bool
+    cycles: int
+    update_history: tuple[float, ...]
+    residual_history: tuple[float, ...]
+
+
+def _validate_hierarchy_shape(shape: Shape3D, levels: int) -> None:
+    divisor = 2 ** (levels - 1)
+    if any(dimension % divisor for dimension in shape):
+        raise ValueError("each dimension must be divisible by 2**(levels - 1)")
+
+
+def _blend_fields(local: Grid3D, projected: Grid3D, weight: float) -> Grid3D:
+    if local.shape != projected.shape:
+        raise ValueError("fields must share a shape before blending")
+    return Grid3D(
+        local.shape,
+        tuple(
+            (1.0 - weight) * local_value + weight * projected_value
+            for local_value, projected_value in zip(local.values, projected.values)
+        ),
+    )
+
+
+def hierarchical_fractional_smooth(
+    field: Grid3D,
+    config: FractionalHierarchyConfig | None = None,
+    omega: Grid3D | None = None,
+) -> HierarchicalSmoothingResult:
+    """Execute one fine-to-coarse-to-fine smoothing transaction."""
+
+    active = config or FractionalHierarchyConfig()
+    active.validate()
+    levels = len(active.alphas)
+    _validate_hierarchy_shape(field.shape, levels)
+    if omega is not None and omega.shape != field.shape:
+        raise ValueError("omega shape must match field shape")
+
+    grids = [field]
+    omega_grids: list[Grid3D | None] = [omega]
+    instructions: list[MechanisticInstruction] = []
+    sequence = 0
+    for level in range(1, levels):
+        grids.append(restrict_half(grids[-1]))
+        parent_omega = omega_grids[-1]
+        omega_grids.append(restrict_half(parent_omega) if parent_omega is not None else None)
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "RESTRICT_2X2X2",
+                level,
+                f"{grids[level - 1].shape} -> {grids[level].shape}",
+            )
+        )
+        sequence += 1
+
+    local_results: list[Grid3D] = []
+    traces: list[LevelTrace] = []
+    for level, source in enumerate(grids):
+        result = spectral_fractional_step(
+            source,
+            active.alphas[level],
+            active.taus[level],
+            active.diffusivity,
+            omega_grids[level],
+            active.zero_mean_omega,
+        )
+        local_results.append(result)
+        traces.append(
+            LevelTrace(
+                level=level,
+                shape=source.shape,
+                alpha=active.alphas[level],
+                tau=active.taus[level],
+                mean_before=source.mean,
+                mean_after=result.mean,
+                variance_before=source.variance,
+                variance_after=result.variance,
+                gradient_energy_before=classical_gradient_energy(source),
+                gradient_energy_after=classical_gradient_energy(result),
+                equilibrium_residual_after=equilibrium_residual(
+                    result,
+                    active.alphas[level],
+                    active.diffusivity,
+                    omega_grids[level],
+                    active.zero_mean_omega,
+                ),
+            )
+        )
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "FRACTIONAL_HEAT_3D",
+                level,
+                f"alpha={active.alphas[level]:.6f} "
+                f"tau={active.taus[level]:.6f} shape={source.shape}",
+            )
+        )
+        sequence += 1
+
+    fused = local_results[-1]
+    for level in range(levels - 2, -1, -1):
+        projected = prolong_double(fused)
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "PROLONG_2X2X2",
+                level,
+                f"{fused.shape} -> {projected.shape}",
+            )
+        )
+        sequence += 1
+        weight = active.coarse_blends[level]
+        fused = _blend_fields(local_results[level], projected, weight)
+        instructions.append(
+            MechanisticInstruction(
+                sequence,
+                "FUSE_COARSE_FINE",
+                level,
+                f"coarse_weight={weight:.6f}",
+            )
+        )
+        sequence += 1
+
+    update_rms = _rms(
+        tuple(after - before for after, before in zip(fused.values, field.values))
+    )
+    mass_before = field.mass
+    mass_after = fused.mass
+    instructions.append(
+        MechanisticInstruction(
+            sequence,
+            "VERIFY_MASS_AND_UPDATE",
+            0,
+            f"mass_drift={mass_after - mass_before:.12e} "
+            f"update_rms={update_rms:.12e}",
+        )
+    )
+    return HierarchicalSmoothingResult(
+        field=fused,
+        traces=tuple(traces),
+        instructions=tuple(instructions),
+        mass_before=mass_before,
+        mass_after=mass_after,
+        mass_drift=mass_after - mass_before,
+        update_rms=update_rms,
+    )
+
+
+def run_to_equilibrium(
+    field: Grid3D,
+    config: FractionalHierarchyConfig | None = None,
+    omega: Grid3D | None = None,
+    tolerance: float = 1.0e-6,
+    max_cycles: int = 100,
+) -> EquilibriumResult:
+    """Repeat hierarchical transactions until update RMS reaches tolerance."""
+
+    if not math.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("tolerance must be finite and positive")
+    if max_cycles < 1:
+        raise ValueError("max_cycles must be positive")
+    active = config or FractionalHierarchyConfig()
+    active.validate()
+
+    current = field
+    updates: list[float] = []
+    residuals: list[float] = []
+    for cycle in range(1, max_cycles + 1):
+        result = hierarchical_fractional_smooth(current, active, omega)
+        current = result.field
+        updates.append(result.update_rms)
+        residuals.append(
+            equilibrium_residual(
+                current,
+                active.alphas[0],
+                active.diffusivity,
+                omega,
+                active.zero_mean_omega,
+            )
+        )
+        if result.update_rms <= tolerance:
+            return EquilibriumResult(
+                current, True, cycle, tuple(updates), tuple(residuals)
+            )
+    return EquilibriumResult(
+        current, False, max_cycles, tuple(updates), tuple(residuals)
+    )

--- a/tests/test_fractional_smoothing_3d.py
+++ b/tests/test_fractional_smoothing_3d.py
@@ -32,9 +32,7 @@ def direct_dft3(field: Grid3D) -> tuple[complex, ...]:
                 for z in range(nz):
                     for y in range(ny):
                         for x in range(nx):
-                            phase = -2j * math.pi * (
-                                kx * x / nx + ky * y / ny + kz * z / nz
-                            )
+                            phase = -2j * math.pi * (kx * x / nx + ky * y / ny + kz * z / nz)
                             total += field.at(x, y, z) * cmath.exp(phase)
                 spectrum.append(total)
     return tuple(spectrum)

--- a/tests/test_fractional_smoothing_3d.py
+++ b/tests/test_fractional_smoothing_3d.py
@@ -1,0 +1,294 @@
+import cmath
+import math
+
+import pytest
+
+from jarvisx.fractional_smoothing_3d import (
+    FractionalHierarchyConfig,
+    Grid3D,
+    classical_gradient_energy,
+    equilibrium_residual,
+    forward_dft3,
+    fractional_laplacian,
+    grid_from_values,
+    hierarchical_fractional_smooth,
+    inverse_dft3,
+    laplacian_eigenvalue,
+    prolong_double,
+    restrict_half,
+    round_trip_error,
+    run_to_equilibrium,
+    spectral_fractional_step,
+)
+
+
+def direct_dft3(field: Grid3D) -> tuple[complex, ...]:
+    nx, ny, nz = field.shape
+    spectrum: list[complex] = []
+    for kz in range(nz):
+        for ky in range(ny):
+            for kx in range(nx):
+                total = 0j
+                for z in range(nz):
+                    for y in range(ny):
+                        for x in range(nx):
+                            phase = -2j * math.pi * (
+                                kx * x / nx + ky * y / ny + kz * z / nz
+                            )
+                            total += field.at(x, y, z) * cmath.exp(phase)
+                spectrum.append(total)
+    return tuple(spectrum)
+
+
+def spatial_negative_laplacian(field: Grid3D) -> Grid3D:
+    nx, ny, nz = field.shape
+    values: list[float] = []
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                center = field.at(x, y, z)
+                neighbours = (
+                    field.at((x - 1) % nx, y, z)
+                    + field.at((x + 1) % nx, y, z)
+                    + field.at(x, (y - 1) % ny, z)
+                    + field.at(x, (y + 1) % ny, z)
+                    + field.at(x, y, (z - 1) % nz)
+                    + field.at(x, y, (z + 1) % nz)
+                )
+                values.append(6.0 * center - neighbours)
+    return Grid3D(field.shape, tuple(values))
+
+
+def test_separable_dft_matches_independent_direct_definition() -> None:
+    field = grid_from_values((2, 2, 2), range(8))
+
+    assert forward_dft3(field) == pytest.approx(direct_dft3(field), abs=1.0e-12)
+
+
+def test_dft_round_trip_recovers_non_cubic_field() -> None:
+    field = grid_from_values((2, 3, 2), (math.sin(index) for index in range(12)))
+
+    restored = inverse_dft3(forward_dft3(field), field.shape)
+
+    assert restored.values == pytest.approx(field.values, abs=1.0e-12)
+
+
+def test_alpha_one_matches_periodic_spatial_stencil() -> None:
+    field = grid_from_values(
+        (3, 2, 2),
+        (math.sin(index * 0.7) + 0.25 * index for index in range(12)),
+    )
+
+    spectral = fractional_laplacian(field, alpha=1.0)
+    spatial = spatial_negative_laplacian(field)
+
+    assert spectral.values == pytest.approx(spatial.values, abs=1.0e-10)
+
+
+def test_laplacian_mode_bounds_and_zero_mode() -> None:
+    assert laplacian_eigenvalue(0, 0, 0, (4, 4, 4)) == pytest.approx(0.0)
+    assert laplacian_eigenvalue(2, 2, 2, (4, 4, 4)) == pytest.approx(12.0)
+    with pytest.raises(ValueError, match="outside"):
+        laplacian_eigenvalue(4, 0, 0, (4, 4, 4))
+
+
+def test_constant_field_is_fractional_equilibrium() -> None:
+    field = Grid3D.constant((4, 4, 4), 3.25)
+
+    result = spectral_fractional_step(field, alpha=0.6, tau=1.0)
+
+    assert result.values == pytest.approx(field.values, abs=1.0e-12)
+    assert equilibrium_residual(result, alpha=0.6) == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_fractional_step_has_semigroup_property_without_forcing() -> None:
+    field = Grid3D.impulse((4, 4, 4), (1, 2, 3), amplitude=2.0)
+
+    split = spectral_fractional_step(field, alpha=0.7, tau=0.125)
+    split = spectral_fractional_step(split, alpha=0.7, tau=0.275)
+    combined = spectral_fractional_step(field, alpha=0.7, tau=0.4)
+
+    assert split.values == pytest.approx(combined.values, abs=1.0e-11)
+
+
+def test_fractional_step_preserves_mass_and_reduces_variance() -> None:
+    field = Grid3D.impulse((4, 4, 4), (1, 1, 1), amplitude=8.0)
+
+    result = spectral_fractional_step(field, alpha=0.7, tau=0.2)
+
+    assert result.mass == pytest.approx(field.mass, abs=1.0e-10)
+    assert result.variance < field.variance
+    assert max(result.values) < max(field.values)
+    assert min(result.values) > -1.0e-12
+
+
+def test_zero_diffusivity_applies_forcing_in_physical_space() -> None:
+    field = Grid3D.constant((2, 2, 2), 1.0)
+    omega = grid_from_values((2, 2, 2), range(8))
+
+    result = spectral_fractional_step(
+        field,
+        alpha=0.5,
+        tau=0.25,
+        diffusivity=0.0,
+        omega=omega,
+        zero_mean_omega=False,
+    )
+
+    expected = tuple(1.0 + 0.25 * value for value in omega.values)
+    assert result.values == pytest.approx(expected)
+
+
+def test_zero_mean_omega_preserves_total_mass() -> None:
+    field = Grid3D.constant((4, 4, 4), 1.0)
+    omega = Grid3D(
+        (4, 4, 4),
+        tuple(1.0 if index == 0 else -1.0 / 63.0 for index in range(64)),
+    )
+
+    result = spectral_fractional_step(
+        field,
+        alpha=0.75,
+        tau=0.1,
+        omega=omega,
+        zero_mean_omega=True,
+    )
+
+    assert result.mass == pytest.approx(field.mass, abs=1.0e-9)
+    assert result.values != pytest.approx(field.values, abs=1.0e-12)
+
+
+def test_tau_zero_returns_authoritative_field_object() -> None:
+    field = Grid3D.impulse((2, 2, 2), (0, 0, 0))
+
+    assert spectral_fractional_step(field, alpha=0.5, tau=0.0) is field
+
+
+def test_coarse_expansion_contraction_is_identity() -> None:
+    coarse = grid_from_values((2, 2, 2), range(8))
+
+    expanded = prolong_double(coarse)
+    reconstructed = restrict_half(expanded)
+
+    assert reconstructed.values == pytest.approx(coarse.values, abs=1.0e-12)
+    assert round_trip_error(coarse) == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_hierarchy_emits_ordered_mechanistic_trace() -> None:
+    field = Grid3D.impulse((4, 4, 4), (0, 0, 0), amplitude=4.0)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.5),
+        taus=(0.05, 0.2),
+        coarse_blends=(0.3,),
+    )
+
+    result = hierarchical_fractional_smooth(field, config)
+    opcodes = tuple(instruction.opcode for instruction in result.instructions)
+    sequences = tuple(instruction.sequence for instruction in result.instructions)
+
+    assert len(result.traces) == 2
+    assert result.traces[0].shape == (4, 4, 4)
+    assert result.traces[1].shape == (2, 2, 2)
+    assert opcodes == (
+        "RESTRICT_2X2X2",
+        "FRACTIONAL_HEAT_3D",
+        "FRACTIONAL_HEAT_3D",
+        "PROLONG_2X2X2",
+        "FUSE_COARSE_FINE",
+        "VERIFY_MASS_AND_UPDATE",
+    )
+    assert sequences == tuple(range(len(sequences)))
+
+
+def test_hierarchy_preserves_mass_and_reduces_gradient_energy() -> None:
+    values = tuple(
+        math.sin(2.0 * math.pi * x / 4.0)
+        + 0.5 * math.cos(2.0 * math.pi * y / 4.0)
+        + (1.0 if (x + y + z) % 2 else -1.0)
+        for z in range(4)
+        for y in range(4)
+        for x in range(4)
+    )
+    field = Grid3D((4, 4, 4), values)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.6),
+        taus=(0.08, 0.2),
+        coarse_blends=(0.25,),
+    )
+
+    result = hierarchical_fractional_smooth(field, config)
+
+    assert result.mass_after == pytest.approx(result.mass_before, abs=1.0e-9)
+    assert abs(result.mass_drift) < 1.0e-9
+    assert classical_gradient_energy(result.field) < classical_gradient_energy(field)
+    assert result.update_rms > 0.0
+
+
+def test_repeated_smoothing_moves_toward_equilibrium() -> None:
+    field = Grid3D.impulse((4, 4, 4), (1, 2, 3), amplitude=1.0)
+    config = FractionalHierarchyConfig(
+        alphas=(1.0, 0.65),
+        taus=(0.2, 0.35),
+        coarse_blends=(0.25,),
+    )
+
+    result = run_to_equilibrium(
+        field,
+        config,
+        tolerance=1.0e-5,
+        max_cycles=80,
+    )
+
+    assert result.converged
+    assert result.update_history[-1] <= 1.0e-5
+    assert result.residual_history[-1] < result.residual_history[0]
+    assert result.field.mass == pytest.approx(field.mass, abs=1.0e-8)
+
+
+def test_validation_rejects_invalid_geometry_and_parameters() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        Grid3D((0, 1, 1), ())
+    with pytest.raises(ValueError, match="value count"):
+        Grid3D((2, 2, 2), (0.0,))
+    with pytest.raises(ValueError, match="finite"):
+        Grid3D.constant((1, 1, 1), math.inf)
+    with pytest.raises(ValueError, match="outside"):
+        Grid3D.impulse((2, 2, 2), (2, 0, 0))
+    with pytest.raises(IndexError, match="out of range"):
+        Grid3D.constant((1, 1, 1), 0.0).at(1, 0, 0)
+    with pytest.raises(ValueError, match="alpha"):
+        spectral_fractional_step(Grid3D.constant((1, 1, 1), 0.0), 0.0, 0.1)
+    with pytest.raises(ValueError, match="tau"):
+        spectral_fractional_step(Grid3D.constant((1, 1, 1), 0.0), 0.5, -0.1)
+    with pytest.raises(ValueError, match="diffusivity"):
+        equilibrium_residual(Grid3D.constant((1, 1, 1), 0.0), 0.5, -1.0)
+    with pytest.raises(ValueError, match="even"):
+        restrict_half(Grid3D.constant((3, 2, 2), 0.0))
+    with pytest.raises(ValueError, match="spectrum size"):
+        inverse_dft3((0j,), (2, 2, 2))
+
+
+def test_hierarchy_configuration_and_convergence_bounds_are_enforced() -> None:
+    field = Grid3D.constant((4, 4, 4), 0.0)
+
+    with pytest.raises(ValueError, match="one value per hierarchy"):
+        FractionalHierarchyConfig(alphas=(1.0, 0.5), taus=(0.1,)).validate()
+    with pytest.raises(ValueError, match="fusion boundary"):
+        FractionalHierarchyConfig(
+            alphas=(1.0, 0.5),
+            taus=(0.1, 0.2),
+            coarse_blends=(),
+        ).validate()
+    with pytest.raises(ValueError, match="divisible"):
+        hierarchical_fractional_smooth(
+            Grid3D.constant((3, 4, 4), 0.0),
+            FractionalHierarchyConfig(
+                alphas=(1.0, 0.5),
+                taus=(0.1, 0.2),
+                coarse_blends=(0.5,),
+            ),
+        )
+    with pytest.raises(ValueError, match="tolerance"):
+        run_to_equilibrium(field, tolerance=0.0)
+    with pytest.raises(ValueError, match="max_cycles"):
+        run_to_equilibrium(field, max_cycles=0)


### PR DESCRIPTION
## Purpose

Replace draft PR #46 with a clean numerical-reference integration built on the canonical foundation and C++ laboratory already merged into `main`.

This PR carries only the fractional solver, independent tests, mathematical documentation, additive status/changelog updates and the formatting gate for the new files. It does not duplicate VM, ledger or packaging repairs.

## Classification

- [x] Numerical reference kernel
- [x] Deterministic small-grid solver
- [x] Mathematical and mechanistic documentation

## Governing equation

```text
du/dt = -D (-Delta)^alpha u + Omega
```

For the periodic six-neighbour lattice:

```text
lambda(kx,ky,kz)
  = 6
    - 2 cos(2 pi kx / Nx)
    - 2 cos(2 pi ky / Ny)
    - 2 cos(2 pi kz / Nz)
```

The implementation advances each Fourier mode analytically over one timestep and supports `0 < alpha <= 1`.

## What changed

- add immutable finite `Grid3D` state with exact flat addressing
- expose dependency-free separable forward and inverse 3D DFT primitives
- expose periodic Laplacian eigenvalues and `(-Delta)^alpha`
- implement exact spectral diffusion with optional constant forcing
- handle `tau = 0` and `D = 0` explicitly
- add zero-mean forcing for mass-preserving correction experiments
- add `2×2×2` restriction and constant prolongation
- enforce `restrict_half(prolong_double(G)) == G` on the coarse subspace
- add fine-to-coarse smoothing and coarse-to-fine weighted fusion
- emit ordered mechanistic instructions and per-level telemetry
- expose mass drift, update RMS, variance, gradient energy and equilibrium residual
- add bounded repeated convergence through `run_to_equilibrium`

## Independent validation

The tests compare:

- the separable transform against the literal direct 3D DFT definition;
- `alpha = 1` against the periodic six-neighbour spatial stencil;
- split timesteps against the exact semigroup identity;
- zero diffusivity against the physical-space forcing update;
- prolongation/restriction against the exact coarse identity;
- hierarchy mass and gradient behavior;
- malformed geometry, spectra, parameters and convergence bounds.

## Complexity and boundary

For a cubic `N³` grid, the dependency-free separable direct DFT costs `O(N⁴)` arithmetic and materializes dense real and complex fields. It is intended for small correctness fixtures and auditable experiments.

It is not a production FFT, sparse-volume solver, calibrated physical model or large-grid performance claim. Production work requires a verified FFT backend, sparse/domain-decomposed storage, physical units and benchmark comparison with established fractional PDE or multigrid solvers.

## Validation completed

- Python 3.10, 3.11, 3.12 and 3.13 tests: passed
- independent numerical reference tests: passed
- Black and isort: passed
- flake8 and mypy: passed
- branch coverage threshold and Codecov upload: passed
- dependency audit: passed
- source distribution and wheel build: passed
- package metadata and installed-wheel smoke test: passed
- CodeQL: passed

```bash
python -m pip install -e ".[dev]"
pytest tests/test_fractional_smoothing_3d.py
pytest
```

## Supersession

This PR supersedes #46. After merge, #46 should close as superseded rather than retain duplicated foundation changes.