### PR TITLE
Operationalize verifiable Hyperion audit service

### DIFF
--- a/.github/workflows/hyperion-operational.yml
+++ b/.github/workflows/hyperion-operational.yml
@@ -1,0 +1,86 @@
+name: Hyperion Operational Service
+
+on:
+  pull_request:
+    paths:
+      - "src/jarvisx/hyperion*.py"
+      - "tests/test_hyperion*.py"
+      - "scripts/smoke_hyperion_service.py"
+      - "configs/hyperion*.json"
+      - "deploy/hyperion*"
+      - "docs/HYPERION*.md"
+      - "pyproject.toml"
+      - ".github/workflows/hyperion-operational.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/hyperion*.py"
+      - "tests/test_hyperion*.py"
+      - "scripts/smoke_hyperion_service.py"
+      - "configs/hyperion*.json"
+      - "deploy/hyperion*"
+      - "docs/HYPERION*.md"
+      - "pyproject.toml"
+      - ".github/workflows/hyperion-operational.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  operational-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install package and test dependencies
+        run: python -m pip install -e ".[test]"
+      - name: Run Hyperion tests
+        run: pytest -q tests/test_hyperion.py tests/test_hyperion_operational.py
+      - name: CLI audit and verification
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          Path("/tmp/hyperion-input.json").write_text(json.dumps({"observations": [
+              {"source": "csv", "timestamp_ms": 0, "value": 100.0, "quantity": "amount", "unit": "ZAR", "correlation_id": "ci", "label": "known"},
+              {"source": "cpu", "timestamp_ms": 1, "value": 100.0, "quantity": "amount", "unit": "ZAR", "correlation_id": "ci", "label": "known"}
+          ]}))
+          PY
+          jarvisx-hyperion audit /tmp/hyperion-input.json \
+            --config configs/hyperion.production.json \
+            --model configs/hyperion.model.v1.json \
+            --output /tmp/hyperion-bundle.json
+          jarvisx-hyperion verify /tmp/hyperion-bundle.json \
+            --config configs/hyperion.production.json \
+            --model configs/hyperion.model.v1.json
+      - name: Authenticated network smoke test
+        env:
+          HYPERION_API_KEY: ci-secret
+          HYPERION_REQUIRE_API_KEY: "true"
+          HYPERION_DATA_DIR: /tmp/hyperion-state
+          HYPERION_CONFIG_FILE: configs/hyperion.production.json
+          HYPERION_MODEL_FILE: configs/hyperion.model.v1.json
+        run: |
+          uvicorn jarvisx.hyperion_service:app_factory --factory --host 127.0.0.1 --port 8080 --workers 1 >/tmp/hyperion.log 2>&1 &
+          service_pid=$!
+          trap 'kill $service_pid' EXIT
+          python - <<'PY'
+          import time
+          import urllib.request
+
+          for _ in range(50):
+              try:
+                  urllib.request.urlopen("http://127.0.0.1:8080/healthz", timeout=1)
+                  break
+              except Exception:
+                  time.sleep(0.1)
+          else:
+              raise SystemExit("service did not become healthy")
+          PY
+          python scripts/smoke_hyperion_service.py
+      - name: Build container image
+        run: docker build -f deploy/hyperion.Dockerfile -t jarvisx-hyperion:ci .

--- a/configs/hyperion.model.v1.json
+++ b/configs/hyperion.model.v1.json
@@ -1,0 +1,12 @@
+{
+  "bias": -3.0,
+  "training_digest": null,
+  "version": 1,
+  "weights": [
+    1.35,
+    1.25,
+    1.3,
+    1.1,
+    1.5
+  ]
+}

--- a/configs/hyperion.production.json
+++ b/configs/hyperion.production.json
@@ -1,0 +1,27 @@
+{
+  "allow_unconfigured_sources": false,
+  "bytecode_absolute_tolerance": 0.01,
+  "bytecode_relative_tolerance": 0.01,
+  "continuity_absolute_tolerance": 0.01,
+  "continuity_relative_tolerance": 0.01,
+  "critical_threshold": 0.75,
+  "epsilon": 1e-12,
+  "event_tolerance_ms": 25,
+  "ghs_exposure_weight": 0.7,
+  "ghs_frequency_weight": 0.3,
+  "lower_bound": null,
+  "minimum_dt_ms": 1,
+  "precision_limit_fraction": 0.02,
+  "precision_quantile": 0.8,
+  "robust_window": 30,
+  "robust_z_threshold": 3.5,
+  "source_weights": {
+    "audio": 1.0,
+    "cpu": 1.0,
+    "csv": 1.0
+  },
+  "target_quantity": "amount",
+  "target_unit": "ZAR",
+  "value_scale": 100,
+  "weight_scale": 1000000
+}

--- a/deploy/hyperion-compose.yml
+++ b/deploy/hyperion-compose.yml
@@ -1,0 +1,26 @@
+services:
+  hyperion:
+    build:
+      context: ..
+      dockerfile: deploy/hyperion.Dockerfile
+    environment:
+      HYPERION_API_KEY: ${HYPERION_API_KEY:?set HYPERION_API_KEY}
+      HYPERION_REQUIRE_API_KEY: "true"
+      HYPERION_DATA_DIR: /var/lib/hyperion
+      HYPERION_CONFIG_FILE: /etc/hyperion/config.json
+      HYPERION_MODEL_FILE: /etc/hyperion/model.json
+    ports:
+      - "127.0.0.1:8080:8080"
+    volumes:
+      - hyperion-data:/var/lib/hyperion
+    read_only: true
+    tmpfs:
+      - /tmp:size=64m,noexec,nosuid,nodev
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    restart: unless-stopped
+
+volumes:
+  hyperion-data:

--- a/deploy/hyperion.Dockerfile
+++ b/deploy/hyperion.Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    HYPERION_DATA_DIR=/var/lib/hyperion \
+    HYPERION_MAX_OBSERVATIONS=50000 \
+    HYPERION_REQUIRE_API_KEY=true \
+    HYPERION_CONFIG_FILE=/etc/hyperion/config.json \
+    HYPERION_MODEL_FILE=/etc/hyperion/model.json
+
+WORKDIR /app
+
+RUN groupadd --system hyperion \
+    && useradd --system --gid hyperion --home-dir /nonexistent --shell /usr/sbin/nologin hyperion \
+    && mkdir -p /var/lib/hyperion /etc/hyperion \
+    && chown -R hyperion:hyperion /var/lib/hyperion
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+COPY configs/hyperion.production.json /etc/hyperion/config.json
+COPY configs/hyperion.model.v1.json /etc/hyperion/model.json
+
+RUN python -m pip install .
+
+USER hyperion
+EXPOSE 8080
+VOLUME ["/var/lib/hyperion"]
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=3)"
+
+CMD ["uvicorn", "jarvisx.hyperion_service:app_factory", "--factory", "--host", "0.0.0.0", "--port", "8080", "--workers", "1", "--proxy-headers"]

--- a/docs/HYPERION_ENGINE.md
+++ b/docs/HYPERION_ENGINE.md
@@ -1,0 +1,279 @@
+# Hyperion Verifiable Audit Engine
+
+## Status
+
+Hyperion is an **experimental deterministic audit kernel** for semantically aligned, multi-source event arithmetic. It makes every fusion, derivative, anomaly score, model version and proof commitment reproducible.
+
+It does not claim that a camera, microphone, database or CPU trace is truthful merely because its arithmetic verifies. Input authenticity remains a chain-of-custody and attestation problem.
+
+## Design goals
+
+1. Never average incompatible quantities or units.
+2. Preserve event identity instead of expanding sparse evidence onto a millisecond matrix.
+3. Use elapsed time in all derivatives.
+4. Predict from prior state before calculating a continuity residual.
+5. Use robust, two-sided statistics for contaminated audit windows.
+6. Normalize the composite anomaly score to `[0, 1]`.
+7. Require explicit labels before reporting supervised precision or adapting score weights.
+8. Version and hash every model and configuration.
+9. Bound the health score to `[0, 100]`.
+10. Export deterministic fixed-point witnesses suitable for an external SNARK/STARK circuit.
+
+## Observation contract
+
+Each source produces an `Observation`:
+
+```python
+Observation(
+    source="csv",
+    timestamp_ms=1_700_000_000_000,
+    value=149_000.00,
+    quantity="amount",
+    unit="ZAR",
+    correlation_id="transaction-42",
+    confidence=1.0,
+    label="beneficiary-name",
+)
+```
+
+The pair `(quantity, unit)` is a dimensional contract. An identity match encoded as `(identity_match, boolean)` is not fused into `(amount, ZAR)`.
+
+Unknown sources are excluded by default. Duplicate observations from one source do not gain extra voting weight; Hyperion selects one deterministic, highest-confidence observation per source and event.
+
+## Event-time alignment
+
+Correlation identifiers are authoritative when supplied. Otherwise, observations are grouped into deterministic time buckets of `event_tolerance_ms`.
+
+For event `k`, compatible source observations are:
+
+\[
+\mathcal O_k = \{x_{s,k}: q_{s,k}=q^*,\;u_{s,k}=u^*\}.
+\]
+
+No cross-modal Kalman imputation is performed without an explicit state-space model. Missing streams are excluded and reflected in the fusion confidence.
+
+## Fixed-point fusion
+
+For each compatible source:
+
+\[
+X_{s,k}=\operatorname{round}(S_x x_{s,k}),
+\]
+
+\[
+W_{s,k}=\operatorname{round}(S_w w_s c_{s,k}).
+\]
+
+The circuit-ready arithmetic is:
+
+\[
+N_k = \sum_s W_{s,k}X_{s,k},
+\qquad
+D_k = \sum_s W_{s,k},
+\]
+
+\[
+M_k = \operatorname{round}\!\left(\frac{N_k}{D_k}\right),
+\]
+
+\[
+N_k = D_kM_k + r_k,
+\qquad
+2|r_k|\le D_k.
+\]
+
+The decoded fused value is:
+
+\[
+\mu_k=M_k/S_x.
+\]
+
+`ArithmeticWitness.verify()` checks the integer relation and commitment. `circuit_inputs()` exports only integer arrays and public relation values.
+
+## Time-correct mechanics
+
+For elapsed time:
+
+\[
+\Delta t_k=\max(t_k-t_{k-1},\Delta t_{\min})/1000,
+\]
+
+Hyperion calculates:
+
+\[
+\Delta\mu_k=\mu_k-\mu_{k-1},
+\]
+
+\[
+v_k=\frac{\Delta\mu_k}{\Delta t_k},
+\qquad
+a_k=\frac{v_k-v_{k-1}}{\Delta t_k},
+\qquad
+j_k=\frac{a_k-a_{k-1}}{\Delta t_k}.
+\]
+
+The minimum time resolution is explicit. Simultaneous events therefore do not cause division by zero, and the chosen resolution remains part of the configuration hash.
+
+## Independent continuity prediction
+
+The current observation is never used to manufacture its own prediction. Hyperion uses prior committed state:
+
+\[
+\widehat\mu_{k|k-1}
+=
+\mu_{k-1}+v_{k-1}\Delta t_k+\tfrac12a_{k-1}\Delta t_k^2.
+\]
+
+The residual is:
+
+\[
+R_k=\mu_k-\widehat\mu_{k|k-1}.
+\]
+
+The scale-aware tolerance is:
+
+\[
+\tau_k=\tau_{\mathrm{abs}}+\tau_{\mathrm{rel}}
+\max(|\widehat\mu_{k|k-1}|,|\mu_{k-1}|).
+\]
+
+The continuity flag activates when `|R_k| / tau_k > 1`.
+
+## Robust filters
+
+All filters produce both a boolean flag and a continuous severity in `[0, 1]`.
+
+### Acceleration spike
+
+The engine uses a causal window and median absolute deviation:
+
+\[
+z_k^{\mathrm{robust}}
+=
+\frac{0.67448975(a_k-\operatorname{median}(a))}
+{\operatorname{MAD}(a)+\epsilon}.
+\]
+
+The test is two-sided.
+
+### Precision strike
+
+Given lower balance bound `L`:
+
+\[
+B_k^{\mathrm{projected}}=B_{k-1}+\Delta\mu_k,
+\qquad
+\operatorname{buffer}_k=B_k^{\mathrm{projected}}-L.
+\]
+
+A candidate requires a negative delta, debit magnitude above the configured historical quantile, and a non-negative buffer inside the limit-proximity band.
+
+### Ghost entity
+
+An event must have no non-empty label and exhibit a robust magnitude anomaly. Missing descriptive metadata alone is never treated as proof of wrongdoing.
+
+### Bytecode divergence
+
+CSV and CPU values are compared only inside the same aligned event. The test uses absolute plus relative tolerance:
+
+\[
+|x_{csv,k}-x_{cpu,k}|
+>
+\tau_{abs}+\tau_{rel}|x_{csv,k}|.
+\]
+
+A divergence proves disagreement between committed observations. It does not by itself identify the cause.
+
+## Composite anomaly score
+
+Hyperion uses a bounded logistic model:
+
+\[
+\operatorname{CAS}_k
+=
+\sigma\!\left(b+\sum_iw_i s_{i,k}\right),
+\qquad
+s_{i,k}\in[0,1].
+\]
+
+The score is always in `[0, 1]`. Model parameters are non-negative, bounded, versioned and hashed.
+
+Supervised fitting requires `TrainingExample` labels. Hyperion does not derive precision from unlabelled data and does not silently reinterpret reconstruction loss as classification precision.
+
+## Geometric health score
+
+Critical exposure ratio:
+
+\[
+A=
+\frac{\sum_k|\mu_k|\mathbf 1[CAS_k\ge\tau_c]}
+{\sum_k|\mu_k|+\epsilon}.
+\]
+
+Critical event-frequency ratio:
+
+\[
+F=\frac{N_{critical}}{N_{events}}.
+\]
+
+The bounded score is:
+
+\[
+GHS=100\operatorname{clip}(1-\lambda_AA-\lambda_FF,0,1).
+\]
+
+## Tamper-evident report
+
+Hyperion builds separate Merkle roots for:
+
+- canonical input observations;
+- arithmetic witnesses;
+- output audit points.
+
+The final report digest commits to:
+
+```text
+model hash
+configuration hash
+input Merkle root
+witness Merkle root
+output Merkle root
+GHS
+```
+
+This is deterministic computation attestation, not a zero-knowledge proof by itself. A proving backend can consume `ArithmeticWitness.circuit_inputs()` and prove the same fixed-point relation without disclosing private source values.
+
+## Reproducibility boundary
+
+A defensible audit must retain:
+
+- raw evidence commitments;
+- source acquisition and clock metadata;
+- correlation identifiers;
+- Hyperion configuration hash;
+- score-model hash and version;
+- source code or release hash;
+- report digest;
+- reviewer labels used for any supervised update.
+
+Adaptive fitting should occur on a training partition. The evidentiary audit partition should use a frozen model.
+
+## Example
+
+```python
+from jarvisx.hyperion import HyperionEngine, Observation
+
+observations = [
+    Observation("csv", 1_000, 149_000.00, "amount", "ZAR", "tx-1"),
+    Observation("audio", 1_003, 149_000.00, "amount", "ZAR", "tx-1", 0.92),
+    Observation("cpu", 1_001, 149_000.00, "amount", "ZAR", "tx-1"),
+]
+
+report = HyperionEngine().audit(observations)
+assert report.verify()
+print(report.report_digest)
+```
+
+## Benchmark policy
+
+The repository includes `scripts/benchmark_hyperion.py` for deterministic synthetic evaluation. Throughput and anomaly-quality numbers must be reported with hardware, Python version, workload size, seed, configuration hash and model hash. No state-of-the-art claim should be made without comparison against named baselines on public or independently reviewable data.

--- a/docs/HYPERION_OPERATIONS.md
+++ b/docs/HYPERION_OPERATIONS.md
@@ -1,0 +1,275 @@
+# Hyperion Operational Service
+
+## Status
+
+Hyperion is operationalised as a deterministic audit service and command-line tool. The runtime accepts already-extracted observations, executes the frozen Hyperion arithmetic, persists a replayable evidence bundle, and verifies stored results by deterministic re-execution.
+
+It does **not** acquire microphone, camera, database, or eBPF evidence inside the service process. Acquisition remains a separate, source-specific boundary with its own authorization, privacy, clock provenance, and chain-of-custody controls.
+
+## Runtime architecture
+
+```text
+signed/source-controlled extractors
+             |
+             v
+     bounded JSON observations
+             |
+             v
+  Hyperion service (frozen config + model)
+             |
+     deterministic audit kernel
+             |
+             v
+ atomic replay bundle on protected volume
+             |
+      +------+------+
+      |             |
+      v             v
+ REST retrieval   deterministic replay verification
+```
+
+One process owns one immutable `HyperionConfig` and one immutable `ScoreModel`. Their hashes are returned in every response and committed into every report.
+
+## Installation
+
+```bash
+python -m pip install -e ".[dev]"
+```
+
+The package exposes:
+
+```text
+jarvisx-hyperion audit
+jarvisx-hyperion verify
+jarvisx-hyperion serve
+```
+
+## CLI audit
+
+Input may be a JSON array or an object containing `observations`:
+
+```json
+{
+  "observations": [
+    {
+      "source": "csv",
+      "timestamp_ms": 1700000000000,
+      "value": 149000.0,
+      "quantity": "amount",
+      "unit": "ZAR",
+      "correlation_id": "transaction-42",
+      "confidence": 1.0,
+      "label": "verified beneficiary"
+    }
+  ]
+}
+```
+
+Create a replay bundle:
+
+```bash
+jarvisx-hyperion audit observations.json \
+  --config configs/hyperion.production.json \
+  --model configs/hyperion.model.v1.json \
+  --output evidence/report.json
+```
+
+Replay and verify it:
+
+```bash
+jarvisx-hyperion verify evidence/report.json \
+  --config configs/hyperion.production.json \
+  --model configs/hyperion.model.v1.json
+```
+
+Verification fails when the bundle, observations, report, model, or configuration differs from the committed values.
+
+## Service startup
+
+Local development:
+
+```bash
+jarvisx-hyperion serve \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --data-dir state/hyperion
+```
+
+Authenticated operation:
+
+```bash
+jarvisx-hyperion serve \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --data-dir /var/lib/hyperion \
+  --config configs/hyperion.production.json \
+  --model configs/hyperion.model.v1.json \
+  --require-api-key \
+  --api-key "$HYPERION_API_KEY"
+```
+
+The ASGI factory can also be run directly:
+
+```bash
+uvicorn jarvisx.hyperion_service:app_factory \
+  --factory \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --workers 1
+```
+
+Configuration through environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `HYPERION_DATA_DIR` | Durable evidence directory |
+| `HYPERION_MAX_OBSERVATIONS` | Maximum observations in one request |
+| `HYPERION_CONFIG_FILE` | Frozen `HyperionConfig` JSON |
+| `HYPERION_MODEL_FILE` | Frozen `ScoreModel` JSON |
+| `HYPERION_REQUIRE_API_KEY` | Require `X-Hyperion-Key` when true |
+| `HYPERION_API_KEY` | Shared API key; inject from a secret manager |
+
+Do not commit real API keys to the repository.
+
+## HTTP contract
+
+Unauthenticated liveness and readiness endpoints:
+
+```text
+GET /healthz
+GET /readyz
+```
+
+Operational endpoints:
+
+```text
+GET  /v1/hyperion/manifest
+POST /v1/hyperion/audits
+GET  /v1/hyperion/audits/{report_digest}
+POST /v1/hyperion/audits/{report_digest}/verify
+GET  /metrics
+```
+
+When authentication is enabled, supply:
+
+```text
+X-Hyperion-Key: <secret>
+```
+
+Create an audit:
+
+```bash
+curl -sS \
+  -H "Content-Type: application/json" \
+  -H "X-Hyperion-Key: $HYPERION_API_KEY" \
+  --data @observations.json \
+  http://127.0.0.1:8080/v1/hyperion/audits
+```
+
+The response contains the report and bundle digests, GHS, event count, critical count, model hash, and configuration hash.
+
+## Persistence semantics
+
+Evidence is written as canonical JSON under:
+
+```text
+<DATA_DIR>/<report_digest>.json
+```
+
+The write protocol is:
+
+```text
+serialize canonically
+→ write temporary file
+→ flush
+→ fsync
+→ atomic replace
+```
+
+A report digest is immutable. Repeating an identical audit is idempotent. Different bytes for an existing report digest fail closed as a collision.
+
+The stored bundle contains the original normalized observations because deterministic replay requires them. The evidence directory therefore contains potentially sensitive information and must use encrypted storage, restricted permissions, retention policy, backup policy, and access logging appropriate to the deployment.
+
+## Authentication and network boundary
+
+The built-in API key is a minimal service boundary, not a full identity platform. Production deployments should additionally use:
+
+- TLS termination;
+- workload or service identity;
+- network policy or private ingress;
+- request-size limits at the proxy;
+- rate limiting;
+- secret-manager injection;
+- audit logging without raw sensitive values;
+- encrypted durable storage.
+
+The service intentionally runs with one Uvicorn worker. Local file locks and in-process metrics do not provide distributed coordination. Horizontal scaling requires an external immutable object store, distributed idempotency control, and centralized metrics.
+
+## Container operation
+
+Build:
+
+```bash
+docker build -f deploy/hyperion.Dockerfile -t jarvisx-hyperion:local .
+```
+
+Run:
+
+```bash
+docker run --rm \
+  -p 8080:8080 \
+  -e HYPERION_API_KEY="$HYPERION_API_KEY" \
+  -v hyperion-data:/var/lib/hyperion \
+  jarvisx-hyperion:local
+```
+
+Or use:
+
+```bash
+HYPERION_API_KEY="$HYPERION_API_KEY" \
+  docker compose -f deploy/hyperion-compose.yml up --build
+```
+
+## Monitoring
+
+`/metrics` exposes Prometheus text metrics:
+
+```text
+hyperion_audits_total
+hyperion_failures_total
+hyperion_observations_total
+hyperion_critical_events_total
+hyperion_reports_stored
+hyperion_last_success_unixtime_seconds
+```
+
+Recommended alerts:
+
+- readiness failure;
+- any persistence failure;
+- sustained audit failure rate;
+- no successful audit within the expected ingestion interval;
+- unexpected increase in critical-event rate;
+- evidence volume approaching capacity.
+
+## Operational invariants
+
+1. A service process never mutates its model or audit configuration.
+2. Requests above the configured observation limit fail before arithmetic execution.
+3. Every successful response corresponds to a report that passed `AuditReport.verify()`.
+4. Stored evidence is immutable by report digest.
+5. Replay uses the exact committed observations, model hash, and configuration hash.
+6. A different model or configuration cannot verify an old bundle silently.
+7. The service proves deterministic computation over supplied evidence, not source truth.
+
+## Deployment gate
+
+Repository compatibility is tested by:
+
+- focused core and operational tests;
+- CLI audit/verify round trip;
+- authenticated network smoke test against Uvicorn;
+- container image build;
+- the existing Jarvis-X quality, type, package, dependency, empirical, and CodeQL gates.
+
+A live release still requires a chosen infrastructure target, secrets, TLS, protected persistent storage, retention policy, and source-acquisition integrations.

--- a/examples/hyperion_demo.py
+++ b/examples/hyperion_demo.py
@@ -1,0 +1,45 @@
+"""Minimal deterministic Hyperion audit demonstration."""
+
+from jarvisx.hyperion import HyperionConfig, HyperionEngine, Observation
+
+
+def observation(
+    source: str,
+    timestamp_ms: int,
+    value: float,
+    event_id: str,
+) -> Observation:
+    return Observation(
+        source=source,
+        timestamp_ms=timestamp_ms,
+        value=value,
+        quantity="amount",
+        unit="ZAR",
+        correlation_id=event_id,
+        confidence=1.0,
+        label="verified beneficiary",
+    )
+
+
+observations = []
+for index, balance in enumerate((0.0, -5_000.0, -10_000.0, -15_000.0, -99_500.0)):
+    event_id = f"tx-{index}"
+    timestamp = index * 1_000
+    observations.extend(
+        [
+            observation("csv", timestamp, balance, event_id),
+            observation("cpu", timestamp + 1, balance, event_id),
+        ]
+    )
+
+engine = HyperionEngine(HyperionConfig(lower_bound=-100_000.0))
+report = engine.audit(observations)
+
+print(f"events={len(report.points)}")
+print(f"ghs={report.geometric_health_score:.3f}")
+print(f"verified={report.verify()}")
+print(f"model={report.model_hash}")
+print(f"report={report.report_digest}")
+for point in report.points:
+    if any(point.flags.values()):
+        print(point.event_id, point.cas, dict(point.flags))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ Changelog = "https://github.com/Lord-Xido/Jarvis-X/blob/main/CHANGELOG.md"
 
 [project.scripts]
 jarvisx = "jarvisx.cli:main"
+jarvisx-hyperion = "jarvisx.hyperion_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/scripts/benchmark_hyperion.py
+++ b/scripts/benchmark_hyperion.py
@@ -1,0 +1,124 @@
+"""Deterministic synthetic benchmark for the Hyperion audit kernel.
+
+Usage:
+    PYTHONPATH=src python scripts/benchmark_hyperion.py --events 10000 --seed 7
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import time
+
+from jarvisx.hyperion import HyperionEngine, Observation
+
+
+def build_fixture(events: int, seed: int) -> tuple[list[Observation], set[str]]:
+    randomizer = random.Random(seed)
+    observations: list[Observation] = []
+    anomalies: set[str] = set()
+    value = 10_000.0
+    for index in range(events):
+        event_id = f"event-{index}"
+        timestamp = index * 10
+        value += randomizer.uniform(-2.0, 2.0)
+        csv_value = value
+        cpu_value = value
+        label = "entity"
+        if index > 30 and index % 257 == 0:
+            csv_value += 500.0
+            anomalies.add(event_id)
+        if index > 30 and index % 389 == 0:
+            cpu_value -= 700.0
+            anomalies.add(event_id)
+        if index > 30 and index % 521 == 0:
+            label = None
+            csv_value *= 1.4
+            anomalies.add(event_id)
+        observations.extend(
+            [
+                Observation(
+                    "csv",
+                    timestamp,
+                    csv_value,
+                    "amount",
+                    "ZAR",
+                    event_id,
+                    1.0,
+                    True,
+                    label,
+                ),
+                Observation(
+                    "cpu",
+                    timestamp + 1,
+                    cpu_value,
+                    "amount",
+                    "ZAR",
+                    event_id,
+                    1.0,
+                    True,
+                    label,
+                ),
+            ]
+        )
+    return observations, anomalies
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--events", type=int, default=10_000)
+    parser.add_argument("--seed", type=int, default=7)
+    arguments = parser.parse_args()
+    if arguments.events < 1:
+        raise SystemExit("--events must be positive")
+
+    observations, known_anomalies = build_fixture(arguments.events, arguments.seed)
+    engine = HyperionEngine()
+    start = time.perf_counter()
+    report = engine.audit(observations)
+    elapsed = time.perf_counter() - start
+
+    detected = {point.event_id for point in report.points if point.critical}
+    true_positive = len(detected & known_anomalies)
+    false_positive = len(detected - known_anomalies)
+    false_negative = len(known_anomalies - detected)
+    precision = true_positive / (true_positive + false_positive) if detected else 0.0
+    recall = (
+        true_positive / (true_positive + false_negative)
+        if known_anomalies
+        else 0.0
+    )
+    f1 = (
+        2.0 * precision * recall / (precision + recall)
+        if precision + recall
+        else 0.0
+    )
+
+    print(
+        json.dumps(
+            {
+                "events": arguments.events,
+                "observations": len(observations),
+                "seed": arguments.seed,
+                "elapsed_seconds": elapsed,
+                "events_per_second": arguments.events / elapsed,
+                "precision": precision,
+                "recall": recall,
+                "f1": f1,
+                "critical_events": len(detected),
+                "known_anomalies": len(known_anomalies),
+                "ghs": report.geometric_health_score,
+                "verified": report.verify(),
+                "model_hash": report.model_hash,
+                "configuration_hash": report.configuration_hash,
+                "report_digest": report.report_digest,
+            },
+            sort_keys=True,
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_hyperion_service.py
+++ b/scripts/smoke_hyperion_service.py
@@ -1,0 +1,70 @@
+"""Network smoke test for a running Hyperion service."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+BASE_URL = os.getenv("HYPERION_SMOKE_URL", "http://127.0.0.1:8080")
+API_KEY = os.getenv("HYPERION_API_KEY", "ci-secret")
+
+
+def request(path: str, *, method: str = "GET", payload: object | None = None) -> object:
+    data = None
+    headers = {"X-Hyperion-Key": API_KEY}
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    message = urllib.request.Request(
+        BASE_URL + path,
+        data=data,
+        method=method,
+        headers=headers,
+    )
+    with urllib.request.urlopen(message, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+health = request("/healthz")
+if not isinstance(health, dict) or health.get("status") != "ok":
+    raise SystemExit("health check failed")
+
+created = request(
+    "/v1/hyperion/audits",
+    method="POST",
+    payload={
+        "request_id": "ci-smoke",
+        "observations": [
+            {
+                "source": "csv",
+                "timestamp_ms": 0,
+                "value": 100.0,
+                "quantity": "amount",
+                "unit": "ZAR",
+                "correlation_id": "ci-0",
+                "label": "known",
+            },
+            {
+                "source": "cpu",
+                "timestamp_ms": 1,
+                "value": 100.0,
+                "quantity": "amount",
+                "unit": "ZAR",
+                "correlation_id": "ci-0",
+                "label": "known",
+            },
+        ],
+    },
+)
+if not isinstance(created, dict) or not created.get("verified"):
+    raise SystemExit("audit creation failed")
+report_digest = created.get("report_digest")
+if not isinstance(report_digest, str):
+    raise SystemExit("report digest missing")
+
+verified = request(f"/v1/hyperion/audits/{report_digest}/verify", method="POST")
+if not isinstance(verified, dict) or not verified.get("verified"):
+    raise SystemExit("report replay failed")
+
+print(json.dumps({"health": True, "report_digest": report_digest, "verified": True}))

--- a/src/jarvisx/hyperion.py
+++ b/src/jarvisx/hyperion.py
@@ -1,0 +1,951 @@
+"""Deterministic, proof-ready multi-stream forensic arithmetic for Jarvis-X.
+
+Hyperion aligns semantically compatible event observations, fuses them with
+confidence-aware fixed-point arithmetic, computes time-correct derivatives,
+applies robust anomaly filters, and emits tamper-evident commitments.
+
+A commitment proves deterministic computation over committed inputs; it does
+not prove that a sensor or source system reported reality truthfully. External
+attestation and chain-of-custody controls remain necessary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import statistics
+from dataclasses import asdict, dataclass, field
+from typing import Iterable, Mapping, Sequence
+
+FILTER_NAMES = (
+    "continuity",
+    "acceleration_spike",
+    "precision_strike",
+    "ghost_entity",
+    "bytecode_divergence",
+)
+
+
+def _canonical_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(value: object) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _sigmoid(value: float) -> float:
+    if value >= 0.0:
+        z = math.exp(-value)
+        return 1.0 / (1.0 + z)
+    z = math.exp(value)
+    return z / (1.0 + z)
+
+
+def _robust_z(value: float, history: Sequence[float], epsilon: float) -> float:
+    if len(history) < 5:
+        return 0.0
+    center = statistics.median(history)
+    mad = statistics.median(abs(item - center) for item in history)
+    if mad <= epsilon:
+        if abs(value - center) <= epsilon:
+            return 0.0
+        return math.copysign(math.inf, value - center)
+    return 0.6744897501960817 * (value - center) / mad
+
+
+def _quantile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * probability
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return float(ordered[lower])
+    fraction = position - lower
+    return float(ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction)
+
+
+def _round_div_nearest(numerator: int, denominator: int) -> int:
+    if denominator <= 0:
+        raise ValueError("denominator must be positive")
+    sign = -1 if numerator < 0 else 1
+    quotient, remainder = divmod(abs(numerator), denominator)
+    if remainder * 2 >= denominator:
+        quotient += 1
+    return sign * quotient
+
+
+def merkle_root(leaves: Sequence[str]) -> str:
+    """Return a deterministic SHA-256 Merkle root for hexadecimal leaves."""
+
+    if not leaves:
+        return hashlib.sha256(b"").hexdigest()
+    level = [bytes.fromhex(leaf) for leaf in leaves]
+    while len(level) > 1:
+        if len(level) % 2:
+            level.append(level[-1])
+        level = [
+            hashlib.sha256(level[index] + level[index + 1]).digest()
+            for index in range(0, len(level), 2)
+        ]
+    return level[0].hex()
+
+
+@dataclass(frozen=True, slots=True)
+class Observation:
+    """One source observation with an explicit semantic dimension."""
+
+    source: str
+    timestamp_ms: int
+    value: float
+    quantity: str
+    unit: str
+    correlation_id: str | None = None
+    confidence: float = 1.0
+    available: bool = True
+    label: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.source:
+            raise ValueError("source must be non-empty")
+        if self.timestamp_ms < 0:
+            raise ValueError("timestamp_ms must be non-negative")
+        if not math.isfinite(self.value):
+            raise ValueError("observation value must be finite")
+        if not self.quantity or not self.unit:
+            raise ValueError("quantity and unit must be non-empty")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be in [0, 1]")
+
+
+@dataclass(frozen=True, slots=True)
+class FusionTerm:
+    source: str
+    value_int: int
+    effective_weight_int: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArithmeticWitness:
+    """Fixed-point weighted-average witness for a proof backend."""
+
+    event_id: str
+    timestamp_ms: int
+    quantity: str
+    unit: str
+    value_scale: int
+    weight_scale: int
+    terms: tuple[FusionTerm, ...]
+    numerator: int
+    denominator: int
+    fused_int: int
+    remainder: int
+    commitment: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        event_id: str,
+        timestamp_ms: int,
+        quantity: str,
+        unit: str,
+        observations: Sequence[Observation],
+        source_weights: Mapping[str, float],
+        value_scale: int,
+        weight_scale: int,
+    ) -> "ArithmeticWitness":
+        terms: list[FusionTerm] = []
+        for observation in sorted(
+            observations,
+            key=lambda item: (item.source, item.timestamp_ms, item.value),
+        ):
+            if not observation.available or observation.confidence <= 0.0:
+                continue
+            source_weight = float(source_weights.get(observation.source, 0.0))
+            if not math.isfinite(source_weight) or source_weight < 0.0:
+                raise ValueError(f"invalid source weight for {observation.source!r}")
+            effective_weight_int = round(
+                source_weight * observation.confidence * weight_scale
+            )
+            if effective_weight_int <= 0:
+                continue
+            terms.append(
+                FusionTerm(
+                    source=observation.source,
+                    value_int=round(observation.value * value_scale),
+                    effective_weight_int=effective_weight_int,
+                )
+            )
+        if not terms:
+            raise ValueError("event has no positive-weight compatible observations")
+
+        numerator = sum(term.value_int * term.effective_weight_int for term in terms)
+        denominator = sum(term.effective_weight_int for term in terms)
+        fused_int = _round_div_nearest(numerator, denominator)
+        remainder = numerator - denominator * fused_int
+        payload = {
+            "event_id": event_id,
+            "timestamp_ms": timestamp_ms,
+            "quantity": quantity,
+            "unit": unit,
+            "value_scale": value_scale,
+            "weight_scale": weight_scale,
+            "terms": [asdict(term) for term in terms],
+            "numerator": numerator,
+            "denominator": denominator,
+            "fused_int": fused_int,
+            "remainder": remainder,
+        }
+        return cls(
+            event_id=event_id,
+            timestamp_ms=timestamp_ms,
+            quantity=quantity,
+            unit=unit,
+            value_scale=value_scale,
+            weight_scale=weight_scale,
+            terms=tuple(terms),
+            numerator=numerator,
+            denominator=denominator,
+            fused_int=fused_int,
+            remainder=remainder,
+            commitment=sha256_hex(payload),
+        )
+
+    @property
+    def fused_value(self) -> float:
+        return self.fused_int / self.value_scale
+
+    def circuit_inputs(self) -> dict[str, object]:
+        """Export the integer relation consumed by a SNARK/STARK circuit."""
+
+        return {
+            "event_id": self.event_id,
+            "timestamp_ms": self.timestamp_ms,
+            "value_scale": self.value_scale,
+            "weight_scale": self.weight_scale,
+            "value_ints": [term.value_int for term in self.terms],
+            "weight_ints": [term.effective_weight_int for term in self.terms],
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "fused_int": self.fused_int,
+            "remainder": self.remainder,
+        }
+
+    def verify(self) -> bool:
+        if self.denominator <= 0 or not self.terms:
+            return False
+        if sum(term.effective_weight_int for term in self.terms) != self.denominator:
+            return False
+        if (
+            sum(term.value_int * term.effective_weight_int for term in self.terms)
+            != self.numerator
+        ):
+            return False
+        if self.numerator != self.denominator * self.fused_int + self.remainder:
+            return False
+        if 2 * abs(self.remainder) > self.denominator:
+            return False
+        payload = {
+            "event_id": self.event_id,
+            "timestamp_ms": self.timestamp_ms,
+            "quantity": self.quantity,
+            "unit": self.unit,
+            "value_scale": self.value_scale,
+            "weight_scale": self.weight_scale,
+            "terms": [asdict(term) for term in self.terms],
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "fused_int": self.fused_int,
+            "remainder": self.remainder,
+        }
+        return self.commitment == sha256_hex(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class TrainingExample:
+    severities: Mapping[str, float]
+    label: int
+
+    def __post_init__(self) -> None:
+        if self.label not in (0, 1):
+            raise ValueError("label must be 0 or 1")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreModel:
+    """Versioned, bounded logistic anomaly aggregator."""
+
+    bias: float = -3.0
+    weights: tuple[float, ...] = (1.35, 1.25, 1.30, 1.10, 1.50)
+    version: int = 1
+    training_digest: str | None = None
+
+    def __post_init__(self) -> None:
+        if len(self.weights) != len(FILTER_NAMES):
+            raise ValueError("one model weight is required per filter")
+        if not math.isfinite(self.bias):
+            raise ValueError("bias must be finite")
+        if any(not math.isfinite(weight) or weight < 0.0 for weight in self.weights):
+            raise ValueError("weights must be finite and non-negative")
+        if self.version < 1:
+            raise ValueError("version must be positive")
+
+    @property
+    def model_hash(self) -> str:
+        return sha256_hex(
+            {
+                "bias": self.bias,
+                "weights": self.weights,
+                "version": self.version,
+                "training_digest": self.training_digest,
+                "features": FILTER_NAMES,
+            }
+        )
+
+    def score(self, severities: Mapping[str, float]) -> float:
+        logit = self.bias + sum(
+            weight * _clamp(float(severities.get(name, 0.0)), 0.0, 1.0)
+            for name, weight in zip(FILTER_NAMES, self.weights)
+        )
+        return _sigmoid(logit)
+
+    def fit_supervised(
+        self,
+        examples: Sequence[TrainingExample],
+        *,
+        learning_rate: float = 0.08,
+        l2: float = 1.0e-3,
+        max_iterations: int = 2_000,
+        convergence_delta: float = 1.0e-3,
+        convergence_patience: int = 10,
+    ) -> "ScoreModel":
+        """Fit only on explicit labels using projected gradient descent."""
+
+        if not examples:
+            raise ValueError("supervised fitting requires labelled examples")
+        if learning_rate <= 0.0 or max_iterations < 1:
+            raise ValueError("invalid training controls")
+
+        weights = list(self.weights)
+        bias = self.bias
+        stable_iterations = 0
+        for _ in range(max_iterations):
+            gradient_weights = [0.0] * len(weights)
+            gradient_bias = 0.0
+            for example in examples:
+                features = [
+                    _clamp(float(example.severities.get(name, 0.0)), 0.0, 1.0)
+                    for name in FILTER_NAMES
+                ]
+                probability = _sigmoid(
+                    bias
+                    + sum(
+                        weight * feature
+                        for weight, feature in zip(weights, features)
+                    )
+                )
+                error = probability - example.label
+                gradient_bias += error
+                for index, feature in enumerate(features):
+                    gradient_weights[index] += error * feature
+            count = len(examples)
+            new_bias = _clamp(
+                bias - learning_rate * gradient_bias / count,
+                -12.0,
+                12.0,
+            )
+            new_weights = [
+                _clamp(
+                    weight
+                    - learning_rate * (gradient / count + l2 * weight),
+                    0.0,
+                    12.0,
+                )
+                for weight, gradient in zip(weights, gradient_weights)
+            ]
+            change = max(
+                [abs(new_bias - bias)]
+                + [abs(new - old) for new, old in zip(new_weights, weights)]
+            )
+            bias, weights = new_bias, new_weights
+            if change < convergence_delta:
+                stable_iterations += 1
+                if stable_iterations >= convergence_patience:
+                    break
+            else:
+                stable_iterations = 0
+
+        digest = sha256_hex(
+            [
+                {
+                    "severities": {
+                        name: float(example.severities.get(name, 0.0))
+                        for name in FILTER_NAMES
+                    },
+                    "label": example.label,
+                }
+                for example in examples
+            ]
+        )
+        return ScoreModel(
+            bias=bias,
+            weights=tuple(weights),
+            version=self.version + 1,
+            training_digest=digest,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HyperionConfig:
+    target_quantity: str = "amount"
+    target_unit: str = "ZAR"
+    source_weights: Mapping[str, float] = field(
+        default_factory=lambda: {"csv": 1.0, "audio": 1.0, "cpu": 1.0}
+    )
+    event_tolerance_ms: int = 25
+    minimum_dt_ms: int = 1
+    allow_unconfigured_sources: bool = False
+    value_scale: int = 100
+    weight_scale: int = 1_000_000
+    robust_window: int = 30
+    continuity_absolute_tolerance: float = 0.01
+    continuity_relative_tolerance: float = 0.01
+    robust_z_threshold: float = 3.5
+    bytecode_absolute_tolerance: float = 0.01
+    bytecode_relative_tolerance: float = 0.01
+    precision_quantile: float = 0.80
+    precision_limit_fraction: float = 0.02
+    lower_bound: float | None = None
+    critical_threshold: float = 0.75
+    ghs_exposure_weight: float = 0.70
+    ghs_frequency_weight: float = 0.30
+    epsilon: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        if not self.target_quantity or not self.target_unit:
+            raise ValueError("target quantity and unit are required")
+        if self.event_tolerance_ms < 1:
+            raise ValueError("event_tolerance_ms must be positive")
+        if self.minimum_dt_ms < 1:
+            raise ValueError("minimum_dt_ms must be positive")
+        if self.value_scale < 1 or self.weight_scale < 1:
+            raise ValueError("fixed-point scales must be positive")
+        if self.robust_window < 5:
+            raise ValueError("robust_window must be at least 5")
+        if not 0.0 < self.precision_quantile < 1.0:
+            raise ValueError("precision_quantile must be in (0, 1)")
+        if not 0.0 < self.critical_threshold < 1.0:
+            raise ValueError("critical_threshold must be in (0, 1)")
+        if not math.isclose(
+            self.ghs_exposure_weight + self.ghs_frequency_weight,
+            1.0,
+            rel_tol=0.0,
+            abs_tol=1.0e-12,
+        ):
+            raise ValueError("GHS weights must sum to 1")
+
+
+@dataclass(frozen=True, slots=True)
+class AuditPoint:
+    event_id: str
+    timestamp_ms: int
+    fused_value: float
+    fusion_confidence: float
+    delta_value: float
+    velocity: float
+    acceleration: float
+    jerk: float
+    predicted_value: float
+    continuity_residual: float
+    severities: Mapping[str, float]
+    flags: Mapping[str, bool]
+    cas: float
+    critical: bool
+    label_present: bool
+    witness_commitment: str
+
+    @property
+    def digest(self) -> str:
+        return sha256_hex(
+            {
+                "event_id": self.event_id,
+                "timestamp_ms": self.timestamp_ms,
+                "fused_value": self.fused_value,
+                "fusion_confidence": self.fusion_confidence,
+                "delta_value": self.delta_value,
+                "velocity": self.velocity,
+                "acceleration": self.acceleration,
+                "jerk": self.jerk,
+                "predicted_value": self.predicted_value,
+                "continuity_residual": self.continuity_residual,
+                "severities": dict(self.severities),
+                "flags": dict(self.flags),
+                "cas": self.cas,
+                "critical": self.critical,
+                "label_present": self.label_present,
+                "witness_commitment": self.witness_commitment,
+            }
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AuditReport:
+    points: tuple[AuditPoint, ...]
+    witnesses: tuple[ArithmeticWitness, ...]
+    geometric_health_score: float
+    model_hash: str
+    configuration_hash: str
+    input_root: str
+    output_root: str
+    witness_root: str
+    report_digest: str
+
+    def verify(self) -> bool:
+        if len(self.points) != len(self.witnesses):
+            return False
+        if any(not witness.verify() for witness in self.witnesses):
+            return False
+        if any(
+            point.witness_commitment != witness.commitment
+            for point, witness in zip(self.points, self.witnesses)
+        ):
+            return False
+        if self.output_root != merkle_root([point.digest for point in self.points]):
+            return False
+        if self.witness_root != merkle_root(
+            [witness.commitment for witness in self.witnesses]
+        ):
+            return False
+        expected = sha256_hex(
+            {
+                "ghs": self.geometric_health_score,
+                "model_hash": self.model_hash,
+                "configuration_hash": self.configuration_hash,
+                "input_root": self.input_root,
+                "output_root": self.output_root,
+                "witness_root": self.witness_root,
+            }
+        )
+        return expected == self.report_digest
+
+
+@dataclass(slots=True)
+class _Event:
+    event_id: str
+    timestamp_ms: int
+    observations: list[Observation]
+
+
+class HyperionEngine:
+    """Deterministic event-time forensic arithmetic engine."""
+
+    def __init__(
+        self,
+        config: HyperionConfig | None = None,
+        model: ScoreModel | None = None,
+    ) -> None:
+        self.config = config or HyperionConfig()
+        self.model = model or ScoreModel()
+
+    @property
+    def configuration_hash(self) -> str:
+        return sha256_hex(
+            {
+                **asdict(self.config),
+                "source_weights": dict(sorted(self.config.source_weights.items())),
+            }
+        )
+
+    def _event_key(self, observation: Observation) -> str:
+        if observation.correlation_id:
+            return f"id:{observation.correlation_id}"
+        bucket = observation.timestamp_ms // self.config.event_tolerance_ms
+        return f"time:{bucket}"
+
+    def align(self, observations: Iterable[Observation]) -> tuple[_Event, ...]:
+        groups: dict[str, list[Observation]] = {}
+        for observation in observations:
+            groups.setdefault(self._event_key(observation), []).append(observation)
+
+        events: list[_Event] = []
+        for key, grouped in groups.items():
+            compatible = [
+                observation
+                for observation in grouped
+                if observation.quantity == self.config.target_quantity
+                and observation.unit == self.config.target_unit
+                and observation.available
+            ]
+            if not compatible:
+                continue
+            timestamp_ms = round(
+                statistics.median(item.timestamp_ms for item in compatible)
+            )
+            event_id = key.removeprefix("id:")
+            events.append(
+                _Event(
+                    event_id=event_id,
+                    timestamp_ms=timestamp_ms,
+                    observations=sorted(
+                        grouped,
+                        key=lambda item: (item.source, item.timestamp_ms, item.value),
+                    ),
+                )
+            )
+        events.sort(key=lambda event: (event.timestamp_ms, event.event_id))
+        return tuple(events)
+
+    def _compatible(self, event: _Event) -> list[Observation]:
+        candidates = [
+            observation
+            for observation in event.observations
+            if observation.available
+            and observation.quantity == self.config.target_quantity
+            and observation.unit == self.config.target_unit
+            and (
+                self.config.allow_unconfigured_sources
+                or observation.source in self.config.source_weights
+            )
+        ]
+        selected: dict[str, Observation] = {}
+        for observation in candidates:
+            current = selected.get(observation.source)
+            if current is None or (
+                observation.confidence,
+                -abs(observation.timestamp_ms - event.timestamp_ms),
+                observation.value,
+            ) > (
+                current.confidence,
+                -abs(current.timestamp_ms - event.timestamp_ms),
+                current.value,
+            ):
+                selected[observation.source] = observation
+        return [selected[source] for source in sorted(selected)]
+
+    @staticmethod
+    def _stream_value(
+        observations: Sequence[Observation], source: str
+    ) -> float | None:
+        candidates = [
+            observation
+            for observation in observations
+            if observation.source == source and observation.available
+        ]
+        if not candidates:
+            return None
+        best = max(
+            candidates,
+            key=lambda item: (item.confidence, -item.timestamp_ms, item.value),
+        )
+        return best.value
+
+    def audit(self, observations: Iterable[Observation]) -> AuditReport:
+        materialized = tuple(observations)
+        input_leaves = [
+            sha256_hex(
+                {
+                    "source": item.source,
+                    "timestamp_ms": item.timestamp_ms,
+                    "value": item.value,
+                    "quantity": item.quantity,
+                    "unit": item.unit,
+                    "correlation_id": item.correlation_id,
+                    "confidence": item.confidence,
+                    "available": item.available,
+                    "label": item.label,
+                    "metadata": dict(item.metadata),
+                }
+            )
+            for item in sorted(
+                materialized,
+                key=lambda item: (
+                    item.timestamp_ms,
+                    item.correlation_id or "",
+                    item.source,
+                    item.value,
+                ),
+            )
+        ]
+        input_root = merkle_root(input_leaves)
+
+        events = self.align(materialized)
+        points: list[AuditPoint] = []
+        witnesses: list[ArithmeticWitness] = []
+        fused_history: list[float] = []
+        acceleration_history: list[float] = []
+        negative_delta_history: list[float] = []
+
+        for event in events:
+            compatible = self._compatible(event)
+            witness = ArithmeticWitness.build(
+                event_id=event.event_id,
+                timestamp_ms=event.timestamp_ms,
+                quantity=self.config.target_quantity,
+                unit=self.config.target_unit,
+                observations=compatible,
+                source_weights=self.config.source_weights,
+                value_scale=self.config.value_scale,
+                weight_scale=self.config.weight_scale,
+            )
+            witnesses.append(witness)
+            fused_value = witness.fused_value
+            effective_weight_sum = sum(
+                float(self.config.source_weights.get(item.source, 1.0))
+                * item.confidence
+                for item in compatible
+            )
+            nominal_weight_sum = sum(
+                max(0.0, float(self.config.source_weights.get(item.source, 1.0)))
+                for item in compatible
+            )
+            fusion_confidence = (
+                _clamp(effective_weight_sum / nominal_weight_sum, 0.0, 1.0)
+                if nominal_weight_sum > self.config.epsilon
+                else 0.0
+            )
+
+            if not points:
+                delta_value = 0.0
+                velocity = 0.0
+                acceleration = 0.0
+                jerk = 0.0
+                predicted = fused_value
+            else:
+                previous = points[-1]
+                delta_ms = event.timestamp_ms - previous.timestamp_ms
+                if delta_ms < 0:
+                    raise ValueError("aligned event timestamps must be non-decreasing")
+                dt_seconds = max(delta_ms, self.config.minimum_dt_ms) / 1000.0
+                delta_value = fused_value - previous.fused_value
+                velocity = delta_value / dt_seconds
+                acceleration = (velocity - previous.velocity) / dt_seconds
+                jerk = (acceleration - previous.acceleration) / dt_seconds
+                predicted = (
+                    previous.fused_value
+                    + previous.velocity * dt_seconds
+                    + 0.5 * previous.acceleration * dt_seconds * dt_seconds
+                )
+
+            residual = fused_value - predicted
+            continuity_scale = (
+                self.config.continuity_absolute_tolerance
+                + self.config.continuity_relative_tolerance
+                * max(abs(predicted), abs(points[-1].fused_value) if points else 0.0)
+            )
+            continuity_ratio = abs(residual) / max(
+                continuity_scale,
+                self.config.epsilon,
+            )
+            continuity_severity = _clamp(continuity_ratio / 3.0, 0.0, 1.0)
+            continuity_flag = continuity_ratio > 1.0
+
+            acceleration_window = acceleration_history[-self.config.robust_window :]
+            acceleration_z = _robust_z(
+                acceleration,
+                acceleration_window,
+                self.config.epsilon,
+            )
+            acceleration_severity = (
+                1.0
+                if math.isinf(acceleration_z)
+                else _clamp(
+                    abs(acceleration_z) / self.config.robust_z_threshold,
+                    0.0,
+                    1.0,
+                )
+            )
+            acceleration_flag = abs(acceleration_z) > self.config.robust_z_threshold
+
+            precision_flag = False
+            precision_severity = 0.0
+            if (
+                points
+                and self.config.lower_bound is not None
+                and delta_value < 0.0
+                and negative_delta_history
+            ):
+                debit_threshold = _quantile(
+                    negative_delta_history[-self.config.robust_window :],
+                    self.config.precision_quantile,
+                )
+                projected_balance = points[-1].fused_value + delta_value
+                buffer = projected_balance - self.config.lower_bound
+                buffer_limit = self.config.precision_limit_fraction * abs(
+                    self.config.lower_bound
+                )
+                magnitude_ratio = abs(delta_value) / max(
+                    debit_threshold,
+                    self.config.epsilon,
+                )
+                proximity = (
+                    _clamp(
+                        1.0 - buffer / max(buffer_limit, self.config.epsilon),
+                        0.0,
+                        1.0,
+                    )
+                    if buffer >= 0.0
+                    else 0.0
+                )
+                precision_severity = _clamp(
+                    min(1.0, magnitude_ratio) * proximity,
+                    0.0,
+                    1.0,
+                )
+                precision_flag = (
+                    abs(delta_value) >= debit_threshold
+                    and 0.0 <= buffer < buffer_limit
+                )
+
+            label_present = any(
+                bool(observation.label and observation.label.strip())
+                for observation in event.observations
+            )
+            value_window = fused_history[-self.config.robust_window :]
+            magnitude_z = _robust_z(
+                fused_value,
+                value_window,
+                self.config.epsilon,
+            )
+            magnitude_severity = (
+                1.0
+                if math.isinf(magnitude_z)
+                else _clamp(
+                    abs(magnitude_z) / self.config.robust_z_threshold,
+                    0.0,
+                    1.0,
+                )
+            )
+            ghost_severity = magnitude_severity if not label_present else 0.0
+            ghost_flag = (
+                not label_present and abs(magnitude_z) > self.config.robust_z_threshold
+            )
+
+            csv_value = self._stream_value(compatible, "csv")
+            cpu_value = self._stream_value(compatible, "cpu")
+            bytecode_flag = False
+            bytecode_severity = 0.0
+            if csv_value is not None and cpu_value is not None:
+                divergence = abs(csv_value - cpu_value)
+                tolerance = (
+                    self.config.bytecode_absolute_tolerance
+                    + self.config.bytecode_relative_tolerance * abs(csv_value)
+                )
+                divergence_ratio = divergence / max(tolerance, self.config.epsilon)
+                bytecode_severity = _clamp(divergence_ratio / 3.0, 0.0, 1.0)
+                bytecode_flag = divergence_ratio > 1.0
+
+            severities = {
+                "continuity": continuity_severity,
+                "acceleration_spike": acceleration_severity,
+                "precision_strike": precision_severity,
+                "ghost_entity": ghost_severity,
+                "bytecode_divergence": bytecode_severity,
+            }
+            flags = {
+                "continuity": continuity_flag,
+                "acceleration_spike": acceleration_flag,
+                "precision_strike": precision_flag,
+                "ghost_entity": ghost_flag,
+                "bytecode_divergence": bytecode_flag,
+            }
+            cas = self.model.score(severities)
+            point = AuditPoint(
+                event_id=event.event_id,
+                timestamp_ms=event.timestamp_ms,
+                fused_value=fused_value,
+                fusion_confidence=fusion_confidence,
+                delta_value=delta_value,
+                velocity=velocity,
+                acceleration=acceleration,
+                jerk=jerk,
+                predicted_value=predicted,
+                continuity_residual=residual,
+                severities=severities,
+                flags=flags,
+                cas=cas,
+                critical=cas >= self.config.critical_threshold,
+                label_present=label_present,
+                witness_commitment=witness.commitment,
+            )
+            points.append(point)
+            fused_history.append(fused_value)
+            acceleration_history.append(acceleration)
+            if delta_value < 0.0:
+                negative_delta_history.append(abs(delta_value))
+
+        total_exposure = sum(abs(point.fused_value) for point in points)
+        critical_exposure = sum(
+            abs(point.fused_value) for point in points if point.critical
+        )
+        exposure_ratio = (
+            critical_exposure / total_exposure
+            if total_exposure > self.config.epsilon
+            else 0.0
+        )
+        frequency_ratio = (
+            sum(point.critical for point in points) / len(points) if points else 0.0
+        )
+        ghs = 100.0 * _clamp(
+            1.0
+            - self.config.ghs_exposure_weight * exposure_ratio
+            - self.config.ghs_frequency_weight * frequency_ratio,
+            0.0,
+            1.0,
+        )
+
+        output_root = merkle_root([point.digest for point in points])
+        witness_root = merkle_root([witness.commitment for witness in witnesses])
+        digest = sha256_hex(
+            {
+                "ghs": ghs,
+                "model_hash": self.model.model_hash,
+                "configuration_hash": self.configuration_hash,
+                "input_root": input_root,
+                "output_root": output_root,
+                "witness_root": witness_root,
+            }
+        )
+        return AuditReport(
+            points=tuple(points),
+            witnesses=tuple(witnesses),
+            geometric_health_score=ghs,
+            model_hash=self.model.model_hash,
+            configuration_hash=self.configuration_hash,
+            input_root=input_root,
+            output_root=output_root,
+            witness_root=witness_root,
+            report_digest=digest,
+        )
+
+
+def binary_cross_entropy(
+    model: ScoreModel,
+    examples: Sequence[TrainingExample],
+) -> float:
+    if not examples:
+        raise ValueError("examples are required")
+    total = 0.0
+    for example in examples:
+        probability = _clamp(
+            model.score(example.severities),
+            1.0e-12,
+            1.0 - 1.0e-12,
+        )
+        total -= example.label * math.log(probability)
+        total -= (1 - example.label) * math.log(1.0 - probability)
+    return total / len(examples)

--- a/src/jarvisx/hyperion_cli.py
+++ b/src/jarvisx/hyperion_cli.py
@@ -1,0 +1,156 @@
+"""Command-line operations for the Hyperion audit engine and service."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Sequence, cast
+
+import uvicorn
+
+from .hyperion import HyperionEngine, Observation
+from .hyperion_service import (
+    HyperionRuntimeSettings,
+    build_evidence_bundle,
+    create_hyperion_app,
+    load_hyperion_config,
+    load_score_model,
+    observation_from_dict,
+    verify_evidence_bundle,
+)
+
+
+def _read_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True, ensure_ascii=True, allow_nan=False)
+        + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def _load_observations(path: Path) -> list[Observation]:
+    value = _read_json(path)
+    if isinstance(value, dict):
+        value = value.get("observations")
+    if not isinstance(value, list) or not value:
+        raise ValueError("input must be a non-empty JSON array or an observations object")
+    observations: list[Observation] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise ValueError("every observation must be a JSON object")
+        observations.append(observation_from_dict(cast(dict[str, object], item)))
+    return observations
+
+
+def _engine(config: Path | None, model: Path | None) -> HyperionEngine:
+    return HyperionEngine(
+        config=load_hyperion_config(config),
+        model=load_score_model(model),
+    )
+
+
+def _audit(args: argparse.Namespace) -> int:
+    engine = _engine(args.config, args.model)
+    observations = _load_observations(args.input)
+    bundle = build_evidence_bundle(engine, observations)
+    _write_json(args.output, bundle)
+    report = cast(dict[str, object], bundle["report"])
+    print(
+        json.dumps(
+            {
+                "report_digest": bundle["report_digest"],
+                "bundle_digest": bundle["bundle_digest"],
+                "verified": True,
+                "geometric_health_score": report["geometric_health_score"],
+                "events": len(cast(list[object], report["points"])),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _verify(args: argparse.Namespace) -> int:
+    value = _read_json(args.bundle)
+    if not isinstance(value, dict):
+        raise ValueError("bundle must be a JSON object")
+    verified, reason = verify_evidence_bundle(value, _engine(args.config, args.model))
+    print(json.dumps({"verified": verified, "reason": reason}, sort_keys=True))
+    return 0 if verified else 1
+
+
+def _serve(args: argparse.Namespace) -> int:
+    settings = HyperionRuntimeSettings(
+        data_dir=args.data_dir,
+        max_observations=args.max_observations,
+        api_key=args.api_key,
+        require_api_key=args.require_api_key,
+    )
+    application = create_hyperion_app(
+        settings=settings,
+        engine=_engine(args.config, args.model),
+    )
+    uvicorn.run(
+        application,
+        host=args.host,
+        port=args.port,
+        workers=1,
+        proxy_headers=True,
+        log_level=args.log_level,
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hyperion", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    audit = subparsers.add_parser("audit", help="create a deterministic evidence bundle")
+    audit.add_argument("input", type=Path)
+    audit.add_argument("--output", type=Path, required=True)
+    audit.add_argument("--config", type=Path)
+    audit.add_argument("--model", type=Path)
+    audit.set_defaults(handler=_audit)
+
+    verify = subparsers.add_parser("verify", help="replay and verify an evidence bundle")
+    verify.add_argument("bundle", type=Path)
+    verify.add_argument("--config", type=Path)
+    verify.add_argument("--model", type=Path)
+    verify.set_defaults(handler=_verify)
+
+    serve = subparsers.add_parser("serve", help="run the Hyperion HTTP service")
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=8080)
+    serve.add_argument("--data-dir", type=Path, default=Path("state/hyperion"))
+    serve.add_argument("--max-observations", type=int, default=50_000)
+    serve.add_argument("--api-key")
+    serve.add_argument("--require-api-key", action="store_true")
+    serve.add_argument("--config", type=Path)
+    serve.add_argument("--model", type=Path)
+    serve.add_argument("--log-level", default="info")
+    serve.set_defaults(handler=_serve)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except (OSError, ValueError, RuntimeError, KeyError, TypeError) as error:
+        print(f"hyperion: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/hyperion_service.py
+++ b/src/jarvisx/hyperion_service.py
@@ -1,0 +1,554 @@
+"""Operational FastAPI surface and durable replay store for Hyperion.
+
+The service freezes one Hyperion configuration and score model per process,
+accepts bounded observation batches, writes deterministic evidence bundles with
+atomic replacement, and verifies stored reports by replaying the committed
+inputs. It does not acquire sensor data or attest source truth.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence, cast
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .hyperion import (
+    AuditReport,
+    HyperionConfig,
+    HyperionEngine,
+    Observation,
+    ScoreModel,
+    sha256_hex,
+)
+
+SERVICE_PROTOCOL = "jarvisx.hyperion-service.v1"
+DEFAULT_DATA_DIR = Path("state/hyperion")
+
+
+class ObservationPayload(BaseModel):
+    """Strict JSON representation of one Hyperion observation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str = Field(min_length=1, max_length=128)
+    timestamp_ms: int = Field(ge=0)
+    value: float
+    quantity: str = Field(min_length=1, max_length=128)
+    unit: str = Field(min_length=1, max_length=64)
+    correlation_id: str | None = Field(default=None, max_length=256)
+    confidence: float = Field(default=1.0, ge=0.0, le=1.0)
+    available: bool = True
+    label: str | None = Field(default=None, max_length=512)
+    metadata: dict[str, object] = Field(default_factory=dict)
+
+    def to_observation(self) -> Observation:
+        return Observation(
+            source=self.source,
+            timestamp_ms=self.timestamp_ms,
+            value=self.value,
+            quantity=self.quantity,
+            unit=self.unit,
+            correlation_id=self.correlation_id,
+            confidence=self.confidence,
+            available=self.available,
+            label=self.label,
+            metadata=self.metadata,
+        )
+
+
+class AuditRequest(BaseModel):
+    """Bounded audit request accepted by the service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    observations: list[ObservationPayload] = Field(min_length=1)
+    request_id: str | None = Field(default=None, max_length=256)
+
+
+@dataclass(frozen=True, slots=True)
+class HyperionRuntimeSettings:
+    """Operational settings that do not alter audit mathematics."""
+
+    data_dir: Path = DEFAULT_DATA_DIR
+    max_observations: int = 50_000
+    api_key: str | None = None
+    require_api_key: bool = False
+
+    def __post_init__(self) -> None:
+        if self.max_observations < 1:
+            raise ValueError("max_observations must be positive")
+        if self.require_api_key and not self.api_key:
+            raise ValueError("HYPERION_API_KEY is required when authentication is enforced")
+
+    @classmethod
+    def from_env(cls) -> "HyperionRuntimeSettings":
+        raw_limit = os.getenv("HYPERION_MAX_OBSERVATIONS", "50000")
+        try:
+            max_observations = int(raw_limit)
+        except ValueError as error:
+            raise ValueError("HYPERION_MAX_OBSERVATIONS must be an integer") from error
+        require_api_key = os.getenv("HYPERION_REQUIRE_API_KEY", "false").lower() in {
+            "1",
+            "true",
+            "yes",
+            "on",
+        }
+        return cls(
+            data_dir=Path(os.getenv("HYPERION_DATA_DIR", str(DEFAULT_DATA_DIR))),
+            max_observations=max_observations,
+            api_key=os.getenv("HYPERION_API_KEY") or None,
+            require_api_key=require_api_key,
+        )
+
+
+class AtomicReportStore:
+    """Filesystem evidence store using deterministic JSON and atomic replace."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self._lock = threading.RLock()
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def _validate_digest(report_digest: str) -> None:
+        if len(report_digest) != 64 or any(
+            character not in "0123456789abcdef" for character in report_digest
+        ):
+            raise ValueError("report digest must be 64 lowercase hexadecimal characters")
+
+    def _path(self, report_digest: str) -> Path:
+        self._validate_digest(report_digest)
+        return self.root / f"{report_digest}.json"
+
+    def put(self, bundle: Mapping[str, object]) -> Path:
+        report_digest = bundle.get("report_digest")
+        if not isinstance(report_digest, str):
+            raise ValueError("bundle report_digest is missing")
+        destination = self._path(report_digest)
+        encoded = json.dumps(
+            bundle,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        ).encode("utf-8")
+        with self._lock:
+            if destination.exists():
+                current = destination.read_bytes()
+                if current != encoded:
+                    raise RuntimeError("immutable report digest collision")
+                return destination
+            temporary = destination.with_suffix(f".tmp-{os.getpid()}-{threading.get_ident()}")
+            with temporary.open("wb") as handle:
+                handle.write(encoded)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, destination)
+        return destination
+
+    def get(self, report_digest: str) -> dict[str, object]:
+        path = self._path(report_digest)
+        value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("stored report bundle must be a JSON object")
+        return cast(dict[str, object], value)
+
+    def ready(self) -> bool:
+        probe = self.root / ".ready"
+        try:
+            probe.write_text("ready", encoding="utf-8")
+            probe.unlink()
+        except OSError:
+            return False
+        return True
+
+    def count(self) -> int:
+        return sum(1 for path in self.root.glob("*.json") if path.is_file())
+
+
+def _json_object(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def load_hyperion_config(path: Path | None) -> HyperionConfig:
+    if path is None:
+        return HyperionConfig()
+    return HyperionConfig(**_json_object(path))
+
+
+def load_score_model(path: Path | None) -> ScoreModel:
+    if path is None:
+        return ScoreModel()
+    payload = _json_object(path)
+    weights = payload.get("weights")
+    if isinstance(weights, list):
+        payload["weights"] = tuple(float(value) for value in weights)
+    return ScoreModel(**payload)
+
+
+def engine_from_env() -> HyperionEngine:
+    config_path = os.getenv("HYPERION_CONFIG_FILE")
+    model_path = os.getenv("HYPERION_MODEL_FILE")
+    return HyperionEngine(
+        config=load_hyperion_config(Path(config_path) if config_path else None),
+        model=load_score_model(Path(model_path) if model_path else None),
+    )
+
+
+def _json_compatible(value: object) -> object:
+    return json.loads(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    )
+
+
+def report_to_dict(report: AuditReport) -> dict[str, object]:
+    value = _json_compatible(asdict(report))
+    if not isinstance(value, dict):
+        raise TypeError("serialized report must be an object")
+    return cast(dict[str, object], value)
+
+
+def observation_to_dict(observation: Observation) -> dict[str, object]:
+    payload = cast(dict[str, object], asdict(observation))
+    metadata = payload.get("metadata")
+    if isinstance(metadata, Mapping):
+        payload["metadata"] = dict(metadata)
+    return payload
+
+
+def observation_from_dict(payload: Mapping[str, object]) -> Observation:
+    return Observation(
+        source=str(payload["source"]),
+        timestamp_ms=int(payload["timestamp_ms"]),
+        value=float(payload["value"]),
+        quantity=str(payload["quantity"]),
+        unit=str(payload["unit"]),
+        correlation_id=(
+            str(payload["correlation_id"])
+            if payload.get("correlation_id") is not None
+            else None
+        ),
+        confidence=float(payload.get("confidence", 1.0)),
+        available=bool(payload.get("available", True)),
+        label=str(payload["label"]) if payload.get("label") is not None else None,
+        metadata=(
+            cast(Mapping[str, object], payload.get("metadata", {}))
+            if isinstance(payload.get("metadata", {}), Mapping)
+            else {}
+        ),
+    )
+
+
+def build_evidence_bundle(
+    engine: HyperionEngine,
+    observations: Sequence[Observation],
+) -> dict[str, object]:
+    report = engine.audit(observations)
+    if not report.verify():
+        raise RuntimeError("Hyperion generated a report that failed internal verification")
+    canonical_observations = sorted(
+        observations,
+        key=lambda item: (
+            item.timestamp_ms,
+            item.correlation_id or "",
+            item.source,
+            item.value,
+            item.confidence,
+        ),
+    )
+    core: dict[str, object] = {
+        "protocol": SERVICE_PROTOCOL,
+        "model_hash": report.model_hash,
+        "configuration_hash": report.configuration_hash,
+        "observations": [observation_to_dict(item) for item in canonical_observations],
+        "report": report_to_dict(report),
+        "report_digest": report.report_digest,
+    }
+    core["bundle_digest"] = sha256_hex(core)
+    return core
+
+
+def verify_evidence_bundle(
+    bundle: Mapping[str, object],
+    engine: HyperionEngine,
+) -> tuple[bool, str]:
+    expected_bundle_digest = bundle.get("bundle_digest")
+    if not isinstance(expected_bundle_digest, str):
+        return False, "bundle digest missing"
+    unsigned = {key: value for key, value in bundle.items() if key != "bundle_digest"}
+    if not hmac.compare_digest(expected_bundle_digest, sha256_hex(unsigned)):
+        return False, "bundle digest mismatch"
+    if bundle.get("protocol") != SERVICE_PROTOCOL:
+        return False, "unsupported protocol"
+    if bundle.get("configuration_hash") != engine.configuration_hash:
+        return False, "configuration hash mismatch"
+    if bundle.get("model_hash") != engine.model.model_hash:
+        return False, "model hash mismatch"
+    raw_observations = bundle.get("observations")
+    if not isinstance(raw_observations, list):
+        return False, "observations missing"
+    observations: list[Observation] = []
+    for payload in raw_observations:
+        if not isinstance(payload, Mapping):
+            return False, "invalid observation payload"
+        observations.append(observation_from_dict(cast(Mapping[str, object], payload)))
+    replay = engine.audit(observations)
+    if not replay.verify():
+        return False, "replayed report failed verification"
+    if bundle.get("report_digest") != replay.report_digest:
+        return False, "report digest mismatch"
+    if bundle.get("report") != report_to_dict(replay):
+        return False, "stored report differs from deterministic replay"
+    return True, "verified"
+
+
+class HyperionRuntime:
+    """Thread-safe operational coordinator around a frozen Hyperion engine."""
+
+    def __init__(
+        self,
+        engine: HyperionEngine,
+        settings: HyperionRuntimeSettings,
+        store: AtomicReportStore | None = None,
+    ) -> None:
+        self.engine = engine
+        self.settings = settings
+        self.store = store or AtomicReportStore(settings.data_dir)
+        self._metrics_lock = threading.Lock()
+        self._audits_total = 0
+        self._failures_total = 0
+        self._observations_total = 0
+        self._critical_events_total = 0
+        self._last_success_time = 0.0
+
+    def audit(
+        self,
+        observations: Sequence[Observation],
+        *,
+        request_id: str | None = None,
+    ) -> dict[str, object]:
+        if not observations:
+            raise ValueError("at least one observation is required")
+        if len(observations) > self.settings.max_observations:
+            raise ValueError(
+                f"observation count exceeds limit {self.settings.max_observations}"
+            )
+        try:
+            bundle = build_evidence_bundle(self.engine, observations)
+            self.store.put(bundle)
+        except Exception:
+            with self._metrics_lock:
+                self._failures_total += 1
+            raise
+        report = cast(Mapping[str, object], bundle["report"])
+        raw_points = report.get("points", [])
+        critical_count = 0
+        if isinstance(raw_points, list):
+            critical_count = sum(
+                1
+                for point in raw_points
+                if isinstance(point, Mapping) and bool(point.get("critical"))
+            )
+        with self._metrics_lock:
+            self._audits_total += 1
+            self._observations_total += len(observations)
+            self._critical_events_total += critical_count
+            self._last_success_time = time.time()
+        return {
+            "request_id": request_id,
+            "report_digest": bundle["report_digest"],
+            "bundle_digest": bundle["bundle_digest"],
+            "verified": True,
+            "geometric_health_score": report["geometric_health_score"],
+            "critical_events": critical_count,
+            "event_count": len(raw_points) if isinstance(raw_points, list) else 0,
+            "model_hash": bundle["model_hash"],
+            "configuration_hash": bundle["configuration_hash"],
+        }
+
+    def get(self, report_digest: str) -> dict[str, object]:
+        return self.store.get(report_digest)
+
+    def verify(self, report_digest: str) -> dict[str, object]:
+        bundle = self.store.get(report_digest)
+        verified, reason = verify_evidence_bundle(bundle, self.engine)
+        return {
+            "report_digest": report_digest,
+            "verified": verified,
+            "reason": reason,
+            "model_hash": self.engine.model.model_hash,
+            "configuration_hash": self.engine.configuration_hash,
+        }
+
+    def metrics_text(self) -> str:
+        with self._metrics_lock:
+            values = {
+                "hyperion_audits_total": self._audits_total,
+                "hyperion_failures_total": self._failures_total,
+                "hyperion_observations_total": self._observations_total,
+                "hyperion_critical_events_total": self._critical_events_total,
+                "hyperion_last_success_unixtime_seconds": self._last_success_time,
+            }
+        values["hyperion_reports_stored"] = self.store.count()
+        lines = [
+            "# TYPE hyperion_audits_total counter",
+            f"hyperion_audits_total {values['hyperion_audits_total']}",
+            "# TYPE hyperion_failures_total counter",
+            f"hyperion_failures_total {values['hyperion_failures_total']}",
+            "# TYPE hyperion_observations_total counter",
+            f"hyperion_observations_total {values['hyperion_observations_total']}",
+            "# TYPE hyperion_critical_events_total counter",
+            f"hyperion_critical_events_total {values['hyperion_critical_events_total']}",
+            "# TYPE hyperion_reports_stored gauge",
+            f"hyperion_reports_stored {values['hyperion_reports_stored']}",
+            "# TYPE hyperion_last_success_unixtime_seconds gauge",
+            (
+                "hyperion_last_success_unixtime_seconds "
+                f"{values['hyperion_last_success_unixtime_seconds']}"
+            ),
+        ]
+        return "\n".join(lines) + "\n"
+
+    def manifest(self) -> dict[str, object]:
+        return {
+            "protocol": SERVICE_PROTOCOL,
+            "maturity": "operational-experimental",
+            "model_hash": self.engine.model.model_hash,
+            "model_version": self.engine.model.version,
+            "configuration_hash": self.engine.configuration_hash,
+            "target_quantity": self.engine.config.target_quantity,
+            "target_unit": self.engine.config.target_unit,
+            "max_observations": self.settings.max_observations,
+            "authentication_required": self.settings.require_api_key,
+            "persistence": "atomic-local-filesystem",
+            "proof_boundary": "deterministic-computation-over-committed-inputs",
+        }
+
+
+def create_hyperion_app(
+    *,
+    settings: HyperionRuntimeSettings | None = None,
+    engine: HyperionEngine | None = None,
+    store: AtomicReportStore | None = None,
+) -> FastAPI:
+    runtime_settings = settings or HyperionRuntimeSettings.from_env()
+    runtime = HyperionRuntime(engine or engine_from_env(), runtime_settings, store)
+    application = FastAPI(
+        title="Jarvis-X Hyperion Audit Service",
+        version="1.0.0",
+        docs_url="/docs",
+        redoc_url=None,
+    )
+    application.state.hyperion_runtime = runtime
+
+    def authorize(x_hyperion_key: str | None = Header(default=None)) -> None:
+        if not runtime_settings.require_api_key:
+            return
+        expected = runtime_settings.api_key
+        if expected is None or x_hyperion_key is None:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+        if not hmac.compare_digest(x_hyperion_key, expected):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+
+    @application.get("/healthz", include_in_schema=False)
+    def healthz() -> dict[str, str]:
+        return {"status": "ok", "protocol": SERVICE_PROTOCOL}
+
+    @application.get("/readyz", include_in_schema=False)
+    def readyz() -> dict[str, object]:
+        ready = runtime.store.ready()
+        if not ready:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="report store is not writable",
+            )
+        return {
+            "status": "ready",
+            "model_hash": runtime.engine.model.model_hash,
+            "configuration_hash": runtime.engine.configuration_hash,
+        }
+
+    @application.get("/v1/hyperion/manifest", dependencies=[Depends(authorize)])
+    def manifest() -> dict[str, object]:
+        return runtime.manifest()
+
+    @application.post(
+        "/v1/hyperion/audits",
+        status_code=status.HTTP_201_CREATED,
+        dependencies=[Depends(authorize)],
+    )
+    def create_audit(request: AuditRequest) -> dict[str, object]:
+        observations = [payload.to_observation() for payload in request.observations]
+        try:
+            return runtime.audit(observations, request_id=request.request_id)
+        except ValueError as error:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(error),
+            ) from error
+        except OSError as error:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="report persistence failed",
+            ) from error
+
+    @application.get(
+        "/v1/hyperion/audits/{report_digest}",
+        dependencies=[Depends(authorize)],
+    )
+    def get_audit(report_digest: str) -> dict[str, object]:
+        try:
+            return runtime.get(report_digest)
+        except (FileNotFoundError, ValueError) as error:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="not found",
+            ) from error
+
+    @application.post(
+        "/v1/hyperion/audits/{report_digest}/verify",
+        dependencies=[Depends(authorize)],
+    )
+    def verify_audit(report_digest: str) -> dict[str, object]:
+        try:
+            result = runtime.verify(report_digest)
+        except (FileNotFoundError, ValueError) as error:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="not found",
+            ) from error
+        if not result["verified"]:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=result,
+            )
+        return result
+
+    @application.get("/metrics", dependencies=[Depends(authorize)], include_in_schema=False)
+    def metrics_endpoint() -> Response:
+        return Response(runtime.metrics_text(), media_type="text/plain; version=0.0.4")
+
+    return application
+
+
+def app_factory() -> FastAPI:
+    """Create the environment-configured ASGI application for Uvicorn."""
+
+    return create_hyperion_app()

--- a/src/jarvisx/hyperion_service.py
+++ b/src/jarvisx/hyperion_service.py
@@ -146,7 +146,9 @@ class AtomicReportStore:
                 if current != encoded:
                     raise RuntimeError("immutable report digest collision")
                 return destination
-            temporary = destination.with_suffix(f".tmp-{os.getpid()}-{threading.get_ident()}")
+            temporary = destination.with_suffix(
+                f".tmp-{os.getpid()}-{threading.get_ident()}"
+            )
             with temporary.open("wb") as handle:
                 handle.write(encoded)
                 handle.flush()
@@ -218,6 +220,35 @@ def _json_compatible(value: object) -> object:
     )
 
 
+def _required_int(value: object, field_name: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be an integer")
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError as error:
+            raise ValueError(f"{field_name} must be an integer") from error
+    raise ValueError(f"{field_name} must be an integer")
+
+
+def _required_float(value: object, field_name: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field_name} must be numeric")
+    if isinstance(value, (int, float, str)):
+        try:
+            converted = float(value)
+        except ValueError as error:
+            raise ValueError(f"{field_name} must be numeric") from error
+        if not converted == converted or converted in (float("inf"), float("-inf")):
+            raise ValueError(f"{field_name} must be finite")
+        return converted
+    raise ValueError(f"{field_name} must be numeric")
+
+
 def report_to_dict(report: AuditReport) -> dict[str, object]:
     value = _json_compatible(asdict(report))
     if not isinstance(value, dict):
@@ -236,8 +267,8 @@ def observation_to_dict(observation: Observation) -> dict[str, object]:
 def observation_from_dict(payload: Mapping[str, object]) -> Observation:
     return Observation(
         source=str(payload["source"]),
-        timestamp_ms=int(payload["timestamp_ms"]),
-        value=float(payload["value"]),
+        timestamp_ms=_required_int(payload["timestamp_ms"], "timestamp_ms"),
+        value=_required_float(payload["value"], "value"),
         quantity=str(payload["quantity"]),
         unit=str(payload["unit"]),
         correlation_id=(
@@ -245,7 +276,7 @@ def observation_from_dict(payload: Mapping[str, object]) -> Observation:
             if payload.get("correlation_id") is not None
             else None
         ),
-        confidence=float(payload.get("confidence", 1.0)),
+        confidence=_required_float(payload.get("confidence", 1.0), "confidence"),
         available=bool(payload.get("available", True)),
         label=str(payload["label"]) if payload.get("label") is not None else None,
         metadata=(
@@ -306,9 +337,11 @@ def verify_evidence_bundle(
         return False, "observations missing"
     observations: list[Observation] = []
     for payload in raw_observations:
-        if not isinstance(payload, Mapping):
+        if not isinstance(payload, dict):
             return False, "invalid observation payload"
-        observations.append(observation_from_dict(cast(Mapping[str, object], payload)))
+        observations.append(
+            observation_from_dict(cast(Mapping[str, object], payload))
+        )
     replay = engine.audit(observations)
     if not replay.verify():
         return False, "replayed report failed verification"
@@ -463,9 +496,15 @@ def create_hyperion_app(
             return
         expected = runtime_settings.api_key
         if expected is None or x_hyperion_key is None:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="unauthorized",
+            )
         if not hmac.compare_digest(x_hyperion_key, expected):
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="unauthorized",
+            )
 
     @application.get("/healthz", include_in_schema=False)
     def healthz() -> dict[str, str]:
@@ -541,7 +580,11 @@ def create_hyperion_app(
             )
         return result
 
-    @application.get("/metrics", dependencies=[Depends(authorize)], include_in_schema=False)
+    @application.get(
+        "/metrics",
+        dependencies=[Depends(authorize)],
+        include_in_schema=False,
+    )
     def metrics_endpoint() -> Response:
         return Response(runtime.metrics_text(), media_type="text/plain; version=0.0.4")
 

--- a/tests/test_hyperion.py
+++ b/tests/test_hyperion.py
@@ -1,0 +1,214 @@
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.hyperion import (
+    FILTER_NAMES,
+    HyperionConfig,
+    HyperionEngine,
+    Observation,
+    ScoreModel,
+    TrainingExample,
+    binary_cross_entropy,
+)
+
+
+def obs(
+    source,
+    timestamp,
+    value,
+    event,
+    *,
+    quantity="amount",
+    unit="ZAR",
+    label="known",
+    confidence=1.0,
+):
+    return Observation(
+        source=source,
+        timestamp_ms=timestamp,
+        value=value,
+        quantity=quantity,
+        unit=unit,
+        correlation_id=event,
+        label=label,
+        confidence=confidence,
+    )
+
+
+def test_semantically_incompatible_video_identity_is_not_averaged() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 1000, 100.0, "e1"),
+            obs("cpu", 1001, 100.0, "e1"),
+            obs(
+                "video",
+                1002,
+                1.0,
+                "e1",
+                quantity="identity_match",
+                unit="boolean",
+            ),
+        ]
+    )
+    assert report.points[0].fused_value == 100.0
+    assert len(report.witnesses[0].terms) == 2
+
+
+def test_time_correct_derivatives_use_seconds() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 0, 0.0, "e0"),
+            obs("csv", 1000, 10.0, "e1"),
+            obs("csv", 3000, 30.0, "e2"),
+        ]
+    )
+    assert report.points[1].velocity == pytest.approx(10.0)
+    assert report.points[2].velocity == pytest.approx(10.0)
+    assert report.points[2].acceleration == pytest.approx(0.0)
+
+
+def test_continuity_residual_is_not_tautologically_zero() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 0, 10.0, "e0"),
+            obs("csv", 1000, 11.0, "e1"),
+            obs("csv", 2000, 12.0, "e2"),
+            obs("csv", 3000, 100.0, "e3"),
+        ]
+    )
+    final = report.points[-1]
+    assert final.continuity_residual != 0.0
+    assert final.flags["continuity"]
+
+
+def test_bytecode_divergence_requires_same_event_and_detects_mismatch() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 1000, 100.0, "e1"),
+            obs("cpu", 1001, 80.0, "e1"),
+            obs("cpu", 1002, 100.0, "other"),
+        ]
+    )
+    point = next(point for point in report.points if point.event_id == "e1")
+    assert point.flags["bytecode_divergence"]
+    assert point.severities["bytecode_divergence"] > 0.0
+
+
+def test_fixed_point_witness_and_report_verify_and_tampering_fails() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 1000, 100.01, "e1", confidence=1.0),
+            obs("audio", 1001, 99.99, "e1", confidence=0.8),
+            obs("cpu", 1002, 100.00, "e1", confidence=1.0),
+        ]
+    )
+    assert report.verify()
+    witness = report.witnesses[0]
+    assert witness.verify()
+    tampered = replace(witness, fused_int=witness.fused_int + 1)
+    assert not tampered.verify()
+
+
+def test_cas_and_ghs_are_bounded() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [obs("csv", index * 1000, float(index), f"e{index}") for index in range(20)]
+    )
+    assert all(0.0 <= point.cas <= 1.0 for point in report.points)
+    assert 0.0 <= report.geometric_health_score <= 100.0
+
+
+def test_supervised_training_requires_labels_and_reduces_loss() -> None:
+    zeros = {name: 0.0 for name in FILTER_NAMES}
+    positives = {name: 1.0 for name in FILTER_NAMES}
+    examples = [
+        TrainingExample(zeros, 0),
+        TrainingExample(zeros, 0),
+        TrainingExample(positives, 1),
+        TrainingExample(positives, 1),
+    ]
+    model = ScoreModel()
+    before = binary_cross_entropy(model, examples)
+    trained = model.fit_supervised(examples)
+    after = binary_cross_entropy(trained, examples)
+    assert trained.version == model.version + 1
+    assert trained.training_digest
+    assert after < before
+    with pytest.raises(ValueError):
+        model.fit_supervised([])
+
+
+def test_deterministic_replay_yields_identical_report_digest() -> None:
+    observations = [
+        obs("csv", index * 1000, 100.0 + index, f"e{index}")
+        for index in range(8)
+    ] + [
+        obs("cpu", index * 1000 + 1, 100.0 + index, f"e{index}")
+        for index in range(8)
+    ]
+    engine = HyperionEngine()
+    first = engine.audit(observations)
+    second = engine.audit(list(reversed(observations)))
+    assert first.report_digest == second.report_digest
+    assert first.input_root == second.input_root
+
+
+def test_precision_strike_uses_projected_balance_and_lower_bound() -> None:
+    config = HyperionConfig(lower_bound=-100.0, robust_window=10)
+    engine = HyperionEngine(config=config)
+    values = [0.0, -5.0, -10.0, -15.0, -20.0, -25.0, -30.0, -35.0, -40.0, -99.0]
+    report = engine.audit(
+        [
+            obs("csv", index * 1000, value, f"e{index}")
+            for index, value in enumerate(values)
+        ]
+    )
+    assert report.points[-1].flags["precision_strike"]
+
+
+def test_configuration_rejects_unbounded_ghs_weights() -> None:
+    with pytest.raises(ValueError):
+        HyperionConfig(ghs_exposure_weight=0.8, ghs_frequency_weight=0.3)
+
+
+def test_duplicate_source_does_not_gain_extra_fusion_weight() -> None:
+    engine = HyperionEngine()
+    report = engine.audit(
+        [
+            obs("csv", 1000, 100.0, "e1", confidence=0.8),
+            obs("csv", 1001, 1000.0, "e1", confidence=0.1),
+            obs("cpu", 1000, 100.0, "e1", confidence=1.0),
+        ]
+    )
+    assert report.points[0].fused_value == 100.0
+    assert len(report.witnesses[0].terms) == 2
+
+
+def test_simultaneous_events_use_declared_minimum_time_resolution() -> None:
+    engine = HyperionEngine(HyperionConfig(minimum_dt_ms=1))
+    report = engine.audit(
+        [
+            obs("csv", 1000, 10.0, "e1"),
+            obs("csv", 1000, 11.0, "e2"),
+        ]
+    )
+    assert report.points[1].velocity == pytest.approx(1000.0)
+
+
+def test_witness_exports_integer_circuit_relation() -> None:
+    report = HyperionEngine().audit(
+        [
+            obs("csv", 1000, 100.0, "e1"),
+            obs("cpu", 1000, 100.0, "e1"),
+        ]
+    )
+    circuit = report.witnesses[0].circuit_inputs()
+    assert circuit["numerator"] == (
+        circuit["denominator"] * circuit["fused_int"] + circuit["remainder"]
+    )

--- a/tests/test_hyperion_operational.py
+++ b/tests/test_hyperion_operational.py
@@ -1,0 +1,215 @@
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from jarvisx.hyperion import HyperionConfig, HyperionEngine, Observation, ScoreModel
+from jarvisx.hyperion_cli import main
+from jarvisx.hyperion_service import (
+    AtomicReportStore,
+    HyperionRuntime,
+    HyperionRuntimeSettings,
+    build_evidence_bundle,
+    create_hyperion_app,
+    verify_evidence_bundle,
+)
+
+
+def observation(source: str, timestamp: int, value: float, event: str) -> Observation:
+    return Observation(
+        source=source,
+        timestamp_ms=timestamp,
+        value=value,
+        quantity="amount",
+        unit="ZAR",
+        correlation_id=event,
+        label="known",
+    )
+
+
+def fixture() -> list[Observation]:
+    return [
+        observation("csv", 0, 100.0, "e0"),
+        observation("cpu", 1, 100.0, "e0"),
+        observation("csv", 1000, 110.0, "e1"),
+        observation("cpu", 1001, 110.0, "e1"),
+    ]
+
+
+def test_evidence_bundle_is_deterministic_and_replayable() -> None:
+    engine = HyperionEngine()
+    first = build_evidence_bundle(engine, fixture())
+    second = build_evidence_bundle(engine, list(reversed(fixture())))
+
+    assert first == second
+    assert verify_evidence_bundle(first, engine) == (True, "verified")
+
+
+def test_tampered_bundle_fails_before_replay() -> None:
+    engine = HyperionEngine()
+    bundle = build_evidence_bundle(engine, fixture())
+    bundle["report_digest"] = "0" * 64
+
+    verified, reason = verify_evidence_bundle(bundle, engine)
+
+    assert not verified
+    assert reason == "bundle digest mismatch"
+
+
+def test_atomic_store_is_idempotent_and_detects_digest_collision(tmp_path: Path) -> None:
+    store = AtomicReportStore(tmp_path)
+    bundle = build_evidence_bundle(HyperionEngine(), fixture())
+
+    first = store.put(bundle)
+    second = store.put(bundle)
+
+    assert first == second
+    assert store.count() == 1
+    conflicting = dict(bundle)
+    conflicting["bundle_digest"] = "f" * 64
+    with pytest.raises(RuntimeError, match="collision"):
+        store.put(conflicting)
+
+
+def test_runtime_persists_and_reverifies_reports(tmp_path: Path) -> None:
+    runtime = HyperionRuntime(
+        HyperionEngine(),
+        HyperionRuntimeSettings(data_dir=tmp_path, max_observations=10),
+    )
+
+    result = runtime.audit(fixture(), request_id="request-1")
+    verification = runtime.verify(str(result["report_digest"]))
+
+    assert result["verified"] is True
+    assert verification["verified"] is True
+    assert runtime.store.count() == 1
+    assert "hyperion_audits_total 1" in runtime.metrics_text()
+    assert "hyperion_observations_total 4" in runtime.metrics_text()
+
+
+def test_runtime_enforces_batch_limit(tmp_path: Path) -> None:
+    runtime = HyperionRuntime(
+        HyperionEngine(),
+        HyperionRuntimeSettings(data_dir=tmp_path, max_observations=1),
+    )
+
+    with pytest.raises(ValueError, match="exceeds limit"):
+        runtime.audit(fixture())
+
+
+def test_authentication_cannot_be_required_without_a_key(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="API_KEY"):
+        HyperionRuntimeSettings(
+            data_dir=tmp_path,
+            require_api_key=True,
+            api_key=None,
+        )
+
+
+def test_app_registers_operational_routes_without_replacing_root(tmp_path: Path) -> None:
+    app = create_hyperion_app(
+        settings=HyperionRuntimeSettings(data_dir=tmp_path),
+        engine=HyperionEngine(),
+    )
+    paths = {route.path for route in app.routes}
+
+    assert "/healthz" in paths
+    assert "/readyz" in paths
+    assert "/metrics" in paths
+    assert "/v1/hyperion/audits" in paths
+    assert "/v1/hyperion/audits/{report_digest}/verify" in paths
+    assert "/" not in paths
+
+
+def test_bundle_rejects_different_frozen_model() -> None:
+    bundle = build_evidence_bundle(HyperionEngine(), fixture())
+    different = HyperionEngine(model=ScoreModel(bias=-2.0))
+
+    verified, reason = verify_evidence_bundle(bundle, different)
+
+    assert not verified
+    assert reason == "model hash mismatch"
+
+
+def test_cli_audit_and_verify_round_trip(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    input_path = tmp_path / "observations.json"
+    bundle_path = tmp_path / "bundle.json"
+    input_path.write_text(
+        json.dumps(
+            {
+                "observations": [
+                    {
+                        "source": item.source,
+                        "timestamp_ms": item.timestamp_ms,
+                        "value": item.value,
+                        "quantity": item.quantity,
+                        "unit": item.unit,
+                        "correlation_id": item.correlation_id,
+                        "confidence": item.confidence,
+                        "available": item.available,
+                        "label": item.label,
+                        "metadata": {},
+                    }
+                    for item in fixture()
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert main(["audit", str(input_path), "--output", str(bundle_path)]) == 0
+    audit_output = json.loads(capsys.readouterr().out)
+    assert audit_output["verified"] is True
+    assert bundle_path.exists()
+
+    assert main(["verify", str(bundle_path)]) == 0
+    verify_output = json.loads(capsys.readouterr().out)
+    assert verify_output == {"reason": "verified", "verified": True}
+
+
+def test_cli_uses_explicit_configuration_file(tmp_path: Path) -> None:
+    input_path = tmp_path / "observations.json"
+    output_path = tmp_path / "bundle.json"
+    config_path = tmp_path / "config.json"
+    input_path.write_text(
+        json.dumps(
+            [
+                {
+                    "source": "csv",
+                    "timestamp_ms": 0,
+                    "value": 5.0,
+                    "quantity": "amount",
+                    "unit": "USD",
+                    "correlation_id": "e0",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    config_path.write_text(
+        json.dumps(
+            {
+                **asdict(HyperionConfig(target_unit="USD")),
+                "source_weights": {"csv": 1.0},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "audit",
+                str(input_path),
+                "--output",
+                str(output_path),
+                "--config",
+                str(config_path),
+            ]
+        )
+        == 0
+    )
+    assert output_path.exists()


### PR DESCRIPTION
## What changed

### Deterministic audit kernel

- enforces semantic quantity/unit compatibility before fusion
- aligns sparse evidence by correlation ID or deterministic event-time bucket
- de-duplicates repeated observations from the same source
- uses confidence-aware fixed-point weighted fusion
- computes elapsed-time velocity, acceleration and jerk
- uses a prior-state continuity prediction rather than a tautological residual
- implements robust two-sided MAD filters and corrected lower-bound geometry
- requires same-event CSV/CPU correlation for bytecode divergence
- aggregates continuous severities with a bounded logistic CAS
- permits model fitting only from explicit supervised labels
- bounds GHS to `[0, 100]`
- emits model, configuration, input, witness and output commitments
- exports integer witness relations for an external SNARK/STARK backend

### Operational runtime

- adds an environment-configured FastAPI/ASGI service
- exposes health, readiness, manifest, audit, retrieval, replay verification and Prometheus metrics endpoints
- freezes one configuration and score model per process and returns their hashes in every audit result
- applies strict request schemas and configurable observation-count limits
- supports optional constant-time API-key authentication through `X-Hyperion-Key`
- persists canonical replay bundles using flush, `fsync` and atomic replacement
- makes identical reports idempotent and fails closed on digest collisions
- verifies stored evidence by deterministic re-execution against the frozen model and configuration
- adds `jarvisx-hyperion audit`, `verify` and `serve` commands
- provides frozen production configuration and model files
- adds a non-root container, read-only Compose deployment, dropped capabilities and a protected evidence volume
- documents security, retention, monitoring, scaling and source-acquisition boundaries

### Validation and automation

- adds focused core, replay, tamper, CLI and runtime tests
- adds an authenticated live Uvicorn network smoke test
- builds the operational container in CI
- retains the deterministic benchmark and example harnesses

## Operational endpoints

```text
GET  /healthz
GET  /readyz
GET  /v1/hyperion/manifest
POST /v1/hyperion/audits
GET  /v1/hyperion/audits/{report_digest}
POST /v1/hyperion/audits/{report_digest}/verify
GET  /metrics
```

## Validation on head `cdafb8bfef121fe88b0371929c53b4446725bade`

- Hyperion Operational Service: **passed**
  - focused tests
  - CLI audit/verify round trip
  - authenticated live-network smoke test
  - container image build
- Jarvis-X CI: **passed**
  - dependency audit
  - compilation and undefined-name checks
  - formatting and import ordering
  - mypy
  - Python 3.10, 3.11, 3.12 and 3.13 tests
  - source/wheel build, metadata validation and wheel smoke test
- Empirical Validation: **passed**
- CodeQL Python analysis: **passed**

## Deployment boundary

This makes Hyperion executable, packageable, observable and deployable. It does not create a live public deployment because no infrastructure target, domain, TLS identity, secret-manager configuration or managed evidence store was supplied.

The service accepts already-extracted observations. Camera, audio, database and eBPF acquisition must remain separate authorized components with clock provenance, privacy controls and chain-of-custody procedures.

A valid report proves deterministic arithmetic over committed observations. It does not prove that the source observations were truthful or establish state-of-the-art anomaly quality without independent benchmark evidence.