### PR TITLE
Add Dr Moagi inward electromagnetic latent transmission equation

### DIFF
--- a/docs/DR_MOAGI_INWARD_EM_LATENT_TRANSMISSION_EQUATION.md
+++ b/docs/DR_MOAGI_INWARD_EM_LATENT_TRANSMISSION_EQUATION.md
@@ -1,0 +1,498 @@
+# Dr Moagi Inward Electromagnetic Latent Transmission Equation
+
+## Status
+
+Proposed canonical systems equation for inward self-observation, 1000:1 model-assisted compression, bytecode encapsulation, electromagnetic transport, high-fidelity expansion, verification, constrained commit, rollback, and operational memory.
+
+The system does **not** claim that arbitrary 1000 GB data can always be represented losslessly by 1 GB. Exact reconstruction is possible only when the receiver already possesses sufficient shared structure in the decoder prior and the capsule carries every irreducible residual required to make the original state uniquely recoverable.
+
+---
+
+## 1. Operational State
+
+Let the complete runtime state be
+
+\[
+\boxed{
+\mathcal X_t=(S_t,\Theta_t,\Omega_t,\Lambda_t,\mathcal J_t)
+}
+\]
+
+where:
+
+- \(S_t\): committed operational state;
+- \(\Theta_t\): shared encoder/decoder and virtual-machine prior;
+- \(\Omega_t\): learned compression, channel, error, and recovery memory;
+- \(\Lambda_t\): structural, semantic, safety, determinism, and resource invariants;
+- \(\mathcal J_t\): immutable provenance and transaction journal.
+
+The system may observe only a bounded projection of itself:
+
+\[
+\boxed{
+o_t=\mathcal O_{\psi_t}(\mathcal X_t)
+}
+\]
+
+where \(\mathcal O_{\psi_t}\) is the declared self-telemetry and self-inspection interface.
+
+---
+
+## 2. Model-Assisted 1000:1 Compression
+
+The latent encoder produces a quantized code:
+
+\[
+\boxed{
+z_t=Q_b\!\left(E_{\phi_t}(o_t\mid\Theta_t,\Omega_t)\right)
+}
+\]
+
+The shared decoder predicts the observable state:
+
+\[
+\widetilde o_t=D_{\Theta_t}(z_t).
+\]
+
+The irreducible correction is
+
+\[
+\boxed{
+r_t=\mathcal R_{\delta_t}\!\left(o_t-\widetilde o_t\right)
+}
+\]
+
+where \(\mathcal R_{\delta_t}\) preserves either all exact residual information or only the residual required by a declared distortion contract.
+
+The logical capsule is
+
+\[
+\boxed{
+p_t=
+\operatorname{SEAL}_{K_t}
+\left(
+\operatorname{BC}
+[m_t,z_t,r_t,h_t]
+\right)
+}
+\]
+
+with:
+
+- \(m_t\): manifest, schema, model version, dimensions, precision, and decoder requirements;
+- \(z_t\): compressed latent state;
+- \(r_t\): residual correction;
+- \(h_t\): integrity, provenance, and transaction commitments;
+- \(\operatorname{BC}\): deterministic bytecode packing;
+- \(\operatorname{SEAL}_{K_t}\): cryptographic sealing under key or trust context \(K_t\).
+
+For a nominal 1000 GB to 1 GB operation:
+
+\[
+\boxed{
+\kappa_t=
+\frac{|o_t|}{|p_t|}=1000,
+\qquad
+|o_t|=1000\ \mathrm{GB},
+\qquad
+|p_t|\le 1\ \mathrm{GB}
+}
+\]
+
+This condition is valid only when the conditional information remaining after the shared decoder is sufficiently small:
+
+\[
+\boxed{
+H(o_t\mid p_t,\Theta_t)\le\varepsilon_H
+}
+\]
+
+For bit-exact reconstruction:
+
+\[
+\boxed{
+H(o_t\mid p_t,\Theta_t)=0
+\quad\text{and}\quad
+r_t\text{ carries every non-inferable bit.}
+}
+\]
+
+For semantic or perceptual reconstruction:
+
+\[
+\boxed{
+d(o_t,\widehat o_t)\le\varepsilon_t
+}
+\]
+
+for a declared distortion metric \(d\).
+
+---
+
+## 3. Channel Coding and Electromagnetic Signalling
+
+The sealed bytecode capsule is protected by forward error correction:
+
+\[
+\boxed{
+c_t=\mathcal C_{ECC,t}(p_t)
+}
+\]
+
+If the code rate is \(R_{ECC,t}\in(0,1]\), then the physical wire payload is
+
+\[
+\boxed{
+|c_t|=\frac{|p_t|}{R_{ECC,t}}
+}
+\]
+
+so a 1 GB logical capsule generally occupies more than 1 GB on the physical channel after redundancy, synchronization, framing, and authentication are added.
+
+The coded symbols are modulated onto an electromagnetic carrier:
+
+\[
+\boxed{
+s_t(\tau)=\mathcal M_{\mu_t}(c_t)
+}
+\]
+
+where \(\mu_t\) defines constellation, symbol rate, carrier, pulse shape, coding mode, synchronization, and power allocation.
+
+Propagation is
+
+\[
+\boxed{
+y_t(\tau)=
+\mathcal H_{EM,t}\{s_t(\tau)\}+n_t(\tau)
+}
+\]
+
+where \(\mathcal H_{EM,t}\) is the channel operator and \(n_t\) is noise, interference, attenuation, dispersion, phase error, timing error, and other distortion.
+
+---
+
+## 4. Reception and Expansion
+
+The receiver reconstructs the sealed capsule through inverse physical operators:
+
+\[
+\boxed{
+\widehat p_t=
+\mathcal C_{ECC,t}^{-1}
+\left(
+\mathcal M_{\mu_t}^{-1}(y_t)
+\right)
+}
+\]
+
+After seal verification and deterministic bytecode parsing:
+
+\[
+(\widehat m_t,\widehat z_t,\widehat r_t,\widehat h_t)
+=
+\operatorname{PARSE}
+\left(
+\operatorname{UNSEAL}_{K_t}(\widehat p_t)
+\right).
+\]
+
+The expanded state is
+
+\[
+\boxed{
+\widehat o_t=
+D_{\Theta_t}(\widehat z_t)
++\mathcal A_r(\widehat r_t)
+}
+\]
+
+where \(\mathcal A_r\) deterministically applies the residual to the decoder reconstruction.
+
+The reconstruction error is
+
+\[
+\boxed{
+e_t=o_t-\widehat o_t
+}
+\]
+
+with fidelity measured by the contract-appropriate quantities:
+
+\[
+\mathrm{BER}_{post},
+\quad
+\|e_t\|,
+\quad
+d_{semantic}(o_t,\widehat o_t),
+\quad
+d_{causal}(o_t,\widehat o_t),
+\quad
+d_{bit}(o_t,\widehat o_t).
+\]
+
+---
+
+## 5. Verification Gate
+
+The reconstructed state is admissible only when
+
+\[
+\boxed{
+V_t=
+V_{ECC}
+\land V_{seal}
+\land V_{hash}
+\land V_{schema}
+\land V_{model}
+\land V_{semantic}
+\land V_{determinism}
+\land V_{policy}
+\land V_{resource}
+\land V_{rollback}
+}
+\]
+
+and
+
+\[
+\boxed{
+d(o_t,\widehat o_t)\le\varepsilon_t.}
+\]
+
+No decoder output is committed merely because it appears plausible.
+
+---
+
+## 6. The Dr Moagi Inward Electromagnetic Latent Transmission Equation
+
+Define the complete inward transmission operator
+
+\[
+\boxed{
+\begin{aligned}
+\mathfrak T_t^{DM}
+={}&
+\Pi_{\Lambda_t}
+\circ
+\operatorname{COMMIT}_{V_t}
+\circ
+\operatorname{MERGE}
+\circ
+\mathcal D_{\Theta_t,r}
+\circ
+\operatorname{PARSE}
+\circ
+\operatorname{UNSEAL}_{K_t}
+\circ
+\mathcal C_{ECC,t}^{-1}
+\circ
+\mathcal M_{\mu_t}^{-1}
+\\[2mm]
+&\circ
+\left(\mathcal H_{EM,t}+n_t\right)
+\circ
+\mathcal M_{\mu_t}
+\circ
+\mathcal C_{ECC,t}
+\circ
+\operatorname{SEAL}_{K_t}
+\circ
+\operatorname{BC}
+\circ
+\mathcal E^{1000:1}_{\phi_t,\Theta_t,\Omega_t}
+\circ
+\mathcal O_{\psi_t}.
+\end{aligned}
+}
+\]
+
+The system transition is
+
+\[
+\boxed{
+\mathcal X_{t+1}
+=
+\mathfrak T_t^{DM}(\mathcal X_t)
+}
+\]
+
+where
+
+\[
+\mathcal E^{1000:1}_{\phi_t,\Theta_t,\Omega_t}(o_t)
+=
+[m_t,z_t,r_t,h_t],
+\qquad
+\frac{|o_t|}{|p_t|}=1000.
+\]
+
+Expanded transaction semantics are
+
+\[
+\boxed{
+\mathcal X_{t+1}=
+\begin{cases}
+\Pi_{\Lambda_t}
+\left[
+\operatorname{MERGE}(\mathcal X_t,\widehat o_t)
+\right],
+&
+V_t=1
+\ \land\ 
+d(o_t,\widehat o_t)\le\varepsilon_t,
+\\[3mm]
+\operatorname{ROLLBACK}(\mathcal X_t,\mathcal J_t),
+&
+\text{otherwise.}
+\end{cases}
+}
+\]
+
+This is the canonical distinction between **expansion** and **recovery**: the decoder may generate a large state from a compact capsule, but the transaction is called high-fidelity recovery only after residual correction and independent verification satisfy the declared contract.
+
+---
+
+## 7. Operational Memory Update
+
+The system learns from each transmission without granting memory commit authority:
+
+\[
+\boxed{
+\Omega_{t+1}
+=
+\mathcal G_{\Lambda_t}
+\left[
+\rho\Omega_t
++
+\eta\,
+\mathcal U_{tx}
+\left(
+ e_t,
+ \mathrm{BER}_{pre},
+ \mathrm{BER}_{post},
+ \mathrm{SNR}_t,
+ \mu_t,
+ R_{ECC,t},
+ \kappa_t,
+ V_t,
+ a_t
+\right)
+\right]
+}
+\]
+
+where \(a_t\in\{\mathrm{COMMIT},\mathrm{ROLLBACK}\}\).
+
+The journal records:
+
+```text
+source_state_version
+observation_contract
+encoder_version
+decoder_version
+bytecode_version
+capsule_size
+source_size
+compression_ratio
+residual_size
+ECC scheme and code rate
+modulation mode
+channel telemetry
+pre/post correction BER
+integrity commitments
+distortion contract
+reconstruction error
+verification vector
+commit or rollback
+logical time
+previous-state reference
+```
+
+---
+
+## 8. Bytecode Virtual-Processor Abstraction
+
+A minimal deterministic instruction flow is
+
+```text
+OBS_SELF
+ENCODE_LATENT
+DECODE_PREVIEW
+EXTRACT_RESIDUAL
+PACK_MANIFEST
+PACK_BYTECODE
+HASH_SEAL
+ECC_ENCODE
+MODULATE_EM
+TRANSMIT_EM
+RECEIVE_EM
+DEMODULATE_EM
+ECC_DECODE
+VERIFY_SEAL
+PARSE_BYTECODE
+DECODE_LATENT
+APPLY_RESIDUAL
+MEASURE_DISTORTION
+VERIFY_SEMANTICS
+VERIFY_DETERMINISM
+PROJECT_LAMBDA
+COMMIT_STATE
+ROLLBACK_STATE
+UPDATE_OMEGA
+JOURNAL_TX
+```
+
+The virtual processor therefore treats electromagnetic transmission as one bounded stage inside a larger transactional encode-transmit-decode-verify-commit runtime.
+
+---
+
+## 9. Canonical Compact Form
+
+\[
+\boxed{
+\mathcal X_{t+1}
+=
+\Pi_{\Lambda_t}
+\left[
+\operatorname{Tx}_{V_t}
+\left(
+\mathcal D_{\Theta_t,r}
+\left[
+\mathcal C^{-1}
+\mathcal M^{-1}
+\left(
+\mathcal H_{EM,t}
+\left\{
+\mathcal M\mathcal C
+\operatorname{Seal}
+\operatorname{BC}
+\mathcal E^{1000:1}
+\mathcal O(\mathcal X_t)
+\right\}
++n_t
+\right)
+\right]
+\right)
++\Omega_{t+1}
+\right]
+}
+\]
+
+subject to
+
+\[
+\boxed{
+\frac{|o_t|}{|p_t|}=1000,
+\quad
+H(o_t\mid p_t,\Theta_t)\le\varepsilon_H,
+\quad
+d(o_t,\widehat o_t)\le\varepsilon_t,
+\quad
+V_t=1.
+}
+\]
+
+The equation encodes the complete systems principle:
+
+> Observe inwardly, compress against a shared model, preserve irreducible novelty as residual bytecode, protect it with error correction and cryptographic provenance, transport it electromagnetically, reconstruct it through the shared decoder, verify it independently, project it through \(\Lambda\), and commit only when fidelity is proven; otherwise roll back and update \(\Omega\).


### PR DESCRIPTION
## What changed

Adds a canonical systems equation for:

- bounded inward self-observation;
- model-assisted 1000:1 compression;
- latent and residual bytecode encapsulation;
- cryptographic sealing and forward error correction;
- electromagnetic modulation, propagation, demodulation, and channel decoding;
- shared-model expansion;
- semantic, deterministic, integrity, policy, and resource verification;
- Lambda-projected transactional commit or rollback;
- Omega transmission and recovery memory updates.

## Why

The existing inward self-optimizing runtime defines bounded mechanics adaptation, but it does not yet provide a single end-to-end equation for compressing an observed runtime state into a compact executable capsule, transmitting that capsule over an electromagnetic channel, reconstructing the state through a shared decoder prior, and committing only after fidelity is independently proven.

## Mathematical boundary

The document explicitly avoids claiming universal lossless 1000 GB to 1 GB compression. Exact reconstruction requires sufficient shared decoder structure and a residual carrying every non-inferable bit. Channel-coding overhead is also distinguished from the 1 GB logical capsule.

## Validation

- Created as a standalone Markdown specification under `docs/`.
- Uses the repository's existing Xi, Theta, Omega, Lambda, bytecode, verification, journaling, commit, and rollback vocabulary.
- No runtime code or existing specification was modified.