### PR TITLE
Add trainable 3D and transactional 4D multimodal C++ ANN runtimes

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -27,6 +27,14 @@ target_include_directories(jarvisx-runtime PRIVATE
 )
 jarvisx_harden(jarvisx-runtime)
 
+add_executable(jarvisx-autoencoder3d
+    src/autoencoder3d_main.cpp
+)
+target_include_directories(jarvisx-autoencoder3d PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-autoencoder3d)
+
 enable_testing()
 
 add_test(
@@ -51,3 +59,14 @@ jarvisx_harden(jarvisx-processor-tests)
 
 add_test(NAME processor-regressions COMMAND jarvisx-processor-tests)
 set_tests_properties(processor-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-autoencoder3d-tests
+    tests/autoencoder3d_tests.cpp
+)
+target_include_directories(jarvisx-autoencoder3d-tests PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-autoencoder3d-tests)
+
+add_test(NAME autoencoder3d-regressions COMMAND jarvisx-autoencoder3d-tests)
+set_tests_properties(autoencoder3d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(JARVISX_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
-option(JARVISX_BUILD_GL_VISUALIZER "Build the OpenGL/GLUT 3D autoencoder visualizer when dependencies are available" ON)
+option(JARVISX_BUILD_GL_VISUALIZER "Build the OpenGL/GLUT ANN visualizers when dependencies are available" ON)
 
 function(jarvisx_harden target)
     if(MSVC)
@@ -20,51 +20,66 @@ function(jarvisx_harden target)
     endif()
 endfunction()
 
+function(jarvisx_include_runtime target)
+    target_include_directories(${target} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+endfunction()
+
 add_executable(jarvisx-runtime
     src/main.cpp
 )
-target_include_directories(jarvisx-runtime PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+jarvisx_include_runtime(jarvisx-runtime)
 jarvisx_harden(jarvisx-runtime)
 
 add_executable(jarvisx-autoencoder3d
     src/autoencoder3d_main.cpp
 )
-target_include_directories(jarvisx-autoencoder3d PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+jarvisx_include_runtime(jarvisx-autoencoder3d)
 jarvisx_harden(jarvisx-autoencoder3d)
+
+add_executable(jarvisx-multimedia4d
+    src/multimedia4d_main.cpp
+)
+jarvisx_include_runtime(jarvisx-multimedia4d)
+jarvisx_harden(jarvisx-multimedia4d)
 
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
 
     if(OpenGL_FOUND AND GLUT_FOUND)
+        function(jarvisx_link_glut target)
+            jarvisx_include_runtime(${target})
+
+            if(TARGET OpenGL::GL)
+                target_link_libraries(${target} PRIVATE OpenGL::GL)
+            else()
+                target_include_directories(${target} PRIVATE ${OPENGL_INCLUDE_DIR})
+                target_link_libraries(${target} PRIVATE ${OPENGL_gl_LIBRARY})
+            endif()
+
+            if(TARGET GLUT::GLUT)
+                target_link_libraries(${target} PRIVATE GLUT::GLUT)
+            else()
+                target_include_directories(${target} PRIVATE ${GLUT_INCLUDE_DIRS})
+                target_link_libraries(${target} PRIVATE ${GLUT_LIBRARIES})
+            endif()
+
+            jarvisx_harden(${target})
+        endfunction()
+
         add_executable(jarvisx-autoencoder3d-gl
             src/autoencoder3d_glut.cpp
         )
-        target_include_directories(jarvisx-autoencoder3d-gl PRIVATE
-            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        jarvisx_link_glut(jarvisx-autoencoder3d-gl)
+
+        add_executable(jarvisx-multimedia4d-gl
+            src/multimedia4d_glut.cpp
         )
-
-        if(TARGET OpenGL::GL)
-            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE OpenGL::GL)
-        else()
-            target_include_directories(jarvisx-autoencoder3d-gl PRIVATE ${OPENGL_INCLUDE_DIR})
-            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE ${OPENGL_gl_LIBRARY})
-        endif()
-
-        if(TARGET GLUT::GLUT)
-            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE GLUT::GLUT)
-        else()
-            target_include_directories(jarvisx-autoencoder3d-gl PRIVATE ${GLUT_INCLUDE_DIRS})
-            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE ${GLUT_LIBRARIES})
-        endif()
-
-        jarvisx_harden(jarvisx-autoencoder3d-gl)
+        jarvisx_link_glut(jarvisx-multimedia4d-gl)
     else()
-        message(STATUS "OpenGL/GLUT not found; skipping jarvisx-autoencoder3d-gl")
+        message(STATUS "OpenGL/GLUT not found; skipping ANN visualizers")
     endif()
 endif()
 
@@ -82,12 +97,22 @@ add_test(
 )
 set_tests_properties(inward-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME multimedia4d-runtime-smoke
+    COMMAND jarvisx-multimedia4d
+        --cycles 2
+        --edge 8
+        --channels 3
+        --temporal-depth 3
+        --output-dir ${CMAKE_CURRENT_BINARY_DIR}/multimedia4d-smoke
+        --quiet
+)
+set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
-target_include_directories(jarvisx-processor-tests PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+jarvisx_include_runtime(jarvisx-processor-tests)
 jarvisx_harden(jarvisx-processor-tests)
 
 add_test(NAME processor-regressions COMMAND jarvisx-processor-tests)
@@ -96,10 +121,17 @@ set_tests_properties(processor-regressions PROPERTIES TIMEOUT 120)
 add_executable(jarvisx-autoencoder3d-tests
     tests/autoencoder3d_tests.cpp
 )
-target_include_directories(jarvisx-autoencoder3d-tests PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-)
+jarvisx_include_runtime(jarvisx-autoencoder3d-tests)
 jarvisx_harden(jarvisx-autoencoder3d-tests)
 
 add_test(NAME autoencoder3d-regressions COMMAND jarvisx-autoencoder3d-tests)
 set_tests_properties(autoencoder3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-multimedia4d-tests
+    tests/multimedia4d_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-multimedia4d-tests)
+jarvisx_harden(jarvisx-multimedia4d-tests)
+
+add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
+set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(JARVISX_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+option(JARVISX_BUILD_GL_VISUALIZER "Build the OpenGL/GLUT 3D autoencoder visualizer when dependencies are available" ON)
 
 function(jarvisx_harden target)
     if(MSVC)
@@ -34,6 +35,38 @@ target_include_directories(jarvisx-autoencoder3d PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 jarvisx_harden(jarvisx-autoencoder3d)
+
+if(JARVISX_BUILD_GL_VISUALIZER)
+    find_package(OpenGL QUIET)
+    find_package(GLUT QUIET)
+
+    if(OpenGL_FOUND AND GLUT_FOUND)
+        add_executable(jarvisx-autoencoder3d-gl
+            src/autoencoder3d_glut.cpp
+        )
+        target_include_directories(jarvisx-autoencoder3d-gl PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+        )
+
+        if(TARGET OpenGL::GL)
+            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE OpenGL::GL)
+        else()
+            target_include_directories(jarvisx-autoencoder3d-gl PRIVATE ${OPENGL_INCLUDE_DIR})
+            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE ${OPENGL_gl_LIBRARY})
+        endif()
+
+        if(TARGET GLUT::GLUT)
+            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE GLUT::GLUT)
+        else()
+            target_include_directories(jarvisx-autoencoder3d-gl PRIVATE ${GLUT_INCLUDE_DIRS})
+            target_link_libraries(jarvisx-autoencoder3d-gl PRIVATE ${GLUT_LIBRARIES})
+        endif()
+
+        jarvisx_harden(jarvisx-autoencoder3d-gl)
+    else()
+        message(STATUS "OpenGL/GLUT not found; skipping jarvisx-autoencoder3d-gl")
+    endif()
+endif()
 
 enable_testing()
 

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -1,6 +1,6 @@
 # Jarvis-X Inward C++ Runtime
 
-This dependency-free C++17 subsystem implements a bounded sparse auto-encoding processor, deterministic parameter/schedule search loop and a trainable dense 3D convolutional autoencoder reference.
+This C++17 subsystem implements a bounded sparse auto-encoding processor, deterministic parameter/schedule search loop and a trainable dense 3D convolutional autoencoder reference. The numerical components are dependency-free; an optional OpenGL/GLUT target renders the actual ANN tensor state interactively.
 
 The sparse processor exposes a virtual `8192 × 8192 × 8192` coordinate domain through lazily materialized `8 × 8 × 8` tiles. The virtual extent is an addressing contract, not a dense allocation.
 
@@ -26,6 +26,8 @@ cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
 cmake --build build/cpp-runtime --config Release --parallel
 ctest --test-dir build/cpp-runtime -C Release --output-on-failure
 ```
+
+OpenGL and GLUT/freeglut are detected automatically. When either dependency is absent, CMake skips only `jarvisx-autoencoder3d-gl`; the headless runtime and regression suite still build. Use `-DJARVISX_BUILD_GL_VISUALIZER=OFF` to disable detection explicitly.
 
 Direct GCC/Clang build for the sparse processor:
 
@@ -84,7 +86,28 @@ Its output directory contains:
 - `reconstruction.obj` — reconstructed voxel point cloud;
 - `model.jx3d` — reloadable model checkpoint.
 
-Supported deterministic fixtures are `sphere`, `shell`, `checker`, `wave` and `noise`. See [`docs/CPP_3D_AUTOENCODER.md`](../docs/CPP_3D_AUTOENCODER.md) for equations, persistence and complexity boundaries.
+## Run the interactive 3D engine
+
+```bash
+./build/cpp-runtime/jarvisx-autoencoder3d-gl \
+  --edge 16 \
+  --channels 4 \
+  --pattern sphere \
+  --learning-rate 0.015
+```
+
+This target evolves the original GLUT voxel demonstration into a live visualization of the actual model state:
+
+- cyan voxels are the input tensor;
+- blue/violet voxels are the multichannel latent field;
+- pink voxels are the decoder reconstruction;
+- gold voxels are the absolute reconstruction residual;
+- cyan, pink and gold streams trace encode, decode and residual-learning flow;
+- the HUD reports real MSE, MAE, latent energy, gradient norm and training step.
+
+Core controls are `T`/Space for training, `Q` for Q3 inference, `P` for pattern changes, `0-4` for tensor views, `S`/`L` for checkpoints, mouse drag for rotation and mouse wheel for zoom.
+
+Supported deterministic fixtures are `sphere`, `shell`, `checker`, `wave` and `noise`. See [`docs/CPP_3D_AUTOENCODER.md`](../docs/CPP_3D_AUTOENCODER.md) for equations, interactive controls, persistence and complexity boundaries.
 
 ## Sparse runtime state artifacts
 
@@ -98,7 +121,7 @@ Use `--reset` to discard an earlier checkpoint, `--state-dir PATH` to isolate an
 
 ## Determinism contract
 
-Sparse candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. The 3D ANN core uses deterministic initialization and update order for the same model configuration and training sequence. Wall-clock latency is telemetry only and excluded from sparse-processor fitness.
+Sparse candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. The 3D ANN core uses deterministic initialization and update order for the same model configuration and training sequence. Wall-clock latency and rendering cadence are telemetry only and excluded from sparse-processor fitness and ANN loss.
 
 Platform floating-point and transcendental implementations may produce small cross-architecture differences; bit-exact portability is not claimed.
 
@@ -120,7 +143,8 @@ Optional sanitizer build:
 ```bash
 cmake -S cpp_runtime -B build/cpp-runtime-san \
   -DCMAKE_BUILD_TYPE=Release \
-  -DJARVISX_ENABLE_SANITIZERS=ON
+  -DJARVISX_ENABLE_SANITIZERS=ON \
+  -DJARVISX_BUILD_GL_VISUALIZER=OFF
 cmake --build build/cpp-runtime-san --parallel
 ctest --test-dir build/cpp-runtime-san --output-on-failure
 ```

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -1,10 +1,10 @@
 # Jarvis-X Inward C++ Runtime
 
-This dependency-free C++17 subsystem implements a bounded sparse auto-encoding processor and deterministic parameter/schedule search loop.
+This dependency-free C++17 subsystem implements a bounded sparse auto-encoding processor, deterministic parameter/schedule search loop and a trainable dense 3D convolutional autoencoder reference.
 
-It exposes a virtual `8192 × 8192 × 8192` coordinate domain through lazily materialized `8 × 8 × 8` tiles. The virtual extent is an addressing contract, not a dense allocation.
+The sparse processor exposes a virtual `8192 × 8192 × 8192` coordinate domain through lazily materialized `8 × 8 × 8` tiles. The virtual extent is an addressing contract, not a dense allocation.
 
-## Operational cycle
+## Sparse processor operational cycle
 
 1. ingest the executable image by default, or accept explicit text/binary input;
 2. extract a fixed-width deterministic feature vector;
@@ -27,7 +27,7 @@ cmake --build build/cpp-runtime --config Release --parallel
 ctest --test-dir build/cpp-runtime -C Release --output-on-failure
 ```
 
-Direct GCC/Clang build:
+Direct GCC/Clang build for the sparse processor:
 
 ```bash
 g++ -std=c++17 -O3 -Wall -Wextra -Wpedantic \
@@ -62,7 +62,31 @@ Text input is also supported:
   --population 5
 ```
 
-## State artifacts
+## Train the 3D ANN autoencoder core
+
+```bash
+./build/cpp-runtime/jarvisx-autoencoder3d \
+  --edge 8 \
+  --channels 4 \
+  --epochs 250 \
+  --pattern sphere \
+  --quantized \
+  --export-dir .jarvisx-autoencoder3d
+```
+
+The 3D core implements a real trainable encode → latent → decode path with shared `3×3×3` kernels, stride-two spatial compression, direct reverse-mode gradients, gradient clipping, L2 regularization and optional signed 3-bit final inference.
+
+Its output directory contains:
+
+- `metrics.csv` — per-step MSE, MAE, maximum error, latent energy and gradient norm;
+- `input.obj` — input voxel point cloud;
+- `latent.obj` — channel-stacked latent point cloud;
+- `reconstruction.obj` — reconstructed voxel point cloud;
+- `model.jx3d` — reloadable model checkpoint.
+
+Supported deterministic fixtures are `sphere`, `shell`, `checker`, `wave` and `noise`. See [`docs/CPP_3D_AUTOENCODER.md`](../docs/CPP_3D_AUTOENCODER.md) for equations, persistence and complexity boundaries.
+
+## Sparse runtime state artifacts
 
 The default `.jarvisx-runtime/` directory contains:
 
@@ -74,7 +98,9 @@ Use `--reset` to discard an earlier checkpoint, `--state-dir PATH` to isolate an
 
 ## Determinism contract
 
-Candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. Wall-clock latency is recorded as telemetry but excluded from fitness. Platform floating-point implementations may still produce small cross-architecture differences; bit-exact portability is not claimed.
+Sparse candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. The 3D ANN core uses deterministic initialization and update order for the same model configuration and training sequence. Wall-clock latency is telemetry only and excluded from sparse-processor fitness.
+
+Platform floating-point and transcendental implementations may produce small cross-architecture differences; bit-exact portability is not claimed.
 
 ## Validation
 
@@ -82,8 +108,12 @@ The CTest suite includes:
 
 - inward executable/text smoke execution;
 - genome normalization before allocation;
-- repeatable processor evaluation;
-- proof that wall-clock latency does not alter deterministic fitness.
+- repeatable sparse processor evaluation;
+- proof that wall-clock latency does not alter deterministic fitness;
+- deterministic 3D ANN initialization;
+- measurable reconstruction-error reduction under training;
+- signed 3-bit latent-level validation;
+- exact model save/load replay on the same platform.
 
 Optional sanitizer build:
 

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -1,6 +1,6 @@
 # Jarvis-X Inward C++ Runtime
 
-This C++17 subsystem implements a bounded sparse auto-encoding processor, deterministic parameter/schedule search loop and a trainable dense 3D convolutional autoencoder reference. The numerical components are dependency-free; an optional OpenGL/GLUT target renders the actual ANN tensor state interactively.
+This C++17 subsystem implements a bounded sparse auto-encoding processor, deterministic parameter/schedule search loop, a trainable dense 3D convolutional autoencoder reference and a transactional 4D multimodal composition runtime. The numerical components are dependency-free; optional OpenGL/GLUT targets render the actual ANN tensor state interactively.
 
 The sparse processor exposes a virtual `8192 × 8192 × 8192` coordinate domain through lazily materialized `8 × 8 × 8` tiles. The virtual extent is an addressing contract, not a dense allocation.
 
@@ -27,7 +27,7 @@ cmake --build build/cpp-runtime --config Release --parallel
 ctest --test-dir build/cpp-runtime -C Release --output-on-failure
 ```
 
-OpenGL and GLUT/freeglut are detected automatically. When either dependency is absent, CMake skips only `jarvisx-autoencoder3d-gl`; the headless runtime and regression suite still build. Use `-DJARVISX_BUILD_GL_VISUALIZER=OFF` to disable detection explicitly.
+OpenGL and GLUT/freeglut are detected automatically. When either dependency is absent, CMake skips only the graphics targets; the headless runtimes and regression suite still build. Use `-DJARVISX_BUILD_GL_VISUALIZER=OFF` to disable detection explicitly.
 
 Direct GCC/Clang build for the sparse processor:
 
@@ -109,6 +109,44 @@ Core controls are `T`/Space for training, `Q` for Q3 inference, `P` for pattern 
 
 Supported deterministic fixtures are `sphere`, `shell`, `checker`, `wave` and `noise`. See [`docs/CPP_3D_AUTOENCODER.md`](../docs/CPP_3D_AUTOENCODER.md) for equations, interactive controls, persistence and complexity boundaries.
 
+## Run the self-optimizing 4D multimodal core
+
+```bash
+./build/cpp-runtime/jarvisx-multimedia4d \
+  --edge 8 \
+  --channels 4 \
+  --temporal-depth 8 \
+  --proposal-steps 2 \
+  --cycles 120 \
+  --learning-rate 0.03 \
+  --temporal-decay 0.72 \
+  --quantized \
+  --output-dir .jarvisx-multimedia4d
+```
+
+The 4D runtime composes four independent 3D ANN models for deterministic visual, audio, text and generic fixtures. Each modality retains a bounded latent-history axis, receives an exponentially fused temporal latent and participates in a deterministic error-priority scheduler.
+
+Every proposed update is evaluated in an isolated model copy. It commits only when reconstruction MSE remains within the configured acceptance gate; otherwise the authoritative model is retained and the transaction is recorded as a rollback.
+
+The output directory contains multimodal CSV telemetry, input/latent/reconstruction OBJ point clouds for every modality and a replayable checkpoint containing all four models and their temporal histories.
+
+## Run the interactive 4D multimedia engine
+
+```bash
+./build/cpp-runtime/jarvisx-multimedia4d-gl \
+  --edge 16 \
+  --channels 4 \
+  --temporal-depth 8 \
+  --proposal-steps 2 \
+  --learning-rate 0.015
+```
+
+The visualizer renders the selected modality input, temporal latent stack, reconstruction and residual directly from the numerical runtime. Controls are `1-4` for modality selection, Space for training, `Q` for Q3 inference, `F` to follow the adaptive scheduler, `R` for camera rotation, `S`/`L` for checkpoint save/load and `+/-` for display density.
+
+Its frame-budget controller adjusts rendered density, visible history depth and update cadence only. Wall-clock timing does not determine numerical candidate acceptance or rollback.
+
+See [`docs/CPP_4D_MULTIMODAL_RUNTIME.md`](../docs/CPP_4D_MULTIMODAL_RUNTIME.md) for equations, transactional semantics, persistence and capability boundaries.
+
 ## Sparse runtime state artifacts
 
 The default `.jarvisx-runtime/` directory contains:
@@ -121,9 +159,9 @@ Use `--reset` to discard an earlier checkpoint, `--state-dir PATH` to isolate an
 
 ## Determinism contract
 
-Sparse candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. The 3D ANN core uses deterministic initialization and update order for the same model configuration and training sequence. Wall-clock latency and rendering cadence are telemetry only and excluded from sparse-processor fitness and ANN loss.
+Sparse candidate generation, feature extraction, encoding, decoding and fitness selection are deterministic for the same input and genome. The 3D ANN core uses deterministic initialization and update order for the same model configuration and training sequence. The 4D multimodal scheduler, candidate evaluation and temporal-history updates are deterministic for the same configuration and checkpoint.
 
-Platform floating-point and transcendental implementations may produce small cross-architecture differences; bit-exact portability is not claimed.
+Wall-clock latency and rendering cadence are telemetry only and excluded from sparse-processor fitness and multimodal commit decisions. Platform floating-point and transcendental implementations may produce small cross-architecture differences; bit-exact portability is not claimed.
 
 ## Validation
 
@@ -136,7 +174,11 @@ The CTest suite includes:
 - deterministic 3D ANN initialization;
 - measurable reconstruction-error reduction under training;
 - signed 3-bit latent-level validation;
-- exact model save/load replay on the same platform.
+- exact 3D model save/load replay on the same platform;
+- distinct deterministic visual/audio/text/generic fixtures;
+- deterministic multimodal scheduling and transactional replay;
+- bounded temporal histories and candidate MSE gates;
+- exact multimodal checkpoint restoration on the same platform.
 
 Optional sanitizer build:
 

--- a/cpp_runtime/include/jarvisx/autoencoder3d.hpp
+++ b/cpp_runtime/include/jarvisx/autoencoder3d.hpp
@@ -1,0 +1,588 @@
+#pragma once
+
+#include "jarvisx/core.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <numeric>
+#include <string>
+#include <vector>
+
+namespace jarvisx {
+
+struct TensorShape4D {
+    std::size_t channels{};
+    std::size_t depth{};
+    std::size_t height{};
+    std::size_t width{};
+
+    std::size_t elements() const {
+        if (channels == 0U || depth == 0U || height == 0U || width == 0U) {
+            throw std::invalid_argument("tensor dimensions must be non-zero");
+        }
+        const std::size_t max = std::numeric_limits<std::size_t>::max();
+        if (channels > max / depth || channels * depth > max / height ||
+            channels * depth * height > max / width) {
+            throw std::overflow_error("tensor size overflow");
+        }
+        return channels * depth * height * width;
+    }
+};
+
+class Tensor4D {
+public:
+    explicit Tensor4D(TensorShape4D shape, float fill = 0.0F)
+        : shape_(shape), values_(shape.elements(), fill) {}
+
+    const TensorShape4D& shape() const noexcept { return shape_; }
+    std::size_t size() const noexcept { return values_.size(); }
+
+    float& operator()(std::size_t channel, std::size_t z,
+                      std::size_t y, std::size_t x) {
+        return values_.at(index(channel, z, y, x));
+    }
+
+    float operator()(std::size_t channel, std::size_t z,
+                     std::size_t y, std::size_t x) const {
+        return values_.at(index(channel, z, y, x));
+    }
+
+    const std::vector<float>& values() const noexcept { return values_; }
+    std::vector<float>& values() noexcept { return values_; }
+
+private:
+    TensorShape4D shape_;
+    std::vector<float> values_;
+
+    std::size_t index(std::size_t channel, std::size_t z,
+                      std::size_t y, std::size_t x) const {
+        if (channel >= shape_.channels || z >= shape_.depth ||
+            y >= shape_.height || x >= shape_.width) {
+            throw std::out_of_range("tensor coordinate out of range");
+        }
+        return x + shape_.width *
+            (y + shape_.height * (z + shape_.depth * channel));
+    }
+};
+
+struct Autoencoder3DConfig {
+    std::size_t input_edge{8U};
+    std::size_t latent_channels{4U};
+    float learning_rate{0.03F};
+    float l2_penalty{1.0e-4F};
+    float gradient_clip{1.0F};
+    std::uint64_t seed{0x4A415256495358ULL};
+
+    void validate() const {
+        if (input_edge < 4U || input_edge > 64U || input_edge % 2U != 0U) {
+            throw std::invalid_argument("input edge must be even and in [4, 64]");
+        }
+        if (latent_channels < 1U || latent_channels > 32U) {
+            throw std::invalid_argument("latent channels must be in [1, 32]");
+        }
+        if (!std::isfinite(learning_rate) || learning_rate <= 0.0F ||
+            learning_rate > 1.0F) {
+            throw std::invalid_argument("learning rate must be in (0, 1]");
+        }
+        if (!std::isfinite(l2_penalty) || l2_penalty < 0.0F ||
+            l2_penalty > 1.0F) {
+            throw std::invalid_argument("L2 penalty must be in [0, 1]");
+        }
+        if (!std::isfinite(gradient_clip) || gradient_clip <= 0.0F ||
+            gradient_clip > 100.0F) {
+            throw std::invalid_argument("gradient clip must be in (0, 100]");
+        }
+    }
+};
+
+struct Autoencoder3DMetrics {
+    std::uint64_t step{};
+    float mse{};
+    float mae{};
+    float max_abs_error{};
+    float latent_energy{};
+    float gradient_l2{};
+};
+
+class Autoencoder3D {
+public:
+    static constexpr std::size_t kKernelEdge = 3U;
+    static constexpr std::size_t kKernelVolume = 27U;
+
+    explicit Autoencoder3D(Autoencoder3DConfig config)
+        : config_(config),
+          encoder_weights_(config.latent_channels * kKernelVolume),
+          encoder_bias_(config.latent_channels, 0.0F),
+          decoder_weights_(config.latent_channels * kKernelVolume),
+          decoder_bias_(0.0F) {
+        config_.validate();
+        initialize_weights();
+    }
+
+    const Autoencoder3DConfig& config() const noexcept { return config_; }
+    std::uint64_t steps() const noexcept { return steps_; }
+
+    Tensor4D encode(const Tensor4D& input, bool quantize = false) const {
+        validate_input(input);
+        const std::size_t latent_edge = config_.input_edge / 2U;
+        Tensor4D latent({config_.latent_channels, latent_edge, latent_edge,
+                         latent_edge});
+
+        for (std::size_t channel = 0; channel < config_.latent_channels;
+             ++channel) {
+            for (std::size_t z = 0; z < latent_edge; ++z) {
+                for (std::size_t y = 0; y < latent_edge; ++y) {
+                    for (std::size_t x = 0; x < latent_edge; ++x) {
+                        float sum = encoder_bias_[channel];
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t iz = wrap_index(
+                                        static_cast<long long>(2U * z + kz) - 1LL,
+                                        config_.input_edge);
+                                    const std::size_t iy = wrap_index(
+                                        static_cast<long long>(2U * y + ky) - 1LL,
+                                        config_.input_edge);
+                                    const std::size_t ix = wrap_index(
+                                        static_cast<long long>(2U * x + kx) - 1LL,
+                                        config_.input_edge);
+                                    sum += encoder_weight(channel, kernel) *
+                                           input(0U, iz, iy, ix);
+                                }
+                            }
+                        }
+                        float value = std::tanh(sum);
+                        if (quantize) {
+                            value = dequantize_q3(quantize_q3(value));
+                        }
+                        latent(channel, z, y, x) = value;
+                    }
+                }
+            }
+        }
+        return latent;
+    }
+
+    Tensor4D decode(const Tensor4D& latent) const {
+        validate_latent(latent);
+        Tensor4D output({1U, config_.input_edge, config_.input_edge,
+                         config_.input_edge});
+        const std::size_t latent_edge = config_.input_edge / 2U;
+
+        for (std::size_t z = 0; z < config_.input_edge; ++z) {
+            for (std::size_t y = 0; y < config_.input_edge; ++y) {
+                for (std::size_t x = 0; x < config_.input_edge; ++x) {
+                    float sum = decoder_bias_;
+                    const std::size_t lz0 = z / 2U;
+                    const std::size_t ly0 = y / 2U;
+                    const std::size_t lx0 = x / 2U;
+                    for (std::size_t channel = 0;
+                         channel < config_.latent_channels; ++channel) {
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t lz = wrap_index(
+                                        static_cast<long long>(lz0 + kz) - 1LL,
+                                        latent_edge);
+                                    const std::size_t ly = wrap_index(
+                                        static_cast<long long>(ly0 + ky) - 1LL,
+                                        latent_edge);
+                                    const std::size_t lx = wrap_index(
+                                        static_cast<long long>(lx0 + kx) - 1LL,
+                                        latent_edge);
+                                    sum += decoder_weight(channel, kernel) *
+                                           latent(channel, lz, ly, lx);
+                                }
+                            }
+                        }
+                    }
+                    output(0U, z, y, x) = std::tanh(sum);
+                }
+            }
+        }
+        return output;
+    }
+
+    Tensor4D reconstruct(const Tensor4D& input, bool quantize = false) const {
+        return decode(encode(input, quantize));
+    }
+
+    Autoencoder3DMetrics train_step(const Tensor4D& input) {
+        validate_input(input);
+        const std::size_t latent_edge = config_.input_edge / 2U;
+        const Tensor4D latent = encode(input, false);
+        const Tensor4D reconstruction = decode(latent);
+        Tensor4D output_delta(reconstruction.shape());
+        Tensor4D latent_gradient(latent.shape());
+        std::vector<float> decoder_gradient(decoder_weights_.size(), 0.0F);
+        std::vector<float> encoder_gradient(encoder_weights_.size(), 0.0F);
+        std::vector<float> encoder_bias_gradient(encoder_bias_.size(), 0.0F);
+        float decoder_bias_gradient = 0.0F;
+
+        double mse_sum = 0.0;
+        double mae_sum = 0.0;
+        float max_abs = 0.0F;
+        const float inverse_count = 1.0F /
+            static_cast<float>(reconstruction.size());
+
+        for (std::size_t z = 0; z < config_.input_edge; ++z) {
+            for (std::size_t y = 0; y < config_.input_edge; ++y) {
+                for (std::size_t x = 0; x < config_.input_edge; ++x) {
+                    const float predicted = reconstruction(0U, z, y, x);
+                    const float error = predicted - input(0U, z, y, x);
+                    const float absolute = std::fabs(error);
+                    mse_sum += static_cast<double>(error) * error;
+                    mae_sum += absolute;
+                    max_abs = std::max(max_abs, absolute);
+                    const float delta = 2.0F * inverse_count * error *
+                                        (1.0F - predicted * predicted);
+                    output_delta(0U, z, y, x) = delta;
+                    decoder_bias_gradient += delta;
+
+                    const std::size_t lz0 = z / 2U;
+                    const std::size_t ly0 = y / 2U;
+                    const std::size_t lx0 = x / 2U;
+                    for (std::size_t channel = 0;
+                         channel < config_.latent_channels; ++channel) {
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t lz = wrap_index(
+                                        static_cast<long long>(lz0 + kz) - 1LL,
+                                        latent_edge);
+                                    const std::size_t ly = wrap_index(
+                                        static_cast<long long>(ly0 + ky) - 1LL,
+                                        latent_edge);
+                                    const std::size_t lx = wrap_index(
+                                        static_cast<long long>(lx0 + kx) - 1LL,
+                                        latent_edge);
+                                    const std::size_t weight = weight_index(channel, kernel);
+                                    decoder_gradient[weight] +=
+                                        delta * latent(channel, lz, ly, lx);
+                                    latent_gradient(channel, lz, ly, lx) +=
+                                        delta * decoder_weights_[weight];
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        double latent_energy_sum = 0.0;
+        for (std::size_t channel = 0; channel < config_.latent_channels;
+             ++channel) {
+            for (std::size_t z = 0; z < latent_edge; ++z) {
+                for (std::size_t y = 0; y < latent_edge; ++y) {
+                    for (std::size_t x = 0; x < latent_edge; ++x) {
+                        const float activation = latent(channel, z, y, x);
+                        latent_energy_sum += static_cast<double>(activation) * activation;
+                        const float delta = latent_gradient(channel, z, y, x) *
+                                            (1.0F - activation * activation);
+                        encoder_bias_gradient[channel] += delta;
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t iz = wrap_index(
+                                        static_cast<long long>(2U * z + kz) - 1LL,
+                                        config_.input_edge);
+                                    const std::size_t iy = wrap_index(
+                                        static_cast<long long>(2U * y + ky) - 1LL,
+                                        config_.input_edge);
+                                    const std::size_t ix = wrap_index(
+                                        static_cast<long long>(2U * x + kx) - 1LL,
+                                        config_.input_edge);
+                                    encoder_gradient[weight_index(channel, kernel)] +=
+                                        delta * input(0U, iz, iy, ix);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        double gradient_square_sum = 0.0;
+        apply_update(encoder_weights_, encoder_gradient, gradient_square_sum);
+        apply_update(decoder_weights_, decoder_gradient, gradient_square_sum);
+        for (std::size_t channel = 0; channel < encoder_bias_.size(); ++channel) {
+            const float gradient = clip(encoder_bias_gradient[channel]);
+            gradient_square_sum += static_cast<double>(gradient) * gradient;
+            encoder_bias_[channel] -= config_.learning_rate * gradient;
+        }
+        decoder_bias_gradient = clip(decoder_bias_gradient);
+        gradient_square_sum += static_cast<double>(decoder_bias_gradient) *
+                               decoder_bias_gradient;
+        decoder_bias_ -= config_.learning_rate * decoder_bias_gradient;
+        ++steps_;
+
+        const double count = static_cast<double>(reconstruction.size());
+        return {
+            steps_,
+            static_cast<float>(mse_sum / count),
+            static_cast<float>(mae_sum / count),
+            max_abs,
+            static_cast<float>(latent_energy_sum /
+                               static_cast<double>(latent.size())),
+            static_cast<float>(std::sqrt(gradient_square_sum))
+        };
+    }
+
+    void save(const fs::path& path) const {
+        if (!path.parent_path().empty()) fs::create_directories(path.parent_path());
+        std::ofstream output(path, std::ios::trunc);
+        if (!output) throw std::runtime_error("cannot write model: " + path.string());
+        output << "JARVISX_AUTOENCODER3D_V1\n"
+               << config_.input_edge << ' ' << config_.latent_channels << ' '
+               << std::setprecision(std::numeric_limits<float>::max_digits10)
+               << config_.learning_rate << ' ' << config_.l2_penalty << ' '
+               << config_.gradient_clip << ' ' << config_.seed << ' ' << steps_ << '\n';
+        write_vector(output, encoder_weights_);
+        write_vector(output, encoder_bias_);
+        write_vector(output, decoder_weights_);
+        output << decoder_bias_ << '\n';
+        if (!output) throw std::runtime_error("cannot flush model: " + path.string());
+    }
+
+    static Autoencoder3D load(const fs::path& path) {
+        std::ifstream input(path);
+        if (!input) throw std::runtime_error("cannot read model: " + path.string());
+        std::string magic;
+        std::getline(input, magic);
+        if (magic != "JARVISX_AUTOENCODER3D_V1") {
+            throw std::runtime_error("unsupported autoencoder model format");
+        }
+        Autoencoder3DConfig config;
+        std::uint64_t steps = 0U;
+        input >> config.input_edge >> config.latent_channels >> config.learning_rate
+              >> config.l2_penalty >> config.gradient_clip >> config.seed >> steps;
+        config.validate();
+        Autoencoder3D model(config);
+        read_vector(input, model.encoder_weights_);
+        read_vector(input, model.encoder_bias_);
+        read_vector(input, model.decoder_weights_);
+        input >> model.decoder_bias_;
+        model.steps_ = steps;
+        if (!input) throw std::runtime_error("truncated autoencoder model");
+        return model;
+    }
+
+private:
+    Autoencoder3DConfig config_;
+    std::vector<float> encoder_weights_;
+    std::vector<float> encoder_bias_;
+    std::vector<float> decoder_weights_;
+    float decoder_bias_{};
+    std::uint64_t steps_{};
+
+    static std::size_t kernel_index(std::size_t z, std::size_t y,
+                                    std::size_t x) noexcept {
+        return x + kKernelEdge * (y + kKernelEdge * z);
+    }
+
+    static std::size_t weight_index(std::size_t channel,
+                                    std::size_t kernel) noexcept {
+        return channel * kKernelVolume + kernel;
+    }
+
+    static std::size_t wrap_index(long long value, std::size_t size) noexcept {
+        const long long signed_size = static_cast<long long>(size);
+        long long wrapped = value % signed_size;
+        if (wrapped < 0) wrapped += signed_size;
+        return static_cast<std::size_t>(wrapped);
+    }
+
+    float encoder_weight(std::size_t channel, std::size_t kernel) const noexcept {
+        return encoder_weights_[weight_index(channel, kernel)];
+    }
+
+    float decoder_weight(std::size_t channel, std::size_t kernel) const noexcept {
+        return decoder_weights_[weight_index(channel, kernel)];
+    }
+
+    void initialize_weights() {
+        const float encoder_scale = std::sqrt(
+            6.0F / static_cast<float>(kKernelVolume +
+                                      config_.latent_channels * kKernelVolume));
+        const float decoder_scale = std::sqrt(
+            6.0F / static_cast<float>(config_.latent_channels * kKernelVolume +
+                                      kKernelVolume));
+        for (std::size_t i = 0; i < encoder_weights_.size(); ++i) {
+            encoder_weights_[i] = encoder_scale *
+                signed_unit(config_.seed ^ static_cast<std::uint64_t>(i));
+        }
+        for (std::size_t i = 0; i < decoder_weights_.size(); ++i) {
+            decoder_weights_[i] = decoder_scale * signed_unit(
+                (config_.seed ^ 0xDEC0DEULL) + static_cast<std::uint64_t>(i));
+        }
+    }
+
+    void validate_input(const Tensor4D& input) const {
+        const TensorShape4D shape = input.shape();
+        if (shape.channels != 1U || shape.depth != config_.input_edge ||
+            shape.height != config_.input_edge || shape.width != config_.input_edge) {
+            throw std::invalid_argument("input must be a single-channel cubic tensor matching input_edge");
+        }
+        for (const float value : input.values()) {
+            if (!std::isfinite(value) || value < -1.0F || value > 1.0F) {
+                throw std::invalid_argument("input values must be finite and in [-1, 1]");
+            }
+        }
+    }
+
+    void validate_latent(const Tensor4D& latent) const {
+        const std::size_t edge = config_.input_edge / 2U;
+        const TensorShape4D shape = latent.shape();
+        if (shape.channels != config_.latent_channels || shape.depth != edge ||
+            shape.height != edge || shape.width != edge) {
+            throw std::invalid_argument("latent tensor shape mismatch");
+        }
+        for (const float value : latent.values()) {
+            if (!std::isfinite(value)) {
+                throw std::invalid_argument("latent values must be finite");
+            }
+        }
+    }
+
+    float clip(float gradient) const noexcept {
+        return clampf(gradient, -config_.gradient_clip, config_.gradient_clip);
+    }
+
+    void apply_update(std::vector<float>& weights,
+                      const std::vector<float>& gradients,
+                      double& gradient_square_sum) {
+        if (weights.size() != gradients.size()) {
+            throw std::runtime_error("gradient dimension mismatch");
+        }
+        for (std::size_t i = 0; i < weights.size(); ++i) {
+            const float gradient = clip(gradients[i] + config_.l2_penalty * weights[i]);
+            gradient_square_sum += static_cast<double>(gradient) * gradient;
+            weights[i] -= config_.learning_rate * gradient;
+        }
+    }
+
+    static void write_vector(std::ostream& output,
+                             const std::vector<float>& values) {
+        output << values.size();
+        for (const float value : values) output << ' ' << value;
+        output << '\n';
+    }
+
+    static void read_vector(std::istream& input, std::vector<float>& values) {
+        std::size_t size = 0U;
+        input >> size;
+        if (size != values.size()) {
+            throw std::runtime_error("model tensor dimension mismatch");
+        }
+        for (float& value : values) input >> value;
+    }
+};
+
+inline Tensor4D make_volume(std::size_t edge, const std::string& pattern,
+                            std::uint64_t seed) {
+    if (edge < 2U) throw std::invalid_argument("volume edge below 2");
+    Tensor4D volume({1U, edge, edge, edge});
+    const float center = (static_cast<float>(edge) - 1.0F) * 0.5F;
+    const float radius = std::max(1.0F, static_cast<float>(edge) * 0.28F);
+
+    for (std::size_t z = 0; z < edge; ++z) {
+        for (std::size_t y = 0; y < edge; ++y) {
+            for (std::size_t x = 0; x < edge; ++x) {
+                const float fx = (static_cast<float>(x) - center) / radius;
+                const float fy = (static_cast<float>(y) - center) / radius;
+                const float fz = (static_cast<float>(z) - center) / radius;
+                float value = 0.0F;
+                if (pattern == "sphere") {
+                    value = std::sqrt(fx * fx + fy * fy + fz * fz) <= 1.0F
+                        ? 1.0F : -1.0F;
+                } else if (pattern == "shell") {
+                    const float distance = std::sqrt(fx * fx + fy * fy + fz * fz);
+                    value = std::fabs(distance - 1.0F) < 0.22F ? 1.0F : -1.0F;
+                } else if (pattern == "checker") {
+                    value = ((x / 2U + y / 2U + z / 2U) % 2U == 0U)
+                        ? 1.0F : -1.0F;
+                } else if (pattern == "wave") {
+                    const float phase = 0.7F * static_cast<float>(x) +
+                                        0.5F * static_cast<float>(y) +
+                                        0.9F * static_cast<float>(z);
+                    value = std::sin(phase);
+                } else if (pattern == "noise") {
+                    const std::uint64_t key = seed ^
+                        (static_cast<std::uint64_t>(x) << 42U) ^
+                        (static_cast<std::uint64_t>(y) << 21U) ^
+                        static_cast<std::uint64_t>(z);
+                    value = signed_unit(key);
+                } else {
+                    throw std::invalid_argument("unknown volume pattern: " + pattern);
+                }
+                volume(0U, z, y, x) = clampf(value, -1.0F, 1.0F);
+            }
+        }
+    }
+    return volume;
+}
+
+inline Autoencoder3DMetrics measure_reconstruction(const Tensor4D& target,
+                                                    const Tensor4D& latent,
+                                                    const Tensor4D& output,
+                                                    std::uint64_t step) {
+    if (target.shape().elements() != output.shape().elements()) {
+        throw std::invalid_argument("measurement tensor shape mismatch");
+    }
+    double mse = 0.0;
+    double mae = 0.0;
+    double energy = 0.0;
+    float max_abs = 0.0F;
+    for (std::size_t i = 0; i < target.size(); ++i) {
+        const float error = output.values()[i] - target.values()[i];
+        const float absolute = std::fabs(error);
+        mse += static_cast<double>(error) * error;
+        mae += absolute;
+        max_abs = std::max(max_abs, absolute);
+    }
+    for (const float value : latent.values()) {
+        energy += static_cast<double>(value) * value;
+    }
+    return {
+        step,
+        static_cast<float>(mse / static_cast<double>(target.size())),
+        static_cast<float>(mae / static_cast<double>(target.size())),
+        max_abs,
+        static_cast<float>(energy / static_cast<double>(latent.size())),
+        0.0F
+    };
+}
+
+inline void export_obj(const Tensor4D& tensor, const fs::path& path,
+                       float threshold = 0.0F, float channel_gap = 2.0F) {
+    if (!path.parent_path().empty()) fs::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::trunc);
+    if (!output) throw std::runtime_error("cannot write OBJ: " + path.string());
+    output << "# Jarvis-X 3D autoencoder voxel point cloud\n";
+    const TensorShape4D shape = tensor.shape();
+    for (std::size_t channel = 0; channel < shape.channels; ++channel) {
+        const float z_offset = static_cast<float>(channel) *
+            (static_cast<float>(shape.depth) + channel_gap);
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    if (tensor(channel, z, y, x) > threshold) {
+                        output << "v " << x << ' ' << y << ' '
+                               << (static_cast<float>(z) + z_offset) << '\n';
+                    }
+                }
+            }
+        }
+    }
+    if (!output) throw std::runtime_error("cannot flush OBJ: " + path.string());
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/multimedia4d.hpp
+++ b/cpp_runtime/include/jarvisx/multimedia4d.hpp
@@ -1,0 +1,565 @@
+#pragma once
+
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cmath>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+enum class MediaType : std::uint8_t {
+    Visual = 0,
+    Audio = 1,
+    Text = 2,
+    Generic = 3
+};
+
+constexpr std::size_t kMediaTypeCount = 4U;
+
+inline std::size_t media_index(MediaType media) noexcept {
+    return static_cast<std::size_t>(media);
+}
+
+inline const char* media_name(MediaType media) noexcept {
+    switch (media) {
+    case MediaType::Visual: return "visual";
+    case MediaType::Audio: return "audio";
+    case MediaType::Text: return "text";
+    case MediaType::Generic: return "generic";
+    }
+    return "unknown";
+}
+
+inline std::array<MediaType, kMediaTypeCount> media_types() noexcept {
+    return {MediaType::Visual, MediaType::Audio,
+            MediaType::Text, MediaType::Generic};
+}
+
+struct Multimedia4DConfig {
+    Autoencoder3DConfig model{};
+    std::size_t temporal_depth{8U};
+    float temporal_decay{0.72F};
+    std::uint16_t proposal_steps{2U};
+    float accept_tolerance{1.0e-6F};
+    bool quantized_inference{};
+
+    void validate() const {
+        model.validate();
+        if (temporal_depth < 1U || temporal_depth > 64U) {
+            throw std::invalid_argument("temporal depth must be in [1, 64]");
+        }
+        if (!std::isfinite(temporal_decay) || temporal_decay < 0.0F ||
+            temporal_decay >= 1.0F) {
+            throw std::invalid_argument("temporal decay must be in [0, 1)");
+        }
+        if (proposal_steps < 1U || proposal_steps > 64U) {
+            throw std::invalid_argument("proposal steps must be in [1, 64]");
+        }
+        if (!std::isfinite(accept_tolerance) || accept_tolerance < 0.0F ||
+            accept_tolerance > 1.0F) {
+            throw std::invalid_argument("accept tolerance must be in [0, 1]");
+        }
+    }
+};
+
+struct ModalityMetrics {
+    float instantaneous_mse{std::numeric_limits<float>::infinity()};
+    float temporal_mse{std::numeric_limits<float>::infinity()};
+    float mae{};
+    float latent_energy{};
+    float temporal_coherence{};
+    float gradient_l2{};
+    std::uint64_t accepted{};
+    std::uint64_t rejected{};
+    std::uint64_t model_steps{};
+};
+
+struct Multimedia4DMetrics {
+    std::uint64_t cycle{};
+    MediaType selected{MediaType::Visual};
+    float aggregate_mse{};
+    float aggregate_temporal_coherence{};
+    std::uint64_t accepted{};
+    std::uint64_t rejected{};
+    std::array<ModalityMetrics, kMediaTypeCount> modalities{};
+};
+
+inline Tensor4D make_media_volume(std::size_t edge, MediaType media,
+                                  std::uint64_t seed) {
+    if (edge < 2U) throw std::invalid_argument("media volume edge below 2");
+    if (media == MediaType::Visual) {
+        return make_volume(edge, "sphere", seed ^ 0x56495355414CULL);
+    }
+    if (media == MediaType::Generic) {
+        return make_volume(edge, "noise", seed ^ 0x47454E45524943ULL);
+    }
+
+    Tensor4D volume({1U, edge, edge, edge});
+    constexpr const char* text =
+        "JARVIS X MULTIMODAL AUTOENCODING DECODING RUNTIME";
+    constexpr std::size_t text_size =
+        sizeof("JARVIS X MULTIMODAL AUTOENCODING DECODING RUNTIME") - 1U;
+    const float center = 0.5F * static_cast<float>(edge - 1U);
+    const float inverse_edge = 1.0F / static_cast<float>(edge);
+
+    for (std::size_t z = 0; z < edge; ++z) {
+        for (std::size_t y = 0; y < edge; ++y) {
+            for (std::size_t x = 0; x < edge; ++x) {
+                float value = 0.0F;
+                if (media == MediaType::Audio) {
+                    const float fx = (static_cast<float>(x) - center) * inverse_edge;
+                    const float fy = (static_cast<float>(y) - center) * inverse_edge;
+                    const float fz = (static_cast<float>(z) - center) * inverse_edge;
+                    const float carrier = std::sin(
+                        18.0F * fx + 11.0F * fy + 7.0F * fz);
+                    const float envelope = std::exp(
+                        -4.0F * (fx * fx + fy * fy + fz * fz));
+                    value = carrier * envelope;
+                } else {
+                    const std::size_t token_index =
+                        (x + 3U * y + 7U * z) % text_size;
+                    const std::uint8_t token =
+                        static_cast<std::uint8_t>(text[token_index]);
+                    const std::uint8_t bit = static_cast<std::uint8_t>(
+                        1U << ((x + y + z) % 7U));
+                    const float lexical = (token & bit) != 0U ? 1.0F : -1.0F;
+                    const float positional = 0.25F * std::sin(
+                        0.7F * static_cast<float>(x) +
+                        0.5F * static_cast<float>(y) +
+                        0.3F * static_cast<float>(z));
+                    value = clampf(0.8F * lexical + positional, -1.0F, 1.0F);
+                }
+                volume(0U, z, y, x) = value;
+            }
+        }
+    }
+    return volume;
+}
+
+inline float tensor_rms_difference(const Tensor4D& left,
+                                   const Tensor4D& right) {
+    if (left.shape().elements() != right.shape().elements()) {
+        throw std::invalid_argument("tensor RMS shape mismatch");
+    }
+    double square_sum = 0.0;
+    for (std::size_t index = 0; index < left.size(); ++index) {
+        const double delta = static_cast<double>(left.values()[index]) -
+                             static_cast<double>(right.values()[index]);
+        square_sum += delta * delta;
+    }
+    return static_cast<float>(std::sqrt(
+        square_sum / static_cast<double>(left.size())));
+}
+
+inline Tensor4D fuse_temporal_latents(const std::deque<Tensor4D>& history,
+                                      float decay) {
+    if (history.empty()) {
+        throw std::invalid_argument("cannot fuse empty temporal history");
+    }
+    Tensor4D fused(history.front().shape(), 0.0F);
+    double weight_sum = 0.0;
+    double weight = 1.0;
+    for (const Tensor4D& frame : history) {
+        if (frame.shape().elements() != fused.shape().elements()) {
+            throw std::invalid_argument("temporal history shape mismatch");
+        }
+        for (std::size_t index = 0; index < fused.size(); ++index) {
+            fused.values()[index] +=
+                static_cast<float>(weight * frame.values()[index]);
+        }
+        weight_sum += weight;
+        weight *= static_cast<double>(decay);
+    }
+    const float inverse = static_cast<float>(1.0 / weight_sum);
+    for (float& value : fused.values()) value *= inverse;
+    return fused;
+}
+
+class MultimediaAutoencoder4D {
+public:
+    explicit MultimediaAutoencoder4D(Multimedia4DConfig config)
+        : config_(std::move(config)), quantized_(config_.quantized_inference) {
+        config_.validate();
+        initialize_states({});
+        refresh_metrics(MediaType::Visual);
+    }
+
+    const Multimedia4DConfig& config() const noexcept { return config_; }
+    const Multimedia4DMetrics& metrics() const noexcept { return metrics_; }
+    bool quantized() const noexcept { return quantized_; }
+
+    const Tensor4D& input(MediaType media) const {
+        return state(media).input;
+    }
+
+    const Tensor4D& latent(MediaType media) const {
+        return state(media).temporal_latent;
+    }
+
+    const Tensor4D& current_latent(MediaType media) const {
+        return state(media).current_latent;
+    }
+
+    const Tensor4D& reconstruction(MediaType media) const {
+        return state(media).reconstruction;
+    }
+
+    const std::deque<Tensor4D>& temporal_history(MediaType media) const {
+        return state(media).history;
+    }
+
+    void set_quantized(bool enabled) {
+        quantized_ = enabled;
+        for (const MediaType media : media_types()) {
+            refresh_state(media, false, 0.0F);
+        }
+        refresh_metrics(metrics_.selected);
+    }
+
+    Multimedia4DMetrics step() {
+        const MediaType selected = select_modality();
+        ModalityState& target = state(selected);
+
+        const float baseline = instantaneous_mse(target.model, target.input);
+        Autoencoder3D candidate = target.model;
+        Autoencoder3DMetrics candidate_training{};
+        for (std::uint16_t step_index = 0U;
+             step_index < config_.proposal_steps; ++step_index) {
+            candidate_training = candidate.train_step(target.input);
+        }
+        const float proposal = instantaneous_mse(candidate, target.input);
+        const bool accept = std::isfinite(proposal) &&
+            proposal <= baseline + config_.accept_tolerance;
+
+        if (accept) {
+            target.model = std::move(candidate);
+            ++target.accepted;
+        } else {
+            ++target.rejected;
+        }
+
+        ++cycle_;
+        refresh_state(selected, true,
+                      accept ? candidate_training.gradient_l2 : 0.0F);
+        refresh_metrics(selected);
+        return metrics_;
+    }
+
+    void save_checkpoint(const fs::path& directory) const {
+        fs::create_directories(directory);
+        std::ofstream manifest(directory / "multimedia4d.manifest",
+                               std::ios::trunc);
+        if (!manifest) {
+            throw std::runtime_error("cannot write multimedia4d manifest");
+        }
+        manifest << std::setprecision(std::numeric_limits<float>::max_digits10)
+                 << "JARVISX_MULTIMEDIA4D_V1\n"
+                 << config_.temporal_depth << ' '
+                 << config_.temporal_decay << ' '
+                 << config_.proposal_steps << ' '
+                 << config_.accept_tolerance << ' '
+                 << cycle_ << ' ' << (quantized_ ? 1 : 0) << '\n';
+        for (const MediaType media : media_types()) {
+            const ModalityState& item = state(media);
+            manifest << media_name(media) << ' '
+                     << item.accepted << ' ' << item.rejected << ' '
+                     << item.gradient_l2 << '\n';
+            const std::string prefix = media_name(media);
+            item.model.save(directory / (prefix + ".jx3d"));
+            write_history(directory / (prefix + ".history"), item.history);
+        }
+        if (!manifest) {
+            throw std::runtime_error("cannot flush multimedia4d manifest");
+        }
+    }
+
+    void load_checkpoint(const fs::path& directory) {
+        std::ifstream manifest(directory / "multimedia4d.manifest");
+        if (!manifest) {
+            throw std::runtime_error("cannot read multimedia4d manifest");
+        }
+        std::string magic;
+        std::getline(manifest, magic);
+        if (magic != "JARVISX_MULTIMEDIA4D_V1") {
+            throw std::runtime_error("unsupported multimedia4d checkpoint");
+        }
+
+        std::size_t temporal_depth = 0U;
+        float temporal_decay = 0.0F;
+        std::uint16_t proposal_steps = 0U;
+        float accept_tolerance = 0.0F;
+        std::uint64_t cycle = 0U;
+        int quantized_flag = 0;
+        manifest >> temporal_depth >> temporal_decay >> proposal_steps
+                 >> accept_tolerance >> cycle >> quantized_flag;
+        if (!manifest || temporal_depth != config_.temporal_depth ||
+            std::fabs(temporal_decay - config_.temporal_decay) > 1.0e-6F ||
+            proposal_steps != config_.proposal_steps ||
+            std::fabs(accept_tolerance - config_.accept_tolerance) > 1.0e-6F) {
+            throw std::runtime_error("multimedia4d checkpoint config mismatch");
+        }
+
+        std::array<std::uint64_t, kMediaTypeCount> accepted{};
+        std::array<std::uint64_t, kMediaTypeCount> rejected{};
+        std::array<float, kMediaTypeCount> gradients{};
+        for (const MediaType media : media_types()) {
+            std::string name;
+            manifest >> name >> accepted[media_index(media)]
+                     >> rejected[media_index(media)]
+                     >> gradients[media_index(media)];
+            if (!manifest || name != media_name(media)) {
+                throw std::runtime_error("multimedia4d modality manifest mismatch");
+            }
+        }
+
+        std::vector<Autoencoder3D> models;
+        models.reserve(kMediaTypeCount);
+        for (const MediaType media : media_types()) {
+            models.push_back(Autoencoder3D::load(
+                directory / (std::string(media_name(media)) + ".jx3d")));
+            validate_model_compatibility(models.back().config());
+        }
+
+        cycle_ = cycle;
+        quantized_ = quantized_flag != 0;
+        initialize_states(std::move(models));
+        for (const MediaType media : media_types()) {
+            state(media).accepted = accepted[media_index(media)];
+            state(media).rejected = rejected[media_index(media)];
+            state(media).gradient_l2 = gradients[media_index(media)];
+            const std::string prefix = media_name(media);
+            state(media).history = read_history(
+                directory / (prefix + ".history"),
+                state(media).current_latent.shape());
+            state(media).current_latent = state(media).history.front();
+            state(media).temporal_latent = fuse_temporal_latents(
+                state(media).history, config_.temporal_decay);
+            state(media).reconstruction =
+                state(media).model.decode(state(media).temporal_latent);
+        }
+        refresh_metrics(metrics_.selected);
+    }
+
+private:
+    struct ModalityState {
+        MediaType media;
+        Autoencoder3D model;
+        Tensor4D input;
+        Tensor4D current_latent;
+        Tensor4D temporal_latent;
+        Tensor4D reconstruction;
+        std::deque<Tensor4D> history;
+        float gradient_l2{};
+        std::uint64_t accepted{};
+        std::uint64_t rejected{};
+
+        ModalityState(MediaType media_value, Autoencoder3D model_value,
+                      Tensor4D input_value, bool quantized)
+            : media(media_value), model(std::move(model_value)),
+              input(std::move(input_value)),
+              current_latent(model.encode(input, quantized)),
+              temporal_latent(current_latent),
+              reconstruction(model.decode(temporal_latent)) {
+            history.push_front(current_latent);
+        }
+    };
+
+    Multimedia4DConfig config_;
+    std::vector<ModalityState> states_;
+    Multimedia4DMetrics metrics_{};
+    std::uint64_t cycle_{};
+    bool quantized_{};
+
+    ModalityState& state(MediaType media) {
+        return states_.at(media_index(media));
+    }
+
+    const ModalityState& state(MediaType media) const {
+        return states_.at(media_index(media));
+    }
+
+    static void write_history(const fs::path& path,
+                              const std::deque<Tensor4D>& history) {
+        std::ofstream output(path, std::ios::trunc);
+        if (!output) throw std::runtime_error("cannot write temporal history");
+        output << history.size() << '\n'
+               << std::setprecision(std::numeric_limits<float>::max_digits10);
+        for (const Tensor4D& frame : history) {
+            output << frame.size();
+            for (const float value : frame.values()) output << ' ' << value;
+            output << '\n';
+        }
+        if (!output) throw std::runtime_error("cannot flush temporal history");
+    }
+
+    static std::deque<Tensor4D> read_history(
+        const fs::path& path, const TensorShape4D& shape) {
+        std::ifstream input(path);
+        if (!input) throw std::runtime_error("cannot read temporal history");
+        std::size_t count = 0U;
+        input >> count;
+        if (count == 0U || count > 64U) {
+            throw std::runtime_error("invalid temporal history length");
+        }
+        std::deque<Tensor4D> history;
+        for (std::size_t frame_index = 0U; frame_index < count; ++frame_index) {
+            std::size_t size = 0U;
+            input >> size;
+            if (size != shape.elements()) {
+                throw std::runtime_error("temporal history tensor mismatch");
+            }
+            Tensor4D frame(shape);
+            for (float& value : frame.values()) input >> value;
+            if (!input) throw std::runtime_error("truncated temporal history");
+            history.push_back(std::move(frame));
+        }
+        return history;
+    }
+
+    void initialize_states(std::vector<Autoencoder3D> models) {
+        states_.clear();
+        states_.reserve(kMediaTypeCount);
+        const bool use_supplied = models.size() == kMediaTypeCount;
+        for (const MediaType media : media_types()) {
+            Autoencoder3D model = use_supplied
+                ? std::move(models[media_index(media)])
+                : Autoencoder3D(modality_config(media));
+            Tensor4D input_tensor = make_media_volume(
+                model.config().input_edge, media, model.config().seed);
+            states_.emplace_back(media, std::move(model),
+                                 std::move(input_tensor), quantized_);
+        }
+        for (const MediaType media : media_types()) {
+            refresh_state(media, false, 0.0F);
+        }
+    }
+
+    Autoencoder3DConfig modality_config(MediaType media) const {
+        Autoencoder3DConfig model = config_.model;
+        model.seed = mix64(model.seed ^
+            (0x9E3779B97F4A7C15ULL *
+             static_cast<std::uint64_t>(media_index(media) + 1U)));
+        return model;
+    }
+
+    void validate_model_compatibility(const Autoencoder3DConfig& model) const {
+        if (model.input_edge != config_.model.input_edge ||
+            model.latent_channels != config_.model.latent_channels) {
+            throw std::runtime_error("multimedia4d model geometry mismatch");
+        }
+    }
+
+    static float instantaneous_mse(const Autoencoder3D& model,
+                                   const Tensor4D& input) {
+        const Tensor4D latent = model.encode(input, false);
+        const Tensor4D reconstruction = model.decode(latent);
+        return measure_reconstruction(input, latent, reconstruction,
+                                      model.steps()).mse;
+    }
+
+    MediaType select_modality() const {
+        MediaType selected = MediaType::Visual;
+        float selected_score = -std::numeric_limits<float>::infinity();
+        for (std::size_t offset = 0U; offset < kMediaTypeCount; ++offset) {
+            const std::size_t index =
+                (static_cast<std::size_t>(cycle_) + offset) % kMediaTypeCount;
+            const MediaType media = static_cast<MediaType>(index);
+            const ModalityMetrics& metric = metrics_.modalities[index];
+            const float rejection_pressure = 0.001F * static_cast<float>(
+                metric.rejected) / static_cast<float>(1U + metric.accepted);
+            const float score = metric.instantaneous_mse + rejection_pressure;
+            if (score > selected_score) {
+                selected_score = score;
+                selected = media;
+            }
+        }
+        return selected;
+    }
+
+    void refresh_state(MediaType media, bool append_history,
+                       float gradient_l2) {
+        ModalityState& item = state(media);
+        item.current_latent = item.model.encode(item.input, quantized_);
+        if (append_history || item.history.empty()) {
+            item.history.push_front(item.current_latent);
+            while (item.history.size() > config_.temporal_depth) {
+                item.history.pop_back();
+            }
+        } else {
+            item.history.front() = item.current_latent;
+        }
+        item.temporal_latent = fuse_temporal_latents(
+            item.history, config_.temporal_decay);
+        item.reconstruction = item.model.decode(item.temporal_latent);
+        item.gradient_l2 = gradient_l2;
+    }
+
+    void refresh_metrics(MediaType selected) {
+        metrics_ = {};
+        metrics_.cycle = cycle_;
+        metrics_.selected = selected;
+        double mse_sum = 0.0;
+        double coherence_sum = 0.0;
+
+        for (const MediaType media : media_types()) {
+            const ModalityState& item = state(media);
+            const Tensor4D immediate_reconstruction =
+                item.model.decode(item.current_latent);
+            const Autoencoder3DMetrics immediate = measure_reconstruction(
+                item.input, item.current_latent, immediate_reconstruction,
+                item.model.steps());
+            const Autoencoder3DMetrics temporal = measure_reconstruction(
+                item.input, item.temporal_latent, item.reconstruction,
+                item.model.steps());
+            float coherence = 1.0F;
+            if (item.history.size() > 1U) {
+                coherence = 1.0F - clampf(
+                    tensor_rms_difference(item.history[0], item.history[1]),
+                    0.0F, 1.0F);
+            }
+            ModalityMetrics metric;
+            metric.instantaneous_mse = immediate.mse;
+            metric.temporal_mse = temporal.mse;
+            metric.mae = temporal.mae;
+            metric.latent_energy = temporal.latent_energy;
+            metric.temporal_coherence = coherence;
+            metric.gradient_l2 = item.gradient_l2;
+            metric.accepted = item.accepted;
+            metric.rejected = item.rejected;
+            metric.model_steps = item.model.steps();
+            metrics_.modalities[media_index(media)] = metric;
+            metrics_.accepted += item.accepted;
+            metrics_.rejected += item.rejected;
+            mse_sum += metric.temporal_mse;
+            coherence_sum += metric.temporal_coherence;
+        }
+        metrics_.aggregate_mse = static_cast<float>(
+            mse_sum / static_cast<double>(kMediaTypeCount));
+        metrics_.aggregate_temporal_coherence = static_cast<float>(
+            coherence_sum / static_cast<double>(kMediaTypeCount));
+    }
+};
+
+inline void export_multimedia4d_snapshot(
+    const MultimediaAutoencoder4D& engine, const fs::path& directory) {
+    fs::create_directories(directory);
+    for (const MediaType media : media_types()) {
+        const std::string prefix = media_name(media);
+        export_obj(engine.input(media), directory / (prefix + "-input.obj"));
+        export_obj(engine.latent(media), directory / (prefix + "-latent.obj"));
+        export_obj(engine.reconstruction(media),
+                   directory / (prefix + "-reconstruction.obj"));
+    }
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/src/autoencoder3d_glut.cpp
+++ b/cpp_runtime/src/autoencoder3d_glut.cpp
@@ -1,0 +1,925 @@
+#include "jarvisx/autoencoder3d.hpp"
+
+#ifdef __APPLE__
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#endif
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr float kPi = 3.14159265358979323846F;
+constexpr float kPipelineExtent = 2.15F;
+constexpr std::size_t kMaxStreams = 96U;
+constexpr unsigned int kTimerMilliseconds = 16U;
+constexpr float kTrainingInterval = 0.075F;
+
+struct Vec3 {
+    float x{};
+    float y{};
+    float z{};
+
+    Vec3 operator+(const Vec3& other) const noexcept {
+        return {x + other.x, y + other.y, z + other.z};
+    }
+
+    Vec3 operator-(const Vec3& other) const noexcept {
+        return {x - other.x, y - other.y, z - other.z};
+    }
+
+    Vec3 operator*(float scalar) const noexcept {
+        return {x * scalar, y * scalar, z * scalar};
+    }
+};
+
+struct Color {
+    float r{};
+    float g{};
+    float b{};
+};
+
+enum class OperationType : std::uint8_t {
+    Encode,
+    Decode,
+    Residual
+};
+
+enum class ViewMode : std::uint8_t {
+    Composite,
+    Input,
+    Latent,
+    Reconstruction,
+    Residual
+};
+
+Vec3 quadratic_bezier(const Vec3& start, const Vec3& control,
+                      const Vec3& end, float t) noexcept {
+    const float one_minus_t = 1.0F - t;
+    return start * (one_minus_t * one_minus_t) +
+           control * (2.0F * one_minus_t * t) + end * (t * t);
+}
+
+struct DataStream {
+    Vec3 start;
+    Vec3 control;
+    Vec3 end;
+    Vec3 position;
+    Color color;
+    OperationType operation{OperationType::Encode};
+    float progress{};
+    float speed{0.8F};
+
+    void update(float delta_seconds) noexcept {
+        progress = std::min(1.0F, progress + speed * delta_seconds);
+        position = quadratic_bezier(start, control, end, progress);
+    }
+
+    bool alive() const noexcept { return progress < 1.0F; }
+
+    void render() const {
+        const float alpha = 0.35F + 0.65F * (1.0F - progress);
+        glColor4f(color.r, color.g, color.b, alpha);
+        glPushMatrix();
+        glTranslatef(position.x, position.y, position.z);
+        const double radius = static_cast<double>(0.035F + 0.025F * alpha);
+        glutSolidSphere(radius, 8, 8);
+        glPopMatrix();
+    }
+};
+
+struct Options {
+    std::size_t edge{16U};
+    std::size_t channels{4U};
+    float learning_rate{0.015F};
+    float l2_penalty{1.0e-4F};
+    float gradient_clip{1.0F};
+    std::uint64_t seed{0x4A415256495358ULL};
+    std::string pattern{"sphere"};
+    std::filesystem::path load_model;
+    bool start_paused{};
+    bool quantized{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const std::uint64_t parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument("invalid integer after " + flag);
+    }
+    return parsed;
+}
+
+float parse_float(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument("invalid floating-point value after " + flag);
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto next_value = [&](int& index, const std::string& flag) -> std::string {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("missing value after " + flag);
+        }
+        ++index;
+        return argv[index];
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--edge") {
+            options.edge = static_cast<std::size_t>(
+                parse_u64(next_value(index, argument), argument));
+        } else if (argument == "--channels") {
+            options.channels = static_cast<std::size_t>(
+                parse_u64(next_value(index, argument), argument));
+        } else if (argument == "--learning-rate") {
+            options.learning_rate = parse_float(next_value(index, argument), argument);
+        } else if (argument == "--l2") {
+            options.l2_penalty = parse_float(next_value(index, argument), argument);
+        } else if (argument == "--gradient-clip") {
+            options.gradient_clip = parse_float(next_value(index, argument), argument);
+        } else if (argument == "--seed") {
+            options.seed = parse_u64(next_value(index, argument), argument);
+        } else if (argument == "--pattern") {
+            options.pattern = next_value(index, argument);
+        } else if (argument == "--load-model") {
+            options.load_model = next_value(index, argument);
+        } else if (argument == "--paused") {
+            options.start_paused = true;
+        } else if (argument == "--quantized") {
+            options.quantized = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: jarvisx-autoencoder3d-gl [options]\n"
+                << "  --edge N              even input edge in [4,64]\n"
+                << "  --channels N          latent channels in [1,32]\n"
+                << "  --learning-rate X     SGD learning rate\n"
+                << "  --l2 X                L2 regularization\n"
+                << "  --gradient-clip X     elementwise gradient clip\n"
+                << "  --seed N              deterministic model seed\n"
+                << "  --pattern NAME        sphere|shell|checker|wave|noise\n"
+                << "  --load-model PATH     load a JX3D checkpoint\n"
+                << "  --quantized           render signed 3-bit latent inference\n"
+                << "  --paused              start with online training paused\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+jarvisx::Autoencoder3D make_model(const Options& options) {
+    if (!options.load_model.empty()) {
+        return jarvisx::Autoencoder3D::load(options.load_model);
+    }
+    return jarvisx::Autoencoder3D({
+        options.edge,
+        options.channels,
+        options.learning_rate,
+        options.l2_penalty,
+        options.gradient_clip,
+        options.seed
+    });
+}
+
+class GeometricAutoencoderEngine {
+public:
+    explicit GeometricAutoencoderEngine(Options options)
+        : options_(std::move(options)),
+          model_(make_model(options_)),
+          input_(jarvisx::make_volume(model_.config().input_edge,
+                                      options_.pattern, model_.config().seed)),
+          latent_(model_.encode(input_, options_.quantized)),
+          reconstruction_(model_.decode(latent_)),
+          rng_(model_.config().seed),
+          unit_distribution_(-1.0F, 1.0F),
+          training_(!options_.start_paused),
+          quantized_(options_.quantized) {
+        const auto found = std::find(patterns_.begin(), patterns_.end(),
+                                     options_.pattern);
+        if (found == patterns_.end()) {
+            throw std::invalid_argument("unknown visualizer pattern: " +
+                                        options_.pattern);
+        }
+        pattern_index_ = static_cast<std::size_t>(
+            std::distance(patterns_.begin(), found));
+        refresh_snapshots(0.0F);
+        spawn_pipeline_burst();
+    }
+
+    void update(float delta_seconds) {
+        const float dt = std::clamp(delta_seconds, 0.0F, 0.1F);
+        if (auto_rotate_) {
+            camera_angle_y_ += dt * 0.22F;
+        }
+
+        if (training_) {
+            training_accumulator_ += dt;
+            unsigned int steps_this_frame = 0U;
+            while (training_accumulator_ >= kTrainingInterval &&
+                   steps_this_frame < 2U) {
+                const jarvisx::Autoencoder3DMetrics training_metrics =
+                    model_.train_step(input_);
+                refresh_snapshots(training_metrics.gradient_l2);
+                training_accumulator_ -= kTrainingInterval;
+                ++steps_this_frame;
+                spawn_pipeline_burst();
+            }
+        }
+
+        stream_spawn_accumulator_ += dt;
+        if (stream_spawn_accumulator_ >= 0.11F) {
+            spawn_stream(next_stream_is_encode_ ? OperationType::Encode
+                                                : OperationType::Decode);
+            next_stream_is_encode_ = !next_stream_is_encode_;
+            stream_spawn_accumulator_ = 0.0F;
+        }
+
+        for (auto iterator = streams_.begin(); iterator != streams_.end();) {
+            iterator->update(dt);
+            if (!iterator->alive()) {
+                iterator = streams_.erase(iterator);
+            } else {
+                ++iterator;
+            }
+        }
+
+        pulse_ = std::max(0.0F, pulse_ - dt * 1.7F);
+        status_time_ = std::max(0.0F, status_time_ - dt);
+    }
+
+    void render(int window_width, int window_height) {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        glTranslatef(0.0F, 0.0F, camera_distance_);
+        glRotatef(camera_angle_x_ * 180.0F / kPi, 1.0F, 0.0F, 0.0F);
+        glRotatef(camera_angle_y_ * 180.0F / kPi, 0.0F, 1.0F, 0.0F);
+
+        const GLfloat light_position[] = {0.0F, 5.0F, 7.0F, 1.0F};
+        glLightfv(GL_LIGHT0, GL_POSITION, light_position);
+
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glDepthMask(GL_FALSE);
+
+        visible_voxels_ = 0U;
+        switch (view_mode_) {
+        case ViewMode::Composite:
+            render_composite();
+            break;
+        case ViewMode::Input:
+            visible_voxels_ += render_scalar_tensor(
+                input_, {0.0F, 0.0F, 0.0F}, 4.5F, threshold_,
+                {0.0F, 1.0F, 0.8F}, false);
+            render_wire_cube({0.0F, 0.0F, 0.0F}, 2.25F,
+                             {0.0F, 1.0F, 0.8F}, 0.45F);
+            break;
+        case ViewMode::Latent:
+            visible_voxels_ += render_latent_tensor(
+                {0.0F, 0.0F, 0.0F}, 4.5F, threshold_ * 0.65F);
+            render_wire_cube({0.0F, 0.0F, 0.0F}, 2.25F,
+                             {0.55F, 0.2F, 1.0F}, 0.45F);
+            break;
+        case ViewMode::Reconstruction:
+            visible_voxels_ += render_scalar_tensor(
+                reconstruction_, {0.0F, 0.0F, 0.0F}, 4.5F, threshold_,
+                {1.0F, 0.35F, 0.8F}, false);
+            render_wire_cube({0.0F, 0.0F, 0.0F}, 2.25F,
+                             {1.0F, 0.35F, 0.8F}, 0.45F);
+            break;
+        case ViewMode::Residual:
+            visible_voxels_ += render_residual_tensor(
+                {0.0F, 0.0F, 0.0F}, 4.5F,
+                std::max(0.08F, threshold_ * 0.45F));
+            render_wire_cube({0.0F, 0.0F, 0.0F}, 2.25F,
+                             {1.0F, 0.75F, 0.15F}, 0.45F);
+            break;
+        }
+
+        for (const DataStream& stream : streams_) {
+            stream.render();
+        }
+        render_base_ring();
+
+        glDepthMask(GL_TRUE);
+        glDisable(GL_BLEND);
+        render_hud(window_width, window_height);
+    }
+
+    void rotate_camera(int delta_x, int delta_y) noexcept {
+        camera_angle_y_ += static_cast<float>(delta_x) * 0.005F;
+        camera_angle_x_ += static_cast<float>(delta_y) * 0.005F;
+        camera_angle_x_ = std::clamp(camera_angle_x_, -1.2F, 1.2F);
+        auto_rotate_ = false;
+    }
+
+    void zoom(float delta) noexcept {
+        camera_distance_ = std::clamp(camera_distance_ + delta, -18.0F, -6.5F);
+    }
+
+    void special_key(int key) noexcept {
+        constexpr float increment = 0.08F;
+        if (key == GLUT_KEY_LEFT) camera_angle_y_ -= increment;
+        if (key == GLUT_KEY_RIGHT) camera_angle_y_ += increment;
+        if (key == GLUT_KEY_UP) camera_angle_x_ -= increment;
+        if (key == GLUT_KEY_DOWN) camera_angle_x_ += increment;
+        camera_angle_x_ = std::clamp(camera_angle_x_, -1.2F, 1.2F);
+        auto_rotate_ = false;
+    }
+
+    void keyboard(unsigned char key) {
+        switch (key) {
+        case '0':
+            view_mode_ = ViewMode::Composite;
+            break;
+        case '1':
+            view_mode_ = ViewMode::Input;
+            break;
+        case '2':
+            view_mode_ = ViewMode::Latent;
+            break;
+        case '3':
+            view_mode_ = ViewMode::Reconstruction;
+            break;
+        case '4':
+            view_mode_ = ViewMode::Residual;
+            break;
+        case 'r':
+        case 'R':
+            auto_rotate_ = !auto_rotate_;
+            break;
+        case 't':
+        case 'T':
+        case ' ':
+            training_ = !training_;
+            set_status(training_ ? "online SGD resumed" : "online SGD paused");
+            break;
+        case 'q':
+        case 'Q':
+            quantized_ = !quantized_;
+            refresh_snapshots(metrics_.gradient_l2);
+            set_status(quantized_ ? "Q3 latent inference enabled"
+                                  : "floating latent inference enabled");
+            break;
+        case 'p':
+        case 'P':
+            cycle_pattern();
+            break;
+        case 'n':
+        case 'N':
+            reset_model();
+            break;
+        case 's':
+        case 'S':
+            save_checkpoint();
+            break;
+        case 'l':
+        case 'L':
+            load_checkpoint();
+            break;
+        case '+':
+        case '=':
+            threshold_ = std::min(0.95F, threshold_ + 0.05F);
+            break;
+        case '-':
+        case '_':
+            threshold_ = std::max(0.0F, threshold_ - 0.05F);
+            break;
+        case 27:
+            std::exit(0);
+        default:
+            break;
+        }
+    }
+
+    std::size_t stream_count() const noexcept { return streams_.size(); }
+    std::size_t visible_voxel_count() const noexcept { return visible_voxels_; }
+    const jarvisx::Autoencoder3DMetrics& metrics() const noexcept { return metrics_; }
+
+private:
+    Options options_;
+    jarvisx::Autoencoder3D model_;
+    jarvisx::Tensor4D input_;
+    jarvisx::Tensor4D latent_;
+    jarvisx::Tensor4D reconstruction_;
+    jarvisx::Autoencoder3DMetrics metrics_{};
+    std::vector<DataStream> streams_;
+    std::vector<std::string> patterns_{"sphere", "shell", "checker", "wave", "noise"};
+    std::size_t pattern_index_{};
+    std::mt19937_64 rng_;
+    std::uniform_real_distribution<float> unit_distribution_;
+    ViewMode view_mode_{ViewMode::Composite};
+    bool auto_rotate_{true};
+    bool training_{true};
+    bool quantized_{};
+    bool next_stream_is_encode_{true};
+    float camera_angle_x_{0.28F};
+    float camera_angle_y_{};
+    float camera_distance_{-11.5F};
+    float threshold_{0.30F};
+    float training_accumulator_{};
+    float stream_spawn_accumulator_{};
+    float pulse_{};
+    float status_time_{};
+    float last_gradient_l2_{};
+    std::size_t visible_voxels_{};
+    std::string status_message_;
+    const std::filesystem::path checkpoint_path_{
+        ".jarvisx-autoencoder3d/visualizer-model.jx3d"};
+
+    static constexpr Vec3 input_origin() noexcept { return {-3.25F, 0.0F, 0.0F}; }
+    static constexpr Vec3 latent_origin() noexcept { return {0.0F, 0.0F, 0.0F}; }
+    static constexpr Vec3 output_origin() noexcept { return {3.25F, 0.0F, 0.0F}; }
+
+    void refresh_snapshots(float gradient_l2) {
+        latent_ = model_.encode(input_, quantized_);
+        reconstruction_ = model_.decode(latent_);
+        metrics_ = jarvisx::measure_reconstruction(
+            input_, latent_, reconstruction_, model_.steps());
+        metrics_.gradient_l2 = gradient_l2;
+        last_gradient_l2_ = gradient_l2;
+        pulse_ = 1.0F;
+    }
+
+    void spawn_pipeline_burst() {
+        for (int index = 0; index < 3; ++index) {
+            spawn_stream(OperationType::Encode);
+            spawn_stream(OperationType::Decode);
+        }
+        spawn_stream(OperationType::Residual);
+    }
+
+    void spawn_stream(OperationType operation) {
+        if (streams_.size() >= kMaxStreams) return;
+
+        const float jitter_y = unit_distribution_(rng_) * 0.85F;
+        const float jitter_z = unit_distribution_(rng_) * 0.85F;
+        DataStream stream;
+        stream.operation = operation;
+        stream.speed = 0.65F + 0.55F *
+            (0.5F + 0.5F * unit_distribution_(rng_));
+
+        if (operation == OperationType::Encode) {
+            stream.start = input_origin() + Vec3{0.8F, jitter_y, jitter_z};
+            stream.end = latent_origin() + Vec3{-0.65F, -0.25F * jitter_y,
+                                                -0.25F * jitter_z};
+            stream.control = (stream.start + stream.end) * 0.5F +
+                             Vec3{0.0F, 0.65F, 0.0F};
+            stream.color = {0.0F, 1.0F, 0.8F};
+        } else if (operation == OperationType::Decode) {
+            stream.start = latent_origin() + Vec3{0.65F, 0.25F * jitter_y,
+                                                  0.25F * jitter_z};
+            stream.end = output_origin() + Vec3{-0.8F, jitter_y, jitter_z};
+            stream.control = (stream.start + stream.end) * 0.5F +
+                             Vec3{0.0F, -0.65F, 0.0F};
+            stream.color = {1.0F, 0.35F, 0.8F};
+        } else {
+            stream.start = output_origin() + Vec3{0.0F, jitter_y, jitter_z};
+            stream.end = input_origin() + Vec3{0.0F, -jitter_y, -jitter_z};
+            stream.control = {0.0F, 3.0F + 0.4F * jitter_y, 0.0F};
+            stream.color = {1.0F, 0.75F, 0.15F};
+            stream.speed *= 0.65F;
+        }
+        stream.position = stream.start;
+        streams_.push_back(stream);
+    }
+
+    void cycle_pattern() {
+        pattern_index_ = (pattern_index_ + 1U) % patterns_.size();
+        options_.pattern = patterns_[pattern_index_];
+        input_ = jarvisx::make_volume(model_.config().input_edge,
+                                      options_.pattern, model_.config().seed);
+        refresh_snapshots(last_gradient_l2_);
+        set_status("input pattern: " + options_.pattern);
+        spawn_pipeline_burst();
+    }
+
+    void reset_model() {
+        const jarvisx::Autoencoder3DConfig config = model_.config();
+        model_ = jarvisx::Autoencoder3D(config);
+        refresh_snapshots(0.0F);
+        set_status("model reinitialized from deterministic seed");
+        spawn_pipeline_burst();
+    }
+
+    void save_checkpoint() {
+        try {
+            model_.save(checkpoint_path_);
+            set_status("checkpoint saved: " + checkpoint_path_.string());
+        } catch (const std::exception& error) {
+            set_status(std::string("save failed: ") + error.what());
+        }
+    }
+
+    void load_checkpoint() {
+        try {
+            model_ = jarvisx::Autoencoder3D::load(checkpoint_path_);
+            input_ = jarvisx::make_volume(model_.config().input_edge,
+                                          options_.pattern,
+                                          model_.config().seed);
+            refresh_snapshots(0.0F);
+            set_status("checkpoint loaded: " + checkpoint_path_.string());
+            spawn_pipeline_burst();
+        } catch (const std::exception& error) {
+            set_status(std::string("load failed: ") + error.what());
+        }
+    }
+
+    void set_status(std::string message) {
+        status_message_ = std::move(message);
+        status_time_ = 4.0F;
+        std::cout << status_message_ << '\n';
+    }
+
+    void render_composite() {
+        const float dynamic_extent = kPipelineExtent + 0.08F * pulse_;
+        visible_voxels_ += render_scalar_tensor(
+            input_, input_origin(), dynamic_extent, threshold_,
+            {0.0F, 1.0F, 0.8F}, false);
+        visible_voxels_ += render_latent_tensor(
+            latent_origin(), dynamic_extent * 0.92F, threshold_ * 0.65F);
+        visible_voxels_ += render_scalar_tensor(
+            reconstruction_, output_origin(), dynamic_extent, threshold_,
+            {1.0F, 0.35F, 0.8F}, false);
+        visible_voxels_ += render_residual_tensor(
+            output_origin(), dynamic_extent,
+            std::max(0.10F, threshold_ * 0.55F));
+
+        render_wire_cube(input_origin(), dynamic_extent * 0.5F,
+                         {0.0F, 1.0F, 0.8F}, 0.32F);
+        render_wire_cube(latent_origin(), dynamic_extent * 0.46F,
+                         {0.55F, 0.2F, 1.0F}, 0.36F);
+        render_wire_cube(output_origin(), dynamic_extent * 0.5F,
+                         {1.0F, 0.35F, 0.8F}, 0.32F);
+        render_pipeline_edges();
+    }
+
+    std::size_t render_scalar_tensor(const jarvisx::Tensor4D& tensor,
+                                     const Vec3& origin, float extent,
+                                     float threshold, const Color& color,
+                                     bool absolute_value) const {
+        const jarvisx::TensorShape4D shape = tensor.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        const float cube_size = spacing * 0.58F;
+        std::size_t count = 0U;
+
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    const float raw = tensor(0U, z, y, x);
+                    const float activation = absolute_value ? std::fabs(raw) : raw;
+                    if (activation <= threshold) continue;
+                    const float intensity = std::clamp(
+                        (activation - threshold) /
+                            std::max(0.001F, 1.0F - threshold),
+                        0.0F, 1.0F);
+                    glColor4f(color.r, color.g, color.b,
+                              0.16F + 0.70F * intensity);
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(cube_size));
+                    glPopMatrix();
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    std::size_t render_latent_tensor(const Vec3& origin, float extent,
+                                     float threshold) const {
+        const jarvisx::TensorShape4D shape = latent_.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        const float cube_size = spacing * 0.62F;
+        const float inverse_channels = 1.0F /
+            static_cast<float>(shape.channels);
+        std::size_t count = 0U;
+
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    float signed_sum = 0.0F;
+                    float square_sum = 0.0F;
+                    for (std::size_t channel = 0; channel < shape.channels;
+                         ++channel) {
+                        const float value = latent_(channel, z, y, x);
+                        signed_sum += value;
+                        square_sum += value * value;
+                    }
+                    const float energy = std::sqrt(square_sum * inverse_channels);
+                    if (energy <= threshold) continue;
+                    const float intensity = std::clamp(
+                        (energy - threshold) /
+                            std::max(0.001F, 1.0F - threshold),
+                        0.0F, 1.0F);
+                    const bool positive = signed_sum >= 0.0F;
+                    const Color color = positive
+                        ? Color{0.15F, 0.55F, 1.0F}
+                        : Color{0.65F, 0.15F, 1.0F};
+                    glColor4f(color.r, color.g, color.b,
+                              0.22F + 0.74F * intensity);
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(cube_size));
+                    glPopMatrix();
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    std::size_t render_residual_tensor(const Vec3& origin, float extent,
+                                       float threshold) const {
+        const jarvisx::TensorShape4D shape = input_.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        const float cube_size = spacing * 0.31F;
+        std::size_t count = 0U;
+
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    const float error = std::fabs(
+                        input_(0U, z, y, x) - reconstruction_(0U, z, y, x));
+                    if (error <= threshold) continue;
+                    const float intensity = std::clamp(error * 0.5F, 0.0F, 1.0F);
+                    glColor4f(1.0F, 0.72F, 0.10F, 0.20F + 0.78F * intensity);
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(cube_size));
+                    glPopMatrix();
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    static void render_wire_cube(const Vec3& origin, float half_extent,
+                                 const Color& color, float alpha) {
+        glColor4f(color.r, color.g, color.b, alpha);
+        glLineWidth(1.35F);
+        glPushMatrix();
+        glTranslatef(origin.x, origin.y, origin.z);
+        glutWireCube(static_cast<double>(2.0F * half_extent));
+        glPopMatrix();
+    }
+
+    static void render_pipeline_edges() {
+        glLineWidth(2.0F);
+        glBegin(GL_LINES);
+        glColor4f(0.0F, 1.0F, 0.8F, 0.55F);
+        glVertex3f(-2.15F, 0.0F, 0.0F);
+        glVertex3f(-1.05F, 0.0F, 0.0F);
+        glColor4f(1.0F, 0.35F, 0.8F, 0.55F);
+        glVertex3f(1.05F, 0.0F, 0.0F);
+        glVertex3f(2.15F, 0.0F, 0.0F);
+        glEnd();
+    }
+
+    static void render_base_ring() {
+        glPushMatrix();
+        glTranslatef(0.0F, -2.15F, 0.0F);
+        glRotatef(90.0F, 1.0F, 0.0F, 0.0F);
+        glColor4f(0.0F, 0.65F, 1.0F, 0.30F);
+        glutWireTorus(0.06, 3.65, 18, 72);
+        glColor4f(0.65F, 0.20F, 1.0F, 0.22F);
+        glutWireTorus(0.04, 4.15, 14, 72);
+        glPopMatrix();
+    }
+
+    static const char* view_name(ViewMode mode) noexcept {
+        switch (mode) {
+        case ViewMode::Composite: return "composite pipeline";
+        case ViewMode::Input: return "input tensor X";
+        case ViewMode::Latent: return "latent tensor Z";
+        case ViewMode::Reconstruction: return "reconstruction X-hat";
+        case ViewMode::Residual: return "residual |X-X-hat|";
+        }
+        return "unknown";
+    }
+
+    static void draw_text(float x, float y, const std::string& text,
+                          void* font = GLUT_BITMAP_8_BY_13) {
+        glRasterPos2f(x, y);
+        for (const unsigned char character : text) {
+            glutBitmapCharacter(font, static_cast<int>(character));
+        }
+    }
+
+    void render_hud(int window_width, int window_height) const {
+        glMatrixMode(GL_PROJECTION);
+        glPushMatrix();
+        glLoadIdentity();
+        glOrtho(0.0, static_cast<double>(window_width), 0.0,
+                static_cast<double>(window_height), -1.0, 1.0);
+        glMatrixMode(GL_MODELVIEW);
+        glPushMatrix();
+        glLoadIdentity();
+        glDisable(GL_LIGHTING);
+        glDisable(GL_DEPTH_TEST);
+
+        const float top = static_cast<float>(window_height) - 28.0F;
+        glColor3f(0.25F, 0.90F, 1.0F);
+        draw_text(18.0F, top,
+                  "DR MOAGI 3D AUTO-ENCODING / DECODING ANN CORE",
+                  GLUT_BITMAP_HELVETICA_18);
+
+        std::ostringstream telemetry;
+        telemetry << std::fixed << std::setprecision(6)
+                  << "step=" << metrics_.step
+                  << "  mse=" << metrics_.mse
+                  << "  mae=" << metrics_.mae
+                  << "  latent_energy=" << metrics_.latent_energy
+                  << "  grad_l2=" << metrics_.gradient_l2;
+        glColor3f(0.75F, 0.88F, 1.0F);
+        draw_text(18.0F, top - 24.0F, telemetry.str());
+
+        std::ostringstream state;
+        state << "X=" << model_.config().input_edge << "^3"
+              << "  Z=" << model_.config().latent_channels << "x"
+              << model_.config().input_edge / 2U << "^3"
+              << "  pattern=" << patterns_[pattern_index_]
+              << "  view=" << view_name(view_mode_)
+              << "  training=" << (training_ ? "ON" : "PAUSED")
+              << "  Q3=" << (quantized_ ? "ON" : "OFF")
+              << "  threshold=" << std::setprecision(2) << threshold_;
+        glColor3f(0.65F, 1.0F, 0.78F);
+        draw_text(18.0F, top - 44.0F, state.str());
+
+        std::ostringstream render_state;
+        render_state << "visible_voxels=" << visible_voxels_
+                     << "  streams=" << streams_.size()
+                     << "  encode -> latent -> decode -> residual -> SGD";
+        glColor3f(1.0F, 0.72F, 0.90F);
+        draw_text(18.0F, top - 64.0F, render_state.str());
+
+        glColor3f(0.65F, 0.75F, 0.88F);
+        draw_text(18.0F, 18.0F,
+                  "Mouse/Arrows rotate | Wheel zoom | T/Space train | Q Q3 | P pattern | N reset | S/L checkpoint | 0-4 views | +/- threshold | R auto | Esc exit");
+
+        if (status_time_ > 0.0F && !status_message_.empty()) {
+            glColor3f(1.0F, 0.82F, 0.20F);
+            draw_text(18.0F, 42.0F, status_message_, GLUT_BITMAP_HELVETICA_12);
+        }
+
+        glEnable(GL_DEPTH_TEST);
+        glEnable(GL_LIGHTING);
+        glPopMatrix();
+        glMatrixMode(GL_PROJECTION);
+        glPopMatrix();
+        glMatrixMode(GL_MODELVIEW);
+    }
+};
+
+std::unique_ptr<GeometricAutoencoderEngine> g_engine;
+int g_last_time = 0;
+int g_window_width = 1280;
+int g_window_height = 720;
+bool g_mouse_down = false;
+int g_last_mouse_x = 0;
+int g_last_mouse_y = 0;
+
+void initialize_opengl() {
+    glClearColor(0.0F, 0.0F, 0.025F, 1.0F);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_COLOR_MATERIAL);
+    glColorMaterial(GL_FRONT_AND_BACK, GL_AMBIENT_AND_DIFFUSE);
+    glEnable(GL_NORMALIZE);
+
+    const GLfloat ambient[] = {0.18F, 0.18F, 0.25F, 1.0F};
+    const GLfloat diffuse[] = {0.90F, 0.90F, 1.0F, 1.0F};
+    glLightfv(GL_LIGHT0, GL_AMBIENT, ambient);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE, diffuse);
+    glEnable(GL_LIGHT0);
+    glEnable(GL_LIGHTING);
+}
+
+void display() {
+    g_engine->render(g_window_width, g_window_height);
+    glutSwapBuffers();
+}
+
+void reshape(int width, int height) {
+    if (height <= 0) height = 1;
+    g_window_width = width;
+    g_window_height = height;
+    glViewport(0, 0, width, height);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+
+    constexpr double near_plane = 0.1;
+    constexpr double far_plane = 100.0;
+    constexpr double field_of_view_degrees = 60.0;
+    const double aspect = static_cast<double>(width) / static_cast<double>(height);
+    const double top = near_plane * std::tan(
+        field_of_view_degrees * static_cast<double>(kPi) / 360.0);
+    const double right = top * aspect;
+    glFrustum(-right, right, -top, top, near_plane, far_plane);
+    glMatrixMode(GL_MODELVIEW);
+}
+
+void timer(int) {
+    const int current_time = glutGet(GLUT_ELAPSED_TIME);
+    const int elapsed_milliseconds = std::max(0, current_time - g_last_time);
+    g_last_time = current_time;
+    g_engine->update(static_cast<float>(elapsed_milliseconds) / 1000.0F);
+    glutPostRedisplay();
+    glutTimerFunc(kTimerMilliseconds, timer, 0);
+}
+
+void mouse(int button, int state, int x, int y) {
+    if (button == GLUT_LEFT_BUTTON) {
+        g_mouse_down = state == GLUT_DOWN;
+        g_last_mouse_x = x;
+        g_last_mouse_y = y;
+    }
+    if (state == GLUT_DOWN && button == 3) g_engine->zoom(0.55F);
+    if (state == GLUT_DOWN && button == 4) g_engine->zoom(-0.55F);
+}
+
+void motion(int x, int y) {
+    if (!g_mouse_down) return;
+    g_engine->rotate_camera(x - g_last_mouse_x, y - g_last_mouse_y);
+    g_last_mouse_x = x;
+    g_last_mouse_y = y;
+}
+
+void keyboard(unsigned char key, int, int) {
+    g_engine->keyboard(key);
+}
+
+void special(int key, int, int) {
+    g_engine->special_key(key);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        glutInit(&argc, argv);
+        glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+        glutInitWindowSize(g_window_width, g_window_height);
+        glutCreateWindow("Dr Moagi 3D Auto-Encoding and Decoding ANN Core");
+
+        initialize_opengl();
+        g_engine = std::make_unique<GeometricAutoencoderEngine>(options);
+
+        glutDisplayFunc(display);
+        glutReshapeFunc(reshape);
+        glutTimerFunc(kTimerMilliseconds, timer, 0);
+        glutMouseFunc(mouse);
+        glutMotionFunc(motion);
+        glutKeyboardFunc(keyboard);
+        glutSpecialFunc(special);
+
+        g_last_time = glutGet(GLUT_ELAPSED_TIME);
+        std::cout
+            << "=== Dr Moagi 3D Auto-Encoding / Decoding ANN Core ===\n"
+            << "The visual field is driven by the real C++17 convolutional "
+               "autoencoder state.\n"
+            << "Press T to train, Q for signed 3-bit latent inference, P to "
+               "change the fixture, and 0-4 to change views.\n";
+
+        glutMainLoop();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis-X OpenGL autoencoder failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/src/autoencoder3d_main.cpp
+++ b/cpp_runtime/src/autoencoder3d_main.cpp
@@ -1,0 +1,169 @@
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::size_t edge{8U};
+    std::size_t channels{4U};
+    std::uint64_t epochs{250U};
+    float learning_rate{0.03F};
+    float l2_penalty{1.0e-4F};
+    float gradient_clip{1.0F};
+    std::uint64_t seed{0x4A415256495358ULL};
+    std::string pattern{"sphere"};
+    std::filesystem::path export_dir{".jarvisx-autoencoder3d"};
+    std::filesystem::path save_model;
+    std::filesystem::path load_model;
+    bool quantized{};
+    bool quiet{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const std::uint64_t parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument("invalid integer after " + flag);
+    }
+    return parsed;
+}
+
+float parse_float(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument("invalid floating-point value after " + flag);
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& index, const std::string& flag) -> std::string {
+        if (index + 1 >= argc) throw std::invalid_argument("missing value after " + flag);
+        ++index;
+        return argv[index];
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--edge") {
+            options.edge = static_cast<std::size_t>(parse_u64(value(index, argument), argument));
+        } else if (argument == "--channels") {
+            options.channels = static_cast<std::size_t>(parse_u64(value(index, argument), argument));
+        } else if (argument == "--epochs") {
+            options.epochs = std::max<std::uint64_t>(1U, parse_u64(value(index, argument), argument));
+        } else if (argument == "--learning-rate") {
+            options.learning_rate = parse_float(value(index, argument), argument);
+        } else if (argument == "--l2") {
+            options.l2_penalty = parse_float(value(index, argument), argument);
+        } else if (argument == "--gradient-clip") {
+            options.gradient_clip = parse_float(value(index, argument), argument);
+        } else if (argument == "--seed") {
+            options.seed = parse_u64(value(index, argument), argument);
+        } else if (argument == "--pattern") {
+            options.pattern = value(index, argument);
+        } else if (argument == "--export-dir") {
+            options.export_dir = value(index, argument);
+        } else if (argument == "--save-model") {
+            options.save_model = value(index, argument);
+        } else if (argument == "--load-model") {
+            options.load_model = value(index, argument);
+        } else if (argument == "--quantized") {
+            options.quantized = true;
+        } else if (argument == "--quiet") {
+            options.quiet = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: jarvisx-autoencoder3d [options]\n"
+                << "  --edge N              even input edge in [4,64]\n"
+                << "  --channels N          latent channels in [1,32]\n"
+                << "  --epochs N            SGD training steps\n"
+                << "  --learning-rate X     learning rate in (0,1]\n"
+                << "  --l2 X                L2 regularization in [0,1]\n"
+                << "  --gradient-clip X     elementwise gradient clip\n"
+                << "  --seed N              deterministic initialization seed\n"
+                << "  --pattern NAME        sphere|shell|checker|wave|noise\n"
+                << "  --quantized           use signed 3-bit latent for final inference\n"
+                << "  --export-dir PATH     write CSV and OBJ artifacts\n"
+                << "  --save-model PATH     persist trained model\n"
+                << "  --load-model PATH     resume a saved model\n"
+                << "  --quiet                suppress progress output\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        jarvisx::Autoencoder3D model = options.load_model.empty()
+            ? jarvisx::Autoencoder3D({options.edge, options.channels,
+                                     options.learning_rate, options.l2_penalty,
+                                     options.gradient_clip, options.seed})
+            : jarvisx::Autoencoder3D::load(options.load_model);
+
+        const auto input = jarvisx::make_volume(
+            model.config().input_edge, options.pattern, model.config().seed);
+        std::filesystem::create_directories(options.export_dir);
+        std::ofstream metrics_file(options.export_dir / "metrics.csv", std::ios::trunc);
+        if (!metrics_file) throw std::runtime_error("cannot write metrics.csv");
+        metrics_file << "step,mse,mae,max_abs_error,latent_energy,gradient_l2\n";
+
+        const std::uint64_t report_interval = std::max<std::uint64_t>(1U, options.epochs / 20U);
+        jarvisx::Autoencoder3DMetrics metrics{};
+        for (std::uint64_t epoch = 0; epoch < options.epochs; ++epoch) {
+            metrics = model.train_step(input);
+            metrics_file << metrics.step << ',' << metrics.mse << ',' << metrics.mae
+                         << ',' << metrics.max_abs_error << ',' << metrics.latent_energy
+                         << ',' << metrics.gradient_l2 << '\n';
+            if (!options.quiet &&
+                (epoch == 0U || epoch + 1U == options.epochs ||
+                 (epoch + 1U) % report_interval == 0U)) {
+                std::cout << "step=" << metrics.step
+                          << " mse=" << metrics.mse
+                          << " mae=" << metrics.mae
+                          << " latent_energy=" << metrics.latent_energy
+                          << " gradient_l2=" << metrics.gradient_l2 << '\n';
+            }
+        }
+
+        const auto latent = model.encode(input, options.quantized);
+        const auto reconstruction = model.decode(latent);
+        const auto final_metrics = jarvisx::measure_reconstruction(
+            input, latent, reconstruction, model.steps());
+
+        jarvisx::export_obj(input, options.export_dir / "input.obj");
+        jarvisx::export_obj(latent, options.export_dir / "latent.obj");
+        jarvisx::export_obj(reconstruction,
+                            options.export_dir / "reconstruction.obj");
+
+        const std::filesystem::path model_path = options.save_model.empty()
+            ? options.export_dir / "model.jx3d"
+            : options.save_model;
+        model.save(model_path);
+
+        if (!options.quiet) {
+            std::cout << "final_mse=" << final_metrics.mse
+                      << " final_mae=" << final_metrics.mae
+                      << " quantized=" << (options.quantized ? "true" : "false")
+                      << " model=" << model_path.string()
+                      << " artifacts=" << options.export_dir.string() << '\n';
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis-X 3D autoencoder failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/src/multimedia4d_glut.cpp
+++ b/cpp_runtime/src/multimedia4d_glut.cpp
@@ -1,0 +1,702 @@
+#if defined(__APPLE__)
+#include <GLUT/glut.h>
+#else
+#include <GL/glut.h>
+#include <GL/gl.h>
+#include <GL/glu.h>
+#endif
+
+#include "jarvisx/multimedia4d.hpp"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <deque>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr float kPi = 3.14159265358979323846F;
+constexpr std::size_t kMaxStreams = 96U;
+
+struct Vec3 {
+    float x{};
+    float y{};
+    float z{};
+    Vec3 operator+(const Vec3& other) const noexcept {
+        return {x + other.x, y + other.y, z + other.z};
+    }
+    Vec3 operator*(float scale) const noexcept {
+        return {x * scale, y * scale, z * scale};
+    }
+};
+
+struct Color { float r{}, g{}, b{}; };
+
+Color media_color(jarvisx::MediaType media) noexcept {
+    switch (media) {
+    case jarvisx::MediaType::Visual: return {0.0F, 1.0F, 0.8F};
+    case jarvisx::MediaType::Audio: return {1.0F, 0.35F, 0.8F};
+    case jarvisx::MediaType::Text: return {1.0F, 0.82F, 0.18F};
+    case jarvisx::MediaType::Generic: return {0.35F, 0.55F, 1.0F};
+    }
+    return {1.0F, 1.0F, 1.0F};
+}
+
+enum class StreamType : std::uint8_t { Encode, Decode, Feedback };
+
+struct DataStream {
+    Vec3 start;
+    Vec3 control;
+    Vec3 end;
+    Vec3 position;
+    Color color;
+    float progress{};
+    float speed{1.0F};
+    StreamType type{StreamType::Encode};
+
+    bool update(float dt) noexcept {
+        progress = std::min(1.0F, progress + speed * dt);
+        const float u = 1.0F - progress;
+        position = start * (u * u) + control * (2.0F * u * progress) +
+                   end * (progress * progress);
+        return progress < 1.0F;
+    }
+
+    void render() const {
+        glColor4f(color.r, color.g, color.b, 1.0F - 0.45F * progress);
+        glPushMatrix();
+        glTranslatef(position.x, position.y, position.z);
+        const float radius = type == StreamType::Feedback ? 0.055F : 0.045F;
+        glutSolidSphere(static_cast<double>(radius), 8, 8);
+        glPopMatrix();
+    }
+};
+
+class FrameBudgetController {
+public:
+    void record(float milliseconds) {
+        history_.push_back(milliseconds);
+        if (history_.size() > 60U) history_.pop_front();
+        double sum = 0.0;
+        for (const float sample : history_) sum += sample;
+        average_ms_ = history_.empty() ? 0.0F :
+            static_cast<float>(sum / static_cast<double>(history_.size()));
+        if (history_.size() == 60U) adapt();
+    }
+
+    float average_ms() const noexcept { return average_ms_; }
+    float threshold_bias() const noexcept { return threshold_bias_; }
+    std::size_t temporal_layers(std::size_t available) const noexcept {
+        return std::min(available, temporal_layers_);
+    }
+    float training_interval() const noexcept { return training_interval_; }
+
+private:
+    std::deque<float> history_;
+    float average_ms_{16.67F};
+    float threshold_bias_{};
+    std::size_t temporal_layers_{8U};
+    float training_interval_{0.075F};
+
+    void adapt() noexcept {
+        if (average_ms_ > 22.0F) {
+            threshold_bias_ = std::min(0.35F, threshold_bias_ + 0.025F);
+            temporal_layers_ = std::max<std::size_t>(1U, temporal_layers_ - 1U);
+            training_interval_ = std::min(0.25F, training_interval_ * 1.08F);
+        } else if (average_ms_ < 13.0F) {
+            threshold_bias_ = std::max(0.0F, threshold_bias_ - 0.015F);
+            temporal_layers_ = std::min<std::size_t>(16U, temporal_layers_ + 1U);
+            training_interval_ = std::max(0.035F, training_interval_ * 0.96F);
+        }
+    }
+};
+
+struct Options {
+    std::size_t edge{16U};
+    std::size_t channels{4U};
+    std::size_t temporal_depth{8U};
+    std::uint16_t proposal_steps{2U};
+    float learning_rate{0.015F};
+    float temporal_decay{0.72F};
+    std::uint64_t seed{0x4A415256495358ULL};
+    bool quantized{};
+    bool paused{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const auto parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument("invalid integer after " + flag);
+    }
+    return parsed;
+}
+
+float parse_float(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument("invalid float after " + flag);
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& index, const std::string& flag) {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("missing value after " + flag);
+        }
+        return std::string(argv[++index]);
+    };
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--edge") {
+            options.edge = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--channels") {
+            options.channels = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--temporal-depth") {
+            options.temporal_depth = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--proposal-steps") {
+            options.proposal_steps = static_cast<std::uint16_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--learning-rate") {
+            options.learning_rate = parse_float(value(index, argument), argument);
+        } else if (argument == "--temporal-decay") {
+            options.temporal_decay = parse_float(value(index, argument), argument);
+        } else if (argument == "--seed") {
+            options.seed = parse_u64(value(index, argument), argument);
+        } else if (argument == "--quantized") {
+            options.quantized = true;
+        } else if (argument == "--paused") {
+            options.paused = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: jarvisx-multimedia4d-gl [options]\n"
+                << "  --edge N --channels N --temporal-depth N\n"
+                << "  --proposal-steps N --learning-rate X\n"
+                << "  --temporal-decay X --seed N --quantized --paused\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+jarvisx::Multimedia4DConfig make_config(const Options& options) {
+    jarvisx::Multimedia4DConfig config;
+    config.model.input_edge = options.edge;
+    config.model.latent_channels = options.channels;
+    config.model.learning_rate = options.learning_rate;
+    config.model.seed = options.seed;
+    config.temporal_depth = options.temporal_depth;
+    config.temporal_decay = options.temporal_decay;
+    config.proposal_steps = options.proposal_steps;
+    config.quantized_inference = options.quantized;
+    return config;
+}
+
+class MultimediaVisualizer {
+public:
+    explicit MultimediaVisualizer(Options options)
+        : options_(std::move(options)), engine_(make_config(options_)),
+          selected_(jarvisx::MediaType::Visual), training_(!options_.paused),
+          rng_(options_.seed), unit_(-1.0F, 1.0F) {
+        spawn_burst();
+    }
+
+    void update(float dt) {
+        const auto start = std::chrono::steady_clock::now();
+        dt = std::clamp(dt, 0.0F, 0.1F);
+        if (auto_rotate_) camera_y_ += dt * 0.22F;
+
+        if (training_) {
+            training_accumulator_ += dt;
+            if (training_accumulator_ >= budget_.training_interval()) {
+                const auto metrics = engine_.step();
+                if (follow_optimizer_) selected_ = metrics.selected;
+                training_accumulator_ = 0.0F;
+                spawn_burst();
+            }
+        }
+
+        stream_accumulator_ += dt;
+        if (stream_accumulator_ >= 0.12F) {
+            spawn_stream(next_encode_ ? StreamType::Encode : StreamType::Decode);
+            next_encode_ = !next_encode_;
+            stream_accumulator_ = 0.0F;
+        }
+        for (auto iterator = streams_.begin(); iterator != streams_.end();) {
+            if (!iterator->update(dt)) iterator = streams_.erase(iterator);
+            else ++iterator;
+        }
+
+        const auto stop = std::chrono::steady_clock::now();
+        budget_.record(static_cast<float>(
+            std::chrono::duration<double, std::milli>(stop - start).count()));
+    }
+
+    void render(int width, int height) {
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        glTranslatef(0.0F, 0.0F, camera_distance_);
+        glRotatef(camera_x_ * 180.0F / kPi, 1.0F, 0.0F, 0.0F);
+        glRotatef(camera_y_ * 180.0F / kPi, 0.0F, 1.0F, 0.0F);
+
+        const GLfloat light_position[] = {2.0F, 6.0F, 8.0F, 1.0F};
+        glLightfv(GL_LIGHT0, GL_POSITION, light_position);
+        glEnable(GL_BLEND);
+        glBlendFunc(GL_SRC_ALPHA, GL_ONE);
+        glDepthMask(GL_FALSE);
+
+        render_pipeline();
+        for (const DataStream& stream : streams_) stream.render();
+        render_base_ring();
+
+        glDepthMask(GL_TRUE);
+        glDisable(GL_BLEND);
+        render_hud(width, height);
+    }
+
+    void keyboard(unsigned char key) {
+        switch (key) {
+        case '1': selected_ = jarvisx::MediaType::Visual; break;
+        case '2': selected_ = jarvisx::MediaType::Audio; break;
+        case '3': selected_ = jarvisx::MediaType::Text; break;
+        case '4': selected_ = jarvisx::MediaType::Generic; break;
+        case ' ': training_ = !training_; break;
+        case 'q': case 'Q': engine_.set_quantized(!engine_.quantized()); break;
+        case 'r': case 'R': auto_rotate_ = !auto_rotate_; break;
+        case 'f': case 'F': follow_optimizer_ = !follow_optimizer_; break;
+        case 's': case 'S': save(); break;
+        case 'l': case 'L': load(); break;
+        case '+': case '=': threshold_ = std::max(0.02F, threshold_ - 0.03F); break;
+        case '-': case '_': threshold_ = std::min(0.92F, threshold_ + 0.03F); break;
+        case 27: std::exit(0);
+        default: break;
+        }
+        spawn_burst();
+    }
+
+    void rotate(int dx, int dy) noexcept {
+        camera_y_ += static_cast<float>(dx) * 0.005F;
+        camera_x_ = std::clamp(
+            camera_x_ + static_cast<float>(dy) * 0.005F, -1.2F, 1.2F);
+        auto_rotate_ = false;
+    }
+
+    void zoom(float delta) noexcept {
+        camera_distance_ = std::clamp(camera_distance_ + delta, -18.0F, -7.5F);
+    }
+
+private:
+    Options options_;
+    jarvisx::MultimediaAutoencoder4D engine_;
+    jarvisx::MediaType selected_;
+    bool training_{true};
+    bool auto_rotate_{true};
+    bool follow_optimizer_{true};
+    bool next_encode_{true};
+    float camera_x_{0.28F};
+    float camera_y_{};
+    float camera_distance_{-12.5F};
+    float threshold_{0.30F};
+    float training_accumulator_{};
+    float stream_accumulator_{};
+    std::mt19937_64 rng_;
+    std::uniform_real_distribution<float> unit_;
+    std::vector<DataStream> streams_;
+    FrameBudgetController budget_;
+    const std::filesystem::path checkpoint_{
+        ".jarvisx-multimedia4d/visualizer-checkpoint"};
+
+    static Vec3 input_origin() noexcept { return {-3.4F, 0.0F, 0.0F}; }
+    static Vec3 latent_origin() noexcept { return {0.0F, 0.0F, 0.0F}; }
+    static Vec3 output_origin() noexcept { return {3.4F, 0.0F, 0.0F}; }
+
+    void render_pipeline() {
+        const Color color = media_color(selected_);
+        const float threshold = std::min(0.95F,
+            threshold_ + budget_.threshold_bias());
+        render_scalar(engine_.input(selected_), input_origin(), 3.4F,
+                      threshold, color, false);
+        render_temporal_latent(latent_origin(), 3.0F,
+                               threshold * 0.65F);
+        render_scalar(engine_.reconstruction(selected_), output_origin(), 3.4F,
+                      threshold, {1.0F, 0.35F, 0.8F}, false);
+        render_residual(output_origin(), 3.4F,
+                        std::max(0.08F, threshold * 0.45F));
+        render_wire_cube(input_origin(), 1.8F, color);
+        render_wire_cube(latent_origin(), 1.65F, {0.45F, 0.25F, 1.0F});
+        render_wire_cube(output_origin(), 1.8F, {1.0F, 0.35F, 0.8F});
+        render_edges(color);
+    }
+
+    static void render_scalar(const jarvisx::Tensor4D& tensor,
+                              const Vec3& origin, float extent, float threshold,
+                              const Color& color, bool absolute) {
+        const auto shape = tensor.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        const float cube = spacing * 0.58F;
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    const float raw = tensor(0U, z, y, x);
+                    const float value = absolute ? std::fabs(raw) : raw;
+                    if (value <= threshold) continue;
+                    const float intensity = std::clamp(
+                        (value - threshold) / std::max(0.001F, 1.0F - threshold),
+                        0.0F, 1.0F);
+                    glColor4f(color.r, color.g, color.b,
+                              0.16F + 0.72F * intensity);
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(cube));
+                    glPopMatrix();
+                }
+            }
+        }
+    }
+
+    void render_temporal_latent(const Vec3& origin, float extent,
+                                float threshold) const {
+        const auto& history = engine_.temporal_history(selected_);
+        const std::size_t layers = budget_.temporal_layers(history.size());
+        std::size_t layer = 0U;
+        for (const auto& frame : history) {
+            if (layer >= layers) break;
+            const float time_fraction = layers <= 1U ? 0.0F :
+                static_cast<float>(layer) / static_cast<float>(layers - 1U);
+            render_latent_frame(frame,
+                {origin.x, origin.y + 0.18F * static_cast<float>(layer),
+                 origin.z - 0.22F * static_cast<float>(layer)},
+                extent * (1.0F - 0.045F * static_cast<float>(layer)),
+                threshold + 0.025F * static_cast<float>(layer),
+                1.0F - 0.75F * time_fraction);
+            ++layer;
+        }
+    }
+
+    static void render_latent_frame(const jarvisx::Tensor4D& tensor,
+                                    const Vec3& origin, float extent,
+                                    float threshold, float alpha_scale) {
+        const auto shape = tensor.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        const float cube = spacing * 0.60F;
+        const float inverse_channels = 1.0F /
+            static_cast<float>(shape.channels);
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    float sum = 0.0F;
+                    float energy = 0.0F;
+                    for (std::size_t channel = 0; channel < shape.channels;
+                         ++channel) {
+                        const float value = tensor(channel, z, y, x);
+                        sum += value;
+                        energy += value * value;
+                    }
+                    energy = std::sqrt(energy * inverse_channels);
+                    if (energy <= threshold) continue;
+                    const Color color = sum >= 0.0F
+                        ? Color{0.12F, 0.58F, 1.0F}
+                        : Color{0.68F, 0.18F, 1.0F};
+                    glColor4f(color.r, color.g, color.b,
+                              alpha_scale * (0.18F + 0.70F * energy));
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(cube));
+                    glPopMatrix();
+                }
+            }
+        }
+    }
+
+    void render_residual(const Vec3& origin, float extent, float threshold) const {
+        const auto& input = engine_.input(selected_);
+        const auto& output = engine_.reconstruction(selected_);
+        const auto shape = input.shape();
+        const float edge = static_cast<float>(shape.width);
+        const float spacing = extent / edge;
+        for (std::size_t z = 0; z < shape.depth; ++z) {
+            for (std::size_t y = 0; y < shape.height; ++y) {
+                for (std::size_t x = 0; x < shape.width; ++x) {
+                    const float error = std::fabs(
+                        input(0U, z, y, x) - output(0U, z, y, x));
+                    if (error <= threshold) continue;
+                    glColor4f(1.0F, 0.72F, 0.10F,
+                              0.18F + 0.68F * std::min(1.0F, error));
+                    glPushMatrix();
+                    glTranslatef(
+                        origin.x + (static_cast<float>(x) + 0.5F - edge * 0.5F) * spacing,
+                        origin.y + (static_cast<float>(y) + 0.5F - edge * 0.5F) * spacing,
+                        origin.z + (static_cast<float>(z) + 0.5F - edge * 0.5F) * spacing);
+                    glutSolidCube(static_cast<double>(spacing * 0.28F));
+                    glPopMatrix();
+                }
+            }
+        }
+    }
+
+    static void render_wire_cube(const Vec3& origin, float half_extent,
+                                 const Color& color) {
+        glColor4f(color.r, color.g, color.b, 0.34F);
+        glPushMatrix();
+        glTranslatef(origin.x, origin.y, origin.z);
+        glutWireCube(static_cast<double>(2.0F * half_extent));
+        glPopMatrix();
+    }
+
+    static void render_edges(const Color& media) {
+        glLineWidth(2.0F);
+        glBegin(GL_LINES);
+        glColor4f(media.r, media.g, media.b, 0.58F);
+        glVertex3f(-2.2F, 0.0F, 0.0F); glVertex3f(-1.1F, 0.0F, 0.0F);
+        glColor4f(1.0F, 0.35F, 0.8F, 0.58F);
+        glVertex3f(1.1F, 0.0F, 0.0F); glVertex3f(2.2F, 0.0F, 0.0F);
+        glColor4f(1.0F, 0.72F, 0.10F, 0.42F);
+        glVertex3f(3.4F, 1.7F, 0.0F); glVertex3f(-3.4F, 1.7F, 0.0F);
+        glEnd();
+    }
+
+    static void render_base_ring() {
+        glDisable(GL_LIGHTING);
+        glColor4f(0.0F, 0.65F, 1.0F, 0.45F);
+        glBegin(GL_LINE_LOOP);
+        for (int segment = 0; segment < 96; ++segment) {
+            const float angle = 2.0F * kPi * static_cast<float>(segment) / 96.0F;
+            glVertex3f(5.3F * std::cos(angle), -2.3F,
+                       5.3F * std::sin(angle));
+        }
+        glEnd();
+        glEnable(GL_LIGHTING);
+    }
+
+    void spawn_burst() {
+        for (int index = 0; index < 2; ++index) {
+            spawn_stream(StreamType::Encode);
+            spawn_stream(StreamType::Decode);
+        }
+        spawn_stream(StreamType::Feedback);
+    }
+
+    void spawn_stream(StreamType type) {
+        if (streams_.size() >= kMaxStreams) return;
+        const float jy = unit_(rng_) * 0.75F;
+        const float jz = unit_(rng_) * 0.75F;
+        DataStream stream;
+        stream.type = type;
+        stream.speed = 0.65F + 0.28F * (1.0F + unit_(rng_));
+        if (type == StreamType::Encode) {
+            stream.start = input_origin() + Vec3{0.9F, jy, jz};
+            stream.end = latent_origin() + Vec3{-0.7F, -0.2F * jy, -0.2F * jz};
+            stream.control = {-1.65F, 1.2F, 0.0F};
+            stream.color = media_color(selected_);
+        } else if (type == StreamType::Decode) {
+            stream.start = latent_origin() + Vec3{0.7F, 0.2F * jy, 0.2F * jz};
+            stream.end = output_origin() + Vec3{-0.9F, jy, jz};
+            stream.control = {1.65F, -1.2F, 0.0F};
+            stream.color = {1.0F, 0.35F, 0.8F};
+        } else {
+            stream.start = output_origin() + Vec3{0.0F, jy, jz};
+            stream.end = input_origin() + Vec3{0.0F, -jy, -jz};
+            stream.control = {0.0F, 3.1F, 0.0F};
+            stream.color = {1.0F, 0.72F, 0.10F};
+            stream.speed *= 0.60F;
+        }
+        stream.position = stream.start;
+        streams_.push_back(stream);
+    }
+
+    void save() {
+        try {
+            engine_.save_checkpoint(checkpoint_);
+            std::cout << "checkpoint saved: " << checkpoint_.string() << '\n';
+        } catch (const std::exception& error) {
+            std::cerr << "save failed: " << error.what() << '\n';
+        }
+    }
+
+    void load() {
+        try {
+            engine_.load_checkpoint(checkpoint_);
+            std::cout << "checkpoint loaded: " << checkpoint_.string() << '\n';
+        } catch (const std::exception& error) {
+            std::cerr << "load failed: " << error.what() << '\n';
+        }
+    }
+
+    static void draw_text(float x, float y, const std::string& text) {
+        glRasterPos2f(x, y);
+        for (const unsigned char character : text) {
+            glutBitmapCharacter(GLUT_BITMAP_8_BY_13, character);
+        }
+    }
+
+    void render_hud(int width, int height) const {
+        glDisable(GL_LIGHTING);
+        glDisable(GL_DEPTH_TEST);
+        glMatrixMode(GL_PROJECTION);
+        glPushMatrix();
+        glLoadIdentity();
+        gluOrtho2D(0.0, static_cast<double>(width), 0.0,
+                   static_cast<double>(height));
+        glMatrixMode(GL_MODELVIEW);
+        glPushMatrix();
+        glLoadIdentity();
+        glColor3f(0.8F, 0.95F, 1.0F);
+
+        const auto& metrics = engine_.metrics();
+        const auto& modality = metrics.modalities[
+            jarvisx::media_index(selected_)];
+        std::ostringstream line;
+        line << "JARVIS-X 4D MULTIMODAL ANN | " << jarvisx::media_name(selected_)
+             << " | cycle " << metrics.cycle
+             << " | " << (training_ ? "TRAINING" : "PAUSED")
+             << " | " << (engine_.quantized() ? "Q3" : "FLOAT");
+        draw_text(18.0F, static_cast<float>(height - 24), line.str());
+        line.str({}); line.clear();
+        line << std::fixed << std::setprecision(5)
+             << "instant MSE " << modality.instantaneous_mse
+             << " | temporal MSE " << modality.temporal_mse
+             << " | coherence " << modality.temporal_coherence
+             << " | commits " << metrics.accepted
+             << " | rollbacks " << metrics.rejected;
+        draw_text(18.0F, static_cast<float>(height - 44), line.str());
+        line.str({}); line.clear();
+        line << std::setprecision(2)
+             << "update " << budget_.average_ms() << " ms"
+             << " | history " << engine_.temporal_history(selected_).size()
+             << "/" << engine_.config().temporal_depth
+             << " | follow " << (follow_optimizer_ ? "ON" : "OFF");
+        draw_text(18.0F, static_cast<float>(height - 64), line.str());
+        draw_text(18.0F, 18.0F,
+            "1-4 modality | SPACE train | Q Q3 | F follow | R rotate | S/L checkpoint | +/- density | ESC exit");
+
+        glPopMatrix();
+        glMatrixMode(GL_PROJECTION);
+        glPopMatrix();
+        glMatrixMode(GL_MODELVIEW);
+        glEnable(GL_DEPTH_TEST);
+        glEnable(GL_LIGHTING);
+    }
+};
+
+std::unique_ptr<MultimediaVisualizer> visualizer;
+int last_time = 0;
+bool mouse_down = false;
+int last_x = 0;
+int last_y = 0;
+int window_width = 1280;
+int window_height = 720;
+
+void display() {
+    visualizer->render(window_width, window_height);
+    glutSwapBuffers();
+}
+
+void reshape(int width, int height) {
+    window_width = std::max(1, width);
+    window_height = std::max(1, height);
+    glViewport(0, 0, window_width, window_height);
+    glMatrixMode(GL_PROJECTION);
+    glLoadIdentity();
+    gluPerspective(55.0, static_cast<double>(window_width) /
+                         static_cast<double>(window_height),
+                   0.1, 100.0);
+    glMatrixMode(GL_MODELVIEW);
+}
+
+void timer(int) {
+    const int now = glutGet(GLUT_ELAPSED_TIME);
+    const float dt = static_cast<float>(now - last_time) / 1000.0F;
+    last_time = now;
+    visualizer->update(dt);
+    glutPostRedisplay();
+    glutTimerFunc(16U, timer, 0);
+}
+
+void keyboard(unsigned char key, int, int) { visualizer->keyboard(key); }
+
+void mouse(int button, int state, int x, int y) {
+    if (button == GLUT_LEFT_BUTTON) {
+        mouse_down = state == GLUT_DOWN;
+        last_x = x;
+        last_y = y;
+    }
+#if defined(GLUT_WHEEL_UP)
+    if (button == GLUT_WHEEL_UP && state == GLUT_DOWN) visualizer->zoom(0.7F);
+    if (button == GLUT_WHEEL_DOWN && state == GLUT_DOWN) visualizer->zoom(-0.7F);
+#endif
+}
+
+void motion(int x, int y) {
+    if (!mouse_down) return;
+    visualizer->rotate(x - last_x, y - last_y);
+    last_x = x;
+    last_y = y;
+}
+
+void initialize_gl() {
+    glClearColor(0.0F, 0.0F, 0.02F, 1.0F);
+    glEnable(GL_DEPTH_TEST);
+    glEnable(GL_COLOR_MATERIAL);
+    glEnable(GL_LIGHT0);
+    glEnable(GL_LIGHTING);
+    const GLfloat ambient[] = {0.25F, 0.25F, 0.35F, 1.0F};
+    const GLfloat diffuse[] = {0.90F, 0.90F, 1.0F, 1.0F};
+    glLightfv(GL_LIGHT0, GL_AMBIENT, ambient);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE, diffuse);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        glutInit(&argc, argv);
+        glutInitDisplayMode(GLUT_DOUBLE | GLUT_RGB | GLUT_DEPTH);
+        glutInitWindowSize(window_width, window_height);
+        glutCreateWindow("Jarvis-X Self-Optimizing 4D Multimedia ANN");
+        initialize_gl();
+        visualizer = std::make_unique<MultimediaVisualizer>(options);
+        glutDisplayFunc(display);
+        glutReshapeFunc(reshape);
+        glutKeyboardFunc(keyboard);
+        glutMouseFunc(mouse);
+        glutMotionFunc(motion);
+        last_time = glutGet(GLUT_ELAPSED_TIME);
+        glutTimerFunc(16U, timer, 0);
+        std::cout << "Jarvis-X 4D multimodal visualizer online.\n";
+        glutMainLoop();
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis-X multimedia4d OpenGL failure: "
+                  << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/src/multimedia4d_main.cpp
+++ b/cpp_runtime/src/multimedia4d_main.cpp
@@ -1,0 +1,171 @@
+#include "jarvisx/multimedia4d.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::size_t edge{8U};
+    std::size_t channels{4U};
+    std::size_t temporal_depth{8U};
+    std::uint16_t proposal_steps{2U};
+    std::uint64_t cycles{120U};
+    float learning_rate{0.03F};
+    float temporal_decay{0.72F};
+    float accept_tolerance{1.0e-6F};
+    std::uint64_t seed{0x4A415256495358ULL};
+    std::filesystem::path output_dir{".jarvisx-multimedia4d"};
+    bool quantized{};
+    bool quiet{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const auto parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument("invalid integer after " + flag);
+    }
+    return parsed;
+}
+
+float parse_float(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument("invalid float after " + flag);
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& index, const std::string& flag) {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("missing value after " + flag);
+        }
+        return std::string(argv[++index]);
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--edge") {
+            options.edge = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--channels") {
+            options.channels = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--temporal-depth") {
+            options.temporal_depth = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--proposal-steps") {
+            options.proposal_steps = static_cast<std::uint16_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--cycles") {
+            options.cycles = std::max<std::uint64_t>(
+                1U, parse_u64(value(index, argument), argument));
+        } else if (argument == "--learning-rate") {
+            options.learning_rate = parse_float(value(index, argument), argument);
+        } else if (argument == "--temporal-decay") {
+            options.temporal_decay = parse_float(value(index, argument), argument);
+        } else if (argument == "--accept-tolerance") {
+            options.accept_tolerance = parse_float(value(index, argument), argument);
+        } else if (argument == "--seed") {
+            options.seed = parse_u64(value(index, argument), argument);
+        } else if (argument == "--output-dir") {
+            options.output_dir = value(index, argument);
+        } else if (argument == "--quantized") {
+            options.quantized = true;
+        } else if (argument == "--quiet") {
+            options.quiet = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: jarvisx-multimedia4d [options]\n"
+                << "  --edge N              even input edge in [4,64]\n"
+                << "  --channels N          latent channels in [1,32]\n"
+                << "  --temporal-depth N    latent history depth in [1,64]\n"
+                << "  --proposal-steps N    candidate SGD steps in [1,64]\n"
+                << "  --cycles N            adaptive transactions\n"
+                << "  --learning-rate X     base SGD learning rate\n"
+                << "  --temporal-decay X    history weight decay in [0,1)\n"
+                << "  --accept-tolerance X  maximum admitted MSE regression\n"
+                << "  --seed N              deterministic seed\n"
+                << "  --quantized           signed 3-bit temporal inference\n"
+                << "  --output-dir PATH     telemetry, OBJ and checkpoint path\n"
+                << "  --quiet               suppress progress output\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        jarvisx::Multimedia4DConfig config;
+        config.model.input_edge = options.edge;
+        config.model.latent_channels = options.channels;
+        config.model.learning_rate = options.learning_rate;
+        config.model.seed = options.seed;
+        config.temporal_depth = options.temporal_depth;
+        config.temporal_decay = options.temporal_decay;
+        config.proposal_steps = options.proposal_steps;
+        config.accept_tolerance = options.accept_tolerance;
+        config.quantized_inference = options.quantized;
+
+        jarvisx::MultimediaAutoencoder4D engine(config);
+        std::filesystem::create_directories(options.output_dir);
+        std::ofstream telemetry(options.output_dir / "multimedia4d.csv",
+                                std::ios::trunc);
+        if (!telemetry) throw std::runtime_error("cannot write multimedia4d.csv");
+        telemetry
+            << "cycle,selected,aggregate_mse,temporal_coherence,accepted,rejected,"
+            << "visual_mse,audio_mse,text_mse,generic_mse\n";
+
+        const std::uint64_t report_interval =
+            std::max<std::uint64_t>(1U, options.cycles / 20U);
+        for (std::uint64_t cycle = 0U; cycle < options.cycles; ++cycle) {
+            const auto metrics = engine.step();
+            telemetry << metrics.cycle << ','
+                      << jarvisx::media_name(metrics.selected) << ','
+                      << metrics.aggregate_mse << ','
+                      << metrics.aggregate_temporal_coherence << ','
+                      << metrics.accepted << ',' << metrics.rejected;
+            for (const auto media : jarvisx::media_types()) {
+                telemetry << ',' << metrics.modalities[
+                    jarvisx::media_index(media)].temporal_mse;
+            }
+            telemetry << '\n';
+
+            if (!options.quiet &&
+                (cycle == 0U || cycle + 1U == options.cycles ||
+                 (cycle + 1U) % report_interval == 0U)) {
+                std::cout << "cycle=" << metrics.cycle
+                          << " selected=" << jarvisx::media_name(metrics.selected)
+                          << " aggregate_mse=" << metrics.aggregate_mse
+                          << " temporal_coherence="
+                          << metrics.aggregate_temporal_coherence
+                          << " commits=" << metrics.accepted
+                          << " rollbacks=" << metrics.rejected << '\n';
+            }
+        }
+
+        jarvisx::export_multimedia4d_snapshot(engine, options.output_dir);
+        engine.save_checkpoint(options.output_dir / "checkpoint");
+        if (!options.quiet) {
+            std::cout << "artifacts=" << options.output_dir.string() << '\n';
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Jarvis-X multimedia4d failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/autoencoder3d_tests.cpp
+++ b/cpp_runtime/tests/autoencoder3d_tests.cpp
@@ -1,0 +1,83 @@
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void deterministic_initialization() {
+    const jarvisx::Autoencoder3DConfig config{8U, 3U, 0.02F, 1.0e-4F, 1.0F, 42U};
+    jarvisx::Autoencoder3D first(config);
+    jarvisx::Autoencoder3D second(config);
+    const auto input = jarvisx::make_volume(8U, "sphere", 42U);
+    const auto a = first.reconstruct(input);
+    const auto b = second.reconstruct(input);
+    require(a.values() == b.values(), "same seed must produce identical output");
+}
+
+void training_reduces_error() {
+    jarvisx::Autoencoder3D model({8U, 4U, 0.03F, 1.0e-4F, 1.0F, 7U});
+    const auto input = jarvisx::make_volume(8U, "sphere", 7U);
+    const auto before_latent = model.encode(input);
+    const auto before_output = model.decode(before_latent);
+    const float before = jarvisx::measure_reconstruction(
+        input, before_latent, before_output, 0U).mse;
+    for (std::size_t step = 0; step < 180U; ++step) {
+        const auto metrics = model.train_step(input);
+        require(std::isfinite(metrics.mse), "training MSE must stay finite");
+    }
+    const auto after_latent = model.encode(input);
+    const auto after_output = model.decode(after_latent);
+    const float after = jarvisx::measure_reconstruction(
+        input, after_latent, after_output, model.steps()).mse;
+    require(after < before * 0.85F, "training must materially reduce reconstruction error");
+}
+
+void q3_latent_is_bounded() {
+    jarvisx::Autoencoder3D model({8U, 2U, 0.02F, 0.0F, 1.0F, 99U});
+    const auto input = jarvisx::make_volume(8U, "wave", 99U);
+    const auto latent = model.encode(input, true);
+    for (const float value : latent.values()) {
+        require(value >= -1.0F && value <= 1.0F, "Q3 latent must remain bounded");
+        const std::int8_t q = jarvisx::quantize_q3(value);
+        require(std::fabs(value - jarvisx::dequantize_q3(q)) < 1.0e-6F,
+                "quantized latent must lie on Q3 reconstruction levels");
+    }
+}
+
+void model_round_trip() {
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "jarvisx-autoencoder3d-test.jx3d";
+    jarvisx::Autoencoder3D model({8U, 3U, 0.02F, 1.0e-4F, 1.0F, 123U});
+    const auto input = jarvisx::make_volume(8U, "shell", 123U);
+    for (std::size_t step = 0; step < 5U; ++step) model.train_step(input);
+    const auto expected = model.reconstruct(input);
+    model.save(path);
+    jarvisx::Autoencoder3D loaded = jarvisx::Autoencoder3D::load(path);
+    const auto actual = loaded.reconstruct(input);
+    std::filesystem::remove(path);
+    require(expected.values() == actual.values(), "saved model must replay exactly");
+    require(loaded.steps() == model.steps(), "saved step count must round-trip");
+}
+
+} // namespace
+
+int main() {
+    try {
+        deterministic_initialization();
+        training_reduces_error();
+        q3_latent_is_bounded();
+        model_round_trip();
+        std::cout << "3D autoencoder tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "3D autoencoder test failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/multimedia4d_tests.cpp
+++ b/cpp_runtime/tests/multimedia4d_tests.cpp
@@ -1,0 +1,116 @@
+#include "jarvisx/multimedia4d.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+
+namespace {
+
+jarvisx::Multimedia4DConfig test_config() {
+    jarvisx::Multimedia4DConfig config;
+    config.model.input_edge = 8U;
+    config.model.latent_channels = 3U;
+    config.model.learning_rate = 0.02F;
+    config.model.seed = 0x4D554C54493444ULL;
+    config.temporal_depth = 4U;
+    config.temporal_decay = 0.65F;
+    config.proposal_steps = 2U;
+    config.accept_tolerance = 1.0e-6F;
+    return config;
+}
+
+void test_media_fixtures_are_distinct() {
+    const auto visual = jarvisx::make_media_volume(
+        8U, jarvisx::MediaType::Visual, 7U);
+    const auto audio = jarvisx::make_media_volume(
+        8U, jarvisx::MediaType::Audio, 7U);
+    const auto text = jarvisx::make_media_volume(
+        8U, jarvisx::MediaType::Text, 7U);
+    double visual_audio = 0.0;
+    double visual_text = 0.0;
+    for (std::size_t index = 0U; index < visual.size(); ++index) {
+        visual_audio += std::fabs(
+            static_cast<double>(visual.values()[index] - audio.values()[index]));
+        visual_text += std::fabs(
+            static_cast<double>(visual.values()[index] - text.values()[index]));
+    }
+    assert(visual_audio > 1.0);
+    assert(visual_text > 1.0);
+}
+
+void test_deterministic_transaction_schedule() {
+    const auto config = test_config();
+    jarvisx::MultimediaAutoencoder4D left(config);
+    jarvisx::MultimediaAutoencoder4D right(config);
+
+    for (int cycle = 0; cycle < 12; ++cycle) {
+        const auto before = left.metrics();
+        const auto left_metrics = left.step();
+        const auto right_metrics = right.step();
+        assert(left_metrics.selected == right_metrics.selected);
+        assert(left_metrics.aggregate_mse == right_metrics.aggregate_mse);
+        assert(left_metrics.accepted == right_metrics.accepted);
+        assert(left_metrics.rejected == right_metrics.rejected);
+        const std::size_t selected = jarvisx::media_index(left_metrics.selected);
+        assert(left_metrics.modalities[selected].instantaneous_mse <=
+               before.modalities[selected].instantaneous_mse +
+                   config.accept_tolerance + 1.0e-6F);
+    }
+
+    assert(left.metrics().accepted + left.metrics().rejected == 12U);
+    for (const auto media : jarvisx::media_types()) {
+        assert(left.temporal_history(media).size() <= config.temporal_depth);
+    }
+}
+
+void test_signed_three_bit_inference() {
+    const auto config = test_config();
+    jarvisx::MultimediaAutoencoder4D engine(config);
+    engine.set_quantized(true);
+    for (const auto media : jarvisx::media_types()) {
+        for (const float value : engine.current_latent(media).values()) {
+            const float level = jarvisx::dequantize_q3(
+                jarvisx::quantize_q3(value));
+            assert(std::fabs(value - level) < 1.0e-6F);
+        }
+    }
+}
+
+void test_checkpoint_replay() {
+    const auto config = test_config();
+    jarvisx::MultimediaAutoencoder4D source(config);
+    for (int cycle = 0; cycle < 9; ++cycle) source.step();
+    source.set_quantized(true);
+
+    const std::filesystem::path directory =
+        std::filesystem::temp_directory_path() /
+        "jarvisx-multimedia4d-tests";
+    std::filesystem::remove_all(directory);
+    source.save_checkpoint(directory);
+
+    jarvisx::MultimediaAutoencoder4D restored(config);
+    restored.load_checkpoint(directory);
+    assert(restored.metrics().cycle == source.metrics().cycle);
+    assert(restored.metrics().accepted == source.metrics().accepted);
+    assert(restored.metrics().rejected == source.metrics().rejected);
+    assert(restored.metrics().aggregate_mse ==
+           source.metrics().aggregate_mse);
+    assert(restored.quantized() == source.quantized());
+    for (const auto media : jarvisx::media_types()) {
+        assert(restored.temporal_history(media).size() ==
+               source.temporal_history(media).size());
+    }
+    std::filesystem::remove_all(directory);
+}
+
+} // namespace
+
+int main() {
+    test_media_fixtures_are_distinct();
+    test_deterministic_transaction_schedule();
+    test_signed_three_bit_inference();
+    test_checkpoint_replay();
+    std::cout << "4D multimedia runtime tests passed\n";
+    return 0;
+}

--- a/docs/CPP_3D_AUTOENCODER.md
+++ b/docs/CPP_3D_AUTOENCODER.md
@@ -4,6 +4,8 @@
 
 This subsystem is a bounded, deterministic C++17 reference implementation of a trainable three-dimensional convolutional autoencoder. It is intended for small cubic fields, correctness experiments and inspectable runtime behavior.
 
+The numerical core has no third-party runtime dependency. The optional interactive visualizer uses OpenGL and GLUT/freeglut.
+
 It is not a production deep-learning framework, GPU implementation, general compressor or claim of lossless reconstruction.
 
 ## Geometry
@@ -68,7 +70,14 @@ cmake --build build/cpp-runtime --parallel
 ctest --test-dir build/cpp-runtime --output-on-failure
 ```
 
-## Run
+The OpenGL target is detected and built only when OpenGL plus GLUT/freeglut are available. Disable its detection explicitly with:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime \
+  -DJARVISX_BUILD_GL_VISUALIZER=OFF
+```
+
+## Headless training runtime
 
 ```bash
 ./build/cpp-runtime/jarvisx-autoencoder3d \
@@ -94,11 +103,71 @@ model.jx3d            reloadable text model checkpoint
 
 OBJ files contain point-cloud vertices rather than watertight meshes. They can be inspected in Blender, MeshLab or another 3D viewer.
 
+## Interactive OpenGL ANN core
+
+The original geometric voxel shell is connected directly to the real model state in `jarvisx-autoencoder3d-gl`. It does not assign random operation colours to unrelated voxels. Every rendered field is derived from one of the current tensors:
+
+```text
+cyan input X
+    ↓ encoder 3×3×3 / stride 2
+blue-violet latent Z
+    ↓ decoder 3×3×3
+pink reconstruction X_hat
+    ↓ compare
+ gold residual |X - X_hat|
+    ↓ reverse-mode gradient
+updated encoder and decoder parameters
+```
+
+Run the live engine:
+
+```bash
+./build/cpp-runtime/jarvisx-autoencoder3d-gl \
+  --edge 16 \
+  --channels 4 \
+  --pattern sphere \
+  --learning-rate 0.015
+```
+
+Useful startup flags:
+
+```text
+--load-model PATH     load an existing model.jx3d checkpoint
+--quantized           render signed 3-bit latent inference
+--paused              open without continuous SGD updates
+--seed N              deterministic model and stream seed
+```
+
+Controls:
+
+```text
+Mouse drag / arrows   rotate the complete 3D pipeline
+Mouse wheel           zoom
+T or Space            pause/resume real SGD training
+Q                     switch floating/Q3 latent inference
+P                     cycle sphere/shell/checker/wave/noise
+N                     reset weights from the deterministic seed
+S / L                 save/load the visualizer checkpoint
+0                     composite encode-latent-decode pipeline
+1 / 2 / 3 / 4         input / latent / reconstruction / residual
++ / -                 change voxel visibility threshold
+R                     toggle automatic rotation
+Esc                   exit
+```
+
+The HUD reports the current model step, MSE, MAE, latent energy, gradient norm, tensor dimensions, quantization mode and visible voxel count. Stream particles are presentation telemetry: cyan follows the encoder direction, pink follows the decoder direction, and gold closes the residual-learning loop.
+
+The checkpoint used by `S` and `L` is:
+
+```text
+.jarvisx-autoencoder3d/visualizer-model.jx3d
+```
+
 ## Persistence and replay
 
 The checkpoint records dimensions, optimizer hyperparameters, seed, step count, encoder weights, decoder weights and biases using round-trip-safe decimal float precision. Loading validates the format and tensor sizes before accepting the model.
 
-For a fixed compiler/platform, seed, input and training sequence, execution is deterministic. Cross-platform bit identity is not claimed because standard floating-point and transcendental implementations may differ slightly.
+For a fixed compiler/platform, seed, input and training sequence, execution is deterministic. Rendering cadence does not enter the loss function. Cross-platform bit identity is not claimed because standard floating-point and transcendental implementations may differ slightly.
 
 ## Complexity boundary
 
@@ -111,4 +180,4 @@ training step:     O(C K N^3)
 model parameters: 2 C K + C + 1
 ```
 
-The tensors are dense. The maximum accepted edge is deliberately bounded to prevent accidental unbounded allocation.
+The tensors are dense. The maximum accepted edge is deliberately bounded to prevent accidental unbounded allocation. The OpenGL view renders thresholded voxels and is a diagnostic interface, not a throughput benchmark.

--- a/docs/CPP_3D_AUTOENCODER.md
+++ b/docs/CPP_3D_AUTOENCODER.md
@@ -1,0 +1,114 @@
+# Dependency-Free C++ 3D Autoencoder Runtime
+
+## Classification
+
+This subsystem is a bounded, deterministic C++17 reference implementation of a trainable three-dimensional convolutional autoencoder. It is intended for small cubic fields, correctness experiments and inspectable runtime behavior.
+
+It is not a production deep-learning framework, GPU implementation, general compressor or claim of lossless reconstruction.
+
+## Geometry
+
+The input is a single-channel cubic tensor
+
+```text
+X ∈ [-1,1]^(1×N×N×N)
+```
+
+with an even edge `N` in `[4,64]`. The encoder produces
+
+```text
+Z ∈ [-1,1]^(C×N/2×N/2×N/2)
+```
+
+where `C` is the number of latent channels.
+
+Both transforms use shared `3×3×3` kernels and periodic boundary conditions. The encoder has stride two. The decoder maps every output coordinate to its corresponding latent coordinate and applies a shared multichannel neighborhood kernel.
+
+## Forward equations
+
+For latent channel `c` and latent coordinate `p`:
+
+```text
+Z[c,p] = tanh(b_e[c] + Σ_k W_e[c,k] X[2p+k-1])
+```
+
+For output coordinate `q`:
+
+```text
+X_hat[q] = tanh(b_d + Σ_c Σ_k W_d[c,k] Z[floor(q/2)+k-1])
+```
+
+All coordinate arithmetic wraps periodically.
+
+Optional final inference quantizes every latent activation into the signed three-bit domain
+
+```text
+Q3 = {-4,-3,-2,-1,0,1,2,3}
+```
+
+and immediately dequantizes it back to `[-1,1]` for decoding. Training uses continuous latent activations; no false differentiability claim is made for the discrete quantizer.
+
+## Learning
+
+The runtime minimizes mean squared reconstruction error with direct reverse-mode differentiation through both kernels and `tanh` activations. Updates use:
+
+- deterministic Xavier-like initialization;
+- single-sample stochastic gradient descent;
+- elementwise gradient clipping;
+- optional L2 weight penalty;
+- finite and bounded input contracts.
+
+The implementation records MSE, MAE, maximum absolute error, latent energy and gradient L2 norm for every step.
+
+## Build and test
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --parallel
+ctest --test-dir build/cpp-runtime --output-on-failure
+```
+
+## Run
+
+```bash
+./build/cpp-runtime/jarvisx-autoencoder3d \
+  --edge 8 \
+  --channels 4 \
+  --epochs 250 \
+  --pattern sphere \
+  --quantized \
+  --export-dir .jarvisx-autoencoder3d
+```
+
+Supported synthetic fixtures are `sphere`, `shell`, `checker`, `wave` and deterministic `noise`.
+
+The output directory contains:
+
+```text
+metrics.csv          per-step training telemetry
+input.obj            input voxel point cloud
+latent.obj           channel-stacked latent point cloud
+reconstruction.obj   reconstructed voxel point cloud
+model.jx3d            reloadable text model checkpoint
+```
+
+OBJ files contain point-cloud vertices rather than watertight meshes. They can be inspected in Blender, MeshLab or another 3D viewer.
+
+## Persistence and replay
+
+The checkpoint records dimensions, optimizer hyperparameters, seed, step count, encoder weights, decoder weights and biases using round-trip-safe decimal float precision. Loading validates the format and tensor sizes before accepting the model.
+
+For a fixed compiler/platform, seed, input and training sequence, execution is deterministic. Cross-platform bit identity is not claimed because standard floating-point and transcendental implementations may differ slightly.
+
+## Complexity boundary
+
+For input edge `N`, latent channels `C` and kernel volume `K=27`:
+
+```text
+encoder forward:  O(C K N^3 / 8)
+decoder forward:  O(C K N^3)
+training step:     O(C K N^3)
+model parameters: 2 C K + C + 1
+```
+
+The tensors are dense. The maximum accepted edge is deliberately bounded to prevent accidental unbounded allocation.

--- a/docs/CPP_4D_MULTIMODAL_RUNTIME.md
+++ b/docs/CPP_4D_MULTIMODAL_RUNTIME.md
@@ -1,0 +1,237 @@
+# Bounded 4D Multimodal C++ Runtime
+
+## Classification
+
+This subsystem is a deterministic C++17 research runtime that composes four bounded 3D autoencoders with discrete latent-history memory, transactional candidate updates and an optional OpenGL/GLUT visualizer.
+
+The four current modalities are represented by deterministic synthetic fixtures:
+
+- **visual** — a solid 3D sphere field;
+- **audio** — a windowed three-axis sinusoidal field;
+- **text** — a token-bit and positional field derived from a fixed phrase;
+- **generic** — deterministic bounded noise.
+
+These fixtures exercise modality-specific state and scheduling. They are not image, video, audio or language codecs and do not ingest arbitrary media files in the current reference implementation.
+
+## 1. State geometry
+
+For each modality `m`, the runtime maintains a single-channel cubic input
+
+```text
+X_m ∈ [-1,1]^(1×N×N×N)
+```
+
+and an independent trainable 3D autoencoder
+
+```text
+Z_m = E_(theta_m)(X_m)
+X_hat_m = D_(phi_m)(Z_m).
+```
+
+The latent geometry is
+
+```text
+Z_m ∈ [-1,1]^(C×N/2×N/2×N/2).
+```
+
+The additional dimension is a bounded discrete temporal history of latent tensors:
+
+```text
+H_m(t) = [Z_m(t), Z_m(t-1), ..., Z_m(t-T+1)].
+```
+
+Therefore the term **4D** means a 3D latent field indexed through discrete runtime time. The implementation does not claim a continuous physical fourth dimension or a learned 4D convolutional kernel.
+
+## 2. Temporal fusion
+
+The decoder receives an exponentially weighted temporal latent:
+
+```text
+Z_bar_m(t)
+  = sum_(tau=0)^(T-1) lambda^tau Z_m(t-tau)
+    / sum_(tau=0)^(T-1) lambda^tau,
+```
+
+where
+
+```text
+0 <= lambda < 1.
+```
+
+`lambda = 0` uses only the newest latent tensor. Larger values retain more history. The history depth is bounded to `[1,64]`.
+
+Temporal coherence is reported as
+
+```text
+coherence_m
+  = 1 - clamp(RMS(Z_m(t) - Z_m(t-1)), 0, 1).
+```
+
+This is a diagnostic similarity score, not a probability or formal stability proof.
+
+## 3. Transactional self-optimization
+
+At each adaptive cycle, the scheduler selects one modality. Its priority is based on current reconstruction MSE plus a small deterministic rejection-pressure term. The purpose is to allocate updates to the modality currently reconstructing least accurately rather than train every model blindly in fixed order.
+
+For the selected modality, the runtime creates an isolated copy of the model and executes a bounded number `K` of SGD steps:
+
+```text
+(theta', phi') = SGD_K(theta, phi; X_m).
+```
+
+The candidate is admitted only when
+
+```text
+L_m(theta', phi') <= L_m(theta, phi) + epsilon,
+```
+
+where `epsilon` is the configured acceptance tolerance.
+
+The transition is therefore
+
+```text
+candidate -> evaluate -> commit or rollback.
+```
+
+A rejected candidate never replaces the authoritative model. Commit and rollback counts are exposed in telemetry and checkpoint state.
+
+This is bounded parameter optimization. The runtime does not rewrite arbitrary C++ code, mutate native instructions, establish consciousness or perform unrestricted autonomous self-modification.
+
+## 4. Quantized inference
+
+Training uses continuous latent activations. Optional final inference maps each activation through the canonical signed three-bit domain
+
+```text
+Q3 = {-4,-3,-2,-1,0,1,2,3}
+```
+
+and dequantizes it back into `[-1,1]` before temporal fusion and decoding.
+
+No straight-through estimator or false differentiability claim is used. Candidate training remains continuous.
+
+## 5. Headless runtime
+
+Build all C++ targets:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --parallel
+ctest --test-dir build/cpp-runtime --output-on-failure
+```
+
+Run the adaptive multimodal engine:
+
+```bash
+./build/cpp-runtime/jarvisx-multimedia4d \
+  --edge 8 \
+  --channels 4 \
+  --temporal-depth 8 \
+  --proposal-steps 2 \
+  --cycles 120 \
+  --learning-rate 0.03 \
+  --temporal-decay 0.72 \
+  --quantized \
+  --output-dir .jarvisx-multimedia4d
+```
+
+The output directory contains:
+
+```text
+multimedia4d.csv
+visual-input.obj
+visual-latent.obj
+visual-reconstruction.obj
+audio-input.obj
+audio-latent.obj
+audio-reconstruction.obj
+text-input.obj
+text-latent.obj
+text-reconstruction.obj
+generic-input.obj
+generic-latent.obj
+generic-reconstruction.obj
+checkpoint/
+```
+
+The OBJ files are voxel point clouds, not watertight meshes.
+
+## 6. Checkpoint contract
+
+A checkpoint persists:
+
+- one `JX3D` autoencoder model per modality;
+- accepted and rejected transaction counts;
+- temporal latent histories using round-trip-safe decimal float precision;
+- temporal configuration, cycle count and Q3 inference state;
+- the most recent gradient telemetry value.
+
+Loading validates the checkpoint version, modality order, tensor dimensions and temporal configuration before replacing runtime state.
+
+For the same compiler/platform, configuration and checkpoint, replay is deterministic. Cross-platform bit identity is not claimed because standard floating-point and transcendental implementations can differ.
+
+## 7. OpenGL visualizer
+
+When OpenGL and GLUT/freeglut are available, CMake also builds:
+
+```bash
+./build/cpp-runtime/jarvisx-multimedia4d-gl \
+  --edge 16 \
+  --channels 4 \
+  --temporal-depth 8 \
+  --proposal-steps 2 \
+  --learning-rate 0.015
+```
+
+The rendered pipeline is directly backed by runtime tensors:
+
+- left cube — selected modality input `X_m`;
+- centre temporal stack — recent latent tensors `H_m(t)`;
+- right cube — decoded temporal reconstruction `X_hat_m`;
+- gold overlay — absolute residual `|X_m-X_hat_m|`;
+- forward particles — encoder and decoder data flow;
+- return particles — residual feedback.
+
+Controls:
+
+```text
+1..4       visual, audio, text, generic
+SPACE      pause/resume adaptive transactions
+Q          toggle floating/Q3 latent inference
+F          follow the scheduler-selected modality
+R          toggle camera auto-rotation
+S / L      save/load the visualizer checkpoint
++ / -      increase/decrease rendered voxel density
+mouse drag rotate camera
+ESC        exit
+```
+
+The frame-budget controller changes only visualization density, temporal layers displayed and training cadence. Wall-clock timing is not used to accept or reject model candidates, preserving deterministic numerical selection.
+
+## 8. Validation
+
+The regression suite checks:
+
+- distinct deterministic modality fixtures;
+- deterministic scheduler and transaction replay;
+- bounded temporal-history depth;
+- no admitted candidate exceeding the configured MSE tolerance;
+- valid signed three-bit latent levels;
+- checkpoint restoration of models, counters, histories and aggregate metrics.
+
+## 9. Complexity boundary
+
+Let input edge be `N`, latent channels `C`, kernel volume `K=27`, temporal depth `T`, modalities `M=4`, and proposal steps `P`.
+
+Approximate per-cycle work for the selected modality is
+
+```text
+O(P C K N^3)
+```
+
+plus temporal fusion
+
+```text
+O(T C N^3 / 8).
+```
+
+All tensors and temporal histories are dense and deliberately bounded. This is a correctness and visualization reference, not a production multimedia model, GPU runtime or large-volume performance claim.


### PR DESCRIPTION
## Summary

Adds two bounded C++17 ANN reference runtimes to the Jarvis-X processor laboratory:

1. a trainable dense 3D convolutional autoencoder with a live OpenGL tensor visualizer;
2. a transactional 4D multimodal composition engine with discrete temporal latent memory, adaptive modality scheduling and an optional OpenGL visualizer.

## 3D numerical engine

- single-channel cubic input with even edge `4..64`
- multichannel half-resolution latent field
- shared `3×3×3` encoder and decoder kernels
- stride-two spatial compression with periodic geometry
- direct reverse-mode differentiation and SGD
- gradient clipping and L2 regularization
- optional signed three-bit latent inference using the canonical Q3 domain
- deterministic sphere, shell, checker, wave and noise fixtures
- checkpoint save/load and OBJ/CSV export

## 4D multimodal engine

- independent visual, audio, text and generic 3D autoencoders
- deterministic modality-specific synthetic input fields
- bounded latent-history axis representing discrete runtime time
- exponentially weighted temporal latent fusion
- deterministic error-priority modality scheduler
- isolated candidate-model training transactions
- MSE acceptance gate with explicit commit or rollback
- continuous and signed three-bit temporal inference
- aggregate and per-modality MSE, MAE, energy, coherence and transaction telemetry
- checkpoint persistence for all models, counters and temporal histories
- per-modality OBJ exports and CSV telemetry

The term **4D** refers to a 3D latent tensor indexed through bounded discrete temporal history. It is not a claim of continuous physical four-dimensional convolution.

## Interactive engines

`jarvisx-autoencoder3d-gl` renders the real input, latent, reconstruction and residual tensors from the 3D numerical model.

`jarvisx-multimedia4d-gl` renders the selected modality input, temporal latent stack, reconstruction and residual from the transactional runtime. It supports modality selection, live training, Q3 inference, scheduler following, checkpoint save/load and adaptive display density.

The frame-budget controller alters only rendering density, visible history layers and update cadence. Wall-clock timing does not determine model acceptance or rollback.

## Build and test

```bash
cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
cmake --build build/cpp-runtime --parallel
ctest --test-dir build/cpp-runtime --output-on-failure
```

Headless multimodal example:

```bash
./build/cpp-runtime/jarvisx-multimedia4d \
  --edge 8 \
  --channels 4 \
  --temporal-depth 8 \
  --proposal-steps 2 \
  --cycles 120 \
  --quantized
```

Interactive multimodal example when OpenGL and GLUT/freeglut are installed:

```bash
./build/cpp-runtime/jarvisx-multimedia4d-gl \
  --edge 16 \
  --channels 4 \
  --temporal-depth 8 \
  --proposal-steps 2 \
  --learning-rate 0.015
```

## Validation

- deterministic 3D initialization and training order
- measurable 3D reconstruction-error reduction
- Q3 latent-level validation
- exact same-platform 3D checkpoint replay
- distinct deterministic visual/audio/text/generic fixtures
- deterministic multimodal scheduler and transaction replay
- bounded temporal histories
- candidate MSE acceptance-gate validation
- exact same-platform multimodal checkpoint replay
- CMake and CTest integration across GCC, Clang and MSVC
- optional OpenGL targets skipped cleanly when dependencies are absent

## Capability boundary

These are small dense CPU research runtimes and diagnostic OpenGL interfaces. They are not production deep-learning frameworks, general multimedia codecs, GPU engines, lossless compressors, large-volume performance claims or evidence of autonomous intelligence or unrestricted self-modification.