### PR TITLE
Add bounded Moagi OmegaFold reference resolver

### DIFF
--- a/benchmarks/benchmark_omega_fold.py
+++ b/benchmarks/benchmark_omega_fold.py
@@ -1,0 +1,57 @@
+"""Minimal reproducible benchmark harness for the bounded OmegaFold resolver."""
+
+from __future__ import annotations
+
+import json
+import platform
+import statistics
+import time
+from typing import Dict, List
+
+from jarvisx.omega_fold import FoldConfig, FoldProblem, resolve, verify_result
+
+
+def run_benchmark(repeats: int = 1000) -> Dict[str, object]:
+    """Measure one documented scalar fixed-point workload."""
+
+    if repeats <= 0:
+        raise ValueError("repeats must be positive")
+
+    problem = FoldProblem(
+        name="benchmark-scalar-contraction",
+        initial_state=(0.0,),
+        transition=lambda state: ((state[0] + 2.0) / 2.0,),
+        residual=lambda state: abs(state[0] - 2.0),
+    )
+    config = FoldConfig(max_iterations=64, tolerance=1.0e-9)
+    samples: List[int] = []
+
+    for _ in range(repeats):
+        start = time.perf_counter_ns()
+        result = resolve(problem, config)
+        samples.append(time.perf_counter_ns() - start)
+        if not verify_result(problem, config, result):
+            raise RuntimeError("benchmark produced an unverifiable result")
+
+    ordered = sorted(samples)
+    p95_index = min(len(ordered) - 1, int(len(ordered) * 0.95))
+    return {
+        "workload": problem.name,
+        "repeats": repeats,
+        "precision": {"tolerance": config.tolerance, "quantization_digits": 12},
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "processor": platform.processor(),
+        },
+        "timing_ns": {
+            "median": statistics.median(samples),
+            "p95": ordered[p95_index],
+            "minimum": min(samples),
+        },
+        "claim_boundary": "Measured timings apply only to this workload and environment.",
+    }
+
+
+if __name__ == "__main__":
+    print(json.dumps(run_benchmark(), indent=2, sort_keys=True))

--- a/docs/adr/ADR-002-bounded-moagi-omega-fold.md
+++ b/docs/adr/ADR-002-bounded-moagi-omega-fold.md
@@ -1,0 +1,46 @@
+# ADR-002: Treat Moagi OmegaFold as a bounded verified optimizer
+
+**Status:** proposed  
+**Date:** 2026-07-31  
+**Tracking:** #62
+
+## Context
+
+The Moagi OmegaFold cosmogram describes a hyper-recursive optimizer using terms such as algorithmic singularity, `O(0)`, temporal collapse, Hilbert-space folding, zero-time execution and a `10^3000x` speedup. These terms express the intended direction—remove sequential work by identifying invariant structure—but do not define executable semantics or measurable performance.
+
+Jarvis-X requires deterministic behavior, bounded execution, explicit capability boundaries, tests and evidence for performance claims. Broad adaptive systems must remain isolated from the authoritative VM until transaction and rollback semantics are complete.
+
+## Decision
+
+Jarvis-X will represent OmegaFold as an experimental bounded optimizer with these rules:
+
+1. Every problem supplies an initial state, transition and independently measured residual.
+2. Every run has an explicit finite iteration bound.
+3. Closed-form candidates are hints, not authority; they must pass shape, finiteness and residual checks.
+4. Repeated canonical states terminate as cycles.
+5. Results include a hash-bound certificate recording method, iterations, residual and terminal reason.
+6. Non-finite values, malformed dimensions and invalid residuals fail closed.
+7. Performance claims require a reproducible benchmark contract.
+8. The subsystem has no authority to mutate canonical VM state.
+9. `O(0)`, zero-time, tachyonic and perfect-loss language remains symbolic and may not appear as an implemented capability.
+
+## Consequences
+
+### Positive
+
+- the cosmogram gains a testable engineering interpretation;
+- closed-form acceleration can be measured without overstating it;
+- non-convergence and cycles become explicit outcomes;
+- deterministic certificates support audit and replay;
+- later spectral, graph, CUDA or RTL work has a stable contract.
+
+### Negative
+
+- the reference implementation cannot promise arbitrary acceleration;
+- Python callables remain outside a complete security boundary;
+- decimal canonicalization is a reference compromise, not a universal floating-point identity guarantee;
+- memoization and advanced reductions remain future work.
+
+## Validation
+
+The initial reference layer must pass tests for convergence, rejected closed forms, cycle detection, iteration limits, dimensional changes, non-finite states, tampered certificates and deterministic replay. Its benchmark must emit workload, precision, environment and measured timings.

--- a/docs/specifications/MOAGI_OMEGA_FOLD.md
+++ b/docs/specifications/MOAGI_OMEGA_FOLD.md
@@ -1,0 +1,128 @@
+# Moagi OmegaFold — Bounded Meta-Optimizer Specification
+
+**Status:** experimental specification  
+**Tracking:** #62  
+**Canonical authority:** none until review and merge
+
+## 1. Purpose
+
+Moagi OmegaFold translates the symbolic idea of "collapsing many iterations into an axiomatic result" into a finite software contract. The subsystem may replace an iterative computation with a closed form, fixed point, memoized result or reduced representation only when the replacement is independently verified against an explicit residual.
+
+The implementation does not claim literal `O(0)` computation, zero elapsed time, tachyonic hardware, causal reversal, perfect loss or `10^3000x` acceleration. Those expressions remain narrative shorthand for eliminating avoidable work.
+
+## 2. Operational equation
+
+For problem state `x`, transition `T`, residual `r`, admissibility set `Λ`, tolerance `ε` and iteration bound `N`:
+
+```text
+x_0 = Π_Λ(initial_state)
+x_(k+1) = Π_Λ(T(x_k))
+stop when r(x_k) <= ε, a prior state repeats, or k = N
+```
+
+A closed-form candidate `C(x_0)` may be evaluated before iteration, but it is accepted only when:
+
+```text
+shape(C(x_0)) = shape(x_0)
+all_finite(C(x_0))
+r(C(x_0)) <= ε
+```
+
+The result is therefore a state plus evidence, not an unverified assertion:
+
+```text
+OmegaFold(problem, config) -> (terminal_state, residual_trace, certificate)
+```
+
+## 3. Symbolic-to-engineering map
+
+| Symbolic term | Implemented interpretation |
+|---|---|
+| `CollapseTime` | eliminate iterations through a verified closed form or fixed point |
+| `HilbertFold` | future spectral, low-rank or Krylov reduction with error bounds |
+| `AxiomaticResolve` | return a candidate state plus independently measured residual |
+| `Eternal Now` | immutable result keyed by canonical input and configuration hashes |
+| topological pruning | future graph equivalence, dead-code and common-subexpression elimination |
+| `PerfectLoss` | `residual <= tolerance`; never an unconditional zero |
+| hash seal | canonical JSON serialization and SHA-256 digest |
+
+## 4. Data contracts
+
+### `FoldConfig`
+
+- `max_iterations >= 0`;
+- `tolerance >= 0`;
+- `quantization_digits >= 0`.
+
+### `FoldProblem`
+
+- non-empty name;
+- non-empty finite initial state;
+- deterministic transition for canonical inputs;
+- non-negative finite residual;
+- optional closed form.
+
+### `FoldCertificate`
+
+The certificate binds:
+
+- problem name;
+- resolution method;
+- iteration count;
+- convergence flag;
+- measured residual;
+- terminal reason;
+- terminal-state digest;
+- configuration digest.
+
+## 5. Termination states
+
+- `residual_satisfied` — measured residual is within tolerance;
+- `cycle_detected` — a canonical state repeated;
+- `iteration_limit` — the configured finite bound was exhausted;
+- validation exception — malformed dimensions or non-finite values fail closed.
+
+## 6. Determinism boundary
+
+Determinism requires deterministic user-supplied transition, residual and closed-form functions. OmegaFold canonicalizes floating values by decimal rounding before comparison and hashing. This creates reproducible reference behavior but does not establish bit-identical floating-point execution across every hardware platform.
+
+## 7. Complexity boundary
+
+For state width `d`, iteration bound `N`, transition cost `C_T` and residual cost `C_r`, the reference path is bounded by:
+
+```text
+O(N * (C_T + C_r + d)) time
+O(N * d) worst-case cycle-memory space
+```
+
+A verified closed form may reduce the iteration count to one, but invocation, validation, hashing and output remain finite operations. No `O(0)` class is claimed.
+
+## 8. Benchmark contract
+
+Every performance statement must report:
+
+- exact workload and input dimensions;
+- baseline algorithm and implementation;
+- tolerance and numeric representation;
+- warm-up and repeat counts;
+- hardware, operating system and runtime versions;
+- median and tail latency;
+- verification result;
+- raw data or reproducible script.
+
+A speedup is valid only for the measured workload and environment.
+
+## 9. Security and authority
+
+OmegaFold operates on Python callables and is not a security sandbox. Untrusted callables must not be executed in-process. The subsystem cannot mutate canonical VM state unless a future integration layer performs explicit policy checks, shadow evaluation, transaction validation and commit.
+
+## 10. Promotion path
+
+1. accept the specification and ADR;
+2. validate the CPU reference resolver;
+3. add property-based and adversarial tests;
+4. add memoization with bounded storage and collision tests;
+5. add graph and spectral reductions with independent numerical references;
+6. define VM integration and rollback semantics;
+7. consider CUDA only after a workload justifies it;
+8. consider RTL only after widths, latency, resource use and verification are specified.

--- a/src/jarvisx/omega_fold/__init__.py
+++ b/src/jarvisx/omega_fold/__init__.py
@@ -1,0 +1,16 @@
+"""Bounded Moagi OmegaFold reference subsystem."""
+
+from .certificates import certificate_payload, verify_result
+from .contracts import FoldCertificate, FoldConfig, FoldProblem, FoldResult, State
+from .resolver import resolve
+
+__all__ = [
+    "FoldCertificate",
+    "FoldConfig",
+    "FoldProblem",
+    "FoldResult",
+    "State",
+    "certificate_payload",
+    "resolve",
+    "verify_result",
+]

--- a/src/jarvisx/omega_fold/certificates.py
+++ b/src/jarvisx/omega_fold/certificates.py
@@ -1,0 +1,85 @@
+"""Canonical hashing and independent verification for OmegaFold results."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict
+from typing import Any, Dict
+
+from .contracts import FoldConfig, FoldProblem, FoldResult, State
+
+
+def canonical_state(state: State, digits: int) -> State:
+    """Return a finite, rounded state suitable for deterministic comparison."""
+
+    if not state:
+        raise ValueError("state must contain at least one value")
+    values = tuple(float(value) for value in state)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("state values must be finite")
+    return tuple(round(value, digits) for value in values)
+
+
+def _digest(payload: Dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def state_digest(state: State) -> str:
+    """Hash a canonical state without relying on platform-specific binary layout."""
+
+    return _digest({"state": list(state)})
+
+
+def config_digest(config: FoldConfig) -> str:
+    """Hash the execution limits that govern a resolution."""
+
+    return _digest(asdict(config))
+
+
+def certificate_payload(result: FoldResult) -> Dict[str, Any]:
+    """Return the canonical JSON-native certificate payload."""
+
+    return {
+        "certificate": asdict(result.certificate),
+        "state": list(result.state),
+        "residual_trace": list(result.residual_trace),
+    }
+
+
+def verify_result(problem: FoldProblem, config: FoldConfig, result: FoldResult) -> bool:
+    """Verify state, residual and execution-bound claims in a result certificate."""
+
+    try:
+        state = canonical_state(result.state, config.quantization_digits)
+        measured_residual = float(problem.residual(state))
+    except (TypeError, ValueError, OverflowError):
+        return False
+
+    certificate = result.certificate
+    if not math.isfinite(measured_residual):
+        return False
+    if certificate.problem_name != problem.name:
+        return False
+    if certificate.iterations < 0 or certificate.iterations > config.max_iterations:
+        return False
+    if certificate.state_digest != state_digest(state):
+        return False
+    if certificate.config_digest != config_digest(config):
+        return False
+    if not math.isclose(
+        certificate.residual,
+        measured_residual,
+        rel_tol=0.0,
+        abs_tol=max(config.tolerance * 1.0e-6, 1.0e-15),
+    ):
+        return False
+    if certificate.converged != (measured_residual <= config.tolerance):
+        return False
+    if not result.residual_trace:
+        return False
+    if any(not math.isfinite(value) or value < 0.0 for value in result.residual_trace):
+        return False
+    return True

--- a/src/jarvisx/omega_fold/contracts.py
+++ b/src/jarvisx/omega_fold/contracts.py
@@ -1,0 +1,69 @@
+"""Data contracts for the bounded Moagi OmegaFold reference resolver."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Tuple
+
+
+State = Tuple[float, ...]
+Transition = Callable[[State], State]
+Residual = Callable[[State], float]
+ClosedForm = Callable[[State], State]
+
+
+@dataclass(frozen=True)
+class FoldConfig:
+    """Deterministic execution limits for one OmegaFold resolution."""
+
+    max_iterations: int = 256
+    tolerance: float = 1.0e-9
+    quantization_digits: int = 12
+
+    def __post_init__(self) -> None:
+        if self.max_iterations < 0:
+            raise ValueError("max_iterations must be non-negative")
+        if self.tolerance < 0.0:
+            raise ValueError("tolerance must be non-negative")
+        if self.quantization_digits < 0:
+            raise ValueError("quantization_digits must be non-negative")
+
+
+@dataclass(frozen=True)
+class FoldProblem:
+    """A finite state-transition problem with an independently measured residual."""
+
+    name: str
+    initial_state: State
+    transition: Transition
+    residual: Residual
+    closed_form: Optional[ClosedForm] = None
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("problem name must be non-empty")
+        if not self.initial_state:
+            raise ValueError("initial_state must contain at least one value")
+
+
+@dataclass(frozen=True)
+class FoldCertificate:
+    """Evidence describing how and why a bounded resolution terminated."""
+
+    problem_name: str
+    method: str
+    iterations: int
+    converged: bool
+    residual: float
+    terminal_reason: str
+    state_digest: str
+    config_digest: str
+
+
+@dataclass(frozen=True)
+class FoldResult:
+    """Terminal state, residual trace and verification certificate."""
+
+    state: State
+    residual_trace: Tuple[float, ...]
+    certificate: FoldCertificate

--- a/src/jarvisx/omega_fold/resolver.py
+++ b/src/jarvisx/omega_fold/resolver.py
@@ -1,0 +1,129 @@
+"""Bounded fixed-point and closed-form resolver for the Moagi OmegaFold track."""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List
+
+from .certificates import canonical_state, config_digest, state_digest
+from .contracts import FoldCertificate, FoldConfig, FoldProblem, FoldResult, State
+
+
+def _measure(problem: FoldProblem, state: State) -> float:
+    residual = float(problem.residual(state))
+    if not math.isfinite(residual) or residual < 0.0:
+        raise ValueError("residual must be finite and non-negative")
+    return residual
+
+
+def _result(
+    problem: FoldProblem,
+    config: FoldConfig,
+    state: State,
+    trace: List[float],
+    *,
+    method: str,
+    iterations: int,
+    terminal_reason: str,
+) -> FoldResult:
+    residual = _measure(problem, state)
+    certificate = FoldCertificate(
+        problem_name=problem.name,
+        method=method,
+        iterations=iterations,
+        converged=residual <= config.tolerance,
+        residual=residual,
+        terminal_reason=terminal_reason,
+        state_digest=state_digest(state),
+        config_digest=config_digest(config),
+    )
+    return FoldResult(state=state, residual_trace=tuple(trace), certificate=certificate)
+
+
+def resolve(problem: FoldProblem, config: FoldConfig = FoldConfig()) -> FoldResult:
+    """Resolve a problem with finite work and independently verifiable termination.
+
+    A supplied closed form is attempted first, but it is never trusted by name: its
+    output must have the same dimension, contain finite values and satisfy the
+    problem residual. If it does not converge, bounded fixed-point iteration begins
+    from the canonical initial state. Repeated states terminate as cycles.
+    """
+
+    state = canonical_state(problem.initial_state, config.quantization_digits)
+    initial_residual = _measure(problem, state)
+    trace: List[float] = [initial_residual]
+
+    if initial_residual <= config.tolerance:
+        return _result(
+            problem,
+            config,
+            state,
+            trace,
+            method="initial_state",
+            iterations=0,
+            terminal_reason="residual_satisfied",
+        )
+
+    if problem.closed_form is not None:
+        closed_state = canonical_state(
+            tuple(problem.closed_form(state)), config.quantization_digits
+        )
+        if len(closed_state) != len(state):
+            raise ValueError("closed_form changed state dimensionality")
+        closed_residual = _measure(problem, closed_state)
+        trace.append(closed_residual)
+        if closed_residual <= config.tolerance:
+            return _result(
+                problem,
+                config,
+                closed_state,
+                trace,
+                method="closed_form",
+                iterations=1,
+                terminal_reason="residual_satisfied",
+            )
+
+    seen: Dict[State, int] = {state: 0}
+    for iteration in range(1, config.max_iterations + 1):
+        next_state = canonical_state(
+            tuple(problem.transition(state)), config.quantization_digits
+        )
+        if len(next_state) != len(state):
+            raise ValueError("transition changed state dimensionality")
+
+        residual = _measure(problem, next_state)
+        trace.append(residual)
+        if residual <= config.tolerance:
+            return _result(
+                problem,
+                config,
+                next_state,
+                trace,
+                method="fixed_point",
+                iterations=iteration,
+                terminal_reason="residual_satisfied",
+            )
+
+        if next_state in seen:
+            return _result(
+                problem,
+                config,
+                next_state,
+                trace,
+                method="fixed_point",
+                iterations=iteration,
+                terminal_reason="cycle_detected",
+            )
+
+        seen[next_state] = iteration
+        state = next_state
+
+    return _result(
+        problem,
+        config,
+        state,
+        trace,
+        method="fixed_point",
+        iterations=config.max_iterations,
+        terminal_reason="iteration_limit",
+    )

--- a/tests/test_omega_fold.py
+++ b/tests/test_omega_fold.py
@@ -1,0 +1,140 @@
+"""Regression and adversarial tests for the bounded OmegaFold resolver."""
+
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.omega_fold import FoldConfig, FoldProblem, resolve, verify_result
+
+
+def test_fixed_point_converges_and_verifies() -> None:
+    problem = FoldProblem(
+        name="scalar-contraction",
+        initial_state=(0.0,),
+        transition=lambda state: ((state[0] + 2.0) / 2.0,),
+        residual=lambda state: abs(state[0] - 2.0),
+    )
+    config = FoldConfig(max_iterations=64, tolerance=1.0e-9)
+
+    result = resolve(problem, config)
+
+    assert result.certificate.converged
+    assert result.certificate.method == "fixed_point"
+    assert result.certificate.iterations <= config.max_iterations
+    assert verify_result(problem, config, result)
+
+
+def test_closed_form_is_verified_before_acceptance() -> None:
+    problem = FoldProblem(
+        name="verified-closed-form",
+        initial_state=(10.0,),
+        transition=lambda state: (state[0] / 2.0,),
+        residual=lambda state: abs(state[0] - 3.0),
+        closed_form=lambda state: (3.0,),
+    )
+
+    result = resolve(problem)
+
+    assert result.state == (3.0,)
+    assert result.certificate.method == "closed_form"
+    assert result.certificate.terminal_reason == "residual_satisfied"
+
+
+def test_invalid_closed_form_falls_back_to_bounded_iteration() -> None:
+    problem = FoldProblem(
+        name="rejected-closed-form",
+        initial_state=(0.0,),
+        transition=lambda state: ((state[0] + 4.0) / 2.0,),
+        residual=lambda state: abs(state[0] - 4.0),
+        closed_form=lambda state: (999.0,),
+    )
+    result = resolve(problem, FoldConfig(max_iterations=64, tolerance=1.0e-9))
+
+    assert result.certificate.method == "fixed_point"
+    assert result.certificate.converged
+
+
+def test_cycle_is_detected_without_unbounded_execution() -> None:
+    problem = FoldProblem(
+        name="two-state-cycle",
+        initial_state=(0.0,),
+        transition=lambda state: (1.0 - state[0],),
+        residual=lambda state: 1.0,
+    )
+    config = FoldConfig(max_iterations=100)
+
+    result = resolve(problem, config)
+
+    assert not result.certificate.converged
+    assert result.certificate.terminal_reason == "cycle_detected"
+    assert result.certificate.iterations == 2
+    assert verify_result(problem, config, result)
+
+
+def test_iteration_limit_is_explicit() -> None:
+    problem = FoldProblem(
+        name="bounded-drift",
+        initial_state=(0.0,),
+        transition=lambda state: (state[0] + 1.0,),
+        residual=lambda state: 1.0,
+    )
+    config = FoldConfig(max_iterations=3)
+
+    result = resolve(problem, config)
+
+    assert result.certificate.terminal_reason == "iteration_limit"
+    assert result.certificate.iterations == 3
+
+
+def test_non_finite_state_fails_closed() -> None:
+    problem = FoldProblem(
+        name="non-finite",
+        initial_state=(0.0,),
+        transition=lambda state: (float("inf"),),
+        residual=lambda state: 1.0,
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        resolve(problem)
+
+
+def test_dimension_change_is_rejected() -> None:
+    problem = FoldProblem(
+        name="dimension-change",
+        initial_state=(0.0,),
+        transition=lambda state: (0.0, 1.0),
+        residual=lambda state: 1.0,
+    )
+
+    with pytest.raises(ValueError, match="dimensionality"):
+        resolve(problem)
+
+
+def test_certificate_tampering_is_detected() -> None:
+    problem = FoldProblem(
+        name="tamper-check",
+        initial_state=(2.0,),
+        transition=lambda state: state,
+        residual=lambda state: abs(state[0] - 2.0),
+    )
+    config = FoldConfig()
+    result = resolve(problem, config)
+    forged = replace(
+        result,
+        certificate=replace(result.certificate, state_digest="0" * 64),
+    )
+
+    assert verify_result(problem, config, result)
+    assert not verify_result(problem, config, forged)
+
+
+def test_resolution_is_deterministic() -> None:
+    problem = FoldProblem(
+        name="deterministic",
+        initial_state=(8.0,),
+        transition=lambda state: (state[0] / 2.0,),
+        residual=lambda state: abs(state[0] - 1.0),
+    )
+    config = FoldConfig(max_iterations=16)
+
+    assert resolve(problem, config) == resolve(problem, config)


### PR DESCRIPTION
## Summary

Introduces the first bounded engineering realization of the Moagi OmegaFold cosmogram.

The new reference layer translates symbolic temporal-collapse language into finite, testable mechanisms:

- deterministic fixed-point resolution;
- independently verified closed-form candidates;
- finite-state and residual validation;
- cycle detection and explicit iteration limits;
- SHA-256-bound state and configuration certificates;
- tamper verification;
- reproducible benchmark metadata;
- a specification and proposed architecture decision record.

## Why

The cosmogram expresses a useful systems objective—eliminate unnecessary sequential work by discovering invariant structure—but terms such as `O(0)`, zero Planck-time execution, tachyonic causality and `10^3000x` acceleration are not executable or measurable contracts.

This PR preserves the intended direction while enforcing Jarvis-X's canonical requirements for bounded execution, determinism, explicit authority, independent validation and evidence-based performance claims.

Closes no issue automatically. Tracks #62 and follows the decomposition rules in #48.

## Files

- `src/jarvisx/omega_fold/` — contracts, resolver and certificate verification;
- `tests/test_omega_fold.py` — convergence, closed-form, cycle, bound, validation, tamper and replay tests;
- `benchmarks/benchmark_omega_fold.py` — environment-aware timing scaffold;
- `docs/specifications/MOAGI_OMEGA_FOLD.md` — operational and complexity contract;
- `docs/adr/ADR-002-bounded-moagi-omega-fold.md` — proposed architectural decision.

## Validation

Executed against the isolated new package surface:

```text
9 passed in 0.06s
```

Remote diff: eight added files, 670 added lines, branch is eight commits ahead and zero commits behind `main` at PR creation.

## Capability boundary

This PR does not claim literal `O(0)` computation, zero elapsed time, causality reversal, physical hardware transcendence, perfect loss, AGI, unrestricted self-modification or an unmeasured speedup. The subsystem has no authority to mutate canonical VM state.