### PR TITLE
Add Dr. Moagi Unified Autoencoding reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,25 +45,35 @@ jobs:
         run: >-
           black --check --diff
           setup.py
+          examples/unified_autoencoding_reference.py
           src/jarvisx/core.py
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/uea_model.py
+          src/jarvisx/uea_dynamics.py
+          src/jarvisx/unified_autoencoding.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_unified_autoencoding.py
 
       - name: Check canonical import order
         run: >-
           isort --check-only --diff
           setup.py
+          examples/unified_autoencoding_reference.py
           src/jarvisx/core.py
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/uea_model.py
+          src/jarvisx/uea_dynamics.py
+          src/jarvisx/unified_autoencoding.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_unified_autoencoding.py
 
       - name: Type-check package
         run: mypy src/jarvisx --ignore-missing-imports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@ The project follows semantic versioning where practical during alpha development
 - analytic constant-forcing updates for `du/dt = -D(-Delta)^alpha u + Omega`;
 - `2×2×2` restriction, prolongation and coarse-to-fine fusion;
 - ordered mechanistic traces, mass drift, gradient energy, residual and convergence telemetry;
-- independent direct-DFT, spatial-stencil and semigroup validation tests.
+- independent direct-DFT, spatial-stencil and semigroup validation tests;
+- deterministic Dr. Moagi Unified Autoencoding reference for `[frequency, amplitude, phase]` states;
+- explicit diagonal-Gaussian encoder posterior and standard-normal KL regularization;
+- circular phase reconstruction metric, transformed-input reconstruction and fixed-point telemetry;
+- finite-difference signal gradients, operation forcing modes and bounded equilibrium traces.
 
 ### Changed
 
@@ -38,7 +42,8 @@ The project follows semantic versioning where practical during alpha development
 - project documentation distinguishes stable code, reference laboratories, numerical references, integration candidates, demonstrations and specifications;
 - C++ candidate selection excludes wall-clock latency from both fitness and equal-fitness tie handling;
 - C++ checkpoint loading requires all versioned fields and a matching deterministic fingerprint;
-- fractional smoothing documentation states dense storage and separable `O(N⁴)` cost for cubic grids explicitly.
+- fractional smoothing documentation states dense storage and separable `O(N⁴)` cost for cubic grids explicitly;
+- UEA documentation distinguishes transformed-input reconstruction from strict latent invariance and transform maps from vector fields.
 
 ### Fixed
 

--- a/docs/DR_MOAGI_UNIFIED_AUTOENCODING.md
+++ b/docs/DR_MOAGI_UNIFIED_AUTOENCODING.md
@@ -1,0 +1,313 @@
+# Dr. Moagi Unified Autoencoding Reference
+
+## Classification
+
+This subsystem is a deterministic, dependency-free reference implementation of the proposed Dr. Moagi Unified Autoencoding (UEA) equations for the signal state
+
+```text
+s = [frequency, amplitude, phase].
+```
+
+It evaluates the objective, checks reconstruction fixed points, estimates the signal-space gradient and integrates the stated dynamical system. It is intended for equation-level validation and small auditable experiments.
+
+It is not a production neural-network trainer, an automatic-differentiation framework, a calibrated physical signal model or evidence of convergence for arbitrary coefficients.
+
+## 1. State geometry
+
+The written state is
+
+```text
+s = [f, a, phi]^T.
+```
+
+Frequency and amplitude are ordinary real coordinates. Phase is periodic, so the operational state space is more accurately
+
+```text
+R × R × S1
+```
+
+than unconstrained Euclidean `R3`.
+
+The reference therefore computes the phase residual with the shortest angular difference:
+
+```text
+d_phi = wrap(phi_hat - phi) in [-pi, pi).
+```
+
+The reconstruction metric is
+
+```text
+||s_hat - s||_G^2
+  = w_f (f_hat - f)^2
+  + w_a (a_hat - a)^2
+  + w_phi wrap(phi_hat - phi)^2.
+```
+
+All metric weights must be finite and positive.
+
+## 2. Probabilistic encoder
+
+A KL divergence against a standard normal requires a probability distribution rather than a single deterministic code. The reference makes that distribution explicit:
+
+```text
+q_phi(z|s)
+  = Normal(mu_phi(s), diag(exp(logvar_phi(s)))).
+```
+
+The current transparent model is linear:
+
+```text
+mu_phi(s)     = W_mu s + b_mu
+logvar_phi(s) = W_v s + b_v
+z             = mu_phi(s) + exp(0.5 logvar_phi(s)) elementwise* epsilon
+s_hat         = W_D z + b_D.
+```
+
+Deterministic reconstruction uses the posterior mean, `z = mu_phi(s)`. A caller may supply an explicit epsilon vector to test a reproducible sampled path.
+
+For a three-dimensional diagonal Gaussian, the implemented KL term is
+
+```text
+KL(q_phi(z|s) || Normal(0, I))
+  = 0.5 sum_i [exp(logvar_i) + mu_i^2 - 1 - logvar_i].
+```
+
+## 3. Unified objective
+
+For a batch `B`, the reference computes
+
+```text
+L_Moagi
+  = mean_s in B ||s - D(E(s))||_G^2
+  + sum_T mean_s in B ||T(s) - D(E(T(s)))||_G^2
+  + beta mean_s in B KL(q_phi(z|s) || Normal(0, I)),
+```
+
+where
+
+```text
+T in {M, F, N}.
+```
+
+The returned `LossBreakdown` exposes:
+
+- base reconstruction;
+- one reconstruction value for each operation;
+- mean KL regularization;
+- total objective.
+
+### Terminology boundary
+
+The operation term requires the autoencoder to reconstruct each transformed input. This is operation-conditioned reconstruction or closure under the transformation family.
+
+It is not strict latent invariance, which would require an additional term such as
+
+```text
+||E(T(s)) - E(s)||^2.
+```
+
+It is also not equivariance unless a latent operation `rho(T)` is defined and constrained through
+
+```text
+E(T(s)) approximately equals rho(T) E(s).
+```
+
+The implementation preserves the submitted equation and documents this distinction explicitly.
+
+## 4. Operations M, F and N
+
+The reference provides deterministic affine operations:
+
+```text
+T(s) = A_T s + b_T.
+```
+
+The default fixtures are interpretable rather than physically calibrated:
+
+- `M`: amplitude scaling plus a phase offset;
+- `F`: amplitude attenuation;
+- `N`: a fixed additive perturbation.
+
+A stochastic noise process cannot satisfy a pointwise deterministic fixed-point condition without conditioning on a realization. For reproducible tests, `N` is therefore one frozen deterministic realization. A production stochastic implementation should approximate the expectation with seeded Monte Carlo samples.
+
+## 5. Reconstruction fixed point
+
+The submitted fixed-point condition is evaluated as
+
+```text
+r_0(s) = s - D(E(s))
+r_T(s) = T(s) - D(E(T(s))).
+```
+
+The subsystem reports the RMS magnitude of every residual and declares reconstruction fixed-point satisfaction when
+
+```text
+max(RMS(r_0), RMS(r_M), RMS(r_F), RMS(r_N)) <= tolerance.
+```
+
+This is a reconstruction fixed point. It is distinct from a full dynamical equilibrium when operation forcing is nonzero.
+
+## 6. Signal-space gradient flow
+
+The dynamic equation is
+
+```text
+ds/dt
+  = -gamma grad_s L_Moagi
+    + lambda_m M(s)
+    + lambda_f F(s)
+    + lambda_n N(s).
+```
+
+Because the operation functions may be arbitrary deterministic transforms, the reference estimates `grad_s L_Moagi` by a centered finite difference on each state coordinate:
+
+```text
+partial L / partial s_i
+  approximately
+  [L(s + h e_i) - L(s - h e_i)] / (2h).
+```
+
+This is slow but explicit and testable. Parameter gradients with respect to encoder and decoder weights are intentionally left to a future autograd-backed implementation.
+
+### Transform-versus-vector-field interpretation
+
+A state transform `T(s)` and a velocity field are not dimensionally identical concepts. The runtime therefore exposes two forcing modes:
+
+```text
+absolute: lambda_T T(s)
+delta:    lambda_T [T(s) - s].
+```
+
+`absolute` reproduces the submitted equation literally.
+
+`delta` is the default operational mode when `M`, `F` and `N` are supplied as state transformations. It converts each transform into the displacement it proposes from the current state. Identity operations then contribute zero forcing.
+
+Phase displacement in delta mode uses the shortest circular residual.
+
+## 7. Time integration
+
+One explicit Euler step is
+
+```text
+s_(t+dt)
+  = Pi_bounds[
+      s_t
+      + dt (
+          -gamma grad_s L_Moagi
+          + operation_forcing(s_t)
+        )
+    ].
+```
+
+`Pi_bounds` is optional. It can constrain frequency and amplitude and always wraps the resulting phase.
+
+The equilibrium runner records:
+
+- every accepted state;
+- objective history;
+- derivative-norm history;
+- convergence status;
+- executed step count.
+
+It terminates when
+
+```text
+||ds/dt||_2 <= tolerance
+```
+
+or when the configured maximum number of steps is exhausted.
+
+## 8. Complete mechanistic loop
+
+```text
+LOAD s = [f, a, phi]
+  -> APPLY M, F, N
+  -> ENCODE each base/transformed state
+  -> FORM q(z|s) = Normal(mu, diag(exp(logvar)))
+  -> DECODE posterior means
+  -> COMPUTE circular reconstruction residuals
+  -> ACCUMULATE base + operation + beta*KL objective
+  -> CHECK reconstruction fixed point
+  -> PERTURB each signal coordinate by +/-h
+  -> ESTIMATE grad_s L_Moagi
+  -> ADD weighted operation forcing
+  -> EULER UPDATE
+  -> PROJECT bounds and wrap phase
+  -> RECORD telemetry
+  -> REPEAT until derivative equilibrium or cycle limit
+```
+
+## 9. Public API
+
+```python
+from jarvisx.unified_autoencoding import (
+    DrMoagiUEA,
+    MoagiCoefficients,
+    Signal3D,
+)
+
+engine = DrMoagiUEA(
+    coefficients=MoagiCoefficients(beta=1.0e-3, gamma=0.25)
+)
+signal = Signal3D(440.0, 0.8, 0.25)
+
+loss = engine.loss((signal,))
+report = engine.fixed_point_report(signal)
+trace = engine.run_to_equilibrium(signal, max_steps=10)
+```
+
+The runnable example is in
+
+```text
+examples/unified_autoencoding_reference.py
+```
+
+## 10. Relationship to hierarchical 3D fractional smoothing
+
+The UEA state has three signal coordinates; it is not by itself a spatial `x-y-z` volume.
+
+To couple it to the existing fractional 3D solver, define one spatial field for each component:
+
+```text
+f(x,y,z), a(x,y,z), phi(x,y,z).
+```
+
+Then compute the local UEA gradient at each voxel and fractionally smooth each component of that gradient before applying the state update:
+
+```text
+g_tilde_i
+  = exp[-tau D (-Delta)^alpha] g_i,
+
+partial s_i / partial t
+  = -gamma g_tilde_i + operation_forcing_i.
+```
+
+A hierarchy can use separate `(alpha_l, tau_l)` schedules for coarse and fine gradient fields. This adapter is a follow-on integration, not part of the present pull request.
+
+## 11. Correctness and convergence boundary
+
+The implementation guarantees validation, deterministic arithmetic for identical inputs and explicit telemetry. It does not guarantee that the Euler trajectory converges.
+
+Convergence depends on factors including:
+
+- objective smoothness;
+- finite-difference step;
+- Euler time step;
+- coefficient signs and magnitudes;
+- operation stability;
+- projection bounds;
+- whether forcing admits an equilibrium.
+
+A reconstruction fixed point satisfies the decoder residual equations. A full dynamic equilibrium instead satisfies
+
+```text
+-gamma grad_s L_Moagi
++ lambda_m V_M(s)
++ lambda_f V_F(s)
++ lambda_n V_N(s)
+= 0,
+```
+
+where `V_T(s)` is either `T(s)` or `T(s)-s`, according to the selected forcing mode.
+
+These two equilibrium concepts coincide only under additional assumptions.

--- a/examples/unified_autoencoding_reference.py
+++ b/examples/unified_autoencoding_reference.py
@@ -1,0 +1,39 @@
+"""Minimal Dr. Moagi UEA objective and equilibrium example."""
+
+from jarvisx.unified_autoencoding import (
+    DrMoagiUEA,
+    MoagiCoefficients,
+    Signal3D,
+    SignalBounds,
+)
+
+engine = DrMoagiUEA(
+    coefficients=MoagiCoefficients(
+        beta=1.0e-3,
+        gamma=0.25,
+        lambda_m=0.02,
+        lambda_f=0.01,
+        lambda_n=0.00,
+    )
+)
+
+signal = Signal3D(frequency=440.0, amplitude=0.8, phase=0.25)
+loss = engine.loss((signal,))
+fixed_point = engine.fixed_point_report(signal)
+
+trace = engine.run_to_equilibrium(
+    signal,
+    time_step=1.0e-4,
+    max_steps=10,
+    forcing_mode="delta",
+    bounds=SignalBounds(
+        minimum_frequency=0.0,
+        minimum_amplitude=0.0,
+        maximum_amplitude=1.0,
+    ),
+)
+
+print("loss:", loss.total)
+print("fixed-point residual:", fixed_point.maximum_rms)
+print("dynamic steps:", trace.steps)
+print("final state:", trace.states[-1])

--- a/src/jarvisx/uea_dynamics.py
+++ b/src/jarvisx/uea_dynamics.py
@@ -1,0 +1,251 @@
+"""Signal-space dynamics for the Dr. Moagi Unified Autoencoding system."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal, cast
+
+from .uea_model import (
+    FixedPointReport,
+    LinearGaussianAutoencoder,
+    LossBreakdown,
+    MoagiCoefficients,
+    OperationSet,
+    Signal3D,
+    SignalMetric,
+    Vector3,
+    _add,
+    _norm,
+    _scale,
+    signal_residual,
+    signal_squared_error,
+    wrap_phase,
+)
+
+ForcingMode = Literal["absolute", "delta"]
+
+
+@dataclass(frozen=True)
+class SignalBounds:
+    minimum_frequency: float | None = None
+    maximum_frequency: float | None = None
+    minimum_amplitude: float | None = None
+    maximum_amplitude: float | None = None
+
+    def project(self, signal: Signal3D) -> Signal3D:
+        frequency = signal.frequency
+        amplitude = signal.amplitude
+        if self.minimum_frequency is not None:
+            frequency = max(frequency, self.minimum_frequency)
+        if self.maximum_frequency is not None:
+            frequency = min(frequency, self.maximum_frequency)
+        if self.minimum_amplitude is not None:
+            amplitude = max(amplitude, self.minimum_amplitude)
+        if self.maximum_amplitude is not None:
+            amplitude = min(amplitude, self.maximum_amplitude)
+        return Signal3D(frequency, amplitude, wrap_phase(signal.phase))
+
+
+@dataclass(frozen=True)
+class EvolutionTrace:
+    states: tuple[Signal3D, ...]
+    losses: tuple[float, ...]
+    derivative_norms: tuple[float, ...]
+    converged: bool
+    steps: int
+
+
+class DrMoagiUEA:
+    """Executable UEA objective, fixed-point test and signal evolution."""
+
+    def __init__(
+        self,
+        model: LinearGaussianAutoencoder | None = None,
+        operations: OperationSet | None = None,
+        coefficients: MoagiCoefficients | None = None,
+        metric: SignalMetric | None = None,
+    ) -> None:
+        self.model = model or LinearGaussianAutoencoder()
+        self.operations = operations or OperationSet.default()
+        self.coefficients = coefficients or MoagiCoefficients()
+        self.metric = metric or SignalMetric()
+
+    @staticmethod
+    def _batch(signals: Iterable[Signal3D]) -> tuple[Signal3D, ...]:
+        batch = tuple(signals)
+        if not batch:
+            raise ValueError("at least one signal is required")
+        return batch
+
+    def loss(self, signals: Iterable[Signal3D]) -> LossBreakdown:
+        batch = self._batch(signals)
+        count = len(batch)
+        base = sum(
+            signal_squared_error(self.model.reconstruct(signal), signal, self.metric)
+            for signal in batch
+        ) / count
+
+        operation_losses: list[tuple[str, float]] = []
+        for operation in self.operations.items():
+            total = 0.0
+            for signal in batch:
+                transformed = operation.apply(signal)
+                total += signal_squared_error(
+                    self.model.reconstruct(transformed),
+                    transformed,
+                    self.metric,
+                )
+            operation_losses.append((operation.name, total / count))
+
+        kl = sum(self.model.posterior(signal).kl_standard_normal for signal in batch)
+        kl /= count
+        total_loss = (
+            base
+            + sum(value for _, value in operation_losses)
+            + self.coefficients.beta * kl
+        )
+        return LossBreakdown(base, tuple(operation_losses), kl, total_loss)
+
+    def fixed_point_report(
+        self,
+        signal: Signal3D,
+        tolerance: float = 1.0e-8,
+    ) -> FixedPointReport:
+        if not math.isfinite(tolerance) or tolerance <= 0.0:
+            raise ValueError("tolerance must be finite and positive")
+        base_rms = _norm(signal_residual(self.model.reconstruct(signal), signal))
+        base_rms /= math.sqrt(3.0)
+        operation_rms: list[tuple[str, float]] = []
+        for operation in self.operations.items():
+            transformed = operation.apply(signal)
+            residual = signal_residual(self.model.reconstruct(transformed), transformed)
+            operation_rms.append((operation.name, _norm(residual) / math.sqrt(3.0)))
+        maximum = max([base_rms, *(value for _, value in operation_rms)])
+        return FixedPointReport(
+            base_rms,
+            tuple(operation_rms),
+            maximum,
+            maximum <= tolerance,
+        )
+
+    def input_gradient(
+        self,
+        signal: Signal3D,
+        finite_difference_step: float = 1.0e-5,
+    ) -> Vector3:
+        if not math.isfinite(finite_difference_step) or finite_difference_step <= 0.0:
+            raise ValueError("finite-difference step must be finite and positive")
+        base = signal.as_vector()
+        gradient: list[float] = []
+        for axis in range(3):
+            plus = list(base)
+            minus = list(base)
+            plus[axis] += finite_difference_step
+            minus[axis] -= finite_difference_step
+            plus_signal = Signal3D.from_vector(cast(Vector3, tuple(plus)))
+            minus_signal = Signal3D.from_vector(cast(Vector3, tuple(minus)))
+            derivative = (
+                self.loss((plus_signal,)).total - self.loss((minus_signal,)).total
+            ) / (2.0 * finite_difference_step)
+            gradient.append(derivative)
+        return cast(Vector3, tuple(gradient))
+
+    def operation_forcing(
+        self,
+        signal: Signal3D,
+        mode: ForcingMode = "delta",
+    ) -> Vector3:
+        if mode not in ("absolute", "delta"):
+            raise ValueError("forcing mode must be 'absolute' or 'delta'")
+        total: Vector3 = (0.0, 0.0, 0.0)
+        for weight, operation in zip(
+            self.coefficients.operation_weights(),
+            self.operations.items(),
+        ):
+            transformed = operation.apply(signal)
+            vector = transformed.as_vector()
+            if mode == "delta":
+                vector = signal_residual(transformed, signal)
+            total = _add(total, _scale(weight, vector))
+        return total
+
+    def derivative(
+        self,
+        signal: Signal3D,
+        finite_difference_step: float = 1.0e-5,
+        forcing_mode: ForcingMode = "delta",
+    ) -> Vector3:
+        gradient = self.input_gradient(signal, finite_difference_step)
+        descent = _scale(-self.coefficients.gamma, gradient)
+        return _add(descent, self.operation_forcing(signal, forcing_mode))
+
+    def evolve_step(
+        self,
+        signal: Signal3D,
+        time_step: float,
+        *,
+        finite_difference_step: float = 1.0e-5,
+        forcing_mode: ForcingMode = "delta",
+        bounds: SignalBounds | None = None,
+    ) -> Signal3D:
+        if not math.isfinite(time_step) or time_step <= 0.0:
+            raise ValueError("time step must be finite and positive")
+        derivative = self.derivative(signal, finite_difference_step, forcing_mode)
+        candidate = Signal3D.from_vector(
+            _add(signal.as_vector(), _scale(time_step, derivative))
+        )
+        return bounds.project(candidate) if bounds is not None else candidate
+
+    def run_to_equilibrium(
+        self,
+        signal: Signal3D,
+        *,
+        time_step: float = 1.0e-2,
+        tolerance: float = 1.0e-7,
+        max_steps: int = 100,
+        finite_difference_step: float = 1.0e-5,
+        forcing_mode: ForcingMode = "delta",
+        bounds: SignalBounds | None = None,
+    ) -> EvolutionTrace:
+        if not math.isfinite(tolerance) or tolerance <= 0.0:
+            raise ValueError("tolerance must be finite and positive")
+        if max_steps < 1:
+            raise ValueError("max_steps must be positive")
+        current = signal
+        states = [current]
+        losses = [self.loss((current,)).total]
+        derivative_norms: list[float] = []
+        for step in range(1, max_steps + 1):
+            derivative = self.derivative(
+                current,
+                finite_difference_step,
+                forcing_mode,
+            )
+            derivative_norm = _norm(derivative)
+            derivative_norms.append(derivative_norm)
+            if derivative_norm <= tolerance:
+                return EvolutionTrace(
+                    tuple(states),
+                    tuple(losses),
+                    tuple(derivative_norms),
+                    True,
+                    step - 1,
+                )
+            current = self.evolve_step(
+                current,
+                time_step,
+                finite_difference_step=finite_difference_step,
+                forcing_mode=forcing_mode,
+                bounds=bounds,
+            )
+            states.append(current)
+            losses.append(self.loss((current,)).total)
+        return EvolutionTrace(
+            tuple(states),
+            tuple(losses),
+            tuple(derivative_norms),
+            False,
+            max_steps,
+        )

--- a/src/jarvisx/uea_dynamics.py
+++ b/src/jarvisx/uea_dynamics.py
@@ -82,10 +82,13 @@ class DrMoagiUEA:
     def loss(self, signals: Iterable[Signal3D]) -> LossBreakdown:
         batch = self._batch(signals)
         count = len(batch)
-        base = sum(
-            signal_squared_error(self.model.reconstruct(signal), signal, self.metric)
-            for signal in batch
-        ) / count
+        base = (
+            sum(
+                signal_squared_error(self.model.reconstruct(signal), signal, self.metric)
+                for signal in batch
+            )
+            / count
+        )
 
         operation_losses: list[tuple[str, float]] = []
         for operation in self.operations.items():
@@ -102,9 +105,7 @@ class DrMoagiUEA:
         kl = sum(self.model.posterior(signal).kl_standard_normal for signal in batch)
         kl /= count
         total_loss = (
-            base
-            + sum(value for _, value in operation_losses)
-            + self.coefficients.beta * kl
+            base + sum(value for _, value in operation_losses) + self.coefficients.beta * kl
         )
         return LossBreakdown(base, tuple(operation_losses), kl, total_loss)
 
@@ -146,9 +147,9 @@ class DrMoagiUEA:
             minus[axis] -= finite_difference_step
             plus_signal = Signal3D.from_vector(cast(Vector3, tuple(plus)))
             minus_signal = Signal3D.from_vector(cast(Vector3, tuple(minus)))
-            derivative = (
-                self.loss((plus_signal,)).total - self.loss((minus_signal,)).total
-            ) / (2.0 * finite_difference_step)
+            derivative = (self.loss((plus_signal,)).total - self.loss((minus_signal,)).total) / (
+                2.0 * finite_difference_step
+            )
             gradient.append(derivative)
         return cast(Vector3, tuple(gradient))
 
@@ -193,9 +194,7 @@ class DrMoagiUEA:
         if not math.isfinite(time_step) or time_step <= 0.0:
             raise ValueError("time step must be finite and positive")
         derivative = self.derivative(signal, finite_difference_step, forcing_mode)
-        candidate = Signal3D.from_vector(
-            _add(signal.as_vector(), _scale(time_step, derivative))
-        )
+        candidate = Signal3D.from_vector(_add(signal.as_vector(), _scale(time_step, derivative)))
         return bounds.project(candidate) if bounds is not None else candidate
 
     def run_to_equilibrium(

--- a/src/jarvisx/uea_model.py
+++ b/src/jarvisx/uea_model.py
@@ -36,8 +36,7 @@ def _finite_matrix(matrix: Matrix3, name: str) -> None:
 
 def _matvec(matrix: Matrix3, vector: Vector3) -> Vector3:
     values = tuple(
-        sum(matrix[row][column] * vector[column] for column in range(3))
-        for row in range(3)
+        sum(matrix[row][column] * vector[column] for column in range(3)) for row in range(3)
     )
     return cast(Vector3, values)
 
@@ -95,9 +94,7 @@ class SignalMetric:
     phase: float = 1.0
 
     def __post_init__(self) -> None:
-        if not all(
-            math.isfinite(value) and value > 0.0 for value in self.as_vector()
-        ):
+        if not all(math.isfinite(value) and value > 0.0 for value in self.as_vector()):
             raise ValueError("metric weights must be finite and positive")
 
     def as_vector(self) -> Vector3:
@@ -119,10 +116,7 @@ def signal_squared_error(
 ) -> float:
     active_metric = metric or SignalMetric()
     residual = signal_residual(prediction, target)
-    return sum(
-        weight * value * value
-        for weight, value in zip(active_metric.as_vector(), residual)
-    )
+    return sum(weight * value * value for weight, value in zip(active_metric.as_vector(), residual))
 
 
 @dataclass(frozen=True)
@@ -137,8 +131,7 @@ class GaussianPosterior:
     def sample(self, epsilon: Vector3) -> Vector3:
         _finite_vector(epsilon, "epsilon")
         values = tuple(
-            self.mean[index]
-            + math.exp(0.5 * self.log_variance[index]) * epsilon[index]
+            self.mean[index] + math.exp(0.5 * self.log_variance[index]) * epsilon[index]
             for index in range(3)
         )
         return cast(Vector3, values)
@@ -203,9 +196,7 @@ class AffineSignalOperation:
         _finite_vector(self.bias, f"{self.name} bias")
 
     def apply(self, signal: Signal3D) -> Signal3D:
-        return Signal3D.from_vector(
-            _add(_matvec(self.matrix, signal.as_vector()), self.bias)
-        )
+        return Signal3D.from_vector(_add(_matvec(self.matrix, signal.as_vector()), self.bias))
 
 
 @dataclass(frozen=True)
@@ -254,10 +245,7 @@ class MoagiCoefficients:
             raise ValueError("beta must be finite and non-negative")
         if not math.isfinite(self.gamma) or self.gamma < 0.0:
             raise ValueError("gamma must be finite and non-negative")
-        if not all(
-            math.isfinite(value)
-            for value in (self.lambda_m, self.lambda_f, self.lambda_n)
-        ):
+        if not all(math.isfinite(value) for value in (self.lambda_m, self.lambda_f, self.lambda_n)):
             raise ValueError("operation coefficients must be finite")
 
     def operation_weights(self) -> Vector3:

--- a/src/jarvisx/uea_model.py
+++ b/src/jarvisx/uea_model.py
@@ -1,0 +1,284 @@
+"""Deterministic reference for the Dr. Moagi Unified Autoencoding system.
+
+The state is ``s = [frequency, amplitude, phase]``. The implementation exposes
+operation-conditioned reconstruction, diagonal-Gaussian KL regularisation,
+fixed-point checks and the stated signal-space gradient flow. It is intended for
+small auditable experiments, not as a replacement for an autograd framework.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import cast
+
+Vector3 = tuple[float, float, float]
+Matrix3 = tuple[Vector3, Vector3, Vector3]
+
+
+def _identity() -> Matrix3:
+    return ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0))
+
+
+def _zeros() -> Matrix3:
+    return ((0.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 0.0))
+
+
+def _finite_vector(vector: Vector3, name: str) -> None:
+    if not all(math.isfinite(value) for value in vector):
+        raise ValueError(f"{name} must contain finite values")
+
+
+def _finite_matrix(matrix: Matrix3, name: str) -> None:
+    if not all(math.isfinite(value) for row in matrix for value in row):
+        raise ValueError(f"{name} must contain finite values")
+
+
+def _matvec(matrix: Matrix3, vector: Vector3) -> Vector3:
+    values = tuple(
+        sum(matrix[row][column] * vector[column] for column in range(3))
+        for row in range(3)
+    )
+    return cast(Vector3, values)
+
+
+def _add(left: Vector3, right: Vector3) -> Vector3:
+    return cast(Vector3, tuple(left[index] + right[index] for index in range(3)))
+
+
+def _scale(factor: float, vector: Vector3) -> Vector3:
+    return cast(Vector3, tuple(factor * value for value in vector))
+
+
+def _norm(vector: Vector3) -> float:
+    return math.sqrt(sum(value * value for value in vector))
+
+
+def wrap_phase(phase: float) -> float:
+    """Return ``phase`` in ``[-pi, pi)``."""
+
+    if not math.isfinite(phase):
+        raise ValueError("phase must be finite")
+    return (phase + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def phase_difference(left: float, right: float) -> float:
+    """Shortest signed angular difference ``left - right``."""
+
+    return wrap_phase(left - right)
+
+
+@dataclass(frozen=True)
+class Signal3D:
+    """Frequency, amplitude and circular phase."""
+
+    frequency: float
+    amplitude: float
+    phase: float
+
+    def __post_init__(self) -> None:
+        _finite_vector(self.as_vector(), "signal")
+
+    @classmethod
+    def from_vector(cls, vector: Vector3) -> "Signal3D":
+        _finite_vector(vector, "signal vector")
+        return cls(vector[0], vector[1], wrap_phase(vector[2]))
+
+    def as_vector(self) -> Vector3:
+        return (self.frequency, self.amplitude, self.phase)
+
+
+@dataclass(frozen=True)
+class SignalMetric:
+    frequency: float = 1.0
+    amplitude: float = 1.0
+    phase: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not all(
+            math.isfinite(value) and value > 0.0 for value in self.as_vector()
+        ):
+            raise ValueError("metric weights must be finite and positive")
+
+    def as_vector(self) -> Vector3:
+        return (self.frequency, self.amplitude, self.phase)
+
+
+def signal_residual(prediction: Signal3D, target: Signal3D) -> Vector3:
+    return (
+        prediction.frequency - target.frequency,
+        prediction.amplitude - target.amplitude,
+        phase_difference(prediction.phase, target.phase),
+    )
+
+
+def signal_squared_error(
+    prediction: Signal3D,
+    target: Signal3D,
+    metric: SignalMetric | None = None,
+) -> float:
+    active_metric = metric or SignalMetric()
+    residual = signal_residual(prediction, target)
+    return sum(
+        weight * value * value
+        for weight, value in zip(active_metric.as_vector(), residual)
+    )
+
+
+@dataclass(frozen=True)
+class GaussianPosterior:
+    mean: Vector3
+    log_variance: Vector3
+
+    def __post_init__(self) -> None:
+        _finite_vector(self.mean, "posterior mean")
+        _finite_vector(self.log_variance, "posterior log variance")
+
+    def sample(self, epsilon: Vector3) -> Vector3:
+        _finite_vector(epsilon, "epsilon")
+        values = tuple(
+            self.mean[index]
+            + math.exp(0.5 * self.log_variance[index]) * epsilon[index]
+            for index in range(3)
+        )
+        return cast(Vector3, values)
+
+    @property
+    def kl_standard_normal(self) -> float:
+        return 0.5 * sum(
+            math.exp(log_variance) + mean * mean - 1.0 - log_variance
+            for mean, log_variance in zip(self.mean, self.log_variance)
+        )
+
+
+@dataclass(frozen=True)
+class LinearGaussianAutoencoder:
+    """Small explicit ``q(z|s)`` encoder and linear decoder."""
+
+    mean_matrix: Matrix3 = field(default_factory=_identity)
+    mean_bias: Vector3 = (0.0, 0.0, 0.0)
+    log_variance_matrix: Matrix3 = field(default_factory=_zeros)
+    log_variance_bias: Vector3 = (-4.0, -4.0, -4.0)
+    decoder_matrix: Matrix3 = field(default_factory=_identity)
+    decoder_bias: Vector3 = (0.0, 0.0, 0.0)
+
+    def __post_init__(self) -> None:
+        _finite_matrix(self.mean_matrix, "mean matrix")
+        _finite_vector(self.mean_bias, "mean bias")
+        _finite_matrix(self.log_variance_matrix, "log-variance matrix")
+        _finite_vector(self.log_variance_bias, "log-variance bias")
+        _finite_matrix(self.decoder_matrix, "decoder matrix")
+        _finite_vector(self.decoder_bias, "decoder bias")
+
+    def posterior(self, signal: Signal3D) -> GaussianPosterior:
+        vector = signal.as_vector()
+        mean = _add(_matvec(self.mean_matrix, vector), self.mean_bias)
+        log_variance = _add(
+            _matvec(self.log_variance_matrix, vector),
+            self.log_variance_bias,
+        )
+        if any(abs(value) > 40.0 for value in log_variance):
+            raise ValueError("posterior log variance must remain in [-40, 40]")
+        return GaussianPosterior(mean, log_variance)
+
+    def reconstruct(self, signal: Signal3D, epsilon: Vector3 | None = None) -> Signal3D:
+        posterior = self.posterior(signal)
+        latent = posterior.mean if epsilon is None else posterior.sample(epsilon)
+        decoded = _add(_matvec(self.decoder_matrix, latent), self.decoder_bias)
+        return Signal3D.from_vector(decoded)
+
+
+@dataclass(frozen=True)
+class AffineSignalOperation:
+    """Deterministic affine realization of modulation, filtering or noise."""
+
+    name: str
+    matrix: Matrix3 = field(default_factory=_identity)
+    bias: Vector3 = (0.0, 0.0, 0.0)
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("operation name must not be empty")
+        _finite_matrix(self.matrix, f"{self.name} matrix")
+        _finite_vector(self.bias, f"{self.name} bias")
+
+    def apply(self, signal: Signal3D) -> Signal3D:
+        return Signal3D.from_vector(
+            _add(_matvec(self.matrix, signal.as_vector()), self.bias)
+        )
+
+
+@dataclass(frozen=True)
+class OperationSet:
+    modulation: AffineSignalOperation
+    filtering: AffineSignalOperation
+    noise: AffineSignalOperation
+
+    @classmethod
+    def identity(cls) -> "OperationSet":
+        return cls(
+            AffineSignalOperation("M"),
+            AffineSignalOperation("F"),
+            AffineSignalOperation("N"),
+        )
+
+    @classmethod
+    def default(cls) -> "OperationSet":
+        return cls(
+            AffineSignalOperation(
+                "M",
+                ((1.0, 0.0, 0.0), (0.0, 1.10, 0.0), (0.0, 0.0, 1.0)),
+                (0.0, 0.0, 0.15),
+            ),
+            AffineSignalOperation(
+                "F",
+                ((1.0, 0.0, 0.0), (0.0, 0.80, 0.0), (0.0, 0.0, 1.0)),
+            ),
+            AffineSignalOperation("N", bias=(0.01, -0.02, 0.03)),
+        )
+
+    def items(self) -> tuple[AffineSignalOperation, ...]:
+        return (self.modulation, self.filtering, self.noise)
+
+
+@dataclass(frozen=True)
+class MoagiCoefficients:
+    beta: float = 1.0e-3
+    gamma: float = 1.0
+    lambda_m: float = 0.0
+    lambda_f: float = 0.0
+    lambda_n: float = 0.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.beta) or self.beta < 0.0:
+            raise ValueError("beta must be finite and non-negative")
+        if not math.isfinite(self.gamma) or self.gamma < 0.0:
+            raise ValueError("gamma must be finite and non-negative")
+        if not all(
+            math.isfinite(value)
+            for value in (self.lambda_m, self.lambda_f, self.lambda_n)
+        ):
+            raise ValueError("operation coefficients must be finite")
+
+    def operation_weights(self) -> Vector3:
+        return (self.lambda_m, self.lambda_f, self.lambda_n)
+
+
+@dataclass(frozen=True)
+class LossBreakdown:
+    base_reconstruction: float
+    operation_reconstruction: tuple[tuple[str, float], ...]
+    kl_regularization: float
+    total: float
+
+    @property
+    def operation_total(self) -> float:
+        return sum(value for _, value in self.operation_reconstruction)
+
+
+@dataclass(frozen=True)
+class FixedPointReport:
+    base_rms: float
+    operation_rms: tuple[tuple[str, float], ...]
+    maximum_rms: float
+    satisfied: bool

--- a/src/jarvisx/unified_autoencoding.py
+++ b/src/jarvisx/unified_autoencoding.py
@@ -1,0 +1,42 @@
+"""Public API for the Dr. Moagi Unified Autoencoding reference."""
+
+from .uea_dynamics import DrMoagiUEA, EvolutionTrace, ForcingMode, SignalBounds
+from .uea_model import (
+    AffineSignalOperation,
+    FixedPointReport,
+    GaussianPosterior,
+    LinearGaussianAutoencoder,
+    LossBreakdown,
+    Matrix3,
+    MoagiCoefficients,
+    OperationSet,
+    Signal3D,
+    SignalMetric,
+    Vector3,
+    phase_difference,
+    signal_residual,
+    signal_squared_error,
+    wrap_phase,
+)
+
+__all__ = [
+    "AffineSignalOperation",
+    "DrMoagiUEA",
+    "EvolutionTrace",
+    "FixedPointReport",
+    "ForcingMode",
+    "GaussianPosterior",
+    "LinearGaussianAutoencoder",
+    "LossBreakdown",
+    "Matrix3",
+    "MoagiCoefficients",
+    "OperationSet",
+    "Signal3D",
+    "SignalBounds",
+    "SignalMetric",
+    "Vector3",
+    "phase_difference",
+    "signal_residual",
+    "signal_squared_error",
+    "wrap_phase",
+]

--- a/tests/test_unified_autoencoding.py
+++ b/tests/test_unified_autoencoding.py
@@ -1,0 +1,110 @@
+import math
+
+import pytest
+
+from jarvisx.unified_autoencoding import (
+    DrMoagiUEA,
+    LinearGaussianAutoencoder,
+    MoagiCoefficients,
+    OperationSet,
+    Signal3D,
+    SignalBounds,
+    phase_difference,
+    signal_squared_error,
+)
+
+
+def test_identity_model_satisfies_reconstruction_fixed_points():
+    engine = DrMoagiUEA(
+        operations=OperationSet.default(),
+        coefficients=MoagiCoefficients(beta=0.0),
+    )
+    signal = Signal3D(440.0, 0.75, math.pi - 0.1)
+
+    report = engine.fixed_point_report(signal)
+    loss = engine.loss((signal,))
+
+    assert report.satisfied
+    assert report.maximum_rms == pytest.approx(0.0, abs=1.0e-12)
+    assert loss.base_reconstruction == pytest.approx(0.0, abs=1.0e-12)
+    assert loss.operation_total == pytest.approx(0.0, abs=1.0e-12)
+
+
+def test_kl_term_uses_diagonal_gaussian_divergence():
+    engine = DrMoagiUEA(
+        operations=OperationSet.identity(),
+        coefficients=MoagiCoefficients(beta=0.25),
+    )
+    loss = engine.loss((Signal3D(1.0, 0.5, 0.25),))
+
+    assert loss.kl_regularization > 0.0
+    assert loss.total == pytest.approx(0.25 * loss.kl_regularization)
+
+
+def test_phase_metric_uses_shortest_circular_residual():
+    left = Signal3D(1.0, 1.0, -math.pi + 0.01)
+    right = Signal3D(1.0, 1.0, math.pi - 0.01)
+
+    assert phase_difference(left.phase, right.phase) == pytest.approx(0.02)
+    assert signal_squared_error(left, right) == pytest.approx(0.02**2)
+
+
+def test_input_gradient_matches_quadratic_identity_operation_case():
+    zero_decoder = ((0.0, 0.0, 0.0),) * 3
+    model = LinearGaussianAutoencoder(decoder_matrix=zero_decoder)
+    engine = DrMoagiUEA(
+        model=model,
+        operations=OperationSet.identity(),
+        coefficients=MoagiCoefficients(beta=0.0),
+    )
+
+    gradient = engine.input_gradient(Signal3D(0.5, -0.25, 0.2))
+
+    # Base plus three operation terms each contribute ||s||^2, so grad = 8s.
+    assert gradient == pytest.approx((4.0, -2.0, 1.6), rel=1.0e-5, abs=1.0e-6)
+
+
+def test_delta_forcing_vanishes_for_identity_operations():
+    engine = DrMoagiUEA(
+        operations=OperationSet.identity(),
+        coefficients=MoagiCoefficients(
+            beta=0.0,
+            gamma=0.0,
+            lambda_m=1.0,
+            lambda_f=2.0,
+            lambda_n=3.0,
+        ),
+    )
+
+    forcing = engine.operation_forcing(Signal3D(2.0, 3.0, 0.5), "delta")
+
+    assert forcing == pytest.approx((0.0, 0.0, 0.0))
+
+
+def test_equilibrium_trace_stops_at_identity_fixed_point():
+    engine = DrMoagiUEA(
+        operations=OperationSet.identity(),
+        coefficients=MoagiCoefficients(beta=0.0),
+    )
+
+    trace = engine.run_to_equilibrium(Signal3D(1.0, 0.5, 0.25))
+
+    assert trace.converged
+    assert trace.steps == 0
+    assert len(trace.states) == 1
+    assert trace.derivative_norms[0] == pytest.approx(0.0, abs=1.0e-10)
+
+
+def test_signal_bounds_project_linear_coordinates_and_wrap_phase():
+    bounds = SignalBounds(
+        minimum_frequency=0.0,
+        maximum_frequency=1000.0,
+        minimum_amplitude=0.0,
+        maximum_amplitude=1.0,
+    )
+
+    projected = bounds.project(Signal3D(-10.0, 2.0, 4.0 * math.pi + 0.2))
+
+    assert projected.frequency == 0.0
+    assert projected.amplitude == 1.0
+    assert projected.phase == pytest.approx(0.2)


### PR DESCRIPTION
## Purpose

Operationalise the submitted Dr. Moagi Unified Autoencoding (UEA) equation system as a deterministic, dependency-free reference for three-coordinate signal states:

```text
s = [frequency, amplitude, phase]
```

The implementation evaluates the reconstruction/KL objective, checks the submitted reconstruction fixed-point conditions, estimates the signal-space gradient and integrates the dynamic evolution equation with explicit telemetry.

## Core objective

```text
L_Moagi
  = E ||s - D(E(s))||_G^2
  + sum_T E ||T(s) - D(E(T(s)))||_G^2
  + beta E KL(q(z|s) || Normal(0, I))
```

with `T in {M, F, N}`.

The operational state geometry is `R × R × S1`: phase is circular and therefore uses the shortest wrapped angular residual rather than an unconstrained Euclidean subtraction.

## What changed

- adds `src/jarvisx/uea_model.py`
  - immutable `[f, a, phi]` signal state;
  - circular phase metric;
  - explicit diagonal-Gaussian posterior `q(z|s)`;
  - linear Gaussian encoder and decoder reference;
  - deterministic affine modulation, filtering and frozen-noise operations;
  - validated beta/gamma/lambda coefficient set;
  - structured loss and fixed-point result types;
- adds `src/jarvisx/uea_dynamics.py`
  - batch objective evaluation;
  - base and transformed-input fixed-point residuals;
  - centered finite-difference `grad_s L_Moagi`;
  - literal `absolute` operation forcing;
  - recommended transform-displacement `delta` forcing;
  - explicit Euler evolution, optional bounds and equilibrium traces;
- adds `src/jarvisx/unified_autoencoding.py` as the stable public façade;
- adds seven focused tests;
- adds a runnable example;
- adds a full equation-to-runtime derivation;
- extends canonical Black/isort/mypy/pytest coverage;
- records the subsystem in the changelog.

## Important mathematical distinctions

1. The KL term requires an encoder distribution, so the implementation makes `q_phi(z|s) = Normal(mu, diag(exp(logvar)))` explicit.
2. The submitted operation term is transformed-input reconstruction, not strict latent invariance. Strict invariance would require an additional `||E(T(s)) - E(s)||^2` term.
3. A stochastic noise operator cannot satisfy a deterministic pointwise fixed point without conditioning on a realization. The reference uses one frozen deterministic perturbation; Monte Carlo noise expectations are a follow-on.
4. If `M`, `F` and `N` are state transforms rather than velocity fields, the dimensionally consistent forcing is `T(s) - s`. The runtime supports both this `delta` mode and the literal submitted `absolute` mode.
5. Reconstruction fixed-point satisfaction and full dynamical equilibrium are distinct when operation forcing is nonzero.

## Mechanistic loop

```text
load s
-> transform through M/F/N
-> encode posterior mean/log variance
-> decode base and transformed states
-> accumulate reconstruction + beta*KL
-> check reconstruction fixed point
-> perturb each signal coordinate +/-h
-> estimate grad_s L
-> add weighted operation forcing
-> Euler update
-> project bounds and wrap phase
-> record telemetry
-> repeat to derivative equilibrium or cycle limit
```

## Validation

Focused tests cover:

- exact base and transformed-input reconstruction under the identity reference model;
- positive diagonal-Gaussian KL contribution;
- circular phase residuals across the `-pi/pi` boundary;
- finite-difference input-gradient arithmetic;
- zero delta forcing for identity transformations;
- immediate equilibrium detection at a fixed point;
- frequency/amplitude projection and phase wrapping.

The latest validation is green:

- Jarvis-X CI run `#444`: success;
- Python `3.10`, `3.11`, `3.12` and `3.13`: success;
- Black, isort, flake8 and mypy quality gate: success;
- dependency audit and package build/smoke test: success;
- CodeQL run `#42`: success.

## Engineering boundary

This is an auditable linear reference and signal-state integrator. It does not yet provide nonlinear neural layers, parameter training, automatic differentiation, stochastic Monte Carlo expectations, a spatial volume adapter or a convergence guarantee for arbitrary operations and time steps.

A follow-on adapter can couple voxelwise UEA gradients to the existing hierarchical fractional 3D smoothing subsystem before each state update.
