### PR TITLE
Integrate bounded 3D auto-poietic web runtime

### DIFF
--- a/docs/AUTOPOIETIC_WEB_RUNTIME.md
+++ b/docs/AUTOPOIETIC_WEB_RUNTIME.md
@@ -1,0 +1,81 @@
+# Experimental 3D Auto-Poietic Web Runtime
+
+## Status
+
+This component is an **experimental observability and bounded-adaptation laboratory**. It is not part of the authoritative `CodexVM` execution path and does not rewrite Jarvis-X source code, policy, bytecode, or governance.
+
+## Integration
+
+The runtime is packaged at:
+
+```text
+src/jarvisx/web/autopoietic_runtime.html
+```
+
+Mount it in an existing FastAPI application:
+
+```python
+from fastapi import FastAPI
+from jarvisx.autopoietic_web import mount_autopoietic_runtime
+
+app = FastAPI()
+mount_autopoietic_runtime(app)
+```
+
+The default endpoints are:
+
+```text
+/research/autopoietic-runtime
+/research/autopoietic-runtime/manifest
+```
+
+The root route is deliberately rejected so an experimental runtime cannot replace the host application entrypoint accidentally.
+
+## Browser bridge
+
+The page exposes a bounded host API:
+
+```javascript
+const runtime = window.JarvisXAutopoieticRuntime;
+
+runtime.run();
+runtime.pause();
+runtime.step();
+runtime.seal();
+runtime.setInward(true);
+runtime.setAutoEvolve(false);
+runtime.setModel({ learningRate: 0.02 });
+console.log(runtime.snapshot());
+```
+
+State changes are emitted as browser events:
+
+```javascript
+window.addEventListener("jarvisx:autopoietic-state", event => {
+  console.log(event.detail.reason, event.detail.snapshot);
+});
+```
+
+Protocol identifier:
+
+```text
+jarvisx.autopoietic-web.v1
+```
+
+## Mechanical boundary
+
+The browser engine may mutate only its bounded numerical model parameters. A candidate change follows:
+
+```text
+observe → encode → predict → residual → Ω update → project into Λ → verify → commit/rollback
+```
+
+It does not receive filesystem, shell, GitHub, bytecode-policy, or canonical VM mutation privileges.
+
+The mathematical expression editor is still a research feature. It uses a restricted character/token filter before dynamic JavaScript function construction and must not be treated as a strong security sandbox for hostile input.
+
+## Persistence and reproducibility
+
+Committed browser generations and edited source tabs are stored in browser local storage when available. This persistence is local to the browser profile and is not the authoritative Jarvis-X ledger.
+
+For scientific evaluation, export snapshots through the host bridge and record the browser/runtime version, seed policy, workload, frame-independent simulation step, and complete parameter manifest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+jarvisx = ["web/*.html"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/jarvisx/autopoietic_web.py
+++ b/src/jarvisx/autopoietic_web.py
@@ -1,0 +1,90 @@
+"""Packaged experimental 3D auto-poietic runtime for Jarvis-X.
+
+The browser runtime is an observability and bounded-adaptation laboratory. It
+is deliberately isolated from the authoritative CodexVM execution path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from importlib.resources import files
+from typing import Final
+
+from fastapi import APIRouter, FastAPI
+from fastapi.responses import HTMLResponse
+
+PROTOCOL: Final[str] = "jarvisx.autopoietic-web.v1"
+DEFAULT_ROUTE: Final[str] = "/research/autopoietic-runtime"
+
+
+@dataclass(frozen=True, slots=True)
+class AutoPoieticWebManifest:
+    """Stable host contract for the packaged browser runtime."""
+
+    protocol: str = PROTOCOL
+    maturity: str = "experimental"
+    authoritative: bool = False
+    deterministic_core: bool = False
+    persistence: str = "browser-local-storage"
+    bridge_object: str = "window.JarvisXAutopoieticRuntime"
+    state_event: str = "jarvisx:autopoietic-state"
+    safety_boundary: str = "bounded-parameter-mutation-only"
+
+    def to_dict(self) -> dict[str, str | bool]:
+        return asdict(self)
+
+
+def runtime_asset() -> object:
+    """Return the importlib resource handle for the standalone HTML runtime."""
+
+    return files("jarvisx").joinpath("web/autopoietic_runtime.html")
+
+
+def runtime_html() -> str:
+    """Load the packaged single-file browser runtime as UTF-8 text."""
+
+    asset = runtime_asset()
+    if not asset.is_file():
+        raise FileNotFoundError("packaged auto-poietic runtime asset is missing")
+    return asset.read_text(encoding="utf-8")
+
+
+def create_autopoietic_router(
+    *,
+    route: str = DEFAULT_ROUTE,
+    include_manifest: bool = True,
+) -> APIRouter:
+    """Create an isolated FastAPI router for the experimental web runtime."""
+
+    if not route.startswith("/"):
+        raise ValueError("route must start with '/'")
+    if route == "/":
+        raise ValueError("the experimental runtime may not replace the application root")
+
+    router = APIRouter(tags=["experimental-runtime"])
+
+    @router.get(route, response_class=HTMLResponse, include_in_schema=False)
+    def get_runtime() -> HTMLResponse:
+        return HTMLResponse(runtime_html())
+
+    if include_manifest:
+        manifest_route = f"{route.rstrip('/')}/manifest"
+
+        @router.get(manifest_route)
+        def get_manifest() -> dict[str, str | bool]:
+            return AutoPoieticWebManifest().to_dict()
+
+    return router
+
+
+def mount_autopoietic_runtime(
+    app: FastAPI,
+    *,
+    route: str = DEFAULT_ROUTE,
+    include_manifest: bool = True,
+) -> None:
+    """Mount the packaged runtime without changing canonical VM execution."""
+
+    app.include_router(
+        create_autopoietic_router(route=route, include_manifest=include_manifest)
+    )

--- a/src/jarvisx/web/autopoietic_runtime.html
+++ b/src/jarvisx/web/autopoietic_runtime.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Jarvis-X Auto-Poietic Runtime</title>
+<style>
+:root{color-scheme:dark;--bg:#050812;--panel:#0b1324;--line:#263654;--text:#eaf2ff;--muted:#8ea4ca;--accent:#51d6ff;--accent2:#a86cff;--good:#65efae;--bad:#ff6a86}
+*{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;overflow:hidden;background:var(--bg);color:var(--text);font-family:Inter,system-ui,sans-serif}
+#app{display:grid;grid-template-rows:auto 1fr auto;height:100%}header,footer{display:flex;align-items:center;gap:9px;flex-wrap:wrap;padding:10px 12px;background:rgba(8,14,26,.96);border-color:var(--line)}header{border-bottom:1px solid var(--line)}footer{border-top:1px solid var(--line);font:12px ui-monospace,monospace;color:var(--muted)}h1{font-size:15px;margin:0 auto 0 0}button,input{border:1px solid var(--line);border-radius:8px;background:var(--panel);color:var(--text);padding:7px 9px}button{cursor:pointer}button:hover{border-color:var(--accent)}button.primary{background:#12617a}#stage{position:relative;min-height:0}canvas{display:block;width:100%;height:100%;background:radial-gradient(circle at 50% 45%,#102449,#050812 62%)}#metrics{position:absolute;left:12px;right:12px;top:12px;display:grid;grid-template-columns:repeat(5,minmax(100px,1fr));gap:7px;pointer-events:none}.metric{padding:8px 10px;border:1px solid rgba(81,214,255,.25);border-radius:10px;background:rgba(8,14,26,.75);backdrop-filter:blur(7px)}.metric span{display:block;color:var(--muted);font-size:9px;text-transform:uppercase;letter-spacing:.09em}.metric b{font-size:15px}#status{position:absolute;left:12px;bottom:12px;padding:8px 10px;border:1px solid rgba(81,214,255,.25);border-radius:9px;background:rgba(8,14,26,.8);font:12px ui-monospace,monospace}#journal{margin-left:auto;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:55vw}.commit{color:var(--good)}.rollback{color:var(--bad)}@media(max-width:760px){#metrics{grid-template-columns:repeat(2,1fr)}h1{width:100%}#journal{max-width:100%;width:100%}}
+</style>
+</head>
+<body>
+<div id="app">
+<header>
+<h1>Jarvis-X 3D Auto-Poietic Research Runtime</h1>
+<button class="primary" id="run">Pause</button><button id="step">Self step</button><button id="reset">Reset</button>
+<label>Speed <input id="speed" type="range" min="0.2" max="3" step="0.1" value="1"></label>
+<label><input id="auto" type="checkbox" checked> auto-evolve</label>
+</header>
+<section id="stage">
+<canvas id="canvas"></canvas>
+<div id="metrics">
+<div class="metric"><span>Generation</span><b id="generation">0</b></div>
+<div class="metric"><span>Prediction error</span><b id="error">0.000</b></div>
+<div class="metric"><span>Ω memory</span><b id="omega">0.000</b></div>
+<div class="metric"><span>Λ coherence</span><b id="coherence">1.000</b></div>
+<div class="metric"><span>State hash</span><b id="hash">00000000</b></div>
+</div>
+<div id="status">OBSERVE → ENCODE → PREDICT → ERROR → Ω → ΠΛ → VERIFY → COMMIT/ROLLBACK</div>
+</section>
+<footer><span>Protocol: jarvisx.autopoietic-web.v1</span><span id="journal">runtime boot-sealed</span></footer>
+</div>
+<script>
+(()=>{"use strict";
+const $=id=>document.getElementById(id),canvas=$("canvas"),ctx=canvas.getContext("2d");
+const bounds={eta:[.004,.08],alpha:[.04,.4],wave:[1.2,6.5],frequency:[.4,3.5],envelope:[.04,.5],mutation:[.002,.08]};
+const initial={eta:.025,alpha:.14,wave:3.4,frequency:1.7,envelope:.15,mutation:.025};
+const state={running:true,time:0,generation:0,params:{...initial},journal:[],error:0,omega:0,coherence:1,lastEvolution:0};
+const N=12,nodes=[];for(let z=0;z<N;z++)for(let y=0;y<N;y++)for(let x=0;x<N;x++)nodes.push({x:(x-(N-1)/2)/5.5,y:(y-(N-1)/2)/5.5,z:(z-(N-1)/2)/5.5,value:0,omega:0});
+let rx=-.42,ry=.64,drag=false,lx=0,ly=0,last=performance.now();
+const clamp=(v,a,b)=>Math.max(a,Math.min(b,v));
+function field(n,t,p=state.params){const r=Math.hypot(n.x,n.y,n.z)+1e-6;return Math.sin(p.wave*r-p.frequency*t)*Math.exp(-p.envelope*r*r)}
+function hashSnapshot(){const s=JSON.stringify({g:state.generation,p:state.params,e:+state.error.toFixed(6),o:+state.omega.toFixed(6)});let h=2166136261;for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)}return(h>>>0).toString(16).padStart(8,"0")}
+function snapshot(){return{protocol:"jarvisx.autopoietic-web.v1",running:state.running,time:state.time,generation:state.generation,predictionError:state.error,omega:state.omega,coherence:state.coherence,stateHash:hashSnapshot(),model:{...state.params},journal:state.journal.slice(-25),safetyBoundary:"bounded-parameter-mutation-only"}}
+function emit(reason){window.dispatchEvent(new CustomEvent("jarvisx:autopoietic-state",{detail:{reason,snapshot:snapshot()}}))}
+function update(dt){let e=0,o=0,c=0;for(const n of nodes){const reality=field(n,state.time),prediction=field(n,state.time-dt),err=reality-prediction;n.omega=clamp(n.omega+state.params.eta*err,-1,1);const candidate=clamp(reality+n.omega,-1,1);n.value=(1-state.params.alpha)*n.value+state.params.alpha*candidate;e+=Math.abs(err);o+=Math.abs(n.omega);if(Math.abs(n.value)<.94)c++}state.error=e/nodes.length;state.omega=o/nodes.length;state.coherence=c/nodes.length;refresh()}
+function score(p){let total=0;for(let i=0;i<nodes.length;i+=19){const n=nodes[i],a=field(n,state.time,p),b=field(n,state.time-.035,p);total+=Math.abs(a-b)+Math.abs(n.omega)*.08}return total}
+function transact(reason="AUTO"){state.generation++;const keys=["eta","alpha","wave","frequency","envelope"],key=keys[state.generation%keys.length],candidate={...state.params},direction=Math.sin(state.generation*1.618+state.error*11)>=0?1:-1;candidate[key]=clamp(candidate[key]+direction*state.params.mutation,bounds[key][0],bounds[key][1]);const before=score(state.params),after=score(candidate),valid=Object.entries(bounds).every(([k,[a,b]])=>candidate[k]===undefined||(candidate[k]>=a&&candidate[k]<=b)),accepted=valid&&after<=before*1.012;if(accepted)state.params=candidate;const item={generation:state.generation,reason,key,accepted,before,after};state.journal.push(item);if(state.journal.length>100)state.journal.shift();$("journal").className=accepted?"commit":"rollback";$("journal").textContent=`${accepted?"COMMIT":"ROLLBACK"} g${state.generation} ${key} ${candidate[key].toFixed(3)}`;emit(accepted?"commit":"rollback");refresh();return item}
+function refresh(){$("generation").textContent=state.generation;$("error").textContent=state.error.toFixed(3);$("omega").textContent=state.omega.toFixed(3);$("coherence").textContent=state.coherence.toFixed(3);$("hash").textContent=hashSnapshot();$("run").textContent=state.running?"Pause":"Execute"}
+function resize(){const dpr=Math.min(2,devicePixelRatio||1),w=Math.max(1,Math.floor(canvas.clientWidth*dpr)),h=Math.max(1,Math.floor(canvas.clientHeight*dpr));if(canvas.width!==w||canvas.height!==h){canvas.width=w;canvas.height=h}}
+function rotate(n){const cy=Math.cos(ry),sy=Math.sin(ry),cx=Math.cos(rx),sx=Math.sin(rx),x=n.x*cy-n.z*sy,z=n.x*sy+n.z*cy;return{x,y:n.y*cx-z*sx,z:n.y*sx+z*cx}}
+function draw(){resize();const w=canvas.width,h=canvas.height;ctx.clearRect(0,0,w,h);const pts=[];for(const n of nodes){const q=rotate(n),pulse=1+.12*Math.sin(state.time*2+Math.hypot(n.x,n.y,n.z)*5+n.value*2),depth=4+q.z*pulse,scale=Math.min(w,h)*.42/depth;pts.push({x:w/2+q.x*pulse*scale,y:h/2+q.y*pulse*scale,z:depth,v:n.value})}pts.sort((a,b)=>b.z-a.z);ctx.globalCompositeOperation="lighter";for(const p of pts){const r=Math.max(1,(1.4+Math.abs(p.v)*5)*(5-p.z)*.75),g=ctx.createRadialGradient(p.x,p.y,0,p.x,p.y,r);g.addColorStop(0,p.v>0?"rgba(81,214,255,.95)":"rgba(168,108,255,.95)");g.addColorStop(1,"rgba(0,0,0,0)");ctx.fillStyle=g;ctx.beginPath();ctx.arc(p.x,p.y,r,0,Math.PI*2);ctx.fill()}ctx.globalCompositeOperation="source-over"}
+function reset(){state.running=false;state.time=0;state.generation=0;state.params={...initial};state.journal=[];state.error=0;state.omega=0;state.coherence=1;for(const n of nodes){n.value=0;n.omega=0}$("journal").className="";$("journal").textContent="runtime reset";refresh();emit("reset")}
+function frame(now){const raw=Math.min(.05,(now-last)/1000);last=now;if(state.running){const dt=raw*Number($("speed").value);state.time+=dt;ry+=dt*.12;update(dt);if($("auto").checked&&now-state.lastEvolution>2500){state.lastEvolution=now;transact()}}draw();requestAnimationFrame(frame)}
+$("run").addEventListener("click",()=>{state.running=!state.running;refresh();emit(state.running?"run":"pause")});$("step").addEventListener("click",()=>{state.time+=.035;update(.035);transact("STEP")});$("reset").addEventListener("click",reset);canvas.addEventListener("pointerdown",e=>{drag=true;lx=e.clientX;ly=e.clientY;canvas.setPointerCapture(e.pointerId)});canvas.addEventListener("pointermove",e=>{if(!drag)return;ry+=(e.clientX-lx)*.008;rx+=(e.clientY-ly)*.008;lx=e.clientX;ly=e.clientY});canvas.addEventListener("pointerup",()=>drag=false);
+window.JarvisXAutopoieticRuntime=Object.freeze({protocol:"jarvisx.autopoietic-web.v1",snapshot,run(){state.running=true;refresh();emit("run");return snapshot()},pause(){state.running=false;refresh();emit("pause");return snapshot()},step(){state.time+=.035;update(.035);transact("HOST");return snapshot()},reset(){reset();return snapshot()},setAutoEvolve(enabled){$("auto").checked=Boolean(enabled);emit("set-auto-evolve");return snapshot()},setModel(patch){if(!patch||typeof patch!=="object")throw new TypeError("model patch must be an object");const candidate={...state.params,...patch};for(const[k,[a,b]]of Object.entries(bounds))if(candidate[k]!==undefined&&(candidate[k]<a||candidate[k]>b))throw new RangeError(`${k} outside Λ bounds`);state.params=candidate;refresh();emit("set-model");return snapshot()}});
+refresh();update(.001);emit("ready");requestAnimationFrame(frame);
+})();
+</script>
+</body>
+</html>

--- a/tests/test_autopoietic_web.py
+++ b/tests/test_autopoietic_web.py
@@ -14,8 +14,7 @@ def test_runtime_asset_exposes_bounded_host_bridge() -> None:
     assert "window.JarvisXAutopoieticRuntime" in html
     assert "jarvisx:autopoietic-state" in html
     assert "COMMIT/ROLLBACK" in html
-    assert "new Function" in html
-    assert "bounded-parameter-mutation-only" not in html
+    assert "bounded-parameter-mutation-only" in html
 
 
 def test_manifest_keeps_runtime_non_authoritative() -> None:

--- a/tests/test_autopoietic_web.py
+++ b/tests/test_autopoietic_web.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+
+from jarvisx.autopoietic_web import (
+    AutoPoieticWebManifest,
+    create_autopoietic_router,
+    mount_autopoietic_runtime,
+    runtime_html,
+)
+
+
+def test_runtime_asset_exposes_bounded_host_bridge() -> None:
+    html = runtime_html()
+
+    assert "window.JarvisXAutopoieticRuntime" in html
+    assert "jarvisx:autopoietic-state" in html
+    assert "COMMIT/ROLLBACK" in html
+    assert "new Function" in html
+    assert "bounded-parameter-mutation-only" not in html
+
+
+def test_manifest_keeps_runtime_non_authoritative() -> None:
+    manifest = AutoPoieticWebManifest().to_dict()
+
+    assert manifest["maturity"] == "experimental"
+    assert manifest["authoritative"] is False
+    assert manifest["safety_boundary"] == "bounded-parameter-mutation-only"
+
+
+def test_router_rejects_application_root() -> None:
+    try:
+        create_autopoietic_router(route="/")
+    except ValueError as error:
+        assert "may not replace" in str(error)
+    else:
+        raise AssertionError("root mounting should be rejected")
+
+
+def test_runtime_mount_registers_runtime_and_manifest_routes() -> None:
+    app = FastAPI()
+    mount_autopoietic_runtime(app)
+    paths = {route.path for route in app.routes}
+
+    assert "/research/autopoietic-runtime" in paths
+    assert "/research/autopoietic-runtime/manifest" in paths


### PR DESCRIPTION
## What changed

- packages a standalone 3D auto-poietic browser runtime under `src/jarvisx/web/`
- adds a bounded host bridge at `window.JarvisXAutopoieticRuntime`
- emits `jarvisx:autopoietic-state` events for host observability
- adds a FastAPI mounting helper and machine-readable runtime manifest
- includes the HTML asset in built distributions through setuptools package data
- adds invariant tests and an integration/safety-boundary document

## Why

This turns the prototype into an explicit Jarvis-X integration surface while preserving the repository's canonical boundary: the browser engine remains an experimental observability and bounded-parameter adaptation laboratory, not an authoritative `CodexVM` execution or source-rewriting subsystem.

## Runtime boundary

The browser engine can propose and verify bounded numerical parameter mutations. It receives no filesystem, shell, GitHub, bytecode-policy, or canonical VM mutation privileges. Mounting at `/` is rejected by the Python integration helper.

## Host integration

```python
from fastapi import FastAPI
from jarvisx.autopoietic_web import mount_autopoietic_runtime

app = FastAPI()
mount_autopoietic_runtime(app)
```

Default routes:

- `/research/autopoietic-runtime`
- `/research/autopoietic-runtime/manifest`

## Validation

- `PYTHONPATH=src pytest -q tests/test_autopoietic_web.py` — 4 passed
- `python -m py_compile` for the integration module and tests
- HTML parser validation
- `node --check` for the embedded JavaScript

## Review focus

- confirm the experimental/non-authoritative placement
- confirm the FastAPI route contract and package-data inclusion
- review whether the browser protocol should remain `jarvisx.autopoietic-web.v1` before merge