### PR TITLE
Add hardened operational 3D billion-instance Dr Moagi field

### DIFF
--- a/docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md
+++ b/docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md
@@ -1,79 +1,91 @@
 # Dr Moagi 3D Billion-Instance Auto-Encoding/Decoding Equation
 
-## Status
+## Status and capability boundary
 
-Operational mathematical specification and bounded sparse reference contract for a virtual
-`1000 x 1000 x 1000` field of interacting auto-encoding and decoding instances.
+This is the canonical operational specification for a virtual `1000 x 1000 x 1000`
+three-dimensional field of interacting auto-encoding and decoding cells.
 
-This document extends, without replacing:
+It extends, without replacing:
 
 - `Dr_Moagi_Equation_3D_Autoencoder_v4.txt`;
 - `DR_MOAGI_3D_SWARM_BYTECODE_PERMEATED_MATHEMATICS.md`;
-- the repository rule that virtual extent must not be confused with physical allocation.
+- the Jarvis-X rule that virtual extent must not be confused with physical allocation.
 
-The logical field contains exactly
+The logical field contains
 
 \[
 N=1000^3=1,000,000,000
 \]
 
-addressable instances. The reference implementation is sparse: it materializes only active
-coordinates and treats all unmaterialized coordinates as a deterministic zero background.
+addressable coordinates. The Python reference is sparse and bounded. It does **not** allocate a
+dense billion-cell tensor, instantiate one billion language models, or claim equivalence to an
+undisclosed proprietary architecture. It implements the equation over an explicitly materialized
+support with deterministic zero boundary values.
 
 ---
 
-## 1. Volumetric address space
+## 1. Geometric address space
 
 Let
 
 \[
-\mathcal L_{1000}=\{0,1,\ldots,999\}^3.
+\mathcal L_S=\{0,1,\ldots,S-1\}^3,
+\qquad S=1000
 \]
 
-For a coordinate
+for the canonical engine. For
 
 \[
-\mathbf r=(x,y,z)\in\mathcal L_{1000},
+\mathbf r=(x,y,z)\in\mathcal L_S,
 \]
 
-its canonical row-major scalar address is
+the scalar address is
 
 \[
 \boxed{
- a(\mathbf r)=x+1000\left(y+1000z\right)
+a(\mathbf r)=x+S(y+Sz)
 }
 \]
 
 with
 
 \[
-0\le a(\mathbf r)<10^9.
+0\le a(\mathbf r)<S^3.
 \]
 
-The inverse address map is
+The exact inverse is
 
 \[
+\boxed{
 \begin{aligned}
-x &= a\bmod 1000,\\
-y &= \left\lfloor a/1000\right\rfloor\bmod1000,\\
-z &= \left\lfloor a/10^6\right\rfloor.
+x &= a\bmod S,\\
+y &= \left\lfloor\frac{a}{S}\right\rfloor\bmod S,\\
+z &= \left\lfloor\frac{a}{S^2}\right\rfloor.
 \end{aligned}
+}
 \]
 
-For bounded execution, the lattice may be partitioned into cubic tiles of side `B`. With
-`B=32`, the padded block grid is
+At `S=1000`, the final coordinate has address
 
 \[
-\left\lceil\frac{1000}{32}\right\rceil^3=32^3=32768
+a(999,999,999)=999,999,999.
 \]
 
-blocks. A block is allocated only when at least one of its coordinates is active.
+For block side length \(B\), the padded block count is
+
+\[
+\boxed{
+N_B=\left\lceil\frac{S}{B}\right\rceil^3.
+}
+\]
+
+With \(B=32\), \(N_B=32^3=32768\).
 
 ---
 
-## 2. Per-instance state
+## 2. Per-cell state
 
-Every logical instance at coordinate \(\mathbf r\) has the state
+Every logical coordinate has the state
 
 \[
 \boxed{
@@ -82,54 +94,118 @@ Every logical instance at coordinate \(\mathbf r\) has the state
 \left(
 X_{\mathbf r,t},
 Z_{\mathbf r,t},
-\widehat X_{\mathbf r,t},
+D_{\mathbf r,t},
+R_{\mathbf r,t},
 E_{\mathbf r,t},
 \Omega_{\mathbf r,t},
 \Xi_{\mathbf r,t},
 \Lambda_{\mathbf r,t}
-\right)
+\right).
 }
 \]
 
-where:
+The components are:
 
-- \(X_{\mathbf r,t}\in[-1,1]\): observed or injected scalar field value;
-- \(Z_{\mathbf r,t}\in\mathcal Q_3=\{-4,-3,-2,-1,0,1,2,3\}\): signed 3-bit latent;
-- \(\widehat X_{\mathbf r,t}\in[-1,1]\): decoded candidate reconstruction;
-- \(E_{\mathbf r,t}=X_{\mathbf r,t}-\widehat X_{\mathbf r,t}\): reconstruction residual;
-- \(\Omega_{\mathbf r,t}\in[-1,1]\): bounded persistent correction memory;
-- \(\Xi_{\mathbf r,t}\in[-1,1]\): last committed field state;
-- \(\Lambda_{\mathbf r,t}\in\{0,1\}\): local validity predicate.
+- \(X_{\mathbf r,t}\in[-1,1]\): persistent observation;
+- \(Z_{\mathbf r,t}\in\mathcal Q_3\): signed three-bit latent code;
+- \(D_{\mathbf r,t}\in[-1,1]\): dequantized latent;
+- \(R_{\mathbf r,t}\in[-1,1]\): high-effort provisional prediction;
+- \(E_{\mathbf r,t}\in[-2,2]\): reconstruction residual;
+- \(\Omega_{\mathbf r,t}\in[-1,1]\): committed correction memory;
+- \(\Xi_{\mathbf r,t}\in[-1,1]\): committed reconstruction;
+- \(\Lambda_{\mathbf r,t}\in\{0,1\}\): local validity gate.
 
-The global field is
-
-\[
-\boxed{
-\Sigma_t=\{\sigma_{\mathbf r,t}:\mathbf r\in\mathcal L_{1000}\}.
-}
-\]
-
-A sparse implementation stores only
+The complete logical field is
 
 \[
-\mathcal A_t=\{\mathbf r:\sigma_{\mathbf r,t}\neq\mathbf 0\},
+\Sigma_t=\{\sigma_{\mathbf r,t}:\mathbf r\in\mathcal L_S\}.
 \]
 
-while preserving the full logical address space.
+The physical sparse state is defined only on an active support
+
+\[
+\mathcal A_t\subseteq\mathcal L_S.
+\]
+
+Outside \(\mathcal A_t\), every field component has the deterministic background value zero.
 
 ---
 
-## 3. Six-neighbour 3D geometry
+## 3. Sparse support closure
 
-For a coordinate \(\mathbf r=(x,y,z)\), define the orthogonal neighbourhood
+Spatial coupling can move information into neighbouring coordinates. The runtime therefore permits
+an explicit halo depth \(d\ge0\).
+
+Define
 
 \[
-\mathcal N_6(\mathbf r)=
-\{(x\pm1,y,z),(x,y\pm1,z),(x,y,z\pm1)\}
-\cap\mathcal L_{1000}.
+\mathcal H_0(A)=A
 \]
 
-The discrete volumetric Laplacian is
+and recursively
+
+\[
+\boxed{
+\mathcal H_{k+1}(A)
+=
+\mathcal H_k(A)
+\cup
+\bigcup_{\mathbf r\in\mathcal H_k(A)}\mathcal N_6(\mathbf r).
+}
+\]
+
+The computational support for cycle \(t\) is
+
+\[
+\boxed{
+\mathcal C_t
+=
+\mathcal H_d
+\left(
+\mathcal A_t
+\cup
+\operatorname{supp}(X_t^{\mathrm{new}})
+\cup
+\operatorname{supp}(U_t)
+\right).
+}
+\]
+
+`halo_depth=0` produces a fixed-support sparse projection. A positive halo depth admits bounded
+outward propagation. The transaction is rejected before mutation when
+
+\[
+|\mathcal C_t|>N_{\max}.
+\]
+
+Thus the virtual billion-cell geometry remains addressable while physical work remains explicitly
+bounded.
+
+---
+
+## 4. Six-neighbour geometry
+
+For \(\mathbf r=(x,y,z)\), the orthogonal neighbourhood is
+
+\[
+\mathcal N_6(\mathbf r)
+=
+\{(x\pm1,y,z),(x,y\pm1,z),(x,y,z\pm1)\}
+\cap\mathcal L_S.
+\]
+
+The observed neighbour mean is
+
+\[
+\boxed{
+\overline X_{\mathbf r,t}
+=
+\frac{1}{|\mathcal N_6(\mathbf r)|}
+\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}X_{\mathbf q,t}.
+}
+\]
+
+The committed-state Laplacian is
 
 \[
 \boxed{
@@ -140,54 +216,54 @@ The discrete volumetric Laplacian is
 }
 \]
 
-The neighbour mean used by the encoder is
-
-\[
-\overline X_{\mathbf r,t}
-=
-\begin{cases}
-\dfrac{1}{|\mathcal N_6(\mathbf r)|}
-\displaystyle\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}X_{\mathbf q,t},
-&|\mathcal N_6(\mathbf r)|>0,\\
-0,&\text{otherwise}.
-\end{cases}
-\]
-
-Unmaterialized sparse neighbours contribute the defined background value zero.
+Unmaterialized neighbours contribute zero.
 
 ---
 
-## 4. Local 3D encoder
+## 5. Canonical signed-Q3 auto-encoder
 
-The pre-quantized activation is
+The latent alphabet is exactly
 
 \[
+\boxed{
+\mathcal Q_3=\{-4,-3,-2,-1,0,1,2,3\}.
+}
+\]
+
+A conventional \(\operatorname{round}(3u)\) map fails to use all eight codes over \([-1,1]\),
+and decoding \(-4/3\) by clipping collapses two negative codes into the same value. The corrected
+canonical quantizer therefore uses piecewise scale factors:
+
+\[
+\boxed{
+Q_3(u)
+=
+\operatorname{clip}_{[-4,3]}
+\begin{cases}
+\operatorname{round}_{\mathrm{away}}(4u),&u<0,\\
+\operatorname{round}_{\mathrm{away}}(3u),&u\ge0.
+\end{cases}
+}
+\]
+
+Here \(\operatorname{round}_{\mathrm{away}}\) rounds exact half values away from zero.
+
+The encoder activation is
+
+\[
+\boxed{
 A_{\mathbf r,t}
 =
 \alpha_E
 \left(
 X_{\mathbf r,t}
-+\gamma_E\overline X_{\mathbf r,t}
++
+\gamma_E\overline X_{\mathbf r,t}
 \right),
-\]
-
-where \(\alpha_E>0\) is encoder gain and \(\gamma_E\ge0\) is spatial context gain.
-
-The canonical signed 3-bit quantizer is
-
-\[
-\boxed{
-Q_3(u)=
-\operatorname{clip}
-\left(
-\operatorname{round}(3u),
--4,
-3
-\right).
 }
 \]
 
-The encoded latent is
+and the encoded latent is
 
 \[
 \boxed{
@@ -195,187 +271,165 @@ Z_{\mathbf r,t}=Q_3(A_{\mathbf r,t}).
 }
 \]
 
-The entire billion-instance encoder is the direct product operator
+This mapping uses every signed three-bit code over the canonical field:
 
-\[
-\boxed{
-\mathbf Z_t
-=
-\mathcal E^{(3D)}_{\Phi}(\mathbf X_t)
-=
-\bigotimes_{\mathbf r\in\mathcal L_{1000}}
-Q_3\left[
-\alpha_E
-\left(
-X_{\mathbf r,t}+\gamma_E\overline X_{\mathbf r,t}
-\right)
-\right].
-}
-\]
-
-The direct product specifies the logical field. It does not require dense simultaneous
-allocation.
+| Field value | Latent |
+|---:|---:|
+| \(-1\) | \(-4\) |
+| \(-3/4\) | \(-3\) |
+| \(-1/2\) | \(-2\) |
+| \(-1/4\) | \(-1\) |
+| \(0\) | \(0\) |
+| \(1/3\) | \(1\) |
+| \(2/3\) | \(2\) |
+| \(1\) | \(3\) |
 
 ---
 
-## 5. Latent decoder
+## 6. Canonical Q3 decoder
 
-The dequantized coarse reconstruction is
-
-\[
-D_3(Z_{\mathbf r,t})=
-\operatorname{clip}\left(\frac{Z_{\mathbf r,t}}{3},-1,1\right).
-\]
-
-The decoder therefore produces
-
-\[
-X^{(0)}_{\mathbf r,t}=D_3(Z_{\mathbf r,t}).
-\]
-
-Persistent correction memory is then applied:
+The inverse codebook is
 
 \[
 \boxed{
-\widehat X_{\mathbf r,t}
+D_3(z)
 =
-\operatorname{clip}
-\left(
-X^{(0)}_{\mathbf r,t}+\Omega_{\mathbf r,t},
--1,
-1
-\right).
+\begin{cases}
+z/4,&z<0,\\
+z/3,&z\ge0.
+\end{cases}
 }
 \]
 
-The full decoder is
+Therefore
 
 \[
-\boxed{
-\widehat{\mathbf X}_t
-=
-\mathcal D^{(3D)}_{\Theta}
-\left(
-\mathbf Z_t,\mathbf\Omega_t
-\right).
-}
+D_{\mathbf r,t}=D_3(Z_{\mathbf r,t}).
 \]
+
+All eight codes decode to distinct points in \([-1,1]\).
 
 ---
 
-## 6. High-effort reasoning trajectory
+## 7. Swarm consensus
 
-Each instance may execute \(H\ge1\) bounded internal refinement substeps before commit. Let
-\(h\in\{0,\ldots,H-1\}\) index those substeps. The provisional state evolves by
-
-\[
-\boxed{
-R^{(h+1)}_{\mathbf r,t}
-=
-R^{(h)}_{\mathbf r,t}
-+
-\eta_R
-\left(
-X^{(0)}_{\mathbf r,t}-R^{(h)}_{\mathbf r,t}
-\right)
-+
-\kappa\Delta_3\Xi_{\mathbf r,t}
-+
-\mu M_{\mathbf r,t}
-+
-U_{\mathbf r,t}.
-}
-\]
-
-Here:
-
-- \(R^{(0)}_{\mathbf r,t}=\Xi_{\mathbf r,t}\);
-- \(\eta_R\in[0,1]\) is latent-to-state assimilation gain;
-- \(\kappa\ge0\) is geometric diffusion/coupling gain;
-- \(M_{\mathbf r,t}\) is a swarm consensus message;
-- \(U_{\mathbf r,t}\) is an external prompt, observation, or control injection.
-
-The high-effort candidate is
-
-\[
-P^{H}_{\mathbf r,t}=R^{(H)}_{\mathbf r,t}.
-\]
-
-Increasing \(H\) increases bounded trajectory length, not the logical dimensionality of the
-field.
-
----
-
-## 7. Swarm consensus over the billion-cell field
-
-Let \(w_{\mathbf r\mathbf q,t}\ge0\) be normalized neighbour weights satisfying
-
-\[
-\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}
-w_{\mathbf r\mathbf q,t}\le1.
-\]
-
-The consensus message is
+Let the normalized six-neighbour latent consensus be
 
 \[
 \boxed{
 M_{\mathbf r,t}
 =
+\frac{1}{|\mathcal N_6(\mathbf r)|}
 \sum_{\mathbf q\in\mathcal N_6(\mathbf r)}
-w_{\mathbf r\mathbf q,t}
-\left(
-Z_{\mathbf q,t}-Z_{\mathbf r,t}
-\right).
+\left(Z_{\mathbf q,t}-Z_{\mathbf r,t}\right).
 }
 \]
 
-This term bends independent local trajectories into a coherent 3D field while retaining local
-residuals and validity gates.
+This is a local disagreement vector. A positive consensus gain bends neighbouring latent
+trajectories toward coherence without erasing the local observation or residual.
 
 ---
 
-## 8. Residual and correction memory
+## 8. High-effort reasoning trajectory
 
-After the high-effort prediction, the pre-correction residual is
+Let \(H\ge1\) be the number of bounded internal refinement substeps. Initialize
 
 \[
-E^{(0)}_{\mathbf r,t}
-=
-X_{\mathbf r,t}-P^{H}_{\mathbf r,t}.
+R^{(0)}_{\mathbf r,t}=\Xi_{\mathbf r,t}.
 \]
 
-The bounded persistent memory recurrence is
+For \(h=0,\ldots,H-1\), compute
 
 \[
 \boxed{
-\Omega_{\mathbf r,t+1}
+R^{(h+1)}_{\mathbf r,t}
 =
-\operatorname{clip}
+\operatorname{clip}_{[-1,1]}
+\left[
+R^{(h)}_{\mathbf r,t}
++
+\eta_R\left(D_{\mathbf r,t}-R^{(h)}_{\mathbf r,t}\right)
++
+\kappa\Delta_3\Xi_{\mathbf r,t}
++
+\mu M_{\mathbf r,t}
++
+U_{\mathbf r,t}
+\right].
+}
+\]
+
+Where:
+
+- \(\eta_R\in[0,1]\): decoder-assimilation gain;
+- \(\kappa\ge0\): geometric coupling gain;
+- \(\mu\ge0\): latent consensus gain;
+- \(U_{\mathbf r,t}\in[-1,1]\): transient external control or prompt injection.
+
+The provisional high-effort prediction is
+
+\[
+\boxed{
+P^H_{\mathbf r,t}=R^{(H)}_{\mathbf r,t}.
+}
+\]
+
+Increasing \(H\) increases bounded trajectory length. It does not increase the logical lattice
+size or claim a change in model architecture.
+
+For frozen \(D\), \(\Delta_3\Xi\), \(M\), and \(U\), the map in its own recurrent argument is
+non-expansive under clipping and contractive when
+
+\[
+0<\eta_R\le1,
+\qquad
+|1-\eta_R|<1.
+\]
+
+This local statement does not by itself prove convergence of the full coupled cycle.
+
+---
+
+## 9. Residual and correction memory
+
+The pre-correction residual is
+
+\[
+\boxed{
+E^{(0)}_{\mathbf r,t}
+=
+X_{\mathbf r,t}-P^H_{\mathbf r,t}.
+}
+\]
+
+The candidate correction memory is
+
+\[
+\boxed{
+\widetilde\Omega_{\mathbf r,t+1}
+=
+\operatorname{clip}_{[-1,1]}
 \left(
 \rho\Omega_{\mathbf r,t}
 +
-\eta_{\Omega}E^{(0)}_{\mathbf r,t},
--1,
-1
+\eta_\Omega E^{(0)}_{\mathbf r,t}
 \right),
 }
 \]
 
-with \(0\le\rho\le1\) and \(\eta_{\Omega}\ge0\).
+with \(0\le\rho\le1\) and \(\eta_\Omega\ge0\).
 
-The corrected reconstruction candidate is
+The candidate reconstruction is
 
 \[
 \boxed{
 \widetilde X_{\mathbf r,t+1}
 =
-\operatorname{clip}
+\operatorname{clip}_{[-1,1]}
 \left(
-P^{H}_{\mathbf r,t}
+P^H_{\mathbf r,t}
 +
-\Omega_{\mathbf r,t+1},
--1,
-1
+\widetilde\Omega_{\mathbf r,t+1}
 \right).
 }
 \]
@@ -392,427 +446,498 @@ X_{\mathbf r,t}-\widetilde X_{\mathbf r,t+1}.
 
 ---
 
-## 9. Local and global validity operators
+## 10. Validity and transaction projection
 
-A local candidate is admissible when
+The local validity predicate is
 
 \[
 \boxed{
 \Lambda_{\mathbf r,t}
 =
-\mathbf 1\left[
+\mathbf1\left[
 \begin{array}{l}
-\widetilde X_{\mathbf r,t+1}\text{ is finite},\\
-|\widetilde X_{\mathbf r,t+1}|\le1,\\
-|E_{\mathbf r,t+1}|\le\tau_E,\\
+\widetilde X_{\mathbf r,t+1}\text{ and }E_{\mathbf r,t+1}\text{ are finite},\\
+\widetilde X_{\mathbf r,t+1}\in[-1,1],\\
 Z_{\mathbf r,t}\in\mathcal Q_3,\\
-\text{the cycle budget is not exceeded}
+|E_{\mathbf r,t+1}|\le\tau_E,\\
+|\mathcal C_t|\le N_{\max}
 \end{array}
 \right].
 }
 \]
 
-The transactional projection is
+The persistent reconstruction and correction memory cross the transaction boundary together:
 
 \[
 \boxed{
-\Pi_{\Lambda_{\mathbf r,t}}[Y;X]
+\Xi_{\mathbf r,t+1}
 =
 \begin{cases}
-Y,&\Lambda_{\mathbf r,t}=1,\\
-X,&\Lambda_{\mathbf r,t}=0.
+\widetilde X_{\mathbf r,t+1},&\Lambda_{\mathbf r,t}=1,\\
+\Xi_{\mathbf r,t},&\Lambda_{\mathbf r,t}=0,
 \end{cases}
 }
 \]
 
-Thus the committed local state is
-
 \[
 \boxed{
-\Xi_{\mathbf r,t+1}
-=
-\Pi_{\Lambda_{\mathbf r,t}}
-\left[
-\widetilde X_{\mathbf r,t+1};
-\Xi_{\mathbf r,t}
-\right].
-}
-\]
-
-A global transaction may require all active instances to pass:
-
-\[
-\Lambda_t^{\mathrm{global}}
-=
-\bigwedge_{\mathbf r\in\mathcal A_t}
-\Lambda_{\mathbf r,t}.
-\]
-
-Alternatively, independently versioned blocks may commit atomically under block-local validity.
-
----
-
-## 10. Fully operational local Dr Moagi equation
-
-Substituting encoder, decoder, reasoning, coupling, residual memory, and projection gives the
-local engine law:
-
-\[
-\boxed{
-\begin{aligned}
-Z_{\mathbf r,t}
-&=
-Q_3\left[
-\alpha_E
-\left(
-X_{\mathbf r,t}+\gamma_E\overline X_{\mathbf r,t}
-\right)
-\right],\\[4pt]
-R^{(0)}_{\mathbf r,t}
-&=\Xi_{\mathbf r,t},\\[4pt]
-R^{(h+1)}_{\mathbf r,t}
-&=
-R^{(h)}_{\mathbf r,t}
-+
-\eta_R
-\left(
-D_3(Z_{\mathbf r,t})-R^{(h)}_{\mathbf r,t}
-\right)
-+
-\kappa\Delta_3\Xi_{\mathbf r,t}
-+
-\mu M_{\mathbf r,t}
-+
-U_{\mathbf r,t},\\[4pt]
-E^{(0)}_{\mathbf r,t}
-&=X_{\mathbf r,t}-R^{(H)}_{\mathbf r,t},\\[4pt]
 \Omega_{\mathbf r,t+1}
-&=
-\operatorname{clip}
-\left(
-\rho\Omega_{\mathbf r,t}
-+
-\eta_{\Omega}E^{(0)}_{\mathbf r,t},
--1,
-1
-\right),\\[4pt]
-\widetilde X_{\mathbf r,t+1}
-&=
-\operatorname{clip}
-\left(
-R^{(H)}_{\mathbf r,t}
-+
-\Omega_{\mathbf r,t+1},
--1,
-1
-\right),\\[4pt]
-E_{\mathbf r,t+1}
-&=X_{\mathbf r,t}-\widetilde X_{\mathbf r,t+1},\\[4pt]
-\Xi_{\mathbf r,t+1}
-&=
-\Pi_{\Lambda_{\mathbf r,t}}
-\left[
-\widetilde X_{\mathbf r,t+1};
-\Xi_{\mathbf r,t}
-\right].
-\end{aligned}
+=
+\begin{cases}
+\widetilde\Omega_{\mathbf r,t+1},&\Lambda_{\mathbf r,t}=1,\\
+\Omega_{\mathbf r,t},&\Lambda_{\mathbf r,t}=0.
+\end{cases}
 }
 \]
 
+Rejected candidate diagnostics remain inspectable, but rejected correction memory cannot leak into
+the next committed cycle.
+
+Input normalization, support expansion, and budget validation occur before any mutation. Therefore,
+a budget or input exception leaves the complete prior state, cycle counter, and digests unchanged.
+
 ---
 
-## 11. Billion-instance master equation
+## 11. Sparse pruning
 
-Let \(\mathbb E_{3D}\), \(\mathbb R_H\), \(\mathbb D_{3D}\), \(\mathbb C_{\Omega}\), and
-\(\mathbb P_{\Lambda}\) denote the field-wide encoder, high-effort trajectory, decoder,
-correction, and transactional projection operators. Then
+When \(\varepsilon_P>0\), an unprotected valid coordinate may be removed from physical storage if
 
 \[
 \boxed{
-\mathbf\Xi_{t+1}
+\max
+\left(
+|X|,|\Omega|,|\Xi|,|E|
+\right)
+\le\varepsilon_P.
+}
+\]
+
+Coordinates explicitly supplied as observations or controls in the current cycle are protected
+from pruning. Invalid cells are retained for diagnosis.
+
+Pruning changes physical allocation only; the removed coordinate returns to the logical zero
+background.
+
+---
+
+## 12. Journal and checkpoint integrity
+
+Let \(C\) be the canonical JSON serialization of the validated configuration and
+\(\operatorname{Canon}(\Sigma_t)\) the scalar-address-ordered binary serialization of active
+states.
+
+The initial digest is
+
+\[
+J_0
 =
-\mathbb P_{\mathbf\Lambda_t}
-\left[
-\mathbb C_{\Omega}
+\operatorname{SHA256}
 \left(
-\mathbb R_H
+\texttt{domain}_{0}\parallel C
+\right).
+\]
+
+Each attempted cycle advances the journal chain:
+
+\[
+\boxed{
+J_{t+1}
+=
+\operatorname{SHA256}
 \left(
-\mathbb D_{3D}
+\texttt{domain}_{J}
+\parallel J_t
+\parallel C
+\parallel(t+1)
+\parallel\operatorname{Canon}(\Sigma_{t+1})
+\right).
+}
+\]
+
+The independent state digest binds configuration, cycle, journal head, and state:
+
+\[
+\boxed{
+S_t
+=
+\operatorname{SHA256}
 \left(
-\mathbb E_{3D}(\mathbf X_t)
-\right),
+\texttt{domain}_{S}
+\parallel C
+\parallel t
+\parallel J_t
+\parallel\operatorname{Canon}(\Sigma_t)
+\right).
+}
+\]
+
+A checkpoint stores:
+
+- schema version;
+- complete validated configuration;
+- cycle number;
+- journal digest;
+- state digest;
+- active cells in canonical address order.
+
+Restoration validates types, coordinate bounds, Q3 range, field bounds, duplicate coordinates,
+active-cell budget, and the state digest. This provides deterministic integrity checking, not
+cryptographic identity or authenticity; authenticity requires an external signature or trusted
+key.
+
+---
+
+## 13. Canonical master equation
+
+Define the support-restricted encoder
+
+\[
+\mathbf Z_t
+=
+Q_3\left[
+\mathcal E_{\Phi}^{(3D)}(\mathbf X_t)
+\right],
+\]
+
+the high-effort predictor
+
+\[
+\mathbf P^H_t
+=
+\mathcal R_{\Theta,H}
+\left(
 \mathbf\Xi_t,
+D_3(\mathbf Z_t),
 \Delta_3\mathbf\Xi_t,
 \mathbf M_t,
 \mathbf U_t
 \right),
-\mathbf X_t,
-\mathbf\Omega_t
-\right);
-\mathbf\Xi_t
-\right].
-}
 \]
 
-Expanded into the canonical Dr Moagi additive form:
+and the candidate correction
 
 \[
-\boxed{
-\mathbf\Xi_{t+1}
-=
-\Pi_{\mathbf\Lambda_t}
-\left[
-\mathbf\Xi_t
-+
-\mathbf P_{\Theta,H}
-\left(
-Q_3\left[
-\mathcal E_{\Phi}^{(3D)}(\mathbf X_t)
-\right]
-\right)
--
-\mathbf E_t
-+
-\mathbf\Omega_{t+1}
-+
-\kappa\Delta_3\mathbf\Xi_t
-+
-\mu\mathbf M_t
-+
-\mathbf U_t;
-\mathbf\Xi_t
-\right],
-}
-\]
-
-with
-
-\[
-\boxed{
-\mathbf\Omega_{t+1}
+\widetilde{\mathbf\Omega}_{t+1}
 =
 \operatorname{clip}
 \left(
 \rho\mathbf\Omega_t
 +
-\eta_{\Omega}\mathbf E^{(0)}_t,
--1,
-1
+\eta_\Omega(\mathbf X_t-\mathbf P^H_t),
+-1,1
 \right).
-}
 \]
 
-This is the complete 3D auto-encoding, high-effort latent evolution, decoding, residual
-correction, geometric coupling, swarm consensus, and commit equation for the logical
-billion-instance engine.
-
----
-
-## 12. Reconstruction objective
-
-For active coordinates, the normalized reconstruction loss is
+The fully operational Dr Moagi equation is
 
 \[
 \boxed{
-\mathcal L_{\mathrm{rec}}(t)
-=
-\frac{1}{|\mathcal A_t|}
-\sum_{\mathbf r\in\mathcal A_t}
-E_{\mathbf r,t}^2.
-}
-\]
-
-A coherence score in \((0,1]\) is
-
-\[
-\boxed{
-C_t=
-\frac{1}{1+
-\dfrac{1}{|\mathcal A_t|}
-\sum_{\mathbf r\in\mathcal A_t}|E_{\mathbf r,t}|}.
-}
-\]
-
-The activation ratio is
-
-\[
-\boxed{
-R_t^{\mathrm{active}}
-=
-\frac{|\mathcal A_t|}{10^9}.
-}
-\]
-
-These metrics distinguish a billion-address virtual field from the number of physically
-materialized instances.
-
----
-
-## 13. Fixed point
-
-A committed fixed point \((\mathbf\Xi^*,\mathbf\Omega^*)\) satisfies
-
-\[
-\boxed{
-\mathbf\Xi^*
-=
-\Pi_{\mathbf\Lambda^*}
-\left[
-\mathcal T_H
-\left(
-\mathbf\Xi^*,
-\mathbf X^*,
-\mathbf\Omega^*,
-\Delta_3\mathbf\Xi^*,
-\mathbf U^*
-\right);
-\mathbf\Xi^*
-\right]
-}
-\]
-
-and
-
-\[
-\boxed{
-\mathbf\Omega^*
-=
+\begin{aligned}
+\widetilde{\mathbf X}_{t+1}
+&=
 \operatorname{clip}
 \left(
-\rho\mathbf\Omega^*
+\mathbf P^H_t
 +
-\eta_{\Omega}
-\left(
-\mathbf X^*-\mathbf\Xi^*
-\right),
--1,
-1
-\right).
-}
-\]
-
-Uniqueness and convergence require an independently established contraction or Lyapunov
-condition for the chosen gains and active topology. They are not assumed automatically.
-
----
-
-## 14. Deterministic execution order
-
-One synchronous cycle executes in this exact order:
-
-```text
-1. SNAPSHOT       Freeze the committed sparse field Xi_t.
-2. ACQUIRE        Validate and clip injected observations X_t.
-3. NEIGHBOURS     Resolve six-neighbour values from the snapshot.
-4. ENCODE_3D      Compute local context activation and Q3 latent Z_t.
-5. CONSENSUS      Compute neighbour latent message M_t.
-6. REASON_H       Execute H bounded provisional reasoning substeps.
-7. RESIDUAL_0     Compute pre-correction residual E^(0)_t.
-8. OMEGA_UPDATE   Update bounded persistent correction memory.
-9. DECODE         Form corrected reconstruction candidate X_tilde.
-10. VERIFY        Evaluate local or block validity Lambda_t.
-11. COMMIT        Commit valid candidates; roll back invalid candidates.
-12. METRICS       Compute residual, coherence and active-ratio metrics.
-13. JOURNAL       Hash or record the versioned transition.
-```
-
-All reads during a cycle come from the frozen snapshot. All writes are staged until the commit
-phase. This prevents update-order dependence.
-
----
-
-## 15. Sparse execution contract
-
-The logical equation ranges over all \(10^9\) coordinates, but bounded software must obey:
-
-1. only active coordinates are materialized;
-2. inactive coordinates have deterministic background state zero;
-3. neighbour reads are pure and snapshot-based;
-4. every coordinate is range-checked;
-5. every latent is clamped to \(\mathcal Q_3\);
-6. every persistent value is bounded;
-7. invalid candidates roll back;
-8. execution has explicit cycle and active-cell budgets;
-9. deterministic input and configuration produce deterministic output;
-10. performance claims require measured hardware and workload evidence.
-
-A dense implementation is permitted only when memory and compute budgets are explicitly
-provisioned. At 32 bytes per instance, dense state alone would require approximately 32 GB,
-excluding indexes, temporary buffers, journals, model parameters, and runtime overhead.
-
----
-
-## 16. Reference parameterization
-
-The accompanying Python reference uses the bounded defaults
-
-\[
-\begin{aligned}
-\alpha_E &= 1.0,\\
-\gamma_E &= 0.25,\\
-\eta_R &= 0.50,\\
-\kappa &= 0.08,\\
-\mu &= 0.00,\\
-\rho &= 7/8,\\
-\eta_{\Omega} &= 1/16,\\
-H &= 3,\\
-\tau_E &= 1.50.
-\end{aligned}
-\]
-
-These are reproducible reference values, not claims of optimality.
-
----
-
-## 17. Canonical compact form
-
-\[
-\boxed{
-\begin{aligned}
-\mathbf Z_t
-&=Q_3\!\left(\mathcal E^{(3D)}_{\Phi}(\mathbf X_t)\right),\\
-\mathbf R_t^{H}
-&=\mathcal R_{\Theta}^{H}
-\!\left(
-\mathbf\Xi_t,
-\mathcal D^{(3D)}_{\Theta}(\mathbf Z_t),
-\Delta_3\mathbf\Xi_t,
-\mathbf M_t,
-\mathbf U_t
-\right),\\
-\mathbf E_t^{(0)}
-&=\mathbf X_t-\mathbf R_t^{H},\\
-\mathbf\Omega_{t+1}
-&=\operatorname{clip}
-\!\left(
-\rho\mathbf\Omega_t+\eta_{\Omega}\mathbf E_t^{(0)},
+\widetilde{\mathbf\Omega}_{t+1},
 -1,1
-\right),\\
-\widetilde{\mathbf X}_{t+1}
-&=\operatorname{clip}
-\!\left(
-\mathbf R_t^{H}+\mathbf\Omega_{t+1},
--1,1
-\right),\\
+\right),\\[3pt]
 \mathbf E_{t+1}
-&=\mathbf X_t-\widetilde{\mathbf X}_{t+1},\\
-\mathbf\Xi_{t+1}
-&=\Pi_{\mathbf\Lambda_t}
-\!\left[
-\widetilde{\mathbf X}_{t+1};
-\mathbf\Xi_t
+&=
+\mathbf X_t-
+\widetilde{\mathbf X}_{t+1},\\[3pt]
+(\mathbf\Xi_{t+1},\mathbf\Omega_{t+1})
+&=
+\Pi_{\mathbf\Lambda_t}
+\left[
+(\widetilde{\mathbf X}_{t+1},\widetilde{\mathbf\Omega}_{t+1});
+(\mathbf\Xi_t,\mathbf\Omega_t)
 \right].
 \end{aligned}
 }
 \]
 
-**Operational identity:**
+Expanded into one transition:
+
+\[
+\boxed{
+\begin{aligned}
+(\mathbf\Xi_{t+1},\mathbf\Omega_{t+1})
+=
+\Pi_{\mathbf\Lambda_t}
+\Bigg[
+&\operatorname{clip}
+\Big(
+\mathcal R_{\Theta,H}
+\big(
+\mathbf\Xi_t,
+D_3(Q_3[\mathcal E_{\Phi}^{(3D)}(\mathbf X_t)]),
+\Delta_3\mathbf\Xi_t,
+\mathbf M_t,
+\mathbf U_t
+\big)\\
+&\quad+
+\operatorname{clip}
+\big(
+\rho\mathbf\Omega_t
++
+\eta_\Omega
+[\mathbf X_t-
+\mathcal R_{\Theta,H}(\cdot)],
+-1,1
+\big),
+-1,1
+\Big),\\
+&\operatorname{clip}
+\big(
+\rho\mathbf\Omega_t
++
+\eta_\Omega
+[\mathbf X_t-
+\mathcal R_{\Theta,H}(\cdot)],
+-1,1
+\big);\\
+&(\mathbf\Xi_t,\mathbf\Omega_t)
+\Bigg].
+\end{aligned}
+}
+\]
+
+The operational sequence is
+
+\[
+\boxed{
+\text{Snapshot}
+\rightarrow
+\text{Support closure}
+\rightarrow
+\text{Encode}_{3D}
+\rightarrow
+Q_3
+\rightarrow
+\text{Reason}_{H}
+\rightarrow
+\text{Couple/Control}
+\rightarrow
+\text{Residual}
+\rightarrow
+\widetilde\Omega
+\rightarrow
+\text{Decode}
+\rightarrow
+\Lambda
+\rightarrow
+\text{Commit/Rollback}
+\rightarrow
+\text{Prune}
+\rightarrow
+\text{Journal}.
+}
+\]
+
+---
+
+## 14. Deterministic algorithm
 
 ```text
-Observe -> Encode 3D -> Quantize Q3 -> Reason H -> Couple -> Compare
--> Update Omega -> Decode -> Verify Lambda -> Commit/Rollback -> Journal
+INPUT:
+    prior sparse state Σt
+    new persistent observations Xt_new
+    transient controls Ut
+    validated configuration C
+
+1. Normalize and validate Xt_new and Ut.
+2. Freeze prior state as snapshot.
+3. Form support seeds from snapshot, observations, and controls.
+4. Expand the support by halo_depth six-neighbour rings.
+5. Reject atomically if the support exceeds max_active_cells.
+6. Read all observations from the frozen snapshot plus current inputs.
+7. Encode every support coordinate with neighbour context.
+8. Quantize with canonical piecewise Q3.
+9. Decode Q3 with the distinct eight-level inverse codebook.
+10. Compute frozen Laplacian and latent-consensus terms.
+11. Execute H clipped reasoning substeps with transient controls.
+12. Compute residual and candidate Ω correction.
+13. Decode the corrected reconstruction candidate.
+14. Evaluate Λ for every coordinate.
+15. Commit both Ξ and Ω when valid; roll both back when invalid.
+16. Retain candidate diagnostics.
+17. Prune eligible quiescent support cells.
+18. Canonically sort by scalar address.
+19. Advance journal and state digests.
+20. Atomically replace the prior sparse state.
 ```
 
-**Capability boundary:** this specification and its sparse Python reference implement the
-mathematical state-transition semantics. They do not instantiate one billion dense neural
-models or claim equivalence to any proprietary model architecture.
+All reads in one cycle come from a frozen snapshot. All writes are staged. Dictionary insertion
+order therefore cannot change the numerical result or digest.
+
+---
+
+## 15. Complexity and memory
+
+Let \(A_t=|\mathcal C_t|\) and let \(H\) be the reasoning-step count.
+
+Time complexity per cycle is
+
+\[
+\boxed{
+T_t=O(A_tH+A_t\log A_t),
+}
+\]
+
+where sorting supplies canonical deterministic order. Six-neighbour operations are constant-time
+per active cell.
+
+Sparse state memory is
+
+\[
+\boxed{
+M_t=O(A_t).
+}
+\]
+
+A hypothetical dense representation using \(b\) bytes per cell requires
+
+\[
+M_{\mathrm{dense}}=10^9b.
+\]
+
+At 32 bytes per cell this is 32,000,000,000 bytes before indexes, parameters, temporary buffers,
+and journal data.
+
+---
+
+## 16. Runtime contract
+
+The reference implementation is:
+
+- `src/jarvisx/dr_moagi_billion_field.py`
+
+The invariant suite is:
+
+- `tests/test_dr_moagi_billion_field.py`
+
+The runtime guarantees:
+
+1. exact address/inverse-address mapping;
+2. no dense billion-cell allocation;
+3. canonical signed-Q3 range and eight distinct decoded levels;
+4. synchronous snapshot semantics;
+5. deterministic canonical ordering and hashes;
+6. bounded support expansion;
+7. pre-mutation active-cell budget enforcement;
+8. finite numeric input and configuration validation;
+9. atomic rollback of both committed reconstruction and correction memory;
+10. transient controls separated from persistent observations;
+11. optional sparse pruning;
+12. checkpoint round-trip validation and integrity detection.
+
+---
+
+## 17. Minimal execution example
+
+```python
+from jarvisx.dr_moagi_billion_field import BillionFieldConfig, SparseBillionField
+
+config = BillionFieldConfig(
+    reasoning_steps=5,
+    halo_depth=1,
+    max_active_cells=10_000,
+    prune_epsilon=1.0e-12,
+)
+field = SparseBillionField(config)
+
+metrics = field.run(
+    cycles=4,
+    observations={
+        (500, 500, 500): 1.0,
+        (501, 500, 500): 0.5,
+        (500, 501, 500): -0.25,
+    },
+    controls={(500, 500, 500): -0.02},
+)
+
+checkpoint = field.checkpoint()
+restored = SparseBillionField.from_checkpoint(checkpoint)
+
+assert restored.metrics() == metrics
+assert restored.virtual_cell_count == 1_000_000_000
+assert restored.active_cell_count <= config.max_active_cells
+```
+
+---
+
+## 18. Fixed-point condition
+
+A committed fixed point \((\mathbf\Xi^*,\mathbf\Omega^*)\) satisfies
+
+\[
+\boxed{
+(\mathbf\Xi^*,\mathbf\Omega^*)
+=
+\Pi_{\mathbf\Lambda^*}
+\left[
+\mathcal T
+(\mathbf X^*,\mathbf\Xi^*,\mathbf\Omega^*,\mathbf U^*);
+(\mathbf\Xi^*,\mathbf\Omega^*)
+\right],
+}
+\]
+
+where \(\mathcal T\) is the complete support-restricted encode, reason, correct, and decode
+operator.
+
+If the committed operator is contractive on a complete admissible state space,
+
+\[
+\|\mathcal T(A)-\mathcal T(B)\|\le q\|A-B\|,
+\qquad 0\le q<1,
+\]
+
+then a unique fixed point exists and
+
+\[
+\|\Sigma_t-\Sigma^*\|\le q^t\|\Sigma_0-\Sigma^*\|.
+\]
+
+This conclusion is conditional. The implementation does not claim global contraction for arbitrary
+gains, observations, support changes, clipping events, or validity gates.
+
+---
+
+## 19. Canonical conclusion
+
+The system is not “one billion dense agents.” It is one deterministic state-transition law over a
+billion-address virtual geometry, executed on a bounded sparse support:
+
+\[
+\boxed{
+\text{Virtual extent}=10^9
+\quad\land\quad
+\text{Physical work}=O(|\mathcal C_t|H).
+}
+\]
+
+Its irreducible law is:
+
+\[
+\boxed{
+\text{Encode reality}
+\rightarrow
+\text{quantize geometry}
+\rightarrow
+\text{traverse a bounded reasoning path}
+\rightarrow
+\text{measure residual}
+\rightarrow
+\text{update correction memory}
+\rightarrow
+\text{validate}
+\rightarrow
+\text{commit or roll back}
+\rightarrow
+\text{seal the transition}.
+}
+\]
+
+**Status:** operational sparse reference specification, version 2.0.

--- a/docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md
+++ b/docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md
@@ -1,0 +1,818 @@
+# Dr Moagi 3D Billion-Instance Auto-Encoding/Decoding Equation
+
+## Status
+
+Operational mathematical specification and bounded sparse reference contract for a virtual
+`1000 x 1000 x 1000` field of interacting auto-encoding and decoding instances.
+
+This document extends, without replacing:
+
+- `Dr_Moagi_Equation_3D_Autoencoder_v4.txt`;
+- `DR_MOAGI_3D_SWARM_BYTECODE_PERMEATED_MATHEMATICS.md`;
+- the repository rule that virtual extent must not be confused with physical allocation.
+
+The logical field contains exactly
+
+\[
+N=1000^3=1,000,000,000
+\]
+
+addressable instances. The reference implementation is sparse: it materializes only active
+coordinates and treats all unmaterialized coordinates as a deterministic zero background.
+
+---
+
+## 1. Volumetric address space
+
+Let
+
+\[
+\mathcal L_{1000}=\{0,1,\ldots,999\}^3.
+\]
+
+For a coordinate
+
+\[
+\mathbf r=(x,y,z)\in\mathcal L_{1000},
+\]
+
+its canonical row-major scalar address is
+
+\[
+\boxed{
+ a(\mathbf r)=x+1000\left(y+1000z\right)
+}
+\]
+
+with
+
+\[
+0\le a(\mathbf r)<10^9.
+\]
+
+The inverse address map is
+
+\[
+\begin{aligned}
+x &= a\bmod 1000,\\
+y &= \left\lfloor a/1000\right\rfloor\bmod1000,\\
+z &= \left\lfloor a/10^6\right\rfloor.
+\end{aligned}
+\]
+
+For bounded execution, the lattice may be partitioned into cubic tiles of side `B`. With
+`B=32`, the padded block grid is
+
+\[
+\left\lceil\frac{1000}{32}\right\rceil^3=32^3=32768
+\]
+
+blocks. A block is allocated only when at least one of its coordinates is active.
+
+---
+
+## 2. Per-instance state
+
+Every logical instance at coordinate \(\mathbf r\) has the state
+
+\[
+\boxed{
+\sigma_{\mathbf r,t}
+=
+\left(
+X_{\mathbf r,t},
+Z_{\mathbf r,t},
+\widehat X_{\mathbf r,t},
+E_{\mathbf r,t},
+\Omega_{\mathbf r,t},
+\Xi_{\mathbf r,t},
+\Lambda_{\mathbf r,t}
+\right)
+}
+\]
+
+where:
+
+- \(X_{\mathbf r,t}\in[-1,1]\): observed or injected scalar field value;
+- \(Z_{\mathbf r,t}\in\mathcal Q_3=\{-4,-3,-2,-1,0,1,2,3\}\): signed 3-bit latent;
+- \(\widehat X_{\mathbf r,t}\in[-1,1]\): decoded candidate reconstruction;
+- \(E_{\mathbf r,t}=X_{\mathbf r,t}-\widehat X_{\mathbf r,t}\): reconstruction residual;
+- \(\Omega_{\mathbf r,t}\in[-1,1]\): bounded persistent correction memory;
+- \(\Xi_{\mathbf r,t}\in[-1,1]\): last committed field state;
+- \(\Lambda_{\mathbf r,t}\in\{0,1\}\): local validity predicate.
+
+The global field is
+
+\[
+\boxed{
+\Sigma_t=\{\sigma_{\mathbf r,t}:\mathbf r\in\mathcal L_{1000}\}.
+}
+\]
+
+A sparse implementation stores only
+
+\[
+\mathcal A_t=\{\mathbf r:\sigma_{\mathbf r,t}\neq\mathbf 0\},
+\]
+
+while preserving the full logical address space.
+
+---
+
+## 3. Six-neighbour 3D geometry
+
+For a coordinate \(\mathbf r=(x,y,z)\), define the orthogonal neighbourhood
+
+\[
+\mathcal N_6(\mathbf r)=
+\{(x\pm1,y,z),(x,y\pm1,z),(x,y,z\pm1)\}
+\cap\mathcal L_{1000}.
+\]
+
+The discrete volumetric Laplacian is
+
+\[
+\boxed{
+\Delta_3\Xi_{\mathbf r,t}
+=
+\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}
+\left(\Xi_{\mathbf q,t}-\Xi_{\mathbf r,t}\right).
+}
+\]
+
+The neighbour mean used by the encoder is
+
+\[
+\overline X_{\mathbf r,t}
+=
+\begin{cases}
+\dfrac{1}{|\mathcal N_6(\mathbf r)|}
+\displaystyle\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}X_{\mathbf q,t},
+&|\mathcal N_6(\mathbf r)|>0,\\
+0,&\text{otherwise}.
+\end{cases}
+\]
+
+Unmaterialized sparse neighbours contribute the defined background value zero.
+
+---
+
+## 4. Local 3D encoder
+
+The pre-quantized activation is
+
+\[
+A_{\mathbf r,t}
+=
+\alpha_E
+\left(
+X_{\mathbf r,t}
++\gamma_E\overline X_{\mathbf r,t}
+\right),
+\]
+
+where \(\alpha_E>0\) is encoder gain and \(\gamma_E\ge0\) is spatial context gain.
+
+The canonical signed 3-bit quantizer is
+
+\[
+\boxed{
+Q_3(u)=
+\operatorname{clip}
+\left(
+\operatorname{round}(3u),
+-4,
+3
+\right).
+}
+\]
+
+The encoded latent is
+
+\[
+\boxed{
+Z_{\mathbf r,t}=Q_3(A_{\mathbf r,t}).
+}
+\]
+
+The entire billion-instance encoder is the direct product operator
+
+\[
+\boxed{
+\mathbf Z_t
+=
+\mathcal E^{(3D)}_{\Phi}(\mathbf X_t)
+=
+\bigotimes_{\mathbf r\in\mathcal L_{1000}}
+Q_3\left[
+\alpha_E
+\left(
+X_{\mathbf r,t}+\gamma_E\overline X_{\mathbf r,t}
+\right)
+\right].
+}
+\]
+
+The direct product specifies the logical field. It does not require dense simultaneous
+allocation.
+
+---
+
+## 5. Latent decoder
+
+The dequantized coarse reconstruction is
+
+\[
+D_3(Z_{\mathbf r,t})=
+\operatorname{clip}\left(\frac{Z_{\mathbf r,t}}{3},-1,1\right).
+\]
+
+The decoder therefore produces
+
+\[
+X^{(0)}_{\mathbf r,t}=D_3(Z_{\mathbf r,t}).
+\]
+
+Persistent correction memory is then applied:
+
+\[
+\boxed{
+\widehat X_{\mathbf r,t}
+=
+\operatorname{clip}
+\left(
+X^{(0)}_{\mathbf r,t}+\Omega_{\mathbf r,t},
+-1,
+1
+\right).
+}
+\]
+
+The full decoder is
+
+\[
+\boxed{
+\widehat{\mathbf X}_t
+=
+\mathcal D^{(3D)}_{\Theta}
+\left(
+\mathbf Z_t,\mathbf\Omega_t
+\right).
+}
+\]
+
+---
+
+## 6. High-effort reasoning trajectory
+
+Each instance may execute \(H\ge1\) bounded internal refinement substeps before commit. Let
+\(h\in\{0,\ldots,H-1\}\) index those substeps. The provisional state evolves by
+
+\[
+\boxed{
+R^{(h+1)}_{\mathbf r,t}
+=
+R^{(h)}_{\mathbf r,t}
++
+\eta_R
+\left(
+X^{(0)}_{\mathbf r,t}-R^{(h)}_{\mathbf r,t}
+\right)
++
+\kappa\Delta_3\Xi_{\mathbf r,t}
++
+\mu M_{\mathbf r,t}
++
+U_{\mathbf r,t}.
+}
+\]
+
+Here:
+
+- \(R^{(0)}_{\mathbf r,t}=\Xi_{\mathbf r,t}\);
+- \(\eta_R\in[0,1]\) is latent-to-state assimilation gain;
+- \(\kappa\ge0\) is geometric diffusion/coupling gain;
+- \(M_{\mathbf r,t}\) is a swarm consensus message;
+- \(U_{\mathbf r,t}\) is an external prompt, observation, or control injection.
+
+The high-effort candidate is
+
+\[
+P^{H}_{\mathbf r,t}=R^{(H)}_{\mathbf r,t}.
+\]
+
+Increasing \(H\) increases bounded trajectory length, not the logical dimensionality of the
+field.
+
+---
+
+## 7. Swarm consensus over the billion-cell field
+
+Let \(w_{\mathbf r\mathbf q,t}\ge0\) be normalized neighbour weights satisfying
+
+\[
+\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}
+w_{\mathbf r\mathbf q,t}\le1.
+\]
+
+The consensus message is
+
+\[
+\boxed{
+M_{\mathbf r,t}
+=
+\sum_{\mathbf q\in\mathcal N_6(\mathbf r)}
+w_{\mathbf r\mathbf q,t}
+\left(
+Z_{\mathbf q,t}-Z_{\mathbf r,t}
+\right).
+}
+\]
+
+This term bends independent local trajectories into a coherent 3D field while retaining local
+residuals and validity gates.
+
+---
+
+## 8. Residual and correction memory
+
+After the high-effort prediction, the pre-correction residual is
+
+\[
+E^{(0)}_{\mathbf r,t}
+=
+X_{\mathbf r,t}-P^{H}_{\mathbf r,t}.
+\]
+
+The bounded persistent memory recurrence is
+
+\[
+\boxed{
+\Omega_{\mathbf r,t+1}
+=
+\operatorname{clip}
+\left(
+\rho\Omega_{\mathbf r,t}
++
+\eta_{\Omega}E^{(0)}_{\mathbf r,t},
+-1,
+1
+\right),
+}
+\]
+
+with \(0\le\rho\le1\) and \(\eta_{\Omega}\ge0\).
+
+The corrected reconstruction candidate is
+
+\[
+\boxed{
+\widetilde X_{\mathbf r,t+1}
+=
+\operatorname{clip}
+\left(
+P^{H}_{\mathbf r,t}
++
+\Omega_{\mathbf r,t+1},
+-1,
+1
+\right).
+}
+\]
+
+The post-correction residual is
+
+\[
+\boxed{
+E_{\mathbf r,t+1}
+=
+X_{\mathbf r,t}-\widetilde X_{\mathbf r,t+1}.
+}
+\]
+
+---
+
+## 9. Local and global validity operators
+
+A local candidate is admissible when
+
+\[
+\boxed{
+\Lambda_{\mathbf r,t}
+=
+\mathbf 1\left[
+\begin{array}{l}
+\widetilde X_{\mathbf r,t+1}\text{ is finite},\\
+|\widetilde X_{\mathbf r,t+1}|\le1,\\
+|E_{\mathbf r,t+1}|\le\tau_E,\\
+Z_{\mathbf r,t}\in\mathcal Q_3,\\
+\text{the cycle budget is not exceeded}
+\end{array}
+\right].
+}
+\]
+
+The transactional projection is
+
+\[
+\boxed{
+\Pi_{\Lambda_{\mathbf r,t}}[Y;X]
+=
+\begin{cases}
+Y,&\Lambda_{\mathbf r,t}=1,\\
+X,&\Lambda_{\mathbf r,t}=0.
+\end{cases}
+}
+\]
+
+Thus the committed local state is
+
+\[
+\boxed{
+\Xi_{\mathbf r,t+1}
+=
+\Pi_{\Lambda_{\mathbf r,t}}
+\left[
+\widetilde X_{\mathbf r,t+1};
+\Xi_{\mathbf r,t}
+\right].
+}
+\]
+
+A global transaction may require all active instances to pass:
+
+\[
+\Lambda_t^{\mathrm{global}}
+=
+\bigwedge_{\mathbf r\in\mathcal A_t}
+\Lambda_{\mathbf r,t}.
+\]
+
+Alternatively, independently versioned blocks may commit atomically under block-local validity.
+
+---
+
+## 10. Fully operational local Dr Moagi equation
+
+Substituting encoder, decoder, reasoning, coupling, residual memory, and projection gives the
+local engine law:
+
+\[
+\boxed{
+\begin{aligned}
+Z_{\mathbf r,t}
+&=
+Q_3\left[
+\alpha_E
+\left(
+X_{\mathbf r,t}+\gamma_E\overline X_{\mathbf r,t}
+\right)
+\right],\\[4pt]
+R^{(0)}_{\mathbf r,t}
+&=\Xi_{\mathbf r,t},\\[4pt]
+R^{(h+1)}_{\mathbf r,t}
+&=
+R^{(h)}_{\mathbf r,t}
++
+\eta_R
+\left(
+D_3(Z_{\mathbf r,t})-R^{(h)}_{\mathbf r,t}
+\right)
++
+\kappa\Delta_3\Xi_{\mathbf r,t}
++
+\mu M_{\mathbf r,t}
++
+U_{\mathbf r,t},\\[4pt]
+E^{(0)}_{\mathbf r,t}
+&=X_{\mathbf r,t}-R^{(H)}_{\mathbf r,t},\\[4pt]
+\Omega_{\mathbf r,t+1}
+&=
+\operatorname{clip}
+\left(
+\rho\Omega_{\mathbf r,t}
++
+\eta_{\Omega}E^{(0)}_{\mathbf r,t},
+-1,
+1
+\right),\\[4pt]
+\widetilde X_{\mathbf r,t+1}
+&=
+\operatorname{clip}
+\left(
+R^{(H)}_{\mathbf r,t}
++
+\Omega_{\mathbf r,t+1},
+-1,
+1
+\right),\\[4pt]
+E_{\mathbf r,t+1}
+&=X_{\mathbf r,t}-\widetilde X_{\mathbf r,t+1},\\[4pt]
+\Xi_{\mathbf r,t+1}
+&=
+\Pi_{\Lambda_{\mathbf r,t}}
+\left[
+\widetilde X_{\mathbf r,t+1};
+\Xi_{\mathbf r,t}
+\right].
+\end{aligned}
+}
+\]
+
+---
+
+## 11. Billion-instance master equation
+
+Let \(\mathbb E_{3D}\), \(\mathbb R_H\), \(\mathbb D_{3D}\), \(\mathbb C_{\Omega}\), and
+\(\mathbb P_{\Lambda}\) denote the field-wide encoder, high-effort trajectory, decoder,
+correction, and transactional projection operators. Then
+
+\[
+\boxed{
+\mathbf\Xi_{t+1}
+=
+\mathbb P_{\mathbf\Lambda_t}
+\left[
+\mathbb C_{\Omega}
+\left(
+\mathbb R_H
+\left(
+\mathbb D_{3D}
+\left(
+\mathbb E_{3D}(\mathbf X_t)
+\right),
+\mathbf\Xi_t,
+\Delta_3\mathbf\Xi_t,
+\mathbf M_t,
+\mathbf U_t
+\right),
+\mathbf X_t,
+\mathbf\Omega_t
+\right);
+\mathbf\Xi_t
+\right].
+}
+\]
+
+Expanded into the canonical Dr Moagi additive form:
+
+\[
+\boxed{
+\mathbf\Xi_{t+1}
+=
+\Pi_{\mathbf\Lambda_t}
+\left[
+\mathbf\Xi_t
++
+\mathbf P_{\Theta,H}
+\left(
+Q_3\left[
+\mathcal E_{\Phi}^{(3D)}(\mathbf X_t)
+\right]
+\right)
+-
+\mathbf E_t
++
+\mathbf\Omega_{t+1}
++
+\kappa\Delta_3\mathbf\Xi_t
++
+\mu\mathbf M_t
++
+\mathbf U_t;
+\mathbf\Xi_t
+\right],
+}
+\]
+
+with
+
+\[
+\boxed{
+\mathbf\Omega_{t+1}
+=
+\operatorname{clip}
+\left(
+\rho\mathbf\Omega_t
++
+\eta_{\Omega}\mathbf E^{(0)}_t,
+-1,
+1
+\right).
+}
+\]
+
+This is the complete 3D auto-encoding, high-effort latent evolution, decoding, residual
+correction, geometric coupling, swarm consensus, and commit equation for the logical
+billion-instance engine.
+
+---
+
+## 12. Reconstruction objective
+
+For active coordinates, the normalized reconstruction loss is
+
+\[
+\boxed{
+\mathcal L_{\mathrm{rec}}(t)
+=
+\frac{1}{|\mathcal A_t|}
+\sum_{\mathbf r\in\mathcal A_t}
+E_{\mathbf r,t}^2.
+}
+\]
+
+A coherence score in \((0,1]\) is
+
+\[
+\boxed{
+C_t=
+\frac{1}{1+
+\dfrac{1}{|\mathcal A_t|}
+\sum_{\mathbf r\in\mathcal A_t}|E_{\mathbf r,t}|}.
+}
+\]
+
+The activation ratio is
+
+\[
+\boxed{
+R_t^{\mathrm{active}}
+=
+\frac{|\mathcal A_t|}{10^9}.
+}
+\]
+
+These metrics distinguish a billion-address virtual field from the number of physically
+materialized instances.
+
+---
+
+## 13. Fixed point
+
+A committed fixed point \((\mathbf\Xi^*,\mathbf\Omega^*)\) satisfies
+
+\[
+\boxed{
+\mathbf\Xi^*
+=
+\Pi_{\mathbf\Lambda^*}
+\left[
+\mathcal T_H
+\left(
+\mathbf\Xi^*,
+\mathbf X^*,
+\mathbf\Omega^*,
+\Delta_3\mathbf\Xi^*,
+\mathbf U^*
+\right);
+\mathbf\Xi^*
+\right]
+}
+\]
+
+and
+
+\[
+\boxed{
+\mathbf\Omega^*
+=
+\operatorname{clip}
+\left(
+\rho\mathbf\Omega^*
++
+\eta_{\Omega}
+\left(
+\mathbf X^*-\mathbf\Xi^*
+\right),
+-1,
+1
+\right).
+}
+\]
+
+Uniqueness and convergence require an independently established contraction or Lyapunov
+condition for the chosen gains and active topology. They are not assumed automatically.
+
+---
+
+## 14. Deterministic execution order
+
+One synchronous cycle executes in this exact order:
+
+```text
+1. SNAPSHOT       Freeze the committed sparse field Xi_t.
+2. ACQUIRE        Validate and clip injected observations X_t.
+3. NEIGHBOURS     Resolve six-neighbour values from the snapshot.
+4. ENCODE_3D      Compute local context activation and Q3 latent Z_t.
+5. CONSENSUS      Compute neighbour latent message M_t.
+6. REASON_H       Execute H bounded provisional reasoning substeps.
+7. RESIDUAL_0     Compute pre-correction residual E^(0)_t.
+8. OMEGA_UPDATE   Update bounded persistent correction memory.
+9. DECODE         Form corrected reconstruction candidate X_tilde.
+10. VERIFY        Evaluate local or block validity Lambda_t.
+11. COMMIT        Commit valid candidates; roll back invalid candidates.
+12. METRICS       Compute residual, coherence and active-ratio metrics.
+13. JOURNAL       Hash or record the versioned transition.
+```
+
+All reads during a cycle come from the frozen snapshot. All writes are staged until the commit
+phase. This prevents update-order dependence.
+
+---
+
+## 15. Sparse execution contract
+
+The logical equation ranges over all \(10^9\) coordinates, but bounded software must obey:
+
+1. only active coordinates are materialized;
+2. inactive coordinates have deterministic background state zero;
+3. neighbour reads are pure and snapshot-based;
+4. every coordinate is range-checked;
+5. every latent is clamped to \(\mathcal Q_3\);
+6. every persistent value is bounded;
+7. invalid candidates roll back;
+8. execution has explicit cycle and active-cell budgets;
+9. deterministic input and configuration produce deterministic output;
+10. performance claims require measured hardware and workload evidence.
+
+A dense implementation is permitted only when memory and compute budgets are explicitly
+provisioned. At 32 bytes per instance, dense state alone would require approximately 32 GB,
+excluding indexes, temporary buffers, journals, model parameters, and runtime overhead.
+
+---
+
+## 16. Reference parameterization
+
+The accompanying Python reference uses the bounded defaults
+
+\[
+\begin{aligned}
+\alpha_E &= 1.0,\\
+\gamma_E &= 0.25,\\
+\eta_R &= 0.50,\\
+\kappa &= 0.08,\\
+\mu &= 0.00,\\
+\rho &= 7/8,\\
+\eta_{\Omega} &= 1/16,\\
+H &= 3,\\
+\tau_E &= 1.50.
+\end{aligned}
+\]
+
+These are reproducible reference values, not claims of optimality.
+
+---
+
+## 17. Canonical compact form
+
+\[
+\boxed{
+\begin{aligned}
+\mathbf Z_t
+&=Q_3\!\left(\mathcal E^{(3D)}_{\Phi}(\mathbf X_t)\right),\\
+\mathbf R_t^{H}
+&=\mathcal R_{\Theta}^{H}
+\!\left(
+\mathbf\Xi_t,
+\mathcal D^{(3D)}_{\Theta}(\mathbf Z_t),
+\Delta_3\mathbf\Xi_t,
+\mathbf M_t,
+\mathbf U_t
+\right),\\
+\mathbf E_t^{(0)}
+&=\mathbf X_t-\mathbf R_t^{H},\\
+\mathbf\Omega_{t+1}
+&=\operatorname{clip}
+\!\left(
+\rho\mathbf\Omega_t+\eta_{\Omega}\mathbf E_t^{(0)},
+-1,1
+\right),\\
+\widetilde{\mathbf X}_{t+1}
+&=\operatorname{clip}
+\!\left(
+\mathbf R_t^{H}+\mathbf\Omega_{t+1},
+-1,1
+\right),\\
+\mathbf E_{t+1}
+&=\mathbf X_t-\widetilde{\mathbf X}_{t+1},\\
+\mathbf\Xi_{t+1}
+&=\Pi_{\mathbf\Lambda_t}
+\!\left[
+\widetilde{\mathbf X}_{t+1};
+\mathbf\Xi_t
+\right].
+\end{aligned}
+}
+\]
+
+**Operational identity:**
+
+```text
+Observe -> Encode 3D -> Quantize Q3 -> Reason H -> Couple -> Compare
+-> Update Omega -> Decode -> Verify Lambda -> Commit/Rollback -> Journal
+```
+
+**Capability boundary:** this specification and its sparse Python reference implement the
+mathematical state-transition semantics. They do not instantiate one billion dense neural
+models or claim equivalence to any proprietary model architecture.

--- a/examples/dr_moagi_billion_field.py
+++ b/examples/dr_moagi_billion_field.py
@@ -1,0 +1,86 @@
+"""Run a bounded sparse Dr Moagi billion-field demonstration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+from jarvisx.dr_moagi_billion_field import BillionFieldConfig, SparseBillionField
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Execute a deterministic sparse simulation over the virtual 1000^3 Dr Moagi field."
+        )
+    )
+    parser.add_argument("--cycles", type=int, default=4, help="number of synchronous cycles")
+    parser.add_argument(
+        "--reasoning-steps",
+        type=int,
+        default=5,
+        help="bounded internal refinement steps per cycle",
+    )
+    parser.add_argument(
+        "--halo-depth",
+        type=int,
+        default=1,
+        help="six-neighbour support rings added per cycle",
+    )
+    parser.add_argument(
+        "--max-active-cells",
+        type=int,
+        default=10_000,
+        help="hard sparse-support budget",
+    )
+    parser.add_argument(
+        "--checkpoint",
+        type=Path,
+        help="optional JSON checkpoint output path",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = BillionFieldConfig(
+        reasoning_steps=args.reasoning_steps,
+        halo_depth=args.halo_depth,
+        max_active_cells=args.max_active_cells,
+        prune_epsilon=1.0e-12,
+    )
+    field = SparseBillionField(config)
+    metrics = field.run(
+        cycles=args.cycles,
+        observations={
+            (500, 500, 500): 1.0,
+            (501, 500, 500): 0.5,
+            (500, 501, 500): -0.25,
+        },
+        controls={(500, 500, 500): -0.02},
+    )
+
+    output = {
+        "config": asdict(config),
+        "metrics": asdict(metrics),
+        "active_coordinates_preview": [
+            list(coordinate) for coordinate in field.active_coordinates()[:16]
+        ],
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+
+    if args.checkpoint is not None:
+        args.checkpoint.parent.mkdir(parents=True, exist_ok=True)
+        args.checkpoint.write_text(
+            json.dumps(field.checkpoint(), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_billion_field.py
+++ b/src/jarvisx/dr_moagi_billion_field.py
@@ -1,0 +1,475 @@
+"""Sparse reference runtime for the Dr Moagi billion-instance 3D field.
+
+The logical lattice contains ``1000 ** 3`` addressable coordinates by default.  This module
+never allocates a dense billion-cell tensor.  It materializes only active coordinates and
+interprets absent coordinates as a deterministic zero background.
+
+The synchronous update implements the operational sequence documented in
+``docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md``:
+
+    snapshot -> encode -> Q3 -> reason -> couple -> residual -> omega
+    -> decode -> validate -> commit/rollback -> journal
+
+It is a bounded mathematical reference, not a claim that one billion proprietary neural
+models are instantiated.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+from dataclasses import dataclass
+from typing import Dict, Iterable, Iterator, Mapping, Tuple
+
+Coordinate = Tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class BillionFieldConfig:
+    """Numerical and execution constraints for one sparse virtual field."""
+
+    side: int = 1000
+    block_side: int = 32
+    encoder_gain: float = 1.0
+    context_gain: float = 0.25
+    reasoning_gain: float = 0.50
+    coupling_gain: float = 0.08
+    consensus_gain: float = 0.0
+    omega_decay: float = 0.875
+    omega_gain: float = 0.0625
+    reasoning_steps: int = 3
+    residual_threshold: float = 1.50
+    value_min: float = -1.0
+    value_max: float = 1.0
+    latent_min: int = -4
+    latent_max: int = 3
+    max_active_cells: int = 100_000
+
+    def __post_init__(self) -> None:
+        if self.side <= 0:
+            raise ValueError("side must be positive")
+        if self.block_side <= 0:
+            raise ValueError("block_side must be positive")
+        if self.reasoning_steps <= 0:
+            raise ValueError("reasoning_steps must be positive")
+        if self.max_active_cells <= 0:
+            raise ValueError("max_active_cells must be positive")
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be less than value_max")
+        if self.latent_min >= self.latent_max:
+            raise ValueError("latent_min must be less than latent_max")
+        if not 0.0 <= self.reasoning_gain <= 1.0:
+            raise ValueError("reasoning_gain must be in [0, 1]")
+        if not 0.0 <= self.omega_decay <= 1.0:
+            raise ValueError("omega_decay must be in [0, 1]")
+        if self.context_gain < 0.0:
+            raise ValueError("context_gain must be non-negative")
+        if self.coupling_gain < 0.0:
+            raise ValueError("coupling_gain must be non-negative")
+        if self.consensus_gain < 0.0:
+            raise ValueError("consensus_gain must be non-negative")
+        if self.omega_gain < 0.0:
+            raise ValueError("omega_gain must be non-negative")
+        if self.residual_threshold < 0.0:
+            raise ValueError("residual_threshold must be non-negative")
+
+
+@dataclass(frozen=True)
+class CellState:
+    """Committed and diagnostic state for one active coordinate."""
+
+    observed: float = 0.0
+    latent: int = 0
+    decoded: float = 0.0
+    predicted: float = 0.0
+    residual: float = 0.0
+    omega: float = 0.0
+    committed: float = 0.0
+    valid: bool = True
+
+
+@dataclass(frozen=True)
+class FieldMetrics:
+    """Deterministic aggregate measurements for one committed cycle."""
+
+    cycle: int
+    virtual_cells: int
+    active_cells: int
+    active_ratio: float
+    mean_absolute_residual: float
+    reconstruction_loss: float
+    coherence: float
+    valid_cells: int
+    rejected_cells: int
+    journal_digest: str
+
+
+_ZERO_STATE = CellState()
+
+
+class SparseBillionField:
+    """Synchronous sparse implementation of the billion-address Dr Moagi field.
+
+    Missing cells are logical zero-valued cells.  Every update reads from a frozen snapshot and
+    writes into a new mapping, so results do not depend on dictionary iteration order.
+    """
+
+    _NEIGHBOUR_OFFSETS: Tuple[Coordinate, ...] = (
+        (-1, 0, 0),
+        (1, 0, 0),
+        (0, -1, 0),
+        (0, 1, 0),
+        (0, 0, -1),
+        (0, 0, 1),
+    )
+
+    def __init__(self, config: BillionFieldConfig | None = None) -> None:
+        self.config = config or BillionFieldConfig()
+        self._cells: Dict[Coordinate, CellState] = {}
+        self._cycle = 0
+        self._journal_digest = hashlib.sha256(b"jarvisx-dr-moagi-field-v1").hexdigest()
+
+    @property
+    def cycle(self) -> int:
+        """Return the number of committed synchronous cycles."""
+
+        return self._cycle
+
+    @property
+    def virtual_cell_count(self) -> int:
+        """Return the full logical address count without allocating it."""
+
+        return self.config.side**3
+
+    @property
+    def active_cell_count(self) -> int:
+        """Return the number of physically materialized coordinates."""
+
+        return len(self._cells)
+
+    @property
+    def padded_block_count(self) -> int:
+        """Return the number of blocks in the padded logical block grid."""
+
+        blocks_per_axis = math.ceil(self.config.side / self.config.block_side)
+        return blocks_per_axis**3
+
+    def estimate_dense_state_bytes(self, bytes_per_cell: int = 32) -> int:
+        """Estimate dense storage for a chosen per-cell representation."""
+
+        if bytes_per_cell <= 0:
+            raise ValueError("bytes_per_cell must be positive")
+        return self.virtual_cell_count * bytes_per_cell
+
+    def address(self, coordinate: Coordinate) -> int:
+        """Map ``(x, y, z)`` to its canonical row-major scalar address."""
+
+        x, y, z = self._validate_coordinate(coordinate)
+        side = self.config.side
+        return x + side * (y + side * z)
+
+    def coordinate(self, address: int) -> Coordinate:
+        """Invert the canonical row-major scalar address."""
+
+        if not isinstance(address, int):
+            raise TypeError("address must be an integer")
+        if address < 0 or address >= self.virtual_cell_count:
+            raise ValueError("address is outside the virtual lattice")
+        side = self.config.side
+        x = address % side
+        y = (address // side) % side
+        z = address // (side * side)
+        return x, y, z
+
+    def block_address(self, coordinate: Coordinate) -> Coordinate:
+        """Return the padded sparse block coordinate that owns ``coordinate``."""
+
+        x, y, z = self._validate_coordinate(coordinate)
+        block = self.config.block_side
+        return x // block, y // block, z // block
+
+    def activate(self, coordinate: Coordinate, observed: float = 0.0) -> CellState:
+        """Materialize or update one coordinate without advancing the field cycle."""
+
+        coordinate = self._validate_coordinate(coordinate)
+        if coordinate not in self._cells and len(self._cells) >= self.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+        value = self._clip_value(self._require_finite(observed, "observed"))
+        previous = self._cells.get(coordinate, _ZERO_STATE)
+        state = CellState(
+            observed=value,
+            latent=previous.latent,
+            decoded=previous.decoded,
+            predicted=previous.predicted,
+            residual=previous.residual,
+            omega=previous.omega,
+            committed=previous.committed,
+            valid=previous.valid,
+        )
+        self._cells[coordinate] = state
+        return state
+
+    def deactivate(self, coordinate: Coordinate) -> None:
+        """Remove one materialized coordinate, restoring logical zero background."""
+
+        coordinate = self._validate_coordinate(coordinate)
+        self._cells.pop(coordinate, None)
+
+    def state(self, coordinate: Coordinate) -> CellState:
+        """Return one state, or the immutable zero background for an inactive cell."""
+
+        coordinate = self._validate_coordinate(coordinate)
+        return self._cells.get(coordinate, _ZERO_STATE)
+
+    def active_coordinates(self) -> Tuple[Coordinate, ...]:
+        """Return active coordinates in canonical scalar-address order."""
+
+        return tuple(sorted(self._cells, key=self.address))
+
+    def iter_active(self) -> Iterator[Tuple[Coordinate, CellState]]:
+        """Iterate over active states in canonical scalar-address order."""
+
+        for coordinate in self.active_coordinates():
+            yield coordinate, self._cells[coordinate]
+
+    def encoded_snapshot(self) -> Dict[Coordinate, int]:
+        """Return a copy of the currently committed signed 3-bit latent field."""
+
+        return {coordinate: state.latent for coordinate, state in self.iter_active()}
+
+    def decoded_value(self, coordinate: Coordinate) -> float:
+        """Return the last committed reconstruction at ``coordinate``."""
+
+        return self.state(coordinate).committed
+
+    def step(self, observations: Mapping[Coordinate, float] | None = None) -> FieldMetrics:
+        """Execute one complete synchronous encode/reason/decode/commit transaction.
+
+        New coordinates supplied by ``observations`` become active.  Existing active coordinates
+        retain their previous observation when not supplied in the current mapping.
+        """
+
+        normalized_inputs = self._normalize_observations(observations or {})
+        prospective_count = len(set(self._cells).union(normalized_inputs))
+        if prospective_count > self.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+
+        snapshot = dict(self._cells)
+        active = tuple(sorted(set(snapshot).union(normalized_inputs), key=self.address))
+        observed = {
+            coordinate: normalized_inputs.get(
+                coordinate,
+                snapshot.get(coordinate, _ZERO_STATE).observed,
+            )
+            for coordinate in active
+        }
+
+        latents: Dict[Coordinate, int] = {}
+        decoded: Dict[Coordinate, float] = {}
+        for coordinate in active:
+            context = self._neighbour_mean(observed, coordinate)
+            activation = self.config.encoder_gain * (
+                observed[coordinate] + self.config.context_gain * context
+            )
+            latent = self._quantize_q3(activation)
+            latents[coordinate] = latent
+            decoded[coordinate] = self._decode_q3(latent)
+
+        staged: Dict[Coordinate, CellState] = {}
+        for coordinate in active:
+            previous = snapshot.get(coordinate, _ZERO_STATE)
+            laplacian = self._laplacian(snapshot, coordinate)
+            consensus = self._latent_consensus(latents, coordinate)
+
+            prediction = previous.committed
+            for _ in range(self.config.reasoning_steps):
+                prediction += self.config.reasoning_gain * (
+                    decoded[coordinate] - prediction
+                )
+                prediction += self.config.coupling_gain * laplacian
+                prediction += self.config.consensus_gain * consensus
+                prediction = self._clip_value(prediction)
+
+            pre_correction_residual = observed[coordinate] - prediction
+            omega = self._clip_value(
+                self.config.omega_decay * previous.omega
+                + self.config.omega_gain * pre_correction_residual
+            )
+            candidate = self._clip_value(prediction + omega)
+            residual = observed[coordinate] - candidate
+            valid = (
+                math.isfinite(candidate)
+                and math.isfinite(residual)
+                and self.config.latent_min <= latents[coordinate] <= self.config.latent_max
+                and abs(residual) <= self.config.residual_threshold
+            )
+            committed = candidate if valid else previous.committed
+
+            staged[coordinate] = CellState(
+                observed=observed[coordinate],
+                latent=latents[coordinate],
+                decoded=decoded[coordinate],
+                predicted=prediction,
+                residual=residual,
+                omega=omega,
+                committed=committed,
+                valid=valid,
+            )
+
+        next_cycle = self._cycle + 1
+        next_digest = self._calculate_journal_digest(next_cycle, staged)
+        self._cells = staged
+        self._cycle = next_cycle
+        self._journal_digest = next_digest
+        return self.metrics()
+
+    def run(
+        self,
+        cycles: int,
+        observations: Mapping[Coordinate, float] | None = None,
+    ) -> FieldMetrics:
+        """Run a fixed number of deterministic cycles and return final metrics."""
+
+        if cycles <= 0:
+            raise ValueError("cycles must be positive")
+        metrics = self.metrics()
+        for cycle_index in range(cycles):
+            metrics = self.step(observations if cycle_index == 0 else None)
+        return metrics
+
+    def metrics(self) -> FieldMetrics:
+        """Measure the currently committed sparse field."""
+
+        active_cells = len(self._cells)
+        if active_cells:
+            residuals = [state.residual for state in self._cells.values()]
+            mean_absolute_residual = sum(abs(value) for value in residuals) / active_cells
+            reconstruction_loss = sum(value * value for value in residuals) / active_cells
+            valid_cells = sum(1 for state in self._cells.values() if state.valid)
+        else:
+            mean_absolute_residual = 0.0
+            reconstruction_loss = 0.0
+            valid_cells = 0
+
+        coherence = 1.0 / (1.0 + mean_absolute_residual)
+        return FieldMetrics(
+            cycle=self._cycle,
+            virtual_cells=self.virtual_cell_count,
+            active_cells=active_cells,
+            active_ratio=active_cells / self.virtual_cell_count,
+            mean_absolute_residual=mean_absolute_residual,
+            reconstruction_loss=reconstruction_loss,
+            coherence=coherence,
+            valid_cells=valid_cells,
+            rejected_cells=active_cells - valid_cells,
+            journal_digest=self._journal_digest,
+        )
+
+    def _normalize_observations(
+        self,
+        observations: Mapping[Coordinate, float],
+    ) -> Dict[Coordinate, float]:
+        normalized: Dict[Coordinate, float] = {}
+        for coordinate, value in observations.items():
+            checked_coordinate = self._validate_coordinate(coordinate)
+            checked_value = self._clip_value(self._require_finite(value, "observation"))
+            normalized[checked_coordinate] = checked_value
+        return normalized
+
+    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
+        if not isinstance(coordinate, tuple) or len(coordinate) != 3:
+            raise TypeError("coordinate must be a three-integer tuple")
+        if not all(isinstance(component, int) for component in coordinate):
+            raise TypeError("coordinate components must be integers")
+        if not all(0 <= component < self.config.side for component in coordinate):
+            raise ValueError("coordinate is outside the virtual lattice")
+        return coordinate
+
+    def _neighbours(self, coordinate: Coordinate) -> Iterable[Coordinate]:
+        x, y, z = coordinate
+        side = self.config.side
+        for dx, dy, dz in self._NEIGHBOUR_OFFSETS:
+            neighbour = x + dx, y + dy, z + dz
+            if all(0 <= component < side for component in neighbour):
+                yield neighbour
+
+    def _neighbour_mean(
+        self,
+        observed: Mapping[Coordinate, float],
+        coordinate: Coordinate,
+    ) -> float:
+        neighbours = tuple(self._neighbours(coordinate))
+        if not neighbours:
+            return 0.0
+        return sum(observed.get(neighbour, 0.0) for neighbour in neighbours) / len(neighbours)
+
+    def _laplacian(
+        self,
+        snapshot: Mapping[Coordinate, CellState],
+        coordinate: Coordinate,
+    ) -> float:
+        center = snapshot.get(coordinate, _ZERO_STATE).committed
+        return sum(
+            snapshot.get(neighbour, _ZERO_STATE).committed - center
+            for neighbour in self._neighbours(coordinate)
+        )
+
+    def _latent_consensus(
+        self,
+        latents: Mapping[Coordinate, int],
+        coordinate: Coordinate,
+    ) -> float:
+        neighbours = tuple(self._neighbours(coordinate))
+        if not neighbours:
+            return 0.0
+        center = latents[coordinate]
+        return sum(latents.get(neighbour, 0) - center for neighbour in neighbours) / len(
+            neighbours
+        )
+
+    def _quantize_q3(self, value: float) -> int:
+        quantized = self._round_half_away_from_zero(3.0 * value)
+        return max(self.config.latent_min, min(self.config.latent_max, quantized))
+
+    def _decode_q3(self, latent: int) -> float:
+        return self._clip_value(latent / 3.0)
+
+    def _clip_value(self, value: float) -> float:
+        return max(self.config.value_min, min(self.config.value_max, value))
+
+    @staticmethod
+    def _round_half_away_from_zero(value: float) -> int:
+        if value >= 0.0:
+            return math.floor(value + 0.5)
+        return math.ceil(value - 0.5)
+
+    @staticmethod
+    def _require_finite(value: float, name: str) -> float:
+        if not isinstance(value, (int, float)):
+            raise TypeError(f"{name} must be numeric")
+        result = float(value)
+        if not math.isfinite(result):
+            raise ValueError(f"{name} must be finite")
+        return result
+
+    def _calculate_journal_digest(
+        self,
+        cycle: int,
+        states: Mapping[Coordinate, CellState],
+    ) -> str:
+        digest = hashlib.sha256()
+        digest.update(bytes.fromhex(self._journal_digest))
+        digest.update(struct.pack(">Q", cycle))
+        for coordinate in sorted(states, key=self.address):
+            state = states[coordinate]
+            digest.update(struct.pack(">Q", self.address(coordinate)))
+            digest.update(struct.pack(">d", state.observed))
+            digest.update(struct.pack(">b", state.latent))
+            digest.update(struct.pack(">d", state.decoded))
+            digest.update(struct.pack(">d", state.predicted))
+            digest.update(struct.pack(">d", state.residual))
+            digest.update(struct.pack(">d", state.omega))
+            digest.update(struct.pack(">d", state.committed))
+            digest.update(b"\x01" if state.valid else b"\x00")
+        return digest.hexdigest()

--- a/src/jarvisx/dr_moagi_billion_field.py
+++ b/src/jarvisx/dr_moagi_billion_field.py
@@ -585,7 +585,7 @@ class SparseBillionField:
         return math.floor(value + 0.5) if value >= 0.0 else math.ceil(value - 0.5)
 
     @staticmethod
-    def _require_finite(value: float, name: str) -> float:
+    def _require_finite(value: object, name: str) -> float:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(f"{name} must be numeric")
         result = float(value)
@@ -659,7 +659,16 @@ class SparseBillionField:
         for name in ("observed", "decoded", "predicted", "omega", "committed"):
             if not self.config.value_min <= numeric[name] <= self.config.value_max:
                 raise ValueError(f"checkpoint {name} is outside field bounds")
-        return CellState(latent=latent, valid=valid, **numeric)
+        return CellState(
+            observed=numeric["observed"],
+            latent=latent,
+            decoded=numeric["decoded"],
+            predicted=numeric["predicted"],
+            residual=numeric["residual"],
+            omega=numeric["omega"],
+            committed=numeric["committed"],
+            valid=valid,
+        )
 
     @staticmethod
     def _is_sha256_hex(value: object) -> bool:

--- a/src/jarvisx/dr_moagi_billion_field.py
+++ b/src/jarvisx/dr_moagi_billion_field.py
@@ -1,33 +1,33 @@
-"""Sparse reference runtime for the Dr Moagi billion-instance 3D field.
+"""Sparse operational runtime for the Dr Moagi billion-instance 3D field.
 
-The logical lattice contains ``1000 ** 3`` addressable coordinates by default.  This module
-never allocates a dense billion-cell tensor.  It materializes only active coordinates and
-interprets absent coordinates as a deterministic zero background.
+The default logical lattice contains ``1000 ** 3`` addressable coordinates. The runtime never
+allocates a dense billion-cell tensor; it materializes only the configured active support and,
+optionally, a bounded neighbour halo. Missing coordinates are deterministic zero background.
 
-The synchronous update implements the operational sequence documented in
-``docs/DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md``:
+The synchronous transaction is:
 
-    snapshot -> encode -> Q3 -> reason -> couple -> residual -> omega
-    -> decode -> validate -> commit/rollback -> journal
+    snapshot -> support closure -> encode -> Q3 -> reason/couple/control
+    -> residual -> omega -> decode -> validate -> commit/rollback -> journal
 
-It is a bounded mathematical reference, not a claim that one billion proprietary neural
-models are instantiated.
+This is a bounded mathematical reference, not a claim that one billion proprietary neural models
+are instantiated.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import struct
-from dataclasses import dataclass
-from typing import Dict, Iterable, Iterator, Mapping, Tuple
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterable, Iterator, Mapping, Tuple, cast
 
 Coordinate = Tuple[int, int, int]
 
 
 @dataclass(frozen=True)
 class BillionFieldConfig:
-    """Numerical and execution constraints for one sparse virtual field."""
+    """Numerical, geometric, and execution constraints for one sparse field."""
 
     side: int = 1000
     block_side: int = 32
@@ -45,39 +45,81 @@ class BillionFieldConfig:
     latent_min: int = -4
     latent_max: int = 3
     max_active_cells: int = 100_000
+    halo_depth: int = 0
+    prune_epsilon: float = 0.0
 
     def __post_init__(self) -> None:
-        if self.side <= 0:
-            raise ValueError("side must be positive")
-        if self.block_side <= 0:
-            raise ValueError("block_side must be positive")
-        if self.reasoning_steps <= 0:
-            raise ValueError("reasoning_steps must be positive")
-        if self.max_active_cells <= 0:
-            raise ValueError("max_active_cells must be positive")
-        if self.value_min >= self.value_max:
-            raise ValueError("value_min must be less than value_max")
-        if self.latent_min >= self.latent_max:
-            raise ValueError("latent_min must be less than latent_max")
-        if not 0.0 <= self.reasoning_gain <= 1.0:
-            raise ValueError("reasoning_gain must be in [0, 1]")
-        if not 0.0 <= self.omega_decay <= 1.0:
-            raise ValueError("omega_decay must be in [0, 1]")
+        self._require_positive_int(self.side, "side")
+        self._require_positive_int(self.block_side, "block_side")
+        self._require_positive_int(self.reasoning_steps, "reasoning_steps")
+        self._require_positive_int(self.max_active_cells, "max_active_cells")
+        self._require_non_negative_int(self.halo_depth, "halo_depth")
+
+        if isinstance(self.latent_min, bool) or not isinstance(self.latent_min, int):
+            raise TypeError("latent_min must be an integer")
+        if isinstance(self.latent_max, bool) or not isinstance(self.latent_max, int):
+            raise TypeError("latent_max must be an integer")
+        if (self.latent_min, self.latent_max) != (-4, 3):
+            raise ValueError("the canonical signed Q3 range is exactly [-4, 3]")
+
+        for name in (
+            "encoder_gain",
+            "context_gain",
+            "reasoning_gain",
+            "coupling_gain",
+            "consensus_gain",
+            "omega_decay",
+            "omega_gain",
+            "residual_threshold",
+            "value_min",
+            "value_max",
+            "prune_epsilon",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.value_min != -1.0 or self.value_max != 1.0:
+            raise ValueError("the canonical field range is exactly [-1, 1]")
+        if self.encoder_gain <= 0.0:
+            raise ValueError("encoder_gain must be positive")
         if self.context_gain < 0.0:
             raise ValueError("context_gain must be non-negative")
+        if not 0.0 <= self.reasoning_gain <= 1.0:
+            raise ValueError("reasoning_gain must be in [0, 1]")
         if self.coupling_gain < 0.0:
             raise ValueError("coupling_gain must be non-negative")
         if self.consensus_gain < 0.0:
             raise ValueError("consensus_gain must be non-negative")
+        if not 0.0 <= self.omega_decay <= 1.0:
+            raise ValueError("omega_decay must be in [0, 1]")
         if self.omega_gain < 0.0:
             raise ValueError("omega_gain must be non-negative")
         if self.residual_threshold < 0.0:
             raise ValueError("residual_threshold must be non-negative")
+        if self.prune_epsilon < 0.0:
+            raise ValueError("prune_epsilon must be non-negative")
+
+    @staticmethod
+    def _require_positive_int(value: int, name: str) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+        if value <= 0:
+            raise ValueError(f"{name} must be positive")
+
+    @staticmethod
+    def _require_non_negative_int(value: int, name: str) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+        if value < 0:
+            raise ValueError(f"{name} must be non-negative")
 
 
 @dataclass(frozen=True)
 class CellState:
-    """Committed and diagnostic state for one active coordinate."""
+    """Committed persistent state plus diagnostics from the latest attempted cycle."""
 
     observed: float = 0.0
     latent: int = 0
@@ -91,7 +133,7 @@ class CellState:
 
 @dataclass(frozen=True)
 class FieldMetrics:
-    """Deterministic aggregate measurements for one committed cycle."""
+    """Deterministic aggregate measurements for one completed cycle."""
 
     cycle: int
     virtual_cells: int
@@ -103,16 +145,19 @@ class FieldMetrics:
     valid_cells: int
     rejected_cells: int
     journal_digest: str
+    state_digest: str
 
 
 _ZERO_STATE = CellState()
+_CHECKPOINT_VERSION = 1
 
 
 class SparseBillionField:
     """Synchronous sparse implementation of the billion-address Dr Moagi field.
 
-    Missing cells are logical zero-valued cells.  Every update reads from a frozen snapshot and
-    writes into a new mapping, so results do not depend on dictionary iteration order.
+    Every update reads a frozen snapshot and writes a new mapping. Canonical address ordering is
+    used for support construction, metrics, serialization, and hashing, so results do not depend
+    on dictionary insertion order.
     """
 
     _NEIGHBOUR_OFFSETS: Tuple[Coordinate, ...] = (
@@ -128,70 +173,51 @@ class SparseBillionField:
         self.config = config or BillionFieldConfig()
         self._cells: Dict[Coordinate, CellState] = {}
         self._cycle = 0
-        self._journal_digest = hashlib.sha256(b"jarvisx-dr-moagi-field-v1").hexdigest()
+        self._journal_digest = self._initial_journal_digest()
 
     @property
     def cycle(self) -> int:
-        """Return the number of committed synchronous cycles."""
-
         return self._cycle
 
     @property
     def virtual_cell_count(self) -> int:
-        """Return the full logical address count without allocating it."""
-
         return self.config.side**3
 
     @property
     def active_cell_count(self) -> int:
-        """Return the number of physically materialized coordinates."""
-
         return len(self._cells)
 
     @property
     def padded_block_count(self) -> int:
-        """Return the number of blocks in the padded logical block grid."""
-
         blocks_per_axis = math.ceil(self.config.side / self.config.block_side)
         return blocks_per_axis**3
 
     def estimate_dense_state_bytes(self, bytes_per_cell: int = 32) -> int:
-        """Estimate dense storage for a chosen per-cell representation."""
-
+        if isinstance(bytes_per_cell, bool) or not isinstance(bytes_per_cell, int):
+            raise TypeError("bytes_per_cell must be an integer")
         if bytes_per_cell <= 0:
             raise ValueError("bytes_per_cell must be positive")
         return self.virtual_cell_count * bytes_per_cell
 
     def address(self, coordinate: Coordinate) -> int:
-        """Map ``(x, y, z)`` to its canonical row-major scalar address."""
-
         x, y, z = self._validate_coordinate(coordinate)
         side = self.config.side
         return x + side * (y + side * z)
 
     def coordinate(self, address: int) -> Coordinate:
-        """Invert the canonical row-major scalar address."""
-
-        if not isinstance(address, int):
+        if isinstance(address, bool) or not isinstance(address, int):
             raise TypeError("address must be an integer")
         if address < 0 or address >= self.virtual_cell_count:
             raise ValueError("address is outside the virtual lattice")
         side = self.config.side
-        x = address % side
-        y = (address // side) % side
-        z = address // (side * side)
-        return x, y, z
+        return address % side, (address // side) % side, address // (side * side)
 
     def block_address(self, coordinate: Coordinate) -> Coordinate:
-        """Return the padded sparse block coordinate that owns ``coordinate``."""
-
         x, y, z = self._validate_coordinate(coordinate)
         block = self.config.block_side
         return x // block, y // block, z // block
 
     def activate(self, coordinate: Coordinate, observed: float = 0.0) -> CellState:
-        """Materialize or update one coordinate without advancing the field cycle."""
-
         coordinate = self._validate_coordinate(coordinate)
         if coordinate not in self._cells and len(self._cells) >= self.config.max_active_cells:
             raise RuntimeError("active-cell budget exceeded")
@@ -211,59 +237,51 @@ class SparseBillionField:
         return state
 
     def deactivate(self, coordinate: Coordinate) -> None:
-        """Remove one materialized coordinate, restoring logical zero background."""
-
-        coordinate = self._validate_coordinate(coordinate)
-        self._cells.pop(coordinate, None)
+        self._cells.pop(self._validate_coordinate(coordinate), None)
 
     def state(self, coordinate: Coordinate) -> CellState:
-        """Return one state, or the immutable zero background for an inactive cell."""
-
-        coordinate = self._validate_coordinate(coordinate)
-        return self._cells.get(coordinate, _ZERO_STATE)
+        return self._cells.get(self._validate_coordinate(coordinate), _ZERO_STATE)
 
     def active_coordinates(self) -> Tuple[Coordinate, ...]:
-        """Return active coordinates in canonical scalar-address order."""
-
         return tuple(sorted(self._cells, key=self.address))
 
     def iter_active(self) -> Iterator[Tuple[Coordinate, CellState]]:
-        """Iterate over active states in canonical scalar-address order."""
-
         for coordinate in self.active_coordinates():
             yield coordinate, self._cells[coordinate]
 
     def encoded_snapshot(self) -> Dict[Coordinate, int]:
-        """Return a copy of the currently committed signed 3-bit latent field."""
-
         return {coordinate: state.latent for coordinate, state in self.iter_active()}
 
     def decoded_value(self, coordinate: Coordinate) -> float:
-        """Return the last committed reconstruction at ``coordinate``."""
-
         return self.state(coordinate).committed
 
-    def step(self, observations: Mapping[Coordinate, float] | None = None) -> FieldMetrics:
-        """Execute one complete synchronous encode/reason/decode/commit transaction.
+    def step(
+        self,
+        observations: Mapping[Coordinate, float] | None = None,
+        controls: Mapping[Coordinate, float] | None = None,
+    ) -> FieldMetrics:
+        """Execute one synchronous transaction.
 
-        New coordinates supplied by ``observations`` become active.  Existing active coordinates
-        retain their previous observation when not supplied in the current mapping.
+        New observation or control coordinates become active. Existing observations persist when
+        omitted. ``controls`` are transient external inputs applied only during this cycle.
+        ``halo_depth`` expands the computational support by the requested bounded neighbour rings.
         """
 
-        normalized_inputs = self._normalize_observations(observations or {})
-        prospective_count = len(set(self._cells).union(normalized_inputs))
-        if prospective_count > self.config.max_active_cells:
+        normalized_inputs = self._normalize_values(observations or {}, "observation")
+        normalized_controls = self._normalize_values(controls or {}, "control")
+        snapshot = dict(self._cells)
+        seed_support = set(snapshot).union(normalized_inputs).union(normalized_controls)
+        active = self._support_closure(seed_support, self.config.halo_depth)
+        if len(active) > self.config.max_active_cells:
             raise RuntimeError("active-cell budget exceeded")
 
-        snapshot = dict(self._cells)
-        active = tuple(sorted(set(snapshot).union(normalized_inputs), key=self.address))
         observed = {
             coordinate: normalized_inputs.get(
-                coordinate,
-                snapshot.get(coordinate, _ZERO_STATE).observed,
+                coordinate, snapshot.get(coordinate, _ZERO_STATE).observed
             )
             for coordinate in active
         }
+        control = {coordinate: normalized_controls.get(coordinate, 0.0) for coordinate in active}
 
         latents: Dict[Coordinate, int] = {}
         decoded: Dict[Coordinate, float] = {}
@@ -284,19 +302,18 @@ class SparseBillionField:
 
             prediction = previous.committed
             for _ in range(self.config.reasoning_steps):
-                prediction += self.config.reasoning_gain * (
-                    decoded[coordinate] - prediction
-                )
+                prediction += self.config.reasoning_gain * (decoded[coordinate] - prediction)
                 prediction += self.config.coupling_gain * laplacian
                 prediction += self.config.consensus_gain * consensus
+                prediction += control[coordinate]
                 prediction = self._clip_value(prediction)
 
             pre_correction_residual = observed[coordinate] - prediction
-            omega = self._clip_value(
+            omega_candidate = self._clip_value(
                 self.config.omega_decay * previous.omega
                 + self.config.omega_gain * pre_correction_residual
             )
-            candidate = self._clip_value(prediction + omega)
+            candidate = self._clip_value(prediction + omega_candidate)
             residual = observed[coordinate] - candidate
             valid = (
                 math.isfinite(candidate)
@@ -304,8 +321,11 @@ class SparseBillionField:
                 and self.config.latent_min <= latents[coordinate] <= self.config.latent_max
                 and abs(residual) <= self.config.residual_threshold
             )
-            committed = candidate if valid else previous.committed
 
+            # Only persistent numeric state crosses the transaction boundary. Rejected candidate
+            # diagnostics remain visible, but committed and omega both roll back atomically.
+            committed = candidate if valid else previous.committed
+            omega = omega_candidate if valid else previous.omega
             staged[coordinate] = CellState(
                 observed=observed[coordinate],
                 latent=latents[coordinate],
@@ -317,6 +337,7 @@ class SparseBillionField:
                 valid=valid,
             )
 
+        staged = self._prune(staged, protected=set(normalized_inputs).union(normalized_controls))
         next_cycle = self._cycle + 1
         next_digest = self._calculate_journal_digest(next_cycle, staged)
         self._cells = staged
@@ -328,19 +349,21 @@ class SparseBillionField:
         self,
         cycles: int,
         observations: Mapping[Coordinate, float] | None = None,
+        controls: Mapping[Coordinate, float] | None = None,
     ) -> FieldMetrics:
-        """Run a fixed number of deterministic cycles and return final metrics."""
-
+        if isinstance(cycles, bool) or not isinstance(cycles, int):
+            raise TypeError("cycles must be an integer")
         if cycles <= 0:
             raise ValueError("cycles must be positive")
         metrics = self.metrics()
         for cycle_index in range(cycles):
-            metrics = self.step(observations if cycle_index == 0 else None)
+            metrics = self.step(
+                observations if cycle_index == 0 else None,
+                controls if cycle_index == 0 else None,
+            )
         return metrics
 
     def metrics(self) -> FieldMetrics:
-        """Measure the currently committed sparse field."""
-
         active_cells = len(self._cells)
         if active_cells:
             residuals = [state.residual for state in self._cells.values()]
@@ -364,23 +387,111 @@ class SparseBillionField:
             valid_cells=valid_cells,
             rejected_cells=active_cells - valid_cells,
             journal_digest=self._journal_digest,
+            state_digest=self.state_digest(),
         )
 
-    def _normalize_observations(
-        self,
-        observations: Mapping[Coordinate, float],
+    def state_digest(self) -> str:
+        """Return a canonical SHA-256 digest of config, cycle, journal, and sparse state."""
+
+        digest = hashlib.sha256()
+        digest.update(b"jarvisx-dr-moagi-state-v1\0")
+        digest.update(self._config_bytes())
+        digest.update(struct.pack(">Q", self._cycle))
+        digest.update(bytes.fromhex(self._journal_digest))
+        self._update_digest_with_states(digest, self._cells)
+        return digest.hexdigest()
+
+    def checkpoint(self) -> Dict[str, object]:
+        """Return a JSON-serializable checkpoint with an independently verifiable state digest."""
+
+        return {
+            "version": _CHECKPOINT_VERSION,
+            "config": asdict(self.config),
+            "cycle": self._cycle,
+            "journal_digest": self._journal_digest,
+            "state_digest": self.state_digest(),
+            "cells": [
+                {
+                    "coordinate": list(coordinate),
+                    "state": asdict(state),
+                }
+                for coordinate, state in self.iter_active()
+            ],
+        }
+
+    @classmethod
+    def from_checkpoint(cls, checkpoint: Mapping[str, object]) -> "SparseBillionField":
+        """Restore a checkpoint and reject malformed or tampered state."""
+
+        if not isinstance(checkpoint, Mapping):
+            raise TypeError("checkpoint must be a mapping")
+        version = checkpoint.get("version")
+        if isinstance(version, bool) or version != _CHECKPOINT_VERSION:
+            raise ValueError("unsupported checkpoint version")
+
+        config_data = checkpoint.get("config")
+        if not isinstance(config_data, Mapping):
+            raise TypeError("checkpoint config must be a mapping")
+        field = cls(BillionFieldConfig(**cast(Any, dict(config_data))))
+
+        cycle = checkpoint.get("cycle")
+        if isinstance(cycle, bool) or not isinstance(cycle, int) or cycle < 0:
+            raise ValueError("checkpoint cycle must be a non-negative integer")
+        journal_digest = checkpoint.get("journal_digest")
+        state_digest = checkpoint.get("state_digest")
+        if not cls._is_sha256_hex(journal_digest):
+            raise ValueError("checkpoint journal_digest must be a SHA-256 hex digest")
+        if not cls._is_sha256_hex(state_digest):
+            raise ValueError("checkpoint state_digest must be a SHA-256 hex digest")
+
+        cells_data = checkpoint.get("cells")
+        if not isinstance(cells_data, list):
+            raise TypeError("checkpoint cells must be a list")
+        if len(cells_data) > field.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+
+        restored: Dict[Coordinate, CellState] = {}
+        for item in cells_data:
+            if not isinstance(item, Mapping):
+                raise TypeError("checkpoint cell entry must be a mapping")
+            raw_coordinate = item.get("coordinate")
+            if not isinstance(raw_coordinate, list) or len(raw_coordinate) != 3:
+                raise TypeError("checkpoint coordinate must be a three-integer list")
+            coordinate = field._validate_coordinate(cast(Coordinate, tuple(raw_coordinate)))
+            if coordinate in restored:
+                raise ValueError("checkpoint contains duplicate coordinates")
+            raw_state = item.get("state")
+            if not isinstance(raw_state, Mapping):
+                raise TypeError("checkpoint state must be a mapping")
+            state = field._validated_cell_state(raw_state)
+            restored[coordinate] = state
+
+        field._cells = restored
+        field._cycle = cycle
+        field._journal_digest = str(journal_digest)
+        if field.state_digest() != state_digest:
+            raise ValueError("checkpoint state digest mismatch")
+        return field
+
+    def _normalize_values(
+        self, values: Mapping[Coordinate, float], name: str
     ) -> Dict[Coordinate, float]:
+        if not isinstance(values, Mapping):
+            raise TypeError(f"{name}s must be a mapping")
         normalized: Dict[Coordinate, float] = {}
-        for coordinate, value in observations.items():
+        for coordinate, value in values.items():
             checked_coordinate = self._validate_coordinate(coordinate)
-            checked_value = self._clip_value(self._require_finite(value, "observation"))
+            checked_value = self._clip_value(self._require_finite(value, name))
             normalized[checked_coordinate] = checked_value
         return normalized
 
     def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
         if not isinstance(coordinate, tuple) or len(coordinate) != 3:
             raise TypeError("coordinate must be a three-integer tuple")
-        if not all(isinstance(component, int) for component in coordinate):
+        if not all(
+            isinstance(component, int) and not isinstance(component, bool)
+            for component in coordinate
+        ):
             raise TypeError("coordinate components must be integers")
         if not all(0 <= component < self.config.side for component in coordinate):
             raise ValueError("coordinate is outside the virtual lattice")
@@ -394,10 +505,23 @@ class SparseBillionField:
             if all(0 <= component < side for component in neighbour):
                 yield neighbour
 
+    def _support_closure(
+        self, coordinates: Iterable[Coordinate], depth: int
+    ) -> Tuple[Coordinate, ...]:
+        support = set(coordinates)
+        frontier = set(support)
+        for _ in range(depth):
+            expanded = set(frontier)
+            for coordinate in frontier:
+                expanded.update(self._neighbours(coordinate))
+            frontier = expanded - support
+            support.update(expanded)
+            if len(support) > self.config.max_active_cells:
+                raise RuntimeError("active-cell budget exceeded")
+        return tuple(sorted(support, key=self.address))
+
     def _neighbour_mean(
-        self,
-        observed: Mapping[Coordinate, float],
-        coordinate: Coordinate,
+        self, observed: Mapping[Coordinate, float], coordinate: Coordinate
     ) -> float:
         neighbours = tuple(self._neighbours(coordinate))
         if not neighbours:
@@ -405,9 +529,7 @@ class SparseBillionField:
         return sum(observed.get(neighbour, 0.0) for neighbour in neighbours) / len(neighbours)
 
     def _laplacian(
-        self,
-        snapshot: Mapping[Coordinate, CellState],
-        coordinate: Coordinate,
+        self, snapshot: Mapping[Coordinate, CellState], coordinate: Coordinate
     ) -> float:
         center = snapshot.get(coordinate, _ZERO_STATE).committed
         return sum(
@@ -416,51 +538,86 @@ class SparseBillionField:
         )
 
     def _latent_consensus(
-        self,
-        latents: Mapping[Coordinate, int],
-        coordinate: Coordinate,
+        self, latents: Mapping[Coordinate, int], coordinate: Coordinate
     ) -> float:
         neighbours = tuple(self._neighbours(coordinate))
         if not neighbours:
             return 0.0
         center = latents[coordinate]
-        return sum(latents.get(neighbour, 0) - center for neighbour in neighbours) / len(
-            neighbours
-        )
+        return sum(latents.get(neighbour, 0) - center for neighbour in neighbours) / len(neighbours)
 
     def _quantize_q3(self, value: float) -> int:
-        quantized = self._round_half_away_from_zero(3.0 * value)
+        # Piecewise scaling uses every signed 3-bit code over the canonical [-1, 1] field.
+        scaled = 4.0 * value if value < 0.0 else 3.0 * value
+        quantized = self._round_half_away_from_zero(scaled)
         return max(self.config.latent_min, min(self.config.latent_max, quantized))
 
     def _decode_q3(self, latent: int) -> float:
-        return self._clip_value(latent / 3.0)
+        if latent < self.config.latent_min or latent > self.config.latent_max:
+            raise ValueError("latent is outside the canonical signed Q3 range")
+        return latent / 4.0 if latent < 0 else latent / 3.0
 
     def _clip_value(self, value: float) -> float:
         return max(self.config.value_min, min(self.config.value_max, value))
 
+    def _prune(
+        self, states: Dict[Coordinate, CellState], protected: set[Coordinate]
+    ) -> Dict[Coordinate, CellState]:
+        epsilon = self.config.prune_epsilon
+        if epsilon <= 0.0:
+            return states
+        return {
+            coordinate: state
+            for coordinate, state in states.items()
+            if coordinate in protected
+            or not state.valid
+            or max(
+                abs(state.observed),
+                abs(state.omega),
+                abs(state.committed),
+                abs(state.residual),
+            )
+            > epsilon
+        }
+
     @staticmethod
     def _round_half_away_from_zero(value: float) -> int:
-        if value >= 0.0:
-            return math.floor(value + 0.5)
-        return math.ceil(value - 0.5)
+        return math.floor(value + 0.5) if value >= 0.0 else math.ceil(value - 0.5)
 
     @staticmethod
     def _require_finite(value: float, name: str) -> float:
-        if not isinstance(value, (int, float)):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(f"{name} must be numeric")
         result = float(value)
         if not math.isfinite(result):
             raise ValueError(f"{name} must be finite")
         return result
 
+    def _initial_journal_digest(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(b"jarvisx-dr-moagi-field-v2\0")
+        digest.update(self._config_bytes())
+        return digest.hexdigest()
+
+    def _config_bytes(self) -> bytes:
+        return json.dumps(
+            asdict(self.config), sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode("utf-8")
+
     def _calculate_journal_digest(
-        self,
-        cycle: int,
-        states: Mapping[Coordinate, CellState],
+        self, cycle: int, states: Mapping[Coordinate, CellState]
     ) -> str:
         digest = hashlib.sha256()
+        digest.update(b"jarvisx-dr-moagi-journal-v2\0")
         digest.update(bytes.fromhex(self._journal_digest))
+        digest.update(self._config_bytes())
         digest.update(struct.pack(">Q", cycle))
+        self._update_digest_with_states(digest, states)
+        return digest.hexdigest()
+
+    def _update_digest_with_states(
+        self, digest: Any, states: Mapping[Coordinate, CellState]
+    ) -> None:
         for coordinate in sorted(states, key=self.address):
             state = states[coordinate]
             digest.update(struct.pack(">Q", self.address(coordinate)))
@@ -472,4 +629,44 @@ class SparseBillionField:
             digest.update(struct.pack(">d", state.omega))
             digest.update(struct.pack(">d", state.committed))
             digest.update(b"\x01" if state.valid else b"\x00")
-        return digest.hexdigest()
+
+    def _validated_cell_state(self, raw: Mapping[str, object]) -> CellState:
+        expected = {
+            "observed",
+            "latent",
+            "decoded",
+            "predicted",
+            "residual",
+            "omega",
+            "committed",
+            "valid",
+        }
+        if set(raw) != expected:
+            raise ValueError("checkpoint cell state has unexpected fields")
+        latent = raw["latent"]
+        valid = raw["valid"]
+        if isinstance(latent, bool) or not isinstance(latent, int):
+            raise TypeError("checkpoint latent must be an integer")
+        if not self.config.latent_min <= latent <= self.config.latent_max:
+            raise ValueError("checkpoint latent is outside Q3 range")
+        if not isinstance(valid, bool):
+            raise TypeError("checkpoint valid must be boolean")
+
+        numeric = {
+            name: self._require_finite(raw[name], f"checkpoint {name}")
+            for name in expected - {"latent", "valid"}
+        }
+        for name in ("observed", "decoded", "predicted", "omega", "committed"):
+            if not self.config.value_min <= numeric[name] <= self.config.value_max:
+                raise ValueError(f"checkpoint {name} is outside field bounds")
+        return CellState(latent=latent, valid=valid, **numeric)
+
+    @staticmethod
+    def _is_sha256_hex(value: object) -> bool:
+        if not isinstance(value, str) or len(value) != 64:
+            return False
+        try:
+            bytes.fromhex(value)
+        except ValueError:
+            return False
+        return True

--- a/tests/test_dr_moagi_billion_field.py
+++ b/tests/test_dr_moagi_billion_field.py
@@ -1,0 +1,112 @@
+"""Invariant tests for the sparse billion-address Dr Moagi field."""
+
+import pytest
+
+from jarvisx.dr_moagi_billion_field import BillionFieldConfig, SparseBillionField
+
+
+def test_default_virtual_geometry_without_dense_allocation() -> None:
+    field = SparseBillionField()
+
+    assert field.virtual_cell_count == 1_000_000_000
+    assert field.active_cell_count == 0
+    assert field.padded_block_count == 32_768
+    assert field.estimate_dense_state_bytes(32) == 32_000_000_000
+
+
+def test_address_and_coordinate_are_exact_inverses() -> None:
+    field = SparseBillionField()
+    coordinates = (
+        (0, 0, 0),
+        (999, 0, 0),
+        (0, 999, 0),
+        (0, 0, 999),
+        (123, 456, 789),
+        (999, 999, 999),
+    )
+
+    for coordinate in coordinates:
+        assert field.coordinate(field.address(coordinate)) == coordinate
+
+    assert field.address((999, 999, 999)) == 999_999_999
+    assert field.block_address((999, 999, 999)) == (31, 31, 31)
+
+
+def test_sparse_transaction_is_deterministic() -> None:
+    observations = {
+        (500, 500, 500): 1.0,
+        (501, 500, 500): 0.5,
+        (500, 501, 500): -0.25,
+    }
+    first = SparseBillionField()
+    second = SparseBillionField()
+
+    first_metrics = first.run(4, observations)
+    second_metrics = second.run(4, dict(reversed(tuple(observations.items()))))
+
+    assert first_metrics == second_metrics
+    assert tuple(first.iter_active()) == tuple(second.iter_active())
+    assert first_metrics.journal_digest == second_metrics.journal_digest
+
+
+def test_latents_remain_in_signed_three_bit_range() -> None:
+    field = SparseBillionField()
+    metrics = field.step(
+        {
+            (0, 0, 0): -1.0,
+            (1, 0, 0): -0.5,
+            (2, 0, 0): 0.0,
+            (3, 0, 0): 0.5,
+            (4, 0, 0): 1.0,
+        }
+    )
+
+    assert metrics.active_cells == 5
+    assert metrics.virtual_cells == 1_000_000_000
+    assert metrics.active_ratio == pytest.approx(5 / 1_000_000_000)
+    assert 0.0 < metrics.coherence <= 1.0
+    assert all(-4 <= latent <= 3 for latent in field.encoded_snapshot().values())
+
+
+def test_invalid_candidate_rolls_back_transactionally() -> None:
+    config = BillionFieldConfig(residual_threshold=0.0)
+    field = SparseBillionField(config)
+
+    metrics = field.step({(10, 10, 10): 1.0})
+    state = field.state((10, 10, 10))
+
+    assert state.valid is False
+    assert state.committed == 0.0
+    assert metrics.valid_cells == 0
+    assert metrics.rejected_cells == 1
+
+
+def test_active_cell_budget_is_enforced_before_commit() -> None:
+    field = SparseBillionField(BillionFieldConfig(max_active_cells=2))
+    field.step({(0, 0, 0): 1.0, (1, 0, 0): 0.5})
+
+    with pytest.raises(RuntimeError, match="active-cell budget exceeded"):
+        field.step({(2, 0, 0): 0.25})
+
+
+def test_input_validation_rejects_non_finite_values_and_bad_coordinates() -> None:
+    field = SparseBillionField()
+
+    with pytest.raises(ValueError, match="finite"):
+        field.step({(0, 0, 0): float("nan")})
+
+    with pytest.raises(ValueError, match="outside"):
+        field.activate((1000, 0, 0), 1.0)
+
+    with pytest.raises(TypeError, match="three-integer tuple"):
+        field.activate((0, 0), 1.0)  # type: ignore[arg-type]
+
+
+def test_journal_digest_advances_with_each_committed_cycle() -> None:
+    field = SparseBillionField()
+    initial = field.metrics().journal_digest
+    first = field.step({(8, 8, 8): 0.75}).journal_digest
+    second = field.step().journal_digest
+
+    assert len(initial) == len(first) == len(second) == 64
+    assert len({initial, first, second}) == 3

--- a/tests/test_dr_moagi_billion_field.py
+++ b/tests/test_dr_moagi_billion_field.py
@@ -1,5 +1,7 @@
 """Invariant tests for the sparse billion-address Dr Moagi field."""
 
+import copy
+
 import pytest
 
 from jarvisx.dr_moagi_billion_field import BillionFieldConfig, SparseBillionField
@@ -14,7 +16,7 @@ def test_default_virtual_geometry_without_dense_allocation() -> None:
     assert field.estimate_dense_state_bytes(32) == 32_000_000_000
 
 
-def test_address_and_coordinate_are_exact_inverses() -> None:
+def test_address_coordinate_and_type_contracts() -> None:
     field = SparseBillionField()
     coordinates = (
         (0, 0, 0),
@@ -30,45 +32,54 @@ def test_address_and_coordinate_are_exact_inverses() -> None:
 
     assert field.address((999, 999, 999)) == 999_999_999
     assert field.block_address((999, 999, 999)) == (31, 31, 31)
+    with pytest.raises(TypeError, match="components must be integers"):
+        field.address((True, 0, 0))
+    with pytest.raises(TypeError, match="address must be an integer"):
+        field.coordinate(True)
 
 
-def test_sparse_transaction_is_deterministic() -> None:
+def test_sparse_transaction_is_deterministic_with_controls() -> None:
     observations = {
         (500, 500, 500): 1.0,
         (501, 500, 500): 0.5,
         (500, 501, 500): -0.25,
     }
+    controls = {(500, 500, 500): -0.02}
     first = SparseBillionField()
     second = SparseBillionField()
 
-    first_metrics = first.run(4, observations)
-    second_metrics = second.run(4, dict(reversed(tuple(observations.items()))))
+    first_metrics = first.run(4, observations, controls)
+    second_metrics = second.run(
+        4,
+        dict(reversed(tuple(observations.items()))),
+        controls,
+    )
 
     assert first_metrics == second_metrics
     assert tuple(first.iter_active()) == tuple(second.iter_active())
     assert first_metrics.journal_digest == second_metrics.journal_digest
+    assert first_metrics.state_digest == second_metrics.state_digest
 
 
-def test_latents_remain_in_signed_three_bit_range() -> None:
-    field = SparseBillionField()
-    metrics = field.step(
-        {
-            (0, 0, 0): -1.0,
-            (1, 0, 0): -0.5,
-            (2, 0, 0): 0.0,
-            (3, 0, 0): 0.5,
-            (4, 0, 0): 1.0,
-        }
+def test_q3_uses_all_eight_codes_and_decodes_distinctly() -> None:
+    config = BillionFieldConfig(
+        context_gain=0.0,
+        reasoning_gain=1.0,
+        coupling_gain=0.0,
+        omega_gain=0.0,
+    )
+    field = SparseBillionField(config)
+    values = (-1.0, -0.75, -0.5, -0.25, 0.0, 1 / 3, 2 / 3, 1.0)
+
+    field.step({(index, 0, 0): value for index, value in enumerate(values)})
+
+    assert list(field.encoded_snapshot().values()) == [-4, -3, -2, -1, 0, 1, 2, 3]
+    assert [field.state((index, 0, 0)).decoded for index in range(8)] == pytest.approx(
+        values
     )
 
-    assert metrics.active_cells == 5
-    assert metrics.virtual_cells == 1_000_000_000
-    assert metrics.active_ratio == pytest.approx(5 / 1_000_000_000)
-    assert 0.0 < metrics.coherence <= 1.0
-    assert all(-4 <= latent <= 3 for latent in field.encoded_snapshot().values())
 
-
-def test_invalid_candidate_rolls_back_transactionally() -> None:
+def test_invalid_candidate_rolls_back_persistent_state_atomically() -> None:
     config = BillionFieldConfig(residual_threshold=0.0)
     field = SparseBillionField(config)
 
@@ -77,36 +88,128 @@ def test_invalid_candidate_rolls_back_transactionally() -> None:
 
     assert state.valid is False
     assert state.committed == 0.0
+    assert state.omega == 0.0
+    assert state.residual != 0.0
     assert metrics.valid_cells == 0
     assert metrics.rejected_cells == 1
 
 
-def test_active_cell_budget_is_enforced_before_commit() -> None:
+def test_active_cell_budget_failure_leaves_state_unchanged() -> None:
     field = SparseBillionField(BillionFieldConfig(max_active_cells=2))
     field.step({(0, 0, 0): 1.0, (1, 0, 0): 0.5})
+    before = field.checkpoint()
 
     with pytest.raises(RuntimeError, match="active-cell budget exceeded"):
         field.step({(2, 0, 0): 0.25})
 
+    assert field.checkpoint() == before
 
-def test_input_validation_rejects_non_finite_values_and_bad_coordinates() -> None:
+
+def test_halo_expands_bounded_support_in_six_neighbour_geometry() -> None:
+    config = BillionFieldConfig(side=5, halo_depth=1, max_active_cells=20)
+    field = SparseBillionField(config)
+
+    field.step({(2, 2, 2): 1.0})
+
+    assert field.active_cell_count == 7
+    assert set(field.active_coordinates()) == {
+        (2, 2, 2),
+        (1, 2, 2),
+        (3, 2, 2),
+        (2, 1, 2),
+        (2, 3, 2),
+        (2, 2, 1),
+        (2, 2, 3),
+    }
+
+
+def test_control_is_transient_while_observation_persists() -> None:
+    config = BillionFieldConfig(
+        context_gain=0.0,
+        reasoning_steps=1,
+        reasoning_gain=0.5,
+        coupling_gain=0.0,
+        omega_gain=0.0,
+    )
+    field = SparseBillionField(config)
+
+    field.step({(1, 1, 1): 0.0}, {(1, 1, 1): 0.5})
+    first = field.state((1, 1, 1)).committed
+    field.step()
+    second = field.state((1, 1, 1)).committed
+
+    assert first == pytest.approx(0.5)
+    assert second == pytest.approx(0.25)
+    assert field.state((1, 1, 1)).observed == 0.0
+
+
+def test_checkpoint_round_trip_and_tamper_detection() -> None:
+    field = SparseBillionField(
+        BillionFieldConfig(halo_depth=1, max_active_cells=50)
+    )
+    field.run(2, {(5, 5, 5): 0.75})
+    checkpoint = field.checkpoint()
+
+    restored = SparseBillionField.from_checkpoint(checkpoint)
+
+    assert restored.config == field.config
+    assert restored.metrics() == field.metrics()
+    assert tuple(restored.iter_active()) == tuple(field.iter_active())
+
+    tampered_state = copy.deepcopy(checkpoint)
+    tampered_state["cells"][0]["state"]["committed"] = 0.123
+    with pytest.raises(ValueError, match="digest mismatch"):
+        SparseBillionField.from_checkpoint(tampered_state)
+
+    tampered_journal = copy.deepcopy(checkpoint)
+    tampered_journal["journal_digest"] = "0" * 64
+    with pytest.raises(ValueError, match="digest mismatch"):
+        SparseBillionField.from_checkpoint(tampered_journal)
+
+
+def test_configuration_rejects_nonfinite_and_noncanonical_values() -> None:
+    with pytest.raises(ValueError, match="finite"):
+        BillionFieldConfig(coupling_gain=float("nan"))
+    with pytest.raises(ValueError, match="canonical signed Q3"):
+        BillionFieldConfig(latent_min=-3)
+    with pytest.raises(ValueError, match="canonical field range"):
+        BillionFieldConfig(value_min=-2.0)
+    with pytest.raises(TypeError, match="side must be an integer"):
+        BillionFieldConfig(side=True)
+
+
+def test_input_validation_rejects_nonfinite_values_and_bad_coordinates() -> None:
     field = SparseBillionField()
 
     with pytest.raises(ValueError, match="finite"):
         field.step({(0, 0, 0): float("nan")})
-
     with pytest.raises(ValueError, match="outside"):
         field.activate((1000, 0, 0), 1.0)
-
     with pytest.raises(TypeError, match="three-integer tuple"):
         field.activate((0, 0), 1.0)  # type: ignore[arg-type]
 
 
-def test_journal_digest_advances_with_each_committed_cycle() -> None:
-    field = SparseBillionField()
-    initial = field.metrics().journal_digest
-    first = field.step({(8, 8, 8): 0.75}).journal_digest
-    second = field.step().journal_digest
+def test_pruning_removes_quiescent_halo_but_protects_explicit_inputs() -> None:
+    config = BillionFieldConfig(
+        side=5,
+        halo_depth=1,
+        prune_epsilon=1.0e-12,
+        max_active_cells=20,
+    )
+    field = SparseBillionField(config)
 
-    assert len(initial) == len(first) == len(second) == 64
-    assert len({initial, first, second}) == 3
+    field.step({(2, 2, 2): 0.0})
+
+    assert field.active_coordinates() == ((2, 2, 2),)
+
+
+def test_journal_and_state_digests_advance_with_each_cycle() -> None:
+    field = SparseBillionField()
+    initial = field.metrics()
+    first = field.step({(8, 8, 8): 0.75})
+    second = field.step()
+
+    assert len(initial.journal_digest) == len(first.journal_digest) == 64
+    assert len(initial.state_digest) == len(first.state_digest) == 64
+    assert len({initial.journal_digest, first.journal_digest, second.journal_digest}) == 3
+    assert len({initial.state_digest, first.state_digest, second.state_digest}) == 3


### PR DESCRIPTION
## What changed

- adds the canonical operational equation for a virtual `1000 x 1000 x 1000` Dr Moagi auto-encoding/decoding field;
- adds a dependency-free sparse Python runtime over the full billion-address logical geometry;
- adds a runnable CLI demonstration with configurable cycles, reasoning depth, halo depth, active-cell budget, and checkpoint output;
- expands the invariant suite across deterministic execution, addressing, quantization, rollback, support growth, controls, pruning, checkpoint restoration, and digest integrity.

## Mathematical corrections and hardening

- replaces the lossy `round(3u)` / clipped `z/3` mapping with a piecewise signed-Q3 encoder/decoder that uses all eight codes `{-4,...,3}` distinctly over `[-1,1]`;
- formalizes bounded six-neighbour support closure through `halo_depth` while preserving the distinction between virtual extent and physical allocation;
- implements the external control term `U` as a transient input separate from persistent observations;
- makes `(Ξ, Ω)` one transactional persistent unit, so rejected correction memory cannot leak into later cycles;
- validates all configuration and runtime numerics for type, finiteness, range, and canonical Q3 contracts;
- adds optional quiescent-cell pruning;
- binds configuration, cycle, journal head, and canonical sparse state into deterministic SHA-256 state digests;
- adds versioned JSON checkpoints with duplicate-coordinate, bounds, budget, Q3, numeric, and digest validation;
- states convergence claims conditionally rather than implying global contraction.

## Capability boundary

This is a bounded sparse mathematical reference. It does not allocate one billion dense model instances and does not claim equivalence to GPT-5.6 or any undisclosed proprietary model architecture.

## Validation

Local isolated validation:

- Python compilation: passed;
- 13 focused invariant tests: passed;
- CLI execution and JSON output validation: passed.

GitHub validation on head `1288b55518c72bc93e9e8bed89d89c72d2045508`:

- quality gate and undefined-name checks: passed;
- mypy package type-check: passed;
- Python 3.10, 3.11, 3.12, and 3.13 test matrices: passed;
- dependency audit: passed;
- source and wheel package build: passed;
- package metadata validation: passed;
- built-wheel smoke test: passed;
- CodeQL Python analysis: passed.