### PR TITLE
Permeate continuous DM-GEOM latent engine

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -27,6 +27,20 @@ target_include_directories(jarvisx-runtime PRIVATE
 )
 jarvisx_harden(jarvisx-runtime)
 
+add_library(jarvisx-dm-geom-core
+    src/dm_geom.cpp
+)
+target_include_directories(jarvisx-dm-geom-core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_harden(jarvisx-dm-geom-core)
+
+add_executable(dm-geom
+    src/dm_geom_main.cpp
+)
+target_link_libraries(dm-geom PRIVATE jarvisx-dm-geom-core)
+jarvisx_harden(dm-geom)
+
 enable_testing()
 
 add_test(
@@ -51,3 +65,12 @@ jarvisx_harden(jarvisx-processor-tests)
 
 add_test(NAME processor-regressions COMMAND jarvisx-processor-tests)
 set_tests_properties(processor-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(dm-geom-tests
+    tests/dm_geom_tests.cpp
+)
+target_link_libraries(dm-geom-tests PRIVATE jarvisx-dm-geom-core)
+jarvisx_harden(dm-geom-tests)
+
+add_test(NAME dm-geom-regressions COMMAND dm-geom-tests)
+set_tests_properties(dm-geom-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/README.md
+++ b/cpp_runtime/README.md
@@ -62,6 +62,27 @@ Text input is also supported:
   --population 5
 ```
 
+## DM-GEOM mechanical latent engine
+
+`dm-geom` is an isolated mesh auto-encoding and decoding executable built on the same hardened C++17 profile. It:
+
+1. extracts nine finite geometric features from a validated triangle mesh;
+2. encodes mean radius and radial disorder into a bounded three-dimensional latent state;
+3. decodes a fixed-topology sphere whose radius, deformation amplitude and deformation frequency vary continuously;
+4. evaluates position, radius and surface-area reconstruction error;
+5. applies central finite-difference gradient descent with gradient clipping and latent projection;
+6. exports deterministic little-endian binary STL artifacts.
+
+The fixed topology is intentional: it prevents the zero numerical gradient produced when loss depends only on an integer segment or vertex count.
+
+Run the demonstration:
+
+```bash
+./build/cpp-runtime/dm-geom
+```
+
+The executable writes `recon.stl` and `optimized.stl` in the working directory and returns a non-zero status if evolution does not improve reconstruction loss.
+
 ## State artifacts
 
 The default `.jarvisx-runtime/` directory contains:
@@ -83,7 +104,11 @@ The CTest suite includes:
 - inward executable/text smoke execution;
 - genome normalization before allocation;
 - repeatable processor evaluation;
-- proof that wall-clock latency does not alter deterministic fitness.
+- proof that wall-clock latency does not alter deterministic fitness;
+- DM-GEOM topology and non-degeneracy checks;
+- nine-feature population and finite-value checks;
+- continuous-loss evolution regression;
+- decoder singularity regression at latent `x = -2`.
 
 Optional sanitizer build:
 

--- a/cpp_runtime/include/jarvisx/dm_geom.hpp
+++ b/cpp_runtime/include/jarvisx/dm_geom.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace jarvisx::dmgeom {
+
+struct Vec3 {
+    float x{0.0F};
+    float y{0.0F};
+    float z{0.0F};
+
+    [[nodiscard]] Vec3 operator+(const Vec3& other) const noexcept;
+    [[nodiscard]] Vec3 operator-(const Vec3& other) const noexcept;
+    [[nodiscard]] Vec3 operator*(float scalar) const noexcept;
+    [[nodiscard]] float dot(const Vec3& other) const noexcept;
+    [[nodiscard]] Vec3 cross(const Vec3& other) const noexcept;
+    [[nodiscard]] float length() const noexcept;
+    [[nodiscard]] Vec3 normalized() const noexcept;
+};
+
+struct Triangle {
+    std::uint32_t i0{0U};
+    std::uint32_t i1{0U};
+    std::uint32_t i2{0U};
+};
+
+struct Mesh {
+    std::vector<Vec3> vertices;
+    std::vector<Triangle> triangles;
+};
+
+struct Latent3D {
+    float x{0.0F};
+    float y{0.0F};
+    float z{0.0F};
+};
+
+using FeatureVector = std::array<float, 9U>;
+
+struct LossBreakdown {
+    float position{0.0F};
+    float radius{0.0F};
+    float area{0.0F};
+    float total{0.0F};
+};
+
+struct EvolutionConfig {
+    int steps{100};
+    int segments{32};
+    float learning_rate{0.05F};
+    float finite_difference_epsilon{1.0e-3F};
+    float gradient_clip{5.0F};
+    float tolerance{1.0e-7F};
+    bool verbose{true};
+};
+
+class Encoder {
+public:
+    [[nodiscard]] static FeatureVector extract_features(const Mesh& mesh);
+    [[nodiscard]] static Latent3D encode(const Mesh& mesh);
+};
+
+class Decoder {
+public:
+    [[nodiscard]] static Mesh decode(const Latent3D& latent, int segments = 32);
+};
+
+[[nodiscard]] bool validate_mesh(const Mesh& mesh, std::string* error = nullptr);
+[[nodiscard]] float surface_area(const Mesh& mesh);
+[[nodiscard]] float mean_radius(const Mesh& mesh);
+[[nodiscard]] LossBreakdown reconstruction_loss(const Mesh& target, const Mesh& decoded);
+[[nodiscard]] Latent3D evolve(const Mesh& target, Latent3D start, const EvolutionConfig& config = {});
+[[nodiscard]] Mesh make_uv_sphere(float radius, int segments);
+void export_binary_stl(const Mesh& mesh, const std::string& path);
+
+}  // namespace jarvisx::dmgeom

--- a/cpp_runtime/src/dm_geom.cpp
+++ b/cpp_runtime/src/dm_geom.cpp
@@ -1,0 +1,367 @@
+#include "jarvisx/dm_geom.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+namespace jarvisx::dmgeom {
+namespace {
+
+constexpr float kPi = 3.14159265358979323846F;
+constexpr float kMinRadius = 1.0e-4F;
+constexpr float kMinLogRadius = -8.0F;
+constexpr float kMaxLogRadius = 8.0F;
+
+[[nodiscard]] float square(float value) noexcept { return value * value; }
+
+[[nodiscard]] float clamp_finite(float value, float low, float high, float fallback) noexcept {
+    return std::isfinite(value) ? std::clamp(value, low, high) : fallback;
+}
+
+[[nodiscard]] float sigmoid(float value) noexcept {
+    const float bounded = std::clamp(value, -20.0F, 20.0F);
+    return 1.0F / (1.0F + std::exp(-bounded));
+}
+
+[[nodiscard]] Latent3D project(Latent3D latent) noexcept {
+    latent.x = clamp_finite(latent.x, kMinLogRadius, kMaxLogRadius, 0.0F);
+    latent.y = clamp_finite(latent.y, -8.0F, 8.0F, 0.0F);
+    latent.z = clamp_finite(latent.z, -8.0F, 8.0F, 0.0F);
+    return latent;
+}
+
+[[nodiscard]] float decoded_radius(const Latent3D& latent) noexcept {
+    return std::exp(project(latent).x);
+}
+
+[[nodiscard]] float decoded_amplitude(const Latent3D& latent) noexcept {
+    return 0.35F * std::tanh(project(latent).y);
+}
+
+[[nodiscard]] float decoded_frequency(const Latent3D& latent) noexcept {
+    return 2.0F + (6.0F * sigmoid(project(latent).z));
+}
+
+[[nodiscard]] float relative_error(float actual, float expected) noexcept {
+    return (actual - expected) / std::max(std::fabs(expected), 1.0e-6F);
+}
+
+void write_u16_le(std::ofstream& stream, std::uint16_t value) {
+    const std::array<char, 2U> bytes{
+        static_cast<char>(value & 0xFFU),
+        static_cast<char>((value >> 8U) & 0xFFU),
+    };
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void write_u32_le(std::ofstream& stream, std::uint32_t value) {
+    const std::array<char, 4U> bytes{
+        static_cast<char>(value & 0xFFU),
+        static_cast<char>((value >> 8U) & 0xFFU),
+        static_cast<char>((value >> 16U) & 0xFFU),
+        static_cast<char>((value >> 24U) & 0xFFU),
+    };
+    stream.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void write_f32_le(std::ofstream& stream, float value) {
+    static_assert(sizeof(float) == sizeof(std::uint32_t), "binary STL requires 32-bit float");
+    std::uint32_t bits = 0U;
+    std::memcpy(&bits, &value, sizeof(bits));
+    write_u32_le(stream, bits);
+}
+
+[[nodiscard]] float radial_stddev(const Mesh& mesh, float mean) {
+    double sum = 0.0;
+    for (const Vec3& vertex : mesh.vertices) {
+        const double delta = static_cast<double>(vertex.length() - mean);
+        sum += delta * delta;
+    }
+    return static_cast<float>(std::sqrt(sum / static_cast<double>(mesh.vertices.size())));
+}
+
+[[nodiscard]] std::vector<float> edge_lengths(const Mesh& mesh) {
+    std::vector<float> lengths;
+    lengths.reserve(mesh.triangles.size() * 3U);
+    for (const Triangle& triangle : mesh.triangles) {
+        const Vec3& a = mesh.vertices[triangle.i0];
+        const Vec3& b = mesh.vertices[triangle.i1];
+        const Vec3& c = mesh.vertices[triangle.i2];
+        lengths.push_back((b - a).length());
+        lengths.push_back((c - b).length());
+        lengths.push_back((a - c).length());
+    }
+    return lengths;
+}
+
+}  // namespace
+
+Vec3 Vec3::operator+(const Vec3& other) const noexcept { return {x + other.x, y + other.y, z + other.z}; }
+Vec3 Vec3::operator-(const Vec3& other) const noexcept { return {x - other.x, y - other.y, z - other.z}; }
+Vec3 Vec3::operator*(float scalar) const noexcept { return {x * scalar, y * scalar, z * scalar}; }
+float Vec3::dot(const Vec3& other) const noexcept { return (x * other.x) + (y * other.y) + (z * other.z); }
+Vec3 Vec3::cross(const Vec3& other) const noexcept {
+    return {(y * other.z) - (z * other.y), (z * other.x) - (x * other.z), (x * other.y) - (y * other.x)};
+}
+float Vec3::length() const noexcept { return std::sqrt(dot(*this)); }
+Vec3 Vec3::normalized() const noexcept {
+    const float magnitude = length();
+    return magnitude > 0.0F ? (*this) * (1.0F / magnitude) : Vec3{};
+}
+
+bool validate_mesh(const Mesh& mesh, std::string* error) {
+    const auto fail = [error](const std::string& message) {
+        if (error != nullptr) { *error = message; }
+        return false;
+    };
+    if (mesh.vertices.empty()) { return fail("mesh contains no vertices"); }
+    if (mesh.triangles.empty()) { return fail("mesh contains no triangles"); }
+    if (mesh.vertices.size() > static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max())) {
+        return fail("mesh exceeds 32-bit index capacity");
+    }
+    for (const Vec3& vertex : mesh.vertices) {
+        if (!std::isfinite(vertex.x) || !std::isfinite(vertex.y) || !std::isfinite(vertex.z)) {
+            return fail("mesh contains a non-finite vertex");
+        }
+    }
+    const std::uint32_t count = static_cast<std::uint32_t>(mesh.vertices.size());
+    for (const Triangle& triangle : mesh.triangles) {
+        if (triangle.i0 >= count || triangle.i1 >= count || triangle.i2 >= count) {
+            return fail("triangle index lies outside the vertex array");
+        }
+        if (triangle.i0 == triangle.i1 || triangle.i1 == triangle.i2 || triangle.i0 == triangle.i2) {
+            return fail("triangle contains repeated indices");
+        }
+    }
+    if (error != nullptr) { error->clear(); }
+    return true;
+}
+
+float surface_area(const Mesh& mesh) {
+    std::string error;
+    if (!validate_mesh(mesh, &error)) { throw std::invalid_argument("surface_area: " + error); }
+    double area = 0.0;
+    for (const Triangle& triangle : mesh.triangles) {
+        const Vec3 a = mesh.vertices[triangle.i1] - mesh.vertices[triangle.i0];
+        const Vec3 b = mesh.vertices[triangle.i2] - mesh.vertices[triangle.i0];
+        area += 0.5 * static_cast<double>(a.cross(b).length());
+    }
+    return static_cast<float>(area);
+}
+
+float mean_radius(const Mesh& mesh) {
+    if (mesh.vertices.empty()) { throw std::invalid_argument("mean_radius: mesh contains no vertices"); }
+    double total = 0.0;
+    for (const Vec3& vertex : mesh.vertices) { total += static_cast<double>(vertex.length()); }
+    return static_cast<float>(total / static_cast<double>(mesh.vertices.size()));
+}
+
+FeatureVector Encoder::extract_features(const Mesh& mesh) {
+    std::string error;
+    if (!validate_mesh(mesh, &error)) { throw std::invalid_argument("extract_features: " + error); }
+
+    const std::vector<float> edges = edge_lengths(mesh);
+    double edge_sum = 0.0;
+    for (float edge : edges) { edge_sum += static_cast<double>(edge); }
+    const float edge_mean = static_cast<float>(edge_sum / static_cast<double>(edges.size()));
+    double variance_sum = 0.0;
+    for (float edge : edges) {
+        const double delta = static_cast<double>(edge - edge_mean);
+        variance_sum += delta * delta;
+    }
+    const float edge_stddev = static_cast<float>(std::sqrt(variance_sum / static_cast<double>(edges.size())));
+    const float edge_cv = edge_mean > 1.0e-6F ? edge_stddev / edge_mean : 0.0F;
+
+    const float radius_mean = mean_radius(mesh);
+    const float radius_cv = radius_mean > 1.0e-6F ? radial_stddev(mesh, radius_mean) / radius_mean : 0.0F;
+    Vec3 minimum = mesh.vertices.front();
+    Vec3 maximum = mesh.vertices.front();
+    for (const Vec3& vertex : mesh.vertices) {
+        minimum.x = std::min(minimum.x, vertex.x); minimum.y = std::min(minimum.y, vertex.y); minimum.z = std::min(minimum.z, vertex.z);
+        maximum.x = std::max(maximum.x, vertex.x); maximum.y = std::max(maximum.y, vertex.y); maximum.z = std::max(maximum.z, vertex.z);
+    }
+
+    return {
+        static_cast<float>(mesh.vertices.size()) / 1000.0F,
+        edge_cv,
+        surface_area(mesh) / 100.0F,
+        radius_mean,
+        radius_cv,
+        maximum.x - minimum.x,
+        maximum.y - minimum.y,
+        maximum.z - minimum.z,
+        static_cast<float>(mesh.triangles.size()) / static_cast<float>(mesh.vertices.size()),
+    };
+}
+
+Latent3D Encoder::encode(const Mesh& mesh) {
+    const FeatureVector features = extract_features(mesh);
+    const float radius = std::max(features[3], kMinRadius);
+    const float normalized_deformation = std::clamp(features[4] / 0.35F, -0.95F, 0.95F);
+    return project({std::log(radius), std::atanh(normalized_deformation), 0.0F});
+}
+
+Mesh make_uv_sphere(float radius, int segments) {
+    if (!std::isfinite(radius) || radius <= 0.0F) {
+        throw std::invalid_argument("make_uv_sphere: radius must be finite and positive");
+    }
+    if (segments < 4 || segments > 512) {
+        throw std::invalid_argument("make_uv_sphere: segments must be in [4, 512]");
+    }
+
+    const int longitudes = segments * 2;
+    Mesh mesh;
+    mesh.vertices.reserve(2U + static_cast<std::size_t>(segments - 1) * static_cast<std::size_t>(longitudes));
+    mesh.triangles.reserve(static_cast<std::size_t>(4 * longitudes * (segments - 1)));
+    mesh.vertices.push_back({0.0F, radius, 0.0F});
+
+    for (int latitude = 1; latitude < segments; ++latitude) {
+        const float phi = kPi * static_cast<float>(latitude) / static_cast<float>(segments);
+        for (int longitude = 0; longitude < longitudes; ++longitude) {
+            const float theta = 2.0F * kPi * static_cast<float>(longitude) / static_cast<float>(longitudes);
+            mesh.vertices.push_back({
+                radius * std::sin(phi) * std::cos(theta),
+                radius * std::cos(phi),
+                radius * std::sin(phi) * std::sin(theta),
+            });
+        }
+    }
+
+    const std::uint32_t bottom = static_cast<std::uint32_t>(mesh.vertices.size());
+    mesh.vertices.push_back({0.0F, -radius, 0.0F});
+    const std::uint32_t width = static_cast<std::uint32_t>(longitudes);
+    for (std::uint32_t longitude = 0U; longitude < width; ++longitude) {
+        const std::uint32_t next = (longitude + 1U) % width;
+        mesh.triangles.push_back({0U, 1U + next, 1U + longitude});
+    }
+    for (int latitude = 0; latitude < segments - 2; ++latitude) {
+        const std::uint32_t ring_a = 1U + static_cast<std::uint32_t>(latitude * longitudes);
+        const std::uint32_t ring_b = ring_a + width;
+        for (std::uint32_t longitude = 0U; longitude < width; ++longitude) {
+            const std::uint32_t next = (longitude + 1U) % width;
+            mesh.triangles.push_back({ring_a + longitude, ring_b + longitude, ring_a + next});
+            mesh.triangles.push_back({ring_a + next, ring_b + longitude, ring_b + next});
+        }
+    }
+    const std::uint32_t last_ring = bottom - width;
+    for (std::uint32_t longitude = 0U; longitude < width; ++longitude) {
+        const std::uint32_t next = (longitude + 1U) % width;
+        mesh.triangles.push_back({last_ring + longitude, last_ring + next, bottom});
+    }
+    return mesh;
+}
+
+Mesh Decoder::decode(const Latent3D& latent, int segments) {
+    const float radius = decoded_radius(latent);
+    const float amplitude = decoded_amplitude(latent);
+    const float frequency = decoded_frequency(latent);
+    Mesh mesh = make_uv_sphere(radius, segments);
+    for (Vec3& vertex : mesh.vertices) {
+        const float base_radius = vertex.length();
+        const float theta = std::atan2(vertex.z, vertex.x);
+        const float phi = std::acos(std::clamp(vertex.y / base_radius, -1.0F, 1.0F));
+        const float scale = 1.0F + (amplitude * std::sin(frequency * theta) * square(std::sin(phi)));
+        vertex = vertex.normalized() * (radius * std::max(scale, 0.1F));
+    }
+    return mesh;
+}
+
+LossBreakdown reconstruction_loss(const Mesh& target, const Mesh& decoded) {
+    std::string error;
+    if (!validate_mesh(target, &error)) { throw std::invalid_argument("reconstruction_loss target: " + error); }
+    if (!validate_mesh(decoded, &error)) { throw std::invalid_argument("reconstruction_loss decoded: " + error); }
+    if (target.vertices.size() != decoded.vertices.size() || target.triangles.size() != decoded.triangles.size()) {
+        throw std::invalid_argument("reconstruction_loss requires matching topology");
+    }
+
+    const float target_radius = std::max(mean_radius(target), kMinRadius);
+    double position_sum = 0.0;
+    for (std::size_t index = 0U; index < target.vertices.size(); ++index) {
+        const Vec3 delta = target.vertices[index] - decoded.vertices[index];
+        position_sum += static_cast<double>(delta.dot(delta));
+    }
+
+    LossBreakdown loss{};
+    loss.position = static_cast<float>(position_sum / static_cast<double>(target.vertices.size())) / square(target_radius);
+    loss.radius = square(relative_error(mean_radius(decoded), target_radius));
+    loss.area = square(relative_error(surface_area(decoded), surface_area(target)));
+    loss.total = loss.position + (0.25F * loss.radius) + (0.10F * loss.area);
+    return loss;
+}
+
+Latent3D evolve(const Mesh& target, Latent3D start, const EvolutionConfig& config) {
+    if (config.steps < 0) { throw std::invalid_argument("evolve: steps must be non-negative"); }
+    if (config.segments < 4 || config.segments > 512) { throw std::invalid_argument("evolve: segments must be in [4, 512]"); }
+    if (!(config.learning_rate > 0.0F) || !std::isfinite(config.learning_rate)) {
+        throw std::invalid_argument("evolve: learning_rate must be finite and positive");
+    }
+    if (!(config.finite_difference_epsilon > 0.0F) || !std::isfinite(config.finite_difference_epsilon)) {
+        throw std::invalid_argument("evolve: finite_difference_epsilon must be finite and positive");
+    }
+    if (!(config.gradient_clip > 0.0F) || !std::isfinite(config.gradient_clip)) {
+        throw std::invalid_argument("evolve: gradient_clip must be finite and positive");
+    }
+
+    Latent3D latent = project(start);
+    const float epsilon = config.finite_difference_epsilon;
+    const auto loss_at = [&target, &config](const Latent3D& candidate) {
+        return reconstruction_loss(target, Decoder::decode(candidate, config.segments)).total;
+    };
+
+    for (int step = 0; step < config.steps; ++step) {
+        const float loss = loss_at(latent);
+        if (loss <= config.tolerance) { break; }
+        float gradient_x = (loss_at({latent.x + epsilon, latent.y, latent.z}) - loss_at({latent.x - epsilon, latent.y, latent.z})) / (2.0F * epsilon);
+        float gradient_y = (loss_at({latent.x, latent.y + epsilon, latent.z}) - loss_at({latent.x, latent.y - epsilon, latent.z})) / (2.0F * epsilon);
+        float gradient_z = (loss_at({latent.x, latent.y, latent.z + epsilon}) - loss_at({latent.x, latent.y, latent.z - epsilon})) / (2.0F * epsilon);
+        gradient_x = std::clamp(gradient_x, -config.gradient_clip, config.gradient_clip);
+        gradient_y = std::clamp(gradient_y, -config.gradient_clip, config.gradient_clip);
+        gradient_z = std::clamp(gradient_z, -config.gradient_clip, config.gradient_clip);
+        latent = project({
+            latent.x - (config.learning_rate * gradient_x),
+            latent.y - (config.learning_rate * gradient_y),
+            latent.z - (config.learning_rate * gradient_z),
+        });
+        if (config.verbose && (((step % 20) == 0) || step == config.steps - 1)) {
+            std::cout << "Step " << step << " Loss: " << loss << " z=("
+                      << latent.x << ',' << latent.y << ',' << latent.z << ")\n";
+        }
+    }
+    return latent;
+}
+
+void export_binary_stl(const Mesh& mesh, const std::string& path) {
+    std::string error;
+    if (!validate_mesh(mesh, &error)) { throw std::invalid_argument("export_binary_stl: " + error); }
+    if (mesh.triangles.size() > static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max())) {
+        throw std::overflow_error("export_binary_stl: triangle count exceeds STL limit");
+    }
+    std::ofstream stream(path, std::ios::binary | std::ios::trunc);
+    if (!stream) { throw std::runtime_error("export_binary_stl: unable to open " + path); }
+    std::array<char, 80U> header{};
+    constexpr char label[] = "DM-GEOM deterministic binary STL";
+    std::copy(label, label + (sizeof(label) - 1U), header.begin());
+    stream.write(header.data(), static_cast<std::streamsize>(header.size()));
+    write_u32_le(stream, static_cast<std::uint32_t>(mesh.triangles.size()));
+    for (const Triangle& triangle : mesh.triangles) {
+        const Vec3& v0 = mesh.vertices[triangle.i0];
+        const Vec3& v1 = mesh.vertices[triangle.i1];
+        const Vec3& v2 = mesh.vertices[triangle.i2];
+        const Vec3 normal = (v1 - v0).cross(v2 - v0).normalized();
+        for (float value : std::array<float, 12U>{
+                 normal.x, normal.y, normal.z,
+                 v0.x, v0.y, v0.z,
+                 v1.x, v1.y, v1.z,
+                 v2.x, v2.y, v2.z}) {
+            write_f32_le(stream, value);
+        }
+        write_u16_le(stream, 0U);
+    }
+    if (!stream) { throw std::runtime_error("export_binary_stl: write failed for " + path); }
+}
+
+}  // namespace jarvisx::dmgeom

--- a/cpp_runtime/src/dm_geom_main.cpp
+++ b/cpp_runtime/src/dm_geom_main.cpp
@@ -1,0 +1,54 @@
+#include "jarvisx/dm_geom.hpp"
+
+#include <chrono>
+#include <exception>
+#include <iostream>
+
+int main() {
+    using namespace jarvisx::dmgeom;
+
+    try {
+        std::cout << "=== DM-GEOM v0.3 PERMEATED BOOT ===\n";
+        const auto started = std::chrono::steady_clock::now();
+
+        constexpr int segments = 32;
+        const Mesh input = make_uv_sphere(2.0F, segments);
+        std::cout << "[1] INPUT: " << input.vertices.size() << " verts, "
+                  << input.triangles.size() << " tris\n";
+
+        const Latent3D encoded = Encoder::encode(input);
+        std::cout << "[2] ENCODED: z=(" << encoded.x << ',' << encoded.y << ',' << encoded.z << ")\n";
+
+        const Latent3D disturbed{encoded.x + 0.35F, encoded.y + 0.40F, encoded.z + 0.20F};
+        const Mesh reconstruction = Decoder::decode(disturbed, segments);
+        export_binary_stl(reconstruction, "recon.stl");
+        const float initial_loss = reconstruction_loss(input, reconstruction).total;
+        std::cout << "[3] DECODED: " << reconstruction.vertices.size()
+                  << " verts -> recon.stl, loss=" << initial_loss << '\n';
+
+        EvolutionConfig config{};
+        config.steps = 120;
+        config.segments = segments;
+        config.learning_rate = 0.08F;
+        std::cout << "[4] EVOLVING...\n";
+        const Latent3D optimized = evolve(input, disturbed, config);
+
+        const Mesh output = Decoder::decode(optimized, segments);
+        export_binary_stl(output, "optimized.stl");
+        const float final_loss = reconstruction_loss(input, output).total;
+        std::cout << "[5] OPTIMIZED: " << output.vertices.size()
+                  << " verts -> optimized.stl, loss=" << final_loss << '\n';
+
+        const std::chrono::duration<double> elapsed = std::chrono::steady_clock::now() - started;
+        std::cout << "TOTAL TIME: " << elapsed.count() << "s\n";
+
+        if (!(final_loss < initial_loss)) {
+            std::cerr << "Evolution failed to improve reconstruction loss\n";
+            return 2;
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "DM-GEOM fatal error: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/dm_geom_tests.cpp
+++ b/cpp_runtime/tests/dm_geom_tests.cpp
@@ -1,0 +1,84 @@
+#include "jarvisx/dm_geom.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+void test_mesh_is_valid_and_non_degenerate() {
+    using namespace jarvisx::dmgeom;
+    const Mesh mesh = make_uv_sphere(2.0F, 16);
+    std::string error;
+    require(validate_mesh(mesh, &error), "generated sphere is invalid: " + error);
+    require(mesh.vertices.size() == 482U, "unexpected unique-pole vertex count");
+    require(mesh.triangles.size() == 960U, "unexpected triangle count");
+
+    for (const Triangle& triangle : mesh.triangles) {
+        const Vec3 normal = (mesh.vertices[triangle.i1] - mesh.vertices[triangle.i0])
+                                .cross(mesh.vertices[triangle.i2] - mesh.vertices[triangle.i0]);
+        require(normal.length() > 1.0e-8F, "generated sphere contains a degenerate triangle");
+    }
+}
+
+void test_encoder_uses_nine_finite_features() {
+    using namespace jarvisx::dmgeom;
+    const FeatureVector features = Encoder::extract_features(make_uv_sphere(2.0F, 16));
+    for (float value : features) {
+        require(std::isfinite(value), "feature vector contains a non-finite value");
+    }
+    require(features[3] > 1.9F && features[3] < 2.1F, "mean-radius feature is incorrect");
+    require(features[5] > 3.9F && features[6] > 3.9F && features[7] > 3.9F,
+            "bounding-box features were not populated");
+}
+
+void test_evolution_reduces_continuous_loss() {
+    using namespace jarvisx::dmgeom;
+    constexpr int segments = 16;
+    const Mesh target = make_uv_sphere(2.0F, segments);
+    const Latent3D encoded = Encoder::encode(target);
+    const Latent3D start{encoded.x + 0.30F, encoded.y + 0.35F, encoded.z + 0.25F};
+    const float before = reconstruction_loss(target, Decoder::decode(start, segments)).total;
+
+    EvolutionConfig config{};
+    config.steps = 100;
+    config.segments = segments;
+    config.learning_rate = 0.08F;
+    config.verbose = false;
+    const Latent3D optimized = evolve(target, start, config);
+    const float after = reconstruction_loss(target, Decoder::decode(optimized, segments)).total;
+
+    require(after < before * 0.10F, "evolution did not materially reduce reconstruction loss");
+}
+
+void test_singularity_is_removed() {
+    using namespace jarvisx::dmgeom;
+    const Mesh mesh = Decoder::decode({-2.0F, 0.0F, 0.0F}, 8);
+    std::string error;
+    require(validate_mesh(mesh, &error), "latent x=-2 produced an invalid mesh: " + error);
+    require(mean_radius(mesh) > 0.0F && std::isfinite(mean_radius(mesh)),
+            "latent x=-2 produced a singular radius");
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_mesh_is_valid_and_non_degenerate();
+        test_encoder_uses_nine_finite_features();
+        test_evolution_reduces_continuous_loss();
+        test_singularity_is_removed();
+        std::cout << "dm-geom regressions passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "dm-geom regression failure: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## What changed

- add a dependency-free `jarvisx-dm-geom-core` C++17 library;
- add the `dm-geom` encode → decode → evolve → STL demonstration executable;
- extract nine populated geometric features from validated triangle meshes;
- replace the discontinuous vertex-count objective with a continuous reconstruction loss over vertex position, mean radius, and surface area;
- use central finite differences, gradient clipping, and bounded latent projection;
- remove the decoder singularity at latent `x = -2` by using a bounded logarithmic-radius parameterization;
- generate UV spheres with unique poles and no duplicated seam vertices;
- write deterministic little-endian binary STL output;
- add CTest regressions for topology, feature population, optimization improvement, and singularity removal;
- document the mechanical DM-GEOM pipeline and execution commands.

## Root cause

The original evolution loop optimized vertex-count difference while decoder topology depended on an integer-clamped segment count. Small finite-difference perturbations therefore left the loss unchanged, producing a numerical gradient of zero and an inert latent update.

## Impact

DM-GEOM now has a mechanically active three-dimensional latent optimization loop. Geometry changes continuously with latent radius, deformation amplitude, and deformation frequency while topology remains fixed during each optimization run.

## Validation

Equivalent sources were compiled locally with:

```bash
g++ -std=c++17 -O2 -Wall -Wextra -Wpedantic -Wconversion -Wshadow
```

The standalone regression binary passed, and the demonstration reduced reconstruction loss during evolution. The branch is also wired into the repository's CMake/CTest build for CI validation.

A direct post-publication clone was unavailable in the execution environment because outbound DNS resolution for `github.com` failed; this PR remains draft pending repository CI confirmation.