### PR TITLE
Permeate Jarvis-X multimodal Windows studio

### DIFF
--- a/.github/workflows/jarvisx-multimodal-windows.yml
+++ b/.github/workflows/jarvisx-multimodal-windows.yml
@@ -1,0 +1,98 @@
+name: Jarvis-X Multimodal Windows
+
+on:
+  pull_request:
+    paths:
+      - "apps/windows/jarvisx-multimodal-studio/**"
+      - ".github/workflows/jarvisx-multimodal-windows.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/windows/jarvisx-multimodal-studio/**"
+      - ".github/workflows/jarvisx-multimodal-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cross-compiler
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld python3 zip binutils
+
+      - name: Reject obvious embedded project keys
+        shell: bash
+        run: |
+          if grep -RInE 'sk-(proj-)?[A-Za-z0-9_-]{20,}' apps/windows/jarvisx-multimodal-studio; then
+            echo "Potential API key material detected" >&2
+            exit 1
+          fi
+
+      - name: Assemble and check browser JavaScript
+        shell: bash
+        run: |
+          APP=apps/windows/jarvisx-multimodal-studio
+          cat "$APP"/src/fragments/index.html/*.part > /tmp/jarvisx-index.html
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          source = Path("/tmp/jarvisx-index.html").read_text(encoding="utf-8")
+          scripts = re.findall(r"<script(?:\s[^>]*)?>(.*?)</script>", source, flags=re.S | re.I)
+          Path("/tmp/jarvisx-ui.js").write_text("\n".join(scripts), encoding="utf-8")
+          PY
+          node --check /tmp/jarvisx-ui.js
+
+      - name: Build twice and prove reproducibility
+        shell: bash
+        run: |
+          cp -a apps/windows/jarvisx-multimodal-studio /tmp/build-a
+          cp -a apps/windows/jarvisx-multimodal-studio /tmp/build-b
+          /tmp/build-a/build-windows.sh
+          /tmp/build-b/build-windows.sh
+          cmp /tmp/build-a/JarvisX-Multimodal-Studio.exe /tmp/build-b/JarvisX-Multimodal-Studio.exe
+
+      - name: Verify PE and embedded assets
+        shell: bash
+        run: |
+          APP=/tmp/build-a
+          file "$APP/JarvisX-Multimodal-Studio.exe" | tee /tmp/file.txt
+          grep -q 'PE32+ executable.*x86-64' /tmp/file.txt
+          objdump -x "$APP/JarvisX-Multimodal-Studio.exe" > /tmp/pe.txt
+          grep -q 'Subsystem.*Windows GUI' /tmp/pe.txt
+          grep -q 'DLL Name: KERNEL32.dll' /tmp/pe.txt
+          grep -q 'DLL Name: USER32.dll' /tmp/pe.txt
+          python3 - <<'PY'
+          from pathlib import Path
+          app = Path("/tmp/build-a")
+          binary = (app / "JarvisX-Multimodal-Studio.exe").read_bytes()
+          for relative in ("src/index.html", "src/JarvisXMultimodal.ps1"):
+              payload = (app / relative).read_bytes()
+              if payload not in binary:
+                  raise SystemExit(f"embedded payload not found: {relative}")
+          PY
+
+      - name: Package release artifact
+        shell: bash
+        run: |
+          APP=/tmp/build-a
+          sha256sum "$APP/JarvisX-Multimodal-Studio.exe" > "$APP/SHA256SUMS.txt"
+          cd "$APP"
+          zip -9 JarvisX-Multimodal-Studio-Windows-x64.zip \
+            JarvisX-Multimodal-Studio.exe README.md SECURITY.md SHA256SUMS.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: JarvisX-Multimodal-Studio-Windows-x64
+          path: |
+            /tmp/build-a/JarvisX-Multimodal-Studio.exe
+            /tmp/build-a/JarvisX-Multimodal-Studio-Windows-x64.zip
+            /tmp/build-a/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/apps/windows/jarvisx-multimodal-studio/README.md
+++ b/apps/windows/jarvisx-multimodal-studio/README.md
@@ -1,0 +1,80 @@
+# JARVIS-X Multimodal Studio for Windows
+
+An experimental Windows x64 desktop interface for OpenAI-backed multimodal workflows.
+The native launcher extracts a local PowerShell runtime and browser UI into the current
+user's LocalAppData directory, starts a loopback-only service, and opens the interface in
+the default browser.
+
+## Implemented surfaces
+
+- multimodal chat with image, PDF, document, spreadsheet, source, and audio inputs;
+- image generation with downloadable PNG output;
+- microphone capture and speech transcription;
+- text-to-speech generation with MP3 playback and download;
+- asynchronous video-job submission, polling, playback, and MP4 download;
+- local browser-profile conversation history;
+- configurable model identifiers and assistant instructions.
+
+Availability of individual media endpoints depends on the selected OpenAI project,
+model access, account limits, and API evolution.
+
+## Capability boundary
+
+This application is a user-operated media client. It is **not** an autonomous operating
+system, AGI runtime, or arbitrary command-execution agent. Model output is rendered as
+data and is never passed to a local shell for execution.
+
+The repository does not contain an API key. On first launch, the user supplies a project
+key through Settings. The local Windows runtime validates it, encrypts it with current-user
+Windows DPAPI, and stores only the protected value.
+
+## Runtime requirements
+
+- Windows 10 or Windows 11, x86-64;
+- Windows PowerShell 5.1 or later;
+- a modern default web browser;
+- internet access to `api.openai.com`;
+- an OpenAI project API key with access to the requested models.
+
+## Build
+
+The build cross-compiles a native PE32+ GUI launcher without a C runtime. It requires:
+
+- Python 3;
+- `clang-cl`;
+- `lld-link`.
+
+```bash
+./build-windows.sh
+```
+
+The linker uses `/Brepro`, so repeated builds with identical inputs and the same toolchain
+produce byte-identical executables.
+
+## Operation
+
+1. Run `JarvisX-Multimodal-Studio.exe`.
+2. The launcher writes its embedded UI and PowerShell runtime beneath
+   `%LOCALAPPDATA%\JarvisXMultimodal`.
+3. It starts a service bound to `127.0.0.1` and opens a tokenized local URL.
+4. Open Settings, enter the project API key, and select **Validate and save**.
+5. Use **Close engine** in the interface to stop the runtime.
+
+## Validation
+
+The CI workflow:
+
+- scans committed source for obvious embedded project keys;
+- checks browser JavaScript syntax with Node.js;
+- builds the executable twice in isolated directories;
+- requires the two binaries to be byte-identical;
+- verifies PE32+ x86-64 structure and GUI subsystem;
+- checks the import table;
+- confirms embedded HTML and PowerShell payloads occur in the final executable;
+- publishes the Windows executable and SHA-256 manifest as a workflow artifact.
+
+## Release status
+
+The generated executable is unsigned. Windows SmartScreen may warn before launch.
+Production distribution should use an organization-controlled code-signing certificate,
+versioned releases, dependency review, and Windows-native runtime testing.

--- a/apps/windows/jarvisx-multimodal-studio/SECURITY.md
+++ b/apps/windows/jarvisx-multimodal-studio/SECURITY.md
@@ -1,0 +1,40 @@
+# Security boundary
+
+## Secrets
+
+- No OpenAI API key is compiled into the launcher, PowerShell runtime, HTML, JavaScript,
+  workflow, or repository history introduced by this subsystem.
+- The browser UI does not receive the plaintext project key.
+- API requests are issued by the loopback PowerShell service.
+- The persisted key is encrypted with Windows DPAPI for the current user.
+
+## Local service
+
+- The HTTP listener binds to `127.0.0.1` only.
+- A random launch token is required for the browser session.
+- The application should not be exposed through port forwarding or a reverse proxy.
+
+## Execution policy
+
+- Model responses are treated as untrusted data.
+- Model output is not executed as PowerShell, CMD, JavaScript, native code, or a system command.
+- File attachments are forwarded only through declared media/API operations.
+
+## Known limitations
+
+- The launcher is unsigned.
+- The backend is implemented in Windows PowerShell 5.1 for portability, not isolation strength.
+- The browser UI is localhost-hosted rather than an embedded hardened WebView.
+- Endpoint and model availability can change independently of this repository.
+- The application has not been dynamically tested on every supported Windows build.
+
+## Production hardening
+
+Before production release:
+
+1. code-sign the executable and release archive;
+2. pin and review API/model configuration;
+3. add Windows integration and failure-injection tests;
+4. apply request-size, media-size, and concurrency quotas appropriate to the deployment;
+5. add an explicit update channel with signed manifests;
+6. conduct threat modelling for localhost token theft, browser extensions, and malicious files.

--- a/apps/windows/jarvisx-multimodal-studio/build-windows.sh
+++ b/apps/windows/jarvisx-multimodal-studio/build-windows.sh
@@ -4,6 +4,32 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 cd "$ROOT/src"
 
+resolve_tool() {
+  local requested="$1"
+  shift
+  if [[ -n "$requested" ]] && command -v "$requested" >/dev/null 2>&1; then
+    command -v "$requested"
+    return 0
+  fi
+  local candidate
+  for candidate in "$@"; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      command -v "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+CLANG_CL_BIN="$(resolve_tool "${CLANG_CL:-}" clang-cl clang-cl-20 clang-cl-19 clang-cl-18 clang-cl-17 clang-cl-16)" || {
+  echo "clang-cl was not found; install LLVM's MSVC-compatible frontend" >&2
+  exit 127
+}
+LLD_LINK_BIN="$(resolve_tool "${LLD_LINK:-}" lld-link lld-link-20 lld-link-19 lld-link-18 lld-link-17 lld-link-16)" || {
+  echo "lld-link was not found; install LLVM's COFF linker" >&2
+  exit 127
+}
+
 cat fragments/index.html/*.part > index.html
 cat fragments/JarvisXMultimodal.ps1/*.part > JarvisXMultimodal.ps1
 
@@ -26,12 +52,12 @@ Path("embedded_assets.inc").write_text(
 )
 PY
 
-lld-link /lib /def:kernel32.def /machine:x64 /out:kernel32.lib
-lld-link /lib /def:user32.def /machine:x64 /out:user32.lib
-clang-cl --target=x86_64-pc-windows-msvc \
+"$LLD_LINK_BIN" /lib /def:kernel32.def /machine:x64 /out:kernel32.lib
+"$LLD_LINK_BIN" /lib /def:user32.def /machine:x64 /out:user32.lib
+"$CLANG_CL_BIN" --target=x86_64-pc-windows-msvc \
   /c /O2 /GS- /GR- /EHs-c- /utf-8 /nologo \
   launcher.c /Folauncher.obj
-lld-link launcher.obj kernel32.lib user32.lib \
+"$LLD_LINK_BIN" launcher.obj kernel32.lib user32.lib \
   /entry:wWinMainCRTStartup /subsystem:windows /nodefaultlib /machine:x64 \
   /opt:ref /opt:icf /Brepro \
   /out:"$ROOT/JarvisX-Multimodal-Studio.exe"

--- a/apps/windows/jarvisx-multimodal-studio/build-windows.sh
+++ b/apps/windows/jarvisx-multimodal-studio/build-windows.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+cd "$ROOT/src"
+
+cat fragments/index.html/*.part > index.html
+cat fragments/JarvisXMultimodal.ps1/*.part > JarvisXMultimodal.ps1
+
+python3 - <<'PY'
+from pathlib import Path
+
+html = Path("index.html").read_bytes()
+powershell = Path("JarvisXMultimodal.ps1").read_bytes()
+
+def emit_array(name: str, data: bytes) -> str:
+    rows = [f"static const unsigned char {name}[] = {{"]
+    for index in range(0, len(data), 16):
+        rows.append("  " + ", ".join(f"0x{value:02x}" for value in data[index:index + 16]) + ",")
+    rows.extend(["};", f"static const unsigned long {name}_len = {len(data)}UL;"])
+    return "\n".join(rows)
+
+Path("embedded_assets.inc").write_text(
+    emit_array("APP_HTML", html) + "\n\n" + emit_array("APP_PS1", powershell),
+    encoding="ascii",
+)
+PY
+
+lld-link /lib /def:kernel32.def /machine:x64 /out:kernel32.lib
+lld-link /lib /def:user32.def /machine:x64 /out:user32.lib
+clang-cl --target=x86_64-pc-windows-msvc \
+  /c /O2 /GS- /GR- /EHs-c- /utf-8 /nologo \
+  launcher.c /Folauncher.obj
+lld-link launcher.obj kernel32.lib user32.lib \
+  /entry:wWinMainCRTStartup /subsystem:windows /nodefaultlib /machine:x64 \
+  /opt:ref /opt:icf /Brepro \
+  /out:"$ROOT/JarvisX-Multimodal-Studio.exe"
+
+sha256sum "$ROOT/JarvisX-Multimodal-Studio.exe"

--- a/apps/windows/jarvisx-multimodal-studio/docs/ARCHITECTURE.md
+++ b/apps/windows/jarvisx-multimodal-studio/docs/ARCHITECTURE.md
@@ -1,0 +1,63 @@
+# Architecture
+
+## Process topology
+
+```text
+Windows GUI launcher
+  -> extracts versioned assets to LocalAppData
+  -> starts hidden Windows PowerShell runtime
+  -> PowerShell binds loopback HTTP listener
+  -> default browser opens tokenized localhost interface
+  -> local backend performs authenticated OpenAI API requests
+```
+
+## Native launcher
+
+`src/launcher.c` is a minimal PE32+ GUI executable with no C runtime dependency. The build
+generates `embedded_assets.inc` from the HTML and PowerShell sources, then links only the
+required Kernel32 and User32 imports declared in the `.def` files.
+
+The launcher is intentionally not an AI execution environment. It only installs the bundled
+assets and starts the local runtime.
+
+## Trust boundary
+
+```text
+Untrusted browser input and model output
+          |
+          v
+Loopback request validation and launch-token check
+          |
+          v
+Declared API operation router
+          |
+          v
+OpenAI HTTPS endpoints
+```
+
+The runtime does not expose a generic shell route. Chat output, generated media metadata,
+and transcriptions remain data.
+
+## Credential lifecycle
+
+1. The user enters a project API key in the local settings interface.
+2. The browser sends it once to the token-protected loopback backend.
+3. The backend validates the key against the API.
+4. The key is protected with current-user Windows DPAPI.
+5. Subsequent requests decrypt it only inside the local backend process.
+
+The repository and distributed executable contain no project credential.
+
+## Media flows
+
+- **Chat:** text and declared file/image inputs are normalized into an API request.
+- **Image:** prompts are submitted to the configured image-generation model.
+- **Speech:** text is submitted for audio synthesis; recorded audio is submitted for transcription.
+- **Video:** the backend creates an asynchronous job, polls status, and downloads the result when complete.
+
+## Build reproducibility
+
+`lld-link /Brepro` derives a deterministic PE timestamp from the linked content. The CI job
+builds twice from isolated copies and rejects the build unless `cmp` confirms byte identity.
+Toolchain upgrades may legitimately change the executable hash; reproducibility is asserted
+within one pinned CI environment and input revision.

--- a/apps/windows/jarvisx-multimodal-studio/provenance/DELIVERED_ARTIFACTS.sha256
+++ b/apps/windows/jarvisx-multimodal-studio/provenance/DELIVERED_ARTIFACTS.sha256
@@ -1,0 +1,3 @@
+7dcf2ccbc94f7348dde693b5233d3dbaf5d835a79ffba58488d9e85706c4a079  JarvisX-Multimodal-Studio.exe (conversation-delivered pre-/Brepro build)
+580df38f76fb1e4750a3be7b2d00adaadb22e4fda33a09f8a28eef6b6eac7fd1  src/index.html
+16681a239f538108e59af079344d31e40c2f9c7fd831ae44bcdf482069b45e4e  src/JarvisXMultimodal.ps1

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/00.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/00.part
@@ -1,0 +1,200 @@
+param()
+
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Add-Type -AssemblyName System.Net.Http
+Add-Type -AssemblyName System.Windows.Forms
+
+$AppVersion = "1.0.0"
+$AppDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$HtmlPath = Join-Path $AppDir "index.html"
+$KeyPath = Join-Path $AppDir "key.dat"
+$LogPath = Join-Path $AppDir "runtime.log"
+$script:StopRequested = $false
+$script:LaunchToken = [Guid]::NewGuid().ToString("N")
+
+function Write-Log {
+    param([string]$Message)
+    try {
+        $line = "[{0}] {1}`r`n" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $Message
+        [IO.File]::AppendAllText($LogPath, $line, [Text.Encoding]::UTF8)
+    } catch {}
+}
+
+function Get-ApiKey {
+    if (-not [string]::IsNullOrWhiteSpace($env:OPENAI_API_KEY)) {
+        return $env:OPENAI_API_KEY.Trim()
+    }
+    if (Test-Path -LiteralPath $KeyPath) {
+        try {
+            $encrypted = [IO.File]::ReadAllText($KeyPath, [Text.Encoding]::UTF8).Trim()
+            if ([string]::IsNullOrWhiteSpace($encrypted)) { return $null }
+            $secure = ConvertTo-SecureString $encrypted
+            return ([Net.NetworkCredential]::new("", $secure)).Password
+        } catch {
+            Write-Log "Unable to decrypt the stored API key."
+        }
+    }
+    return $null
+}
+
+function Save-ApiKey {
+    param([string]$Key)
+    $secure = ConvertTo-SecureString $Key -AsPlainText -Force
+    $encrypted = ConvertFrom-SecureString $secure
+    [IO.File]::WriteAllText($KeyPath, $encrypted, [Text.Encoding]::UTF8)
+}
+
+function Remove-SavedApiKey {
+    if (Test-Path -LiteralPath $KeyPath) {
+        Remove-Item -LiteralPath $KeyPath -Force
+    }
+}
+
+function New-OpenAIClient {
+    param([string]$Key)
+    $handler = [System.Net.Http.HttpClientHandler]::new()
+    $client = [System.Net.Http.HttpClient]::new($handler)
+    $client.Timeout = [TimeSpan]::FromMinutes(12)
+    $client.DefaultRequestHeaders.Authorization =
+        [System.Net.Http.Headers.AuthenticationHeaderValue]::new("Bearer", $Key)
+    [void]$client.DefaultRequestHeaders.TryAddWithoutValidation(
+        "X-Client-Request-Id", [Guid]::NewGuid().ToString()
+    )
+    return $client
+}
+
+function Read-OpenAIError {
+    param([string]$Text, [int]$StatusCode)
+    try {
+        $parsed = $Text | ConvertFrom-Json
+        if ($parsed.error.message) { return [string]$parsed.error.message }
+    } catch {}
+    if ($Text.Length -gt 500) { $Text = $Text.Substring(0, 500) }
+    if ([string]::IsNullOrWhiteSpace($Text)) { return "OpenAI API returned HTTP $StatusCode." }
+    return $Text
+}
+
+function Invoke-OpenAIJson {
+    param(
+        [ValidateSet("GET","POST","DELETE")][string]$Method,
+        [string]$Path,
+        $Body = $null
+    )
+    $key = Get-ApiKey
+    if ([string]::IsNullOrWhiteSpace($key)) {
+        throw "No OpenAI API key is configured."
+    }
+
+    $client = New-OpenAIClient $key
+    try {
+        $uri = "https://api.openai.com/v1$Path"
+        if ($Method -eq "GET") {
+            $response = $client.GetAsync($uri).GetAwaiter().GetResult()
+        } elseif ($Method -eq "DELETE") {
+            $response = $client.DeleteAsync($uri).GetAwaiter().GetResult()
+        } else {
+            $json = $Body | ConvertTo-Json -Depth 100 -Compress
+            $content = [System.Net.Http.StringContent]::new(
+                $json, [Text.Encoding]::UTF8, "application/json"
+            )
+            $response = $client.PostAsync($uri, $content).GetAwaiter().GetResult()
+            $content.Dispose()
+        }
+
+        $text = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+        $status = [int]$response.StatusCode
+        if (-not $response.IsSuccessStatusCode) {
+            throw (Read-OpenAIError $text $status)
+        }
+        if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+        return ($text | ConvertFrom-Json)
+    } finally {
+        if ($response) { $response.Dispose() }
+        $client.Dispose()
+    }
+}
+
+function Invoke-OpenAIBinaryJson {
+    param([string]$Path, $Body)
+    $key = Get-ApiKey
+    if ([string]::IsNullOrWhiteSpace($key)) {
+        throw "No OpenAI API key is configured."
+    }
+    $client = New-OpenAIClient $key
+    try {
+        $json = $Body | ConvertTo-Json -Depth 50 -Compress
+        $content = [System.Net.Http.StringContent]::new(
+            $json, [Text.Encoding]::UTF8, "application/json"
+        )
+        $response = $client.PostAsync(
+            "https://api.openai.com/v1$Path", $content
+        ).GetAwaiter().GetResult()
+        $content.Dispose()
+        $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+            $text = [Text.Encoding]::UTF8.GetString($bytes)
+            throw (Read-OpenAIError $text ([int]$response.StatusCode))
+        }
+        return $bytes
+    } finally {
+        if ($response) { $response.Dispose() }
+        $client.Dispose()
+    }
+}
+
+function Invoke-OpenAIMultipart {
+    param([string]$Path, [hashtable]$Fields, $File = $null)
+    $key = Get-ApiKey
+    if ([string]::IsNullOrWhiteSpace($key)) {
+        throw "No OpenAI API key is configured."
+    }
+    $client = New-OpenAIClient $key
+    $multipart = [System.Net.Http.MultipartFormDataContent]::new()
+    try {
+        foreach ($entry in $Fields.GetEnumerator()) {
+            if ($null -ne $entry.Value) {
+                $stringContent = [System.Net.Http.StringContent]::new([string]$entry.Value)
+                $multipart.Add($stringContent, [string]$entry.Key)
+            }
+        }
+
+        if ($null -ne $File) {
+            $bytes = [Convert]::FromBase64String([string]$File.base64)
+            $fileContent = [System.Net.Http.ByteArrayContent]::new($bytes)
+            $mime = if ([string]::IsNullOrWhiteSpace([string]$File.mime)) {
+                "application/octet-stream"
+            } else {
+                [string]$File.mime
+            }
+            $fileContent.Headers.ContentType =
+                [System.Net.Http.Headers.MediaTypeHeaderValue]::new($mime)
+            $multipart.Add($fileContent, "file", [string]$File.name)
+        }
+
+        $response = $client.PostAsync(
+            "https://api.openai.com/v1$Path", $multipart
+        ).GetAwaiter().GetResult()
+        $text = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+            throw (Read-OpenAIError $text ([int]$response.StatusCode))
+        }
+        return ($text | ConvertFrom-Json)
+    } finally {
+        if ($response) { $response.Dispose() }
+        $multipart.Dispose()
+        $client.Dispose()
+    }
+}
+
+function Invoke-OpenAIGetBytes {
+    param([string]$Path)
+    $key = Get-ApiKey
+    if ([string]::IsNullOrWhiteSpace($key)) {
+        throw "No OpenAI API key is configured."
+    }
+    $client = New-OpenAIClient $key
+    try {
+        $response = $client.GetAsync(
+            "https://api.openai.com/v1$Path"
+        ).GetAwaiter().GetResult()

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/01.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/01.part
@@ -1,0 +1,212 @@
+        $bytes = $response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult()
+        if (-not $response.IsSuccessStatusCode) {
+            $text = [Text.Encoding]::UTF8.GetString($bytes)
+            throw (Read-OpenAIError $text ([int]$response.StatusCode))
+        }
+        return $bytes
+    } finally {
+        if ($response) { $response.Dispose() }
+        $client.Dispose()
+    }
+}
+
+function Read-Request {
+    param([System.Net.Sockets.TcpClient]$Client)
+    $stream = $Client.GetStream()
+    $header = [IO.MemoryStream]::new()
+    $matched = 0
+    while ($header.Length -lt 65536) {
+        $value = $stream.ReadByte()
+        if ($value -lt 0) { break }
+        $header.WriteByte([byte]$value)
+        switch ($matched) {
+            0 { if ($value -eq 13) { $matched = 1 } }
+            1 { if ($value -eq 10) { $matched = 2 } elseif ($value -ne 13) { $matched = 0 } }
+            2 { if ($value -eq 13) { $matched = 3 } else { $matched = 0 } }
+            3 {
+                if ($value -eq 10) { $matched = 4 } else { $matched = 0 }
+            }
+        }
+        if ($matched -eq 4) { break }
+    }
+
+    if ($matched -ne 4) { throw "Invalid HTTP request." }
+    $headerText = [Text.Encoding]::ASCII.GetString($header.ToArray())
+    $header.Dispose()
+    $lines = $headerText -split "`r`n"
+    $requestLine = $lines[0] -split " "
+    if ($requestLine.Count -lt 2) { throw "Invalid HTTP request line." }
+
+    $headers = @{}
+    for ($i = 1; $i -lt $lines.Count; $i++) {
+        $line = $lines[$i]
+        if ([string]::IsNullOrEmpty($line)) { continue }
+        $index = $line.IndexOf(":")
+        if ($index -gt 0) {
+            $name = $line.Substring(0, $index).Trim().ToLowerInvariant()
+            $value = $line.Substring($index + 1).Trim()
+            $headers[$name] = $value
+        }
+    }
+
+    $contentLength = 0
+    if ($headers.ContainsKey("content-length")) {
+        $contentLength = [int]$headers["content-length"]
+    }
+    if ($contentLength -gt 33554432) {
+        throw "Request body exceeds 32 MB."
+    }
+
+    $body = New-Object byte[] $contentLength
+    $offset = 0
+    while ($offset -lt $contentLength) {
+        $read = $stream.Read($body, $offset, $contentLength - $offset)
+        if ($read -le 0) { throw "Unexpected end of request body." }
+        $offset += $read
+    }
+
+    return [pscustomobject]@{
+        Method = $requestLine[0].ToUpperInvariant()
+        Target = $requestLine[1]
+        Headers = $headers
+        Body = $body
+        Stream = $stream
+    }
+}
+
+function Get-ReasonPhrase {
+    param([int]$Status)
+    switch ($Status) {
+        200 { "OK" }
+        204 { "No Content" }
+        400 { "Bad Request" }
+        401 { "Unauthorized" }
+        404 { "Not Found" }
+        405 { "Method Not Allowed" }
+        413 { "Payload Too Large" }
+        500 { "Internal Server Error" }
+        default { "Response" }
+    }
+}
+
+function Send-Bytes {
+    param(
+        [System.Net.Sockets.NetworkStream]$Stream,
+        [int]$Status,
+        [string]$ContentType,
+        [byte[]]$Body,
+        [hashtable]$ExtraHeaders = @{}
+    )
+    $reason = Get-ReasonPhrase $Status
+    $headers = "HTTP/1.1 $Status $reason`r`n" +
+        "Content-Type: $ContentType`r`n" +
+        "Content-Length: $($Body.Length)`r`n" +
+        "Cache-Control: no-store`r`n" +
+        "X-Content-Type-Options: nosniff`r`n" +
+        "Referrer-Policy: no-referrer`r`n" +
+        "Connection: close`r`n"
+    foreach ($entry in $ExtraHeaders.GetEnumerator()) {
+        $headers += "$($entry.Key): $($entry.Value)`r`n"
+    }
+    $headers += "`r`n"
+    $headerBytes = [Text.Encoding]::ASCII.GetBytes($headers)
+    $Stream.Write($headerBytes, 0, $headerBytes.Length)
+    if ($Body.Length -gt 0) {
+        $Stream.Write($Body, 0, $Body.Length)
+    }
+    $Stream.Flush()
+}
+
+function Send-Json {
+    param(
+        [System.Net.Sockets.NetworkStream]$Stream,
+        [int]$Status,
+        $Object
+    )
+    $json = $Object | ConvertTo-Json -Depth 100 -Compress
+    $bytes = [Text.Encoding]::UTF8.GetBytes($json)
+    Send-Bytes $Stream $Status "application/json; charset=utf-8" $bytes
+}
+
+function Get-RequestToken {
+    param($Request, [Uri]$Uri)
+    if ($Request.Headers.ContainsKey("x-jarvis-token")) {
+        return [string]$Request.Headers["x-jarvis-token"]
+    }
+    $query = $Uri.Query.TrimStart("?") -split "&"
+    foreach ($part in $query) {
+        $kv = $part -split "=", 2
+        if ($kv.Count -eq 2 -and $kv[0] -eq "token") {
+            return [Uri]::UnescapeDataString($kv[1])
+        }
+    }
+    if ($Request.Headers.ContainsKey("cookie")) {
+        foreach ($cookie in ([string]$Request.Headers["cookie"] -split ";")) {
+            $kv = $cookie.Trim() -split "=", 2
+            if ($kv.Count -eq 2 -and $kv[0] -eq "jarvis_token") {
+                return $kv[1]
+            }
+        }
+    }
+    return ""
+}
+
+function Get-QueryValue {
+    param([Uri]$Uri, [string]$Name)
+    foreach ($part in ($Uri.Query.TrimStart("?") -split "&")) {
+        $kv = $part -split "=", 2
+        if ($kv.Count -eq 2 -and $kv[0] -eq $Name) {
+            return [Uri]::UnescapeDataString($kv[1])
+        }
+    }
+    return $null
+}
+
+function Get-JsonBody {
+    param($Request)
+    if ($Request.Body.Length -eq 0) { return $null }
+    $text = [Text.Encoding]::UTF8.GetString($Request.Body)
+    return ($text | ConvertFrom-Json)
+}
+
+function Extract-ResponseText {
+    param($Response)
+    $parts = New-Object System.Collections.Generic.List[string]
+    if ($Response.output) {
+        foreach ($item in $Response.output) {
+            if ($item.type -eq "message" -and $item.content) {
+                foreach ($content in $item.content) {
+                    if ($content.type -eq "output_text" -and $content.text) {
+                        $parts.Add([string]$content.text)
+                    } elseif ($content.type -eq "refusal" -and $content.refusal) {
+                        $parts.Add([string]$content.refusal)
+                    }
+                }
+            }
+        }
+    }
+    if ($parts.Count -eq 0 -and $Response.output_text) {
+        $parts.Add([string]$Response.output_text)
+    }
+    return ($parts -join "`n")
+}
+
+function Handle-Request {
+    param($Request)
+    $uri = [Uri]("http://127.0.0.1" + $Request.Target)
+    $path = $uri.AbsolutePath
+    $token = Get-RequestToken $Request $uri
+
+    if ($token -ne $script:LaunchToken) {
+        Send-Json $Request.Stream 401 @{ error = "Unauthorized local request." }
+        return
+    }
+
+    if ($Request.Method -eq "GET" -and $path -eq "/") {
+        if (-not (Test-Path -LiteralPath $HtmlPath)) {
+            Send-Json $Request.Stream 500 @{ error = "Application interface is missing." }
+            return
+        }
+        $body = [IO.File]::ReadAllBytes($HtmlPath)
+        $headers = @{
+            "Set-Cookie" = "jarvis_token=$script:LaunchToken; Path=/; HttpOnly; SameSite=Strict"

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/02.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/02.part
@@ -1,0 +1,189 @@
+            "Content-Security-Policy" = "default-src 'self' data: blob:; img-src 'self' data: blob:; media-src 'self' data: blob:; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src 'self'; object-src 'none'; base-uri 'none'; frame-ancestors 'none'"
+        }
+        Send-Bytes $Request.Stream 200 "text/html; charset=utf-8" $body $headers
+        return
+    }
+
+    if ($Request.Method -eq "GET" -and $path -eq "/api/status") {
+        $key = Get-ApiKey
+        $source = if (-not [string]::IsNullOrWhiteSpace($env:OPENAI_API_KEY)) {
+            "environment"
+        } elseif (Test-Path -LiteralPath $KeyPath) {
+            "dpapi"
+        } else {
+            "none"
+        }
+        Send-Json $Request.Stream 200 @{
+            version = $AppVersion
+            keyPresent = -not [string]::IsNullOrWhiteSpace($key)
+            keySource = $source
+        }
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/key") {
+        $data = Get-JsonBody $Request
+        $key = [string]$data.apiKey
+        if ([string]::IsNullOrWhiteSpace($key)) { throw "API key is empty." }
+        $key = $key.Trim()
+
+        $client = New-OpenAIClient $key
+        try {
+            $response = $client.GetAsync(
+                "https://api.openai.com/v1/models"
+            ).GetAwaiter().GetResult()
+            $text = $response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+            if (-not $response.IsSuccessStatusCode) {
+                throw (Read-OpenAIError $text ([int]$response.StatusCode))
+            }
+        } finally {
+            if ($response) { $response.Dispose() }
+            $client.Dispose()
+        }
+
+        Save-ApiKey $key
+        Send-Json $Request.Stream 200 @{ ok = $true }
+        return
+    }
+
+    if ($Request.Method -eq "DELETE" -and $path -eq "/api/key") {
+        Remove-SavedApiKey
+        Send-Json $Request.Stream 200 @{ ok = $true }
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/chat") {
+        $data = Get-JsonBody $Request
+        $input = New-Object System.Collections.Generic.List[object]
+
+        if ($data.history) {
+            foreach ($message in $data.history) {
+                $role = [string]$message.role
+                if ($role -ne "user" -and $role -ne "assistant") { continue }
+                $input.Add(@{
+                    role = $role
+                    content = [string]$message.content
+                })
+            }
+        }
+
+        $content = New-Object System.Collections.Generic.List[object]
+        $content.Add(@{
+            type = "input_text"
+            text = [string]$data.prompt
+        })
+
+        if ($data.attachments) {
+            foreach ($attachment in $data.attachments) {
+                $mime = [string]$attachment.mime
+                $base64 = [string]$attachment.base64
+                if ($mime.StartsWith("image/")) {
+                    $content.Add(@{
+                        type = "input_image"
+                        image_url = "data:$mime;base64,$base64"
+                        detail = "auto"
+                    })
+                } else {
+                    $content.Add(@{
+                        type = "input_file"
+                        filename = [string]$attachment.name
+                        file_data = "data:$mime;base64,$base64"
+                    })
+                }
+            }
+        }
+
+        $input.Add(@{
+            role = "user"
+            content = $content
+        })
+
+        $body = @{
+            model = if ($data.model) { [string]$data.model } else { "gpt-5.2" }
+            instructions = [string]$data.instructions
+            input = $input
+            max_output_tokens = [int]$data.maxOutputTokens
+            store = $false
+        }
+
+        $response = Invoke-OpenAIJson "POST" "/responses" $body
+        $text = Extract-ResponseText $response
+        Send-Json $Request.Stream 200 @{
+            text = $text
+            responseId = $response.id
+            usage = $response.usage
+        }
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/image") {
+        $data = Get-JsonBody $Request
+        $body = @{
+            model = if ($data.model) { [string]$data.model } else { "gpt-image-1" }
+            prompt = [string]$data.prompt
+            size = [string]$data.size
+            quality = [string]$data.quality
+            background = if ([bool]$data.transparent) { "transparent" } else { "auto" }
+            output_format = "png"
+            n = 1
+        }
+        $response = Invoke-OpenAIJson "POST" "/images/generations" $body
+        $base64 = $null
+        if ($response.data -and $response.data.Count -gt 0) {
+            $base64 = [string]$response.data[0].b64_json
+        }
+        if ([string]::IsNullOrWhiteSpace($base64)) {
+            throw "The image endpoint returned no image data."
+        }
+        Send-Json $Request.Stream 200 @{ base64 = $base64 }
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/speech") {
+        $data = Get-JsonBody $Request
+        $text = [string]$data.text
+        if ($text.Length -gt 4096) { $text = $text.Substring(0, 4096) }
+        $body = @{
+            model = if ($data.model) { [string]$data.model } else { "gpt-4o-mini-tts" }
+            voice = if ($data.voice) { [string]$data.voice } else { "alloy" }
+            input = $text
+            response_format = "mp3"
+            speed = [double]$data.speed
+        }
+        $bytes = Invoke-OpenAIBinaryJson "/audio/speech" $body
+        Send-Bytes $Request.Stream 200 "audio/mpeg" $bytes
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/transcribe") {
+        $data = Get-JsonBody $Request
+        $file = [pscustomobject]@{
+            name = if ($data.name) { [string]$data.name } else { "recording.webm" }
+            mime = if ($data.mime) { [string]$data.mime } else { "audio/webm" }
+            base64 = [string]$data.base64
+        }
+        $fields = @{
+            model = if ($data.model) { [string]$data.model } else { "gpt-4o-mini-transcribe" }
+            response_format = "json"
+        }
+        $response = Invoke-OpenAIMultipart "/audio/transcriptions" $fields $file
+        Send-Json $Request.Stream 200 @{ text = [string]$response.text }
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/video") {
+        $data = Get-JsonBody $Request
+        $fields = @{
+            model = if ($data.model) { [string]$data.model } else { "sora-2" }
+            prompt = [string]$data.prompt
+            seconds = [string]$data.seconds
+            size = [string]$data.size
+        }
+        $response = Invoke-OpenAIMultipart "/videos" $fields $null
+        Send-Json $Request.Stream 200 $response
+        return
+    }
+
+    if ($Request.Method -eq "GET" -and $path -eq "/api/video/status") {
+        $id = Get-QueryValue $uri "id"
+        if ([string]::IsNullOrWhiteSpace($id)) { throw "Video job ID is missing." }

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/03.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/JarvisXMultimodal.ps1/03.part
@@ -1,0 +1,85 @@
+        $response = Invoke-OpenAIJson "GET" ("/videos/" + [Uri]::EscapeDataString($id))
+        Send-Json $Request.Stream 200 $response
+        return
+    }
+
+    if ($Request.Method -eq "GET" -and $path -eq "/api/video/content") {
+        $id = Get-QueryValue $uri "id"
+        if ([string]::IsNullOrWhiteSpace($id)) { throw "Video job ID is missing." }
+        $bytes = Invoke-OpenAIGetBytes (
+            "/videos/" + [Uri]::EscapeDataString($id) + "/content"
+        )
+        Send-Bytes $Request.Stream 200 "video/mp4" $bytes
+        return
+    }
+
+    if ($Request.Method -eq "POST" -and $path -eq "/api/close") {
+        Send-Json $Request.Stream 200 @{ ok = $true }
+        $script:StopRequested = $true
+        return
+    }
+
+    Send-Json $Request.Stream 404 @{ error = "Not found." }
+}
+
+if (-not (Test-Path -LiteralPath $HtmlPath)) {
+    [System.Windows.Forms.MessageBox]::Show(
+        "The JARVIS-X interface file is missing.",
+        "JARVIS-X",
+        [System.Windows.Forms.MessageBoxButtons]::OK,
+        [System.Windows.Forms.MessageBoxIcon]::Error
+    ) | Out-Null
+    exit 1
+}
+
+$listener = $null
+$port = 0
+foreach ($candidate in 39147..39167) {
+    try {
+        $listener = [System.Net.Sockets.TcpListener]::new(
+            [Net.IPAddress]::Loopback, $candidate
+        )
+        $listener.Start()
+        $port = $candidate
+        break
+    } catch {
+        if ($listener) {
+            try { $listener.Stop() } catch {}
+        }
+        $listener = $null
+    }
+}
+
+if (-not $listener) {
+    Write-Log "No local port was available."
+    exit 2
+}
+
+$url = "http://127.0.0.1:$port/?token=$script:LaunchToken"
+Write-Log "Runtime $AppVersion started on loopback port $port."
+Start-Process $url
+
+try {
+    while (-not $script:StopRequested) {
+        $client = $listener.AcceptTcpClient()
+        try {
+            $request = Read-Request $client
+            try {
+                Handle-Request $request
+            } catch {
+                $message = $_.Exception.Message
+                Write-Log "Request error: $message"
+                try {
+                    Send-Json $request.Stream 500 @{ error = $message }
+                } catch {}
+            }
+        } catch {
+            Write-Log "Transport error: $($_.Exception.Message)"
+        } finally {
+            try { $client.Close() } catch {}
+        }
+    }
+} finally {
+    try { $listener.Stop() } catch {}
+    Write-Log "Runtime stopped."
+}

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/00.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/00.part
@@ -1,0 +1,68 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>JARVIS-X Multimodal Studio</title>
+<style>
+:root{
+  --bg:#050711;--bg2:#090d1a;--panel:#0d1324;--panel2:#111a30;--line:#25365e;
+  --text:#eaf2ff;--muted:#8fa2c2;--cyan:#4de8ff;--blue:#6b8cff;--magenta:#ff62be;
+  --green:#49e59b;--amber:#ffc866;--red:#ff6f7f;--shadow:0 22px 70px rgba(0,0,0,.45);
+}
+*{box-sizing:border-box}
+html,body{width:100%;height:100%;margin:0;overflow:hidden;background:
+radial-gradient(circle at 75% 5%,rgba(107,140,255,.16),transparent 30%),
+radial-gradient(circle at 18% 95%,rgba(255,98,190,.10),transparent 28%),var(--bg);
+color:var(--text);font-family:Inter,Segoe UI,system-ui,sans-serif}
+button,input,textarea,select{font:inherit}
+button{cursor:pointer}
+.app{display:grid;grid-template-columns:270px minmax(0,1fr);height:100%}
+.sidebar{background:rgba(7,10,21,.92);border-right:1px solid var(--line);padding:18px;display:flex;flex-direction:column;gap:16px;backdrop-filter:blur(20px)}
+.brand{display:flex;align-items:center;gap:12px}
+.logo{width:42px;height:42px;border:1px solid rgba(77,232,255,.7);border-radius:14px;display:grid;place-items:center;color:var(--cyan);font-weight:900;box-shadow:0 0 25px rgba(77,232,255,.18);background:linear-gradient(145deg,rgba(77,232,255,.13),rgba(107,140,255,.08))}
+.brand h1{font-size:14px;margin:0;letter-spacing:1.4px}
+.brand p{font-size:9px;color:var(--muted);margin:4px 0 0;letter-spacing:.5px}
+.nav{display:grid;gap:7px}
+.nav button,.utility-btn{border:1px solid transparent;background:transparent;color:var(--muted);padding:11px 12px;border-radius:11px;text-align:left;transition:.15s}
+.nav button:hover,.utility-btn:hover{background:rgba(107,140,255,.09);color:var(--text)}
+.nav button.active{border-color:rgba(77,232,255,.35);background:linear-gradient(90deg,rgba(77,232,255,.13),rgba(107,140,255,.08));color:var(--cyan)}
+.nav-icon{display:inline-block;width:24px}
+.sidebar-section{border-top:1px solid rgba(37,54,94,.7);padding-top:13px}
+.sidebar-label{font-size:9px;text-transform:uppercase;letter-spacing:1.3px;color:#6f84a7;margin-bottom:8px}
+.session-list{overflow:auto;display:grid;gap:5px;max-height:34vh}
+.session{border:1px solid transparent;border-radius:9px;padding:9px 10px;color:var(--muted);font-size:11px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;cursor:pointer}
+.session:hover,.session.active{border-color:rgba(107,140,255,.25);background:rgba(107,140,255,.08);color:var(--text)}
+.sidebar-footer{margin-top:auto;display:grid;gap:8px}
+.status-card{padding:11px;border:1px solid var(--line);border-radius:12px;background:rgba(13,19,36,.72);font-size:10px;color:var(--muted)}
+.status-line{display:flex;align-items:center;gap:8px;margin-bottom:6px}.dot{width:8px;height:8px;border-radius:50%;background:var(--amber);box-shadow:0 0 10px currentColor}.dot.ok{background:var(--green)}.dot.bad{background:var(--red)}
+.main{min-width:0;display:flex;flex-direction:column}
+.topbar{height:70px;flex:none;padding:12px 20px;border-bottom:1px solid var(--line);background:rgba(7,11,22,.72);backdrop-filter:blur(18px);display:flex;align-items:center;justify-content:space-between;gap:16px}
+.view-title h2{font-size:15px;margin:0}.view-title p{font-size:9px;color:var(--muted);margin:4px 0 0}
+.top-actions{display:flex;align-items:center;gap:8px}
+.pill{display:flex;align-items:center;gap:7px;padding:7px 10px;border:1px solid var(--line);border-radius:999px;background:rgba(13,19,36,.8);font-size:9px;color:var(--muted)}
+.icon-btn,.primary,.secondary,.danger{border:1px solid var(--line);border-radius:10px;padding:9px 12px;background:var(--panel);color:var(--text)}
+.icon-btn:hover,.secondary:hover{border-color:#5571aa;background:var(--panel2)}
+.primary{border-color:rgba(77,232,255,.5);background:linear-gradient(135deg,#13778a,#3159a8);font-weight:700}
+.primary:hover{filter:brightness(1.12)}.primary:disabled{opacity:.5;cursor:not-allowed}
+.danger{border-color:rgba(255,111,127,.4);color:#ff9ba7;background:rgba(90,20,30,.25)}
+.content{flex:1;min-height:0;position:relative}
+.view{position:absolute;inset:0;display:none}.view.active{display:flex}
+.chat-view{flex-direction:column}
+.messages{flex:1;overflow:auto;padding:26px max(22px,calc((100% - 900px)/2));scroll-behavior:smooth}
+.empty{height:100%;display:grid;place-items:center;text-align:center;color:var(--muted)}
+.empty-orb{width:96px;height:96px;margin:0 auto 20px;border-radius:50%;border:1px solid rgba(77,232,255,.45);background:radial-gradient(circle,rgba(77,232,255,.24),rgba(107,140,255,.06) 55%,transparent 70%);box-shadow:0 0 60px rgba(77,232,255,.14);animation:breathe 3s ease-in-out infinite}
+@keyframes breathe{50%{transform:scale(1.07);filter:brightness(1.25)}}
+.empty h3{color:var(--text);margin:0 0 8px;font-size:22px}.empty p{max-width:580px;font-size:12px;line-height:1.7}
+.msg{display:grid;grid-template-columns:36px minmax(0,1fr);gap:13px;margin-bottom:23px}
+.avatar{width:36px;height:36px;border-radius:12px;display:grid;place-items:center;font-weight:900;font-size:11px;border:1px solid var(--line);background:var(--panel)}
+.msg.user .avatar{color:var(--magenta);border-color:rgba(255,98,190,.36)}.msg.assistant .avatar{color:var(--cyan);border-color:rgba(77,232,255,.36)}
+.msg-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:7px}.msg-role{font-size:10px;font-weight:800;letter-spacing:.8px}.msg-time{font-size:8px;color:#617698}
+.msg-body{font-size:13px;line-height:1.65;color:#dce8fa;overflow-wrap:anywhere}
+.msg-body p{margin:0 0 10px}.msg-body pre{background:#030610;border:1px solid #1d2c4c;border-radius:10px;padding:13px;overflow:auto}.msg-body code{font-family:Consolas,monospace;color:#a8eaff}
+.msg-tools{display:flex;gap:6px;margin-top:9px}.mini{font-size:8px;padding:5px 8px;border:1px solid #25365e;border-radius:7px;background:#0b1120;color:#8fa2c2}
+.attachments-inline{display:flex;flex-wrap:wrap;gap:7px;margin-top:9px}.file-chip{padding:6px 8px;border:1px solid #2a3d69;border-radius:8px;background:#0d1529;font-size:9px;color:#aac0e4}
+.composer-wrap{flex:none;padding:10px max(18px,calc((100% - 940px)/2)) 18px;background:linear-gradient(transparent,rgba(5,7,17,.95) 20%)}
+.attach-preview{display:flex;gap:7px;overflow-x:auto;margin-bottom:8px}.attach-preview:empty{display:none}
+.attach-item{display:flex;align-items:center;gap:7px;min-width:150px;max-width:230px;padding:7px;border:1px solid #2b3d66;border-radius:9px;background:#0c1325;font-size:9px}.attach-item span{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.attach-item button{margin-left:auto;border:0;background:none;color:#ff8e9b}
+.composer{border:1px solid #31466f;border-radius:16px;background:rgba(12,18,34,.96);box-shadow:var(--shadow);padding:10px;transition:.15s}.composer:focus-within{border-color:rgba(77,232,255,.6);box-shadow:0 0 0 3px rgba(77,232,255,.05),var(--shadow)}

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/01.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/01.part
@@ -1,0 +1,77 @@
+.composer textarea{width:100%;min-height:58px;max-height:190px;resize:none;border:0;outline:0;background:transparent;color:var(--text);padding:7px;font-size:13px;line-height:1.45}
+.composer-bottom{display:flex;justify-content:space-between;align-items:center;gap:10px}.tool-row{display:flex;gap:6px;align-items:center}.tool-row button{border:0;background:transparent;color:var(--muted);padding:7px;border-radius:8px}.tool-row button:hover{background:#18223b;color:var(--cyan)}
+.send-row{display:flex;align-items:center;gap:9px}.hint{font-size:8px;color:#607392}
+.studio{padding:24px;overflow:auto;width:100%}.studio-grid{display:grid;grid-template-columns:minmax(320px,420px) minmax(0,1fr);gap:18px;max-width:1200px;margin:0 auto}
+.card{border:1px solid var(--line);border-radius:16px;background:rgba(12,18,34,.86);padding:18px;box-shadow:var(--shadow)}
+.card h3{margin:0 0 4px;font-size:14px}.card-sub{color:var(--muted);font-size:9px;margin-bottom:17px;line-height:1.5}
+.field{display:grid;gap:6px;margin-bottom:13px}.field label{font-size:9px;color:#9db1d1;text-transform:uppercase;letter-spacing:.7px}
+.field input,.field textarea,.field select{width:100%;border:1px solid #2d416c;border-radius:9px;background:#080d19;color:var(--text);padding:10px;outline:0}.field textarea{resize:vertical;min-height:120px}.field input:focus,.field textarea:focus,.field select:focus{border-color:var(--cyan)}
+.two{display:grid;grid-template-columns:1fr 1fr;gap:10px}.result-panel{min-height:520px;display:grid;place-items:center;position:relative;overflow:hidden}
+.result-placeholder{text-align:center;color:var(--muted);font-size:11px}.result-panel img,.result-panel video{max-width:100%;max-height:72vh;border-radius:12px;box-shadow:0 12px 55px rgba(0,0,0,.5)}
+.loader{width:45px;height:45px;border:3px solid #24375d;border-top-color:var(--cyan);border-radius:50%;animation:spin .8s linear infinite;margin:0 auto 12px}@keyframes spin{to{transform:rotate(360deg)}}
+.audio-box{width:100%;padding:22px;border:1px dashed #324a78;border-radius:14px;text-align:center}.audio-box audio{width:100%;margin-top:15px}
+.progress{height:8px;background:#10192d;border-radius:99px;overflow:hidden;margin-top:12px}.progress>div{height:100%;background:linear-gradient(90deg,var(--cyan),var(--blue));width:0;transition:.3s}
+.modal-backdrop{position:fixed;inset:0;z-index:100;background:rgba(1,3,9,.74);backdrop-filter:blur(8px);display:none;place-items:center;padding:20px}.modal-backdrop.open{display:grid}
+.modal{width:min(650px,100%);max-height:90vh;overflow:auto;border:1px solid #344d80;border-radius:18px;background:#09101f;box-shadow:0 30px 100px rgba(0,0,0,.65);padding:22px}
+.modal-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:18px}.modal-head h3{margin:0}.close{border:0;background:none;color:var(--muted);font-size:22px}
+.notice{font-size:10px;line-height:1.55;padding:10px;border:1px solid rgba(73,229,155,.25);border-radius:9px;background:rgba(73,229,155,.06);color:#a9eecf;margin-bottom:15px}
+.toast{position:fixed;right:18px;bottom:18px;z-index:200;padding:11px 14px;border:1px solid #354e7c;border-radius:10px;background:#0a1222;color:var(--text);box-shadow:var(--shadow);font-size:10px;opacity:0;transform:translateY(10px);pointer-events:none;transition:.2s}.toast.show{opacity:1;transform:none}.toast.error{border-color:#8c3342;color:#ffb0b9}
+.recording{color:var(--red)!important;animation:pulse 1s infinite}@keyframes pulse{50%{opacity:.45}}
+@media(max-width:900px){.app{grid-template-columns:72px minmax(0,1fr)}.sidebar{padding:12px 8px}.brand h1,.brand p,.nav-label,.sidebar-section,.status-card .status-text{display:none}.brand{justify-content:center}.nav button{text-align:center}.nav-icon{width:auto;font-size:18px}.sidebar-footer .utility-btn{text-align:center;padding:10px}.studio-grid{grid-template-columns:1fr}.topbar{padding:10px 12px}.pill{display:none}}
+</style>
+</head>
+<body>
+<div class="app">
+  <aside class="sidebar">
+    <div class="brand"><div class="logo">JX</div><div><h1>JARVIS-X</h1><p>MULTIMODAL MEDIA ENGINE</p></div></div>
+    <nav class="nav">
+      <button class="active" data-view="chat"><span class="nav-icon">◈</span><span class="nav-label">Multimodal Chat</span></button>
+      <button data-view="image"><span class="nav-icon">▧</span><span class="nav-label">Image Studio</span></button>
+      <button data-view="voice"><span class="nav-icon">◉</span><span class="nav-label">Voice Studio</span></button>
+      <button data-view="video"><span class="nav-icon">▶</span><span class="nav-label">Video Studio</span></button>
+    </nav>
+    <div class="sidebar-section">
+      <div class="sidebar-label">Conversations</div>
+      <button id="new-chat" class="utility-btn">＋ New conversation</button>
+      <div id="sessions" class="session-list"></div>
+    </div>
+    <div class="sidebar-footer">
+      <div class="status-card">
+        <div class="status-line"><span id="key-dot" class="dot"></span><strong id="key-status">Checking key</strong></div>
+        <div class="status-text">API requests remain in the local Windows process. The key is never embedded in this executable.</div>
+      </div>
+      <button id="settings-btn" class="utility-btn"><span class="nav-icon">⚙</span><span class="nav-label">Settings</span></button>
+      <button id="close-app" class="utility-btn"><span class="nav-icon">⏻</span><span class="nav-label">Close engine</span></button>
+    </div>
+  </aside>
+
+  <main class="main">
+    <header class="topbar">
+      <div class="view-title"><h2 id="view-title">Multimodal Chat</h2><p id="view-subtitle">Reason over text, images, documents, and recorded audio.</p></div>
+      <div class="top-actions">
+        <div class="pill"><span id="runtime-dot" class="dot ok"></span><span>LOCAL RUNTIME ACTIVE</span></div>
+        <button id="top-settings" class="icon-btn">Settings</button>
+      </div>
+    </header>
+
+    <section class="content">
+      <div id="view-chat" class="view chat-view active">
+        <div id="messages" class="messages"></div>
+        <div class="composer-wrap">
+          <div id="attach-preview" class="attach-preview"></div>
+          <div class="composer">
+            <textarea id="prompt" placeholder="Describe, ask, analyze, generate, or attach media…"></textarea>
+            <div class="composer-bottom">
+              <div class="tool-row">
+                <button id="attach-btn" title="Attach files">＋ File</button>
+                <button id="mic-btn" title="Record and transcribe">● Mic</button>
+                <input id="file-input" type="file" multiple hidden accept="image/*,audio/*,.pdf,.txt,.md,.csv,.json,.html,.js,.py,.doc,.docx,.ppt,.pptx,.xls,.xlsx">
+              </div>
+              <div class="send-row"><span class="hint">Ctrl + Enter</span><button id="send" class="primary">Send</button></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div id="view-image" class="view studio">
+        <div class="studio-grid">

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/02.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/02.part
@@ -1,0 +1,82 @@
+          <div class="card">
+            <h3>Image Generation</h3><div class="card-sub">Generate a new image from a detailed visual specification.</div>
+            <div class="field"><label>Prompt</label><textarea id="image-prompt" placeholder="A cinematic holographic neural city, precision technical visualization…"></textarea></div>
+            <div class="two">
+              <div class="field"><label>Size</label><select id="image-size"><option>1024x1024</option><option>1536x1024</option><option>1024x1536</option></select></div>
+              <div class="field"><label>Quality</label><select id="image-quality"><option value="auto">Auto</option><option value="low">Low</option><option value="medium" selected>Medium</option><option value="high">High</option></select></div>
+            </div>
+            <div class="field"><label><input id="image-transparent" type="checkbox"> Transparent background</label></div>
+            <button id="generate-image" class="primary">Generate image</button>
+          </div>
+          <div id="image-result" class="card result-panel"><div class="result-placeholder">Generated imagery will appear here.</div></div>
+        </div>
+      </div>
+
+      <div id="view-voice" class="view studio">
+        <div class="studio-grid">
+          <div class="card">
+            <h3>Speech Synthesis</h3><div class="card-sub">Convert text into generated audio, or record speech and transcribe it.</div>
+            <div class="field"><label>Speech text</label><textarea id="speech-text" placeholder="Enter text to synthesize…"></textarea></div>
+            <div class="two">
+              <div class="field"><label>Voice</label><select id="voice-select"><option>alloy</option><option>ash</option><option>ballad</option><option>coral</option><option>echo</option><option>fable</option><option>nova</option><option>onyx</option><option>sage</option><option>shimmer</option><option>verse</option><option>marin</option><option>cedar</option></select></div>
+              <div class="field"><label>Speed</label><input id="voice-speed" type="number" min=".25" max="4" step=".05" value="1"></div>
+            </div>
+            <button id="generate-speech" class="primary">Generate speech</button>
+            <button id="voice-record" class="secondary" style="margin-left:6px">Record to transcribe</button>
+          </div>
+          <div class="card result-panel"><div class="audio-box"><div id="voice-state">No audio generated.</div><audio id="audio-player" controls hidden></audio><a id="audio-download" class="primary" style="display:none;text-decoration:none;margin-top:12px" download="jarvisx-speech.mp3">Download MP3</a></div></div>
+        </div>
+      </div>
+
+      <div id="view-video" class="view studio">
+        <div class="studio-grid">
+          <div class="card">
+            <h3>Video Generation</h3><div class="card-sub">Creates an asynchronous video job. Availability, cost, and completion time depend on your project.</div>
+            <div class="field"><label>Prompt</label><textarea id="video-prompt" placeholder="A four-second cinematic orbital pass through a luminous computational world…"></textarea></div>
+            <div class="two">
+              <div class="field"><label>Duration</label><select id="video-seconds"><option value="4">4 seconds</option><option value="8">8 seconds</option><option value="12">12 seconds</option></select></div>
+              <div class="field"><label>Resolution</label><select id="video-size"><option value="1280x720">1280 × 720</option><option value="720x1280">720 × 1280</option><option value="1792x1024">1792 × 1024</option><option value="1024x1792">1024 × 1792</option></select></div>
+            </div>
+            <button id="generate-video" class="primary">Create video job</button>
+          </div>
+          <div id="video-result" class="card result-panel"><div class="result-placeholder">Video status and completed media will appear here.</div></div>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+
+<div id="settings-modal" class="modal-backdrop">
+  <div class="modal">
+    <div class="modal-head"><h3>Runtime Settings</h3><button class="close" id="settings-close">×</button></div>
+    <div class="notice">The API key is validated and encrypted with Windows Data Protection API for the current Windows user. It is not stored in the HTML, conversation history, or executable.</div>
+    <div class="field"><label>OpenAI API key</label><input id="api-key" type="password" autocomplete="off" placeholder="Paste the key created in the secure setup flow"></div>
+    <div class="two">
+      <div class="field"><label>Chat model</label><input id="chat-model" value="gpt-5.2"></div>
+      <div class="field"><label>Image model</label><input id="image-model" value="gpt-image-1"></div>
+      <div class="field"><label>Speech model</label><input id="speech-model" value="gpt-4o-mini-tts"></div>
+      <div class="field"><label>Transcription model</label><input id="transcribe-model" value="gpt-4o-mini-transcribe"></div>
+      <div class="field"><label>Video model</label><input id="video-model" value="sora-2"></div>
+      <div class="field"><label>Maximum output tokens</label><input id="max-tokens" type="number" min="128" max="32768" value="4096"></div>
+    </div>
+    <div class="field"><label>Assistant instructions</label><textarea id="instructions">You are JARVIS-X, a precise multimodal assistant. Analyze supplied media carefully, distinguish observation from inference, and provide clear operational answers.</textarea></div>
+    <div style="display:flex;gap:8px;justify-content:flex-end"><button id="delete-key" class="danger">Delete saved key</button><button id="save-settings" class="primary">Validate and save</button></div>
+  </div>
+</div>
+<div id="toast" class="toast"></div>
+
+<script>
+(()=>{
+"use strict";
+const $=s=>document.querySelector(s), $$=s=>[...document.querySelectorAll(s)];
+const query=new URLSearchParams(location.search); const launchToken=query.get("token")||sessionStorage.getItem("jx_token")||"";
+if(query.get("token")){sessionStorage.setItem("jx_token",launchToken);history.replaceState(null,"",location.pathname)}
+const api=(path,opts={})=>fetch(path,{...opts,headers:{"X-Jarvis-Token":launchToken,...(opts.headers||{})}});
+const state={
+  settings:JSON.parse(localStorage.getItem("jx_settings")||"null")||{
+    chatModel:"gpt-5.2",imageModel:"gpt-image-1",speechModel:"gpt-4o-mini-tts",
+    transcribeModel:"gpt-4o-mini-transcribe",videoModel:"sora-2",maxTokens:4096,
+    instructions:"You are JARVIS-X, a precise multimodal assistant. Analyze supplied media carefully, distinguish observation from inference, and provide clear operational answers."
+  },
+  sessions:JSON.parse(localStorage.getItem("jx_sessions")||"[]"), active:null, attachments:[], mediaRecorder:null, chunks:[]
+};

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/03.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/03.part
@@ -1,0 +1,47 @@
+const titles={chat:["Multimodal Chat","Reason over text, images, documents, and recorded audio."],image:["Image Studio","Create original visual media from a text specification."],voice:["Voice Studio","Synthesize speech and transcribe recorded audio."],video:["Video Studio","Submit and retrieve asynchronous video-generation jobs."]};
+function toast(text,error=false){const t=$("#toast");t.textContent=text;t.className="toast show"+(error?" error":"");clearTimeout(t._x);t._x=setTimeout(()=>t.className="toast",3500)}
+function escapeHtml(s){return String(s).replace(/[&<>"']/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]))}
+function renderMarkdown(s){let x=escapeHtml(s);x=x.replace(/```([\s\S]*?)```/g,(_,c)=>"<pre><code>"+c.trim()+"</code></pre>");x=x.replace(/`([^`]+)`/g,"<code>$1</code>");x=x.replace(/\*\*([^*]+)\*\*/g,"<strong>$1</strong>");x=x.replace(/\n\n+/g,"</p><p>").replace(/\n/g,"<br>");return "<p>"+x+"</p>"}
+function persist(){localStorage.setItem("jx_settings",JSON.stringify(state.settings));localStorage.setItem("jx_sessions",JSON.stringify(state.sessions.slice(0,30)))}
+function newSession(){const s={id:crypto.randomUUID(),title:"New conversation",created:Date.now(),messages:[]};state.sessions.unshift(s);state.active=s.id;persist();renderSessions();renderMessages()}
+function current(){return state.sessions.find(s=>s.id===state.active)}
+function renderSessions(){const box=$("#sessions");box.innerHTML="";state.sessions.forEach(s=>{const d=document.createElement("div");d.className="session"+(s.id===state.active?" active":"");d.textContent=s.title;d.onclick=()=>{state.active=s.id;renderSessions();renderMessages()};box.appendChild(d)})}
+function renderMessages(){
+  const s=current(),box=$("#messages");box.innerHTML="";
+  if(!s||!s.messages.length){box.innerHTML='<div class="empty"><div><div class="empty-orb"></div><h3>Multimodal system ready</h3><p>Attach an image, PDF, document, spreadsheet, source file, or audio recording. The desktop process—not the browser—holds and uses your encrypted API credential.</p></div></div>';return}
+  s.messages.forEach(m=>{
+    const d=document.createElement("div");d.className="msg "+m.role;
+    const chips=(m.files||[]).map(f=>`<span class="file-chip">${escapeHtml(f)}</span>`).join("");
+    d.innerHTML=`<div class="avatar">${m.role==="user"?"YOU":"JX"}</div><div><div class="msg-head"><span class="msg-role">${m.role==="user"?"USER":"JARVIS-X"}</span><span class="msg-time">${new Date(m.time).toLocaleTimeString()}</span></div><div class="msg-body">${renderMarkdown(m.content)}</div>${chips?`<div class="attachments-inline">${chips}</div>`:""}<div class="msg-tools"><button class="mini copy">Copy</button>${m.role==="assistant"?'<button class="mini speak">Speak</button>':""}</div></div>`;
+    d.querySelector(".copy").onclick=()=>navigator.clipboard.writeText(m.content).then(()=>toast("Copied"));
+    const speak=d.querySelector(".speak");if(speak)speak.onclick=()=>speakText(m.content);
+    box.appendChild(d)
+  });box.scrollTop=box.scrollHeight
+}
+function showView(name){$$(".nav button").forEach(b=>b.classList.toggle("active",b.dataset.view===name));$$(".view").forEach(v=>v.classList.toggle("active",v.id==="view-"+name));$("#view-title").textContent=titles[name][0];$("#view-subtitle").textContent=titles[name][1]}
+$$(".nav button").forEach(b=>b.onclick=()=>showView(b.dataset.view));
+$("#new-chat").onclick=newSession;
+function openSettings(){const s=state.settings;$("#chat-model").value=s.chatModel;$("#image-model").value=s.imageModel;$("#speech-model").value=s.speechModel;$("#transcribe-model").value=s.transcribeModel;$("#video-model").value=s.videoModel;$("#max-tokens").value=s.maxTokens;$("#instructions").value=s.instructions;$("#api-key").value="";$("#settings-modal").classList.add("open")}
+$("#settings-btn").onclick=$("#top-settings").onclick=openSettings;$("#settings-close").onclick=()=>$("#settings-modal").classList.remove("open");$("#settings-modal").onclick=e=>{if(e.target.id==="settings-modal")e.currentTarget.classList.remove("open")}
+async function readJson(r){const text=await r.text();let j;try{j=JSON.parse(text)}catch{j={error:text||r.statusText}}if(!r.ok)throw new Error(j.error||"Request failed");return j}
+async function status(){try{const j=await readJson(await api("/api/status"));$("#key-status").textContent=j.keyPresent?(j.keySource==="environment"?"Key from environment":"Encrypted key ready"):"API key required";$("#key-dot").className="dot "+(j.keyPresent?"ok":"");if(!j.keyPresent)setTimeout(openSettings,350)}catch(e){$("#key-status").textContent="Runtime unavailable";$("#key-dot").className="dot bad"}}
+$("#save-settings").onclick=async()=>{
+  state.settings={chatModel:$("#chat-model").value.trim(),imageModel:$("#image-model").value.trim(),speechModel:$("#speech-model").value.trim(),transcribeModel:$("#transcribe-model").value.trim(),videoModel:$("#video-model").value.trim(),maxTokens:+$("#max-tokens").value||4096,instructions:$("#instructions").value.trim()};persist();
+  const key=$("#api-key").value.trim();
+  if(key){try{$("#save-settings").disabled=true;await readJson(await api("/api/key",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({apiKey:key})}));toast("API key validated and encrypted")}catch(e){toast(e.message,true);return}finally{$("#save-settings").disabled=false}}
+  $("#settings-modal").classList.remove("open");status()
+};
+$("#delete-key").onclick=async()=>{if(!confirm("Delete the encrypted key saved by this app?"))return;try{await readJson(await api("/api/key",{method:"DELETE"}));toast("Saved key deleted");status()}catch(e){toast(e.message,true)}};
+function autosize(){const p=$("#prompt");p.style.height="auto";p.style.height=Math.min(p.scrollHeight,190)+"px"}$("#prompt").oninput=autosize;
+$("#attach-btn").onclick=()=>$("#file-input").click();
+$("#file-input").onchange=async e=>{
+  for(const f of [...e.target.files]){
+    if(f.size>15*1024*1024){toast(`${f.name} exceeds 15 MB`,true);continue}
+    if(state.attachments.length>=4){toast("Maximum four attachments per message",true);break}
+    const b64=await fileBase64(f);state.attachments.push({name:f.name,mime:f.type||"application/octet-stream",base64:b64,size:f.size})
+  }e.target.value="";renderAttachments()
+};
+function fileBase64(f){return new Promise((res,rej)=>{const r=new FileReader();r.onload=()=>res(String(r.result).split(",")[1]);r.onerror=rej;r.readAsDataURL(f)})}
+function renderAttachments(){const b=$("#attach-preview");b.innerHTML="";state.attachments.forEach((a,i)=>{const d=document.createElement("div");d.className="attach-item";d.innerHTML=`<span>${escapeHtml(a.name)}</span><button>×</button>`;d.querySelector("button").onclick=()=>{state.attachments.splice(i,1);renderAttachments()};b.appendChild(d)})}
+async function send(){
+  const prompt=$("#prompt").value.trim();if(!prompt&&!state.attachments.length)return;if(!current())newSession();

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/04.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/04.part
@@ -1,0 +1,35 @@
+  const s=current(),files=state.attachments.map(a=>a.name);s.messages.push({role:"user",content:prompt||"Analyze the attached media.",files,time:Date.now()});if(s.messages.length===1)s.title=(prompt||files[0]||"Multimodal input").slice(0,42);persist();renderSessions();renderMessages();
+  const attachments=state.attachments;state.attachments=[];renderAttachments();$("#prompt").value="";autosize();$("#send").disabled=true;
+  const pending={role:"assistant",content:"Processing multimodal input…",time:Date.now(),pending:true};s.messages.push(pending);renderMessages();
+  try{
+    const history=s.messages.filter(m=>!m.pending).slice(-20,-1).map(m=>({role:m.role,content:m.content}));
+    const j=await readJson(await api("/api/chat",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:state.settings.chatModel,instructions:state.settings.instructions,maxOutputTokens:state.settings.maxTokens,history,prompt:prompt||"Analyze the attached media.",attachments})}));
+    Object.assign(pending,{content:j.text||"(No text returned)",pending:false,responseId:j.responseId})
+  }catch(e){Object.assign(pending,{content:"Error: "+e.message,pending:false})}finally{$("#send").disabled=false;persist();renderMessages()}
+}
+$("#send").onclick=send;$("#prompt").onkeydown=e=>{if(e.ctrlKey&&e.key==="Enter"){e.preventDefault();send()}};
+let recPurpose="chat";
+async function beginRecording(purpose,button){
+  if(!navigator.mediaDevices?.getUserMedia){toast("Microphone recording is unavailable in this browser",true);return}
+  if(state.mediaRecorder){state.mediaRecorder.stop();return}
+  try{const stream=await navigator.mediaDevices.getUserMedia({audio:true});state.chunks=[];recPurpose=purpose;const rec=new MediaRecorder(stream);state.mediaRecorder=rec;button.classList.add("recording");button.textContent="■ Stop";rec.ondataavailable=e=>{if(e.data.size)state.chunks.push(e.data)};rec.onstop=async()=>{button.classList.remove("recording");button.textContent=purpose==="chat"?"● Mic":"Record to transcribe";stream.getTracks().forEach(t=>t.stop());state.mediaRecorder=null;const blob=new Blob(state.chunks,{type:rec.mimeType||"audio/webm"});await transcribeBlob(blob,purpose)};rec.start()}catch(e){toast(e.message,true)}
+}
+$("#mic-btn").onclick=()=>beginRecording("chat",$("#mic-btn"));$("#voice-record").onclick=()=>beginRecording("voice",$("#voice-record"));
+async function transcribeBlob(blob,purpose){try{toast("Transcribing recording…");const b64=await fileBase64(new File([blob],"recording.webm",{type:blob.type}));const j=await readJson(await api("/api/transcribe",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:state.settings.transcribeModel,name:"recording.webm",mime:blob.type,base64:b64})}));if(purpose==="chat"){$("#prompt").value=($("#prompt").value+" "+j.text).trim();autosize()}else $("#speech-text").value=j.text;toast("Transcription complete")}catch(e){toast(e.message,true)}}
+async function speakText(text){$("#speech-text").value=text.slice(0,4000);showView("voice");generateSpeech()}
+async function generateSpeech(){
+  const text=$("#speech-text").value.trim();if(!text)return;$("#generate-speech").disabled=true;$("#voice-state").innerHTML='<div class="loader"></div>Generating speech…';
+  try{const r=await api("/api/speech",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:state.settings.speechModel,text,voice:$("#voice-select").value,speed:+$("#voice-speed").value||1})});if(!r.ok)throw new Error((await r.json()).error);const blob=await r.blob(),url=URL.createObjectURL(blob),p=$("#audio-player");p.src=url;p.hidden=false;$("#audio-download").href=url;$("#audio-download").style.display="inline-block";$("#voice-state").textContent="Generated speech ready.";p.play().catch(()=>{})}catch(e){$("#voice-state").textContent=e.message;toast(e.message,true)}finally{$("#generate-speech").disabled=false}
+}
+$("#generate-speech").onclick=generateSpeech;
+$("#generate-image").onclick=async()=>{
+  const prompt=$("#image-prompt").value.trim();if(!prompt)return;const box=$("#image-result");box.innerHTML='<div class="result-placeholder"><div class="loader"></div>Generating image…</div>';$("#generate-image").disabled=true;
+  try{const j=await readJson(await api("/api/image",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:state.settings.imageModel,prompt,size:$("#image-size").value,quality:$("#image-quality").value,transparent:$("#image-transparent").checked})}));const url="data:image/png;base64,"+j.base64;box.innerHTML=`<div><img src="${url}" alt="Generated image"><div style="text-align:center;margin-top:12px"><a class="primary" style="text-decoration:none" download="jarvisx-image.png" href="${url}">Download PNG</a></div></div>`}catch(e){box.innerHTML=`<div class="result-placeholder">${escapeHtml(e.message)}</div>`;toast(e.message,true)}finally{$("#generate-image").disabled=false}
+};
+let videoTimer=null;
+$("#generate-video").onclick=async()=>{
+  const prompt=$("#video-prompt").value.trim();if(!prompt)return;clearInterval(videoTimer);const box=$("#video-result");box.innerHTML='<div class="result-placeholder"><div class="loader"></div>Submitting video job…</div>';$("#generate-video").disabled=true;
+  try{const j=await readJson(await api("/api/video",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify({model:state.settings.videoModel,prompt,seconds:$("#video-seconds").value,size:$("#video-size").value})}));renderVideoStatus(j);videoTimer=setInterval(()=>pollVideo(j.id),5000)}catch(e){box.innerHTML=`<div class="result-placeholder">${escapeHtml(e.message)}</div>`;toast(e.message,true)}finally{$("#generate-video").disabled=false}
+};
+function renderVideoStatus(j){const box=$("#video-result"),p=Number(j.progress||0);box.innerHTML=`<div style="width:min(480px,100%);text-align:center"><h3>${escapeHtml(String(j.status||"queued").toUpperCase())}</h3><p class="card-sub">Job ${escapeHtml(j.id||"")}</p><div class="progress"><div style="width:${Math.max(2,p)}%"></div></div><p style="font-size:10px;color:var(--muted);margin-top:9px">${p}% complete</p></div>`}
+async function pollVideo(id){try{const j=await readJson(await api("/api/video/status?id="+encodeURIComponent(id)));if(j.status==="completed"){clearInterval(videoTimer);const url="/api/video/content?id="+encodeURIComponent(id)+"&token="+encodeURIComponent(launchToken);$("#video-result").innerHTML=`<div><video controls src="${url}"></video><div style="text-align:center;margin-top:12px"><a class="primary" style="text-decoration:none" href="${url}" download="jarvisx-video.mp4">Download MP4</a></div></div>`}else if(j.status==="failed"){clearInterval(videoTimer);throw new Error(j.error?.message||"Video generation failed")}else renderVideoStatus(j)}catch(e){clearInterval(videoTimer);toast(e.message,true)}}

--- a/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/05.part
+++ b/apps/windows/jarvisx-multimodal-studio/src/fragments/index.html/05.part
@@ -1,0 +1,7 @@
+$("#close-app").onclick=async()=>{if(!confirm("Close the local JARVIS-X engine?"))return;try{await api("/api/close",{method:"POST"});document.body.innerHTML='<div class="empty"><div><h3>JARVIS-X closed</h3><p>You may close this browser tab.</p></div></div>'}catch{}};
+if(!state.sessions.length)newSession();else{state.active=state.sessions[0].id;renderSessions();renderMessages()}
+status();
+})();
+</script>
+</body>
+</html>

--- a/apps/windows/jarvisx-multimodal-studio/src/kernel32.def
+++ b/apps/windows/jarvisx-multimodal-studio/src/kernel32.def
@@ -1,0 +1,12 @@
+LIBRARY KERNEL32.dll
+EXPORTS
+  GetEnvironmentVariableW
+  CreateDirectoryW
+  CreateFileW
+  WriteFile
+  CloseHandle
+  GetProcessHeap
+  HeapAlloc
+  HeapFree
+  CreateProcessW
+  ExitProcess

--- a/apps/windows/jarvisx-multimodal-studio/src/launcher.c
+++ b/apps/windows/jarvisx-multimodal-studio/src/launcher.c
@@ -1,0 +1,181 @@
+// JARVIS-X Multimodal Studio Windows launcher.
+// Builds without a C runtime and extracts the embedded PowerShell runtime and HTML UI.
+
+typedef void* HANDLE;
+typedef void* LPVOID;
+typedef const void* LPCVOID;
+typedef unsigned long DWORD;
+typedef int BOOL;
+typedef unsigned short WORD;
+typedef unsigned long long SIZE_T;
+typedef unsigned short WCHAR;
+typedef WCHAR* LPWSTR;
+typedef const WCHAR* LPCWSTR;
+
+#define WINAPI __stdcall
+#define NULL ((void*)0)
+#define INVALID_HANDLE_VALUE ((HANDLE)(long long)-1)
+
+#define GENERIC_WRITE 0x40000000UL
+#define FILE_SHARE_READ 0x00000001UL
+#define CREATE_ALWAYS 2UL
+#define FILE_ATTRIBUTE_NORMAL 0x00000080UL
+#define HEAP_ZERO_MEMORY 0x00000008UL
+#define CREATE_NO_WINDOW 0x08000000UL
+#define STARTF_USESHOWWINDOW 0x00000001UL
+#define SW_HIDE 0
+#define MB_OK 0x00000000UL
+#define MB_ICONERROR 0x00000010UL
+
+typedef struct _STARTUPINFOW {
+    DWORD cb;
+    LPWSTR lpReserved;
+    LPWSTR lpDesktop;
+    LPWSTR lpTitle;
+    DWORD dwX;
+    DWORD dwY;
+    DWORD dwXSize;
+    DWORD dwYSize;
+    DWORD dwXCountChars;
+    DWORD dwYCountChars;
+    DWORD dwFillAttribute;
+    DWORD dwFlags;
+    WORD wShowWindow;
+    WORD cbReserved2;
+    unsigned char* lpReserved2;
+    HANDLE hStdInput;
+    HANDLE hStdOutput;
+    HANDLE hStdError;
+} STARTUPINFOW;
+
+typedef struct _PROCESS_INFORMATION {
+    HANDLE hProcess;
+    HANDLE hThread;
+    DWORD dwProcessId;
+    DWORD dwThreadId;
+} PROCESS_INFORMATION;
+
+__declspec(dllimport) DWORD WINAPI GetEnvironmentVariableW(LPCWSTR, LPWSTR, DWORD);
+__declspec(dllimport) BOOL WINAPI CreateDirectoryW(LPCWSTR, LPVOID);
+__declspec(dllimport) HANDLE WINAPI CreateFileW(LPCWSTR, DWORD, DWORD, LPVOID, DWORD, DWORD, HANDLE);
+__declspec(dllimport) BOOL WINAPI WriteFile(HANDLE, LPCVOID, DWORD, DWORD*, LPVOID);
+__declspec(dllimport) BOOL WINAPI CloseHandle(HANDLE);
+__declspec(dllimport) HANDLE WINAPI GetProcessHeap(void);
+__declspec(dllimport) LPVOID WINAPI HeapAlloc(HANDLE, DWORD, SIZE_T);
+__declspec(dllimport) BOOL WINAPI HeapFree(HANDLE, DWORD, LPVOID);
+__declspec(dllimport) BOOL WINAPI CreateProcessW(
+    LPCWSTR, LPWSTR, LPVOID, LPVOID, BOOL, DWORD, LPVOID, LPCWSTR,
+    STARTUPINFOW*, PROCESS_INFORMATION*
+);
+__declspec(dllimport) void WINAPI ExitProcess(DWORD);
+__declspec(dllimport) int WINAPI MessageBoxW(void*, LPCWSTR, LPCWSTR, unsigned int);
+
+#include "embedded_assets.inc"
+
+static SIZE_T wlen(const WCHAR* s) {
+    SIZE_T n = 0;
+    while (s && s[n]) n++;
+    return n;
+}
+
+static void wcopy(WCHAR* dst, const WCHAR* src) {
+    while ((*dst++ = *src++) != 0) {}
+}
+
+static void wcat(WCHAR* dst, const WCHAR* src) {
+    SIZE_T n = wlen(dst);
+    wcopy(dst + n, src);
+}
+
+static void zero_mem(void* ptr, SIZE_T bytes) {
+    unsigned char* p = (unsigned char*)ptr;
+    SIZE_T i;
+    for (i = 0; i < bytes; i++) p[i] = 0;
+}
+
+static BOOL write_asset(const WCHAR* path, const unsigned char* data, DWORD size) {
+    HANDLE file = CreateFileW(
+        path, GENERIC_WRITE, FILE_SHARE_READ, NULL, CREATE_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL, NULL
+    );
+    DWORD written = 0;
+    BOOL ok;
+    if (file == INVALID_HANDLE_VALUE) return 0;
+    ok = WriteFile(file, data, size, &written, NULL);
+    CloseHandle(file);
+    return ok && written == size;
+}
+
+static void fail(const WCHAR* message, DWORD code) {
+    MessageBoxW(NULL, message, L"JARVIS-X Multimodal Studio", MB_OK | MB_ICONERROR);
+    ExitProcess(code);
+}
+
+void wWinMainCRTStartup(void) {
+    HANDLE heap = GetProcessHeap();
+    WCHAR* appDir = (WCHAR*)HeapAlloc(heap, HEAP_ZERO_MEMORY, 8192 * sizeof(WCHAR));
+    WCHAR* scriptPath = (WCHAR*)HeapAlloc(heap, HEAP_ZERO_MEMORY, 8192 * sizeof(WCHAR));
+    WCHAR* htmlPath = (WCHAR*)HeapAlloc(heap, HEAP_ZERO_MEMORY, 8192 * sizeof(WCHAR));
+    WCHAR* commandLine = (WCHAR*)HeapAlloc(heap, HEAP_ZERO_MEMORY, 16384 * sizeof(WCHAR));
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
+    DWORD length;
+    BOOL started;
+
+    if (!appDir || !scriptPath || !htmlPath || !commandLine) {
+        fail(L"Unable to allocate launcher memory.", 10);
+    }
+
+    length = GetEnvironmentVariableW(L"LOCALAPPDATA", appDir, 8190);
+    if (length == 0 || length >= 8190) {
+        length = GetEnvironmentVariableW(L"USERPROFILE", appDir, 8150);
+        if (length == 0 || length >= 8150) {
+            fail(L"Unable to resolve the Windows user application-data folder.", 11);
+        }
+        wcat(appDir, L"\\AppData\\Local");
+    }
+
+    wcat(appDir, L"\\JarvisXMultimodal");
+    CreateDirectoryW(appDir, NULL);
+
+    wcopy(scriptPath, appDir);
+    wcat(scriptPath, L"\\JarvisXMultimodal.ps1");
+    wcopy(htmlPath, appDir);
+    wcat(htmlPath, L"\\index.html");
+
+    if (!write_asset(scriptPath, APP_PS1, APP_PS1_len)) {
+        fail(L"Unable to install the local JARVIS-X runtime script.", 12);
+    }
+    if (!write_asset(htmlPath, APP_HTML, APP_HTML_len)) {
+        fail(L"Unable to install the JARVIS-X graphical interface.", 13);
+    }
+
+    wcopy(commandLine, L"powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File \"");
+    wcat(commandLine, scriptPath);
+    wcat(commandLine, L"\"");
+
+    zero_mem(&si, sizeof(si));
+    zero_mem(&pi, sizeof(pi));
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESHOWWINDOW;
+    si.wShowWindow = SW_HIDE;
+
+    started = CreateProcessW(
+        NULL, commandLine, NULL, NULL, 0, CREATE_NO_WINDOW, NULL, appDir, &si, &pi
+    );
+
+    if (!started) {
+        fail(
+            L"Unable to start Windows PowerShell. Windows PowerShell 5.1 or later is required.",
+            14
+        );
+    }
+
+    CloseHandle(pi.hThread);
+    CloseHandle(pi.hProcess);
+    HeapFree(heap, 0, commandLine);
+    HeapFree(heap, 0, htmlPath);
+    HeapFree(heap, 0, scriptPath);
+    HeapFree(heap, 0, appDir);
+    ExitProcess(0);
+}

--- a/apps/windows/jarvisx-multimodal-studio/src/user32.def
+++ b/apps/windows/jarvisx-multimodal-studio/src/user32.def
@@ -1,0 +1,3 @@
+LIBRARY USER32.dll
+EXPORTS
+  MessageBoxW


### PR DESCRIPTION
## What changed

- add `apps/windows/jarvisx-multimodal-studio`, a native Windows x64 launcher plus a local multimodal graphical interface
- support multimodal chat, image generation, speech synthesis, microphone transcription, and asynchronous video jobs through declared OpenAI API routes
- keep the project API key outside the binary and browser JavaScript; validate and persist it with current-user Windows DPAPI
- bind the local service to `127.0.0.1` and require a random launch token
- explicitly prohibit model-output command execution
- document the process topology, credential lifecycle, trust boundary, limitations, and production-hardening requirements
- add a cross-platform build using `clang-cl` and `lld-link` with `/Brepro`
- add CI that scans for obvious embedded keys, checks browser JavaScript, builds twice, proves byte identity, verifies PE32+ GUI structure/imports, verifies embedded assets, and uploads the Windows release artifact

## Source transport

The authoritative HTML and PowerShell sources are stored as ordered, line-preserving fragments under `src/fragments/`. `build-windows.sh` concatenates them into the original byte streams before embedding and compilation. Local verification confirmed the reconstructed files are byte-for-byte identical to the audited source inputs.

## Capability boundary

This is a user-operated multimodal media client. It is not an autonomous operating system, AGI runtime, or arbitrary shell agent. Model responses remain data and are never executed as PowerShell, CMD, JavaScript, native code, or system commands.

## Security boundary

- no project API key is committed or compiled into the application
- browser code does not retain the plaintext key
- API calls are issued by the loopback Windows process
- saved credentials are protected with current-user DPAPI
- the service is loopback-only and token-gated
- the launcher is currently unsigned and should not be treated as a production-signed release

## Validation performed before push

- scanned the source bundle for embedded `sk-`/project-key patterns
- checked browser JavaScript syntax with Node.js
- assembled the fragment sources and compared them byte-for-byte with the audited originals
- built twice in isolated directories using `/Brepro`
- confirmed the two executables were byte-identical
- reproducible local SHA-256: `65d2d317eb8cc8de11799259b24b13568340dbf22b39d21051c7d2cd34737088`
- verified the executable as PE32+ Windows GUI x86-64
- verified only the declared Kernel32/User32 import boundary
- verified the HTML and PowerShell payloads are embedded in the final executable

## Release posture

Kept as a draft because dynamic execution has not been tested on a physical Windows host in this environment and the binary is unsigned.