### PR TITLE
Record DMVX Pages deployment receipt

### DIFF
--- a/.github/workflows/dmvx-matrix-pages.yml
+++ b/.github/workflows/dmvx-matrix-pages.yml
@@ -18,6 +18,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  issues: write
 
 concurrency:
   group: dmvx-matrix-pages
@@ -57,3 +58,22 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+      - name: Record deployment receipt on PR 70
+        uses: actions/github-script@v8
+        env:
+          PAGE_URL: ${{ steps.deployment.outputs.page_url }}
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: 70,
+              body: [
+                'DMVX matrix runtime deployed successfully.',
+                '',
+                `- live URL: ${process.env.PAGE_URL}`,
+                `- deployed commit: \`${context.sha}\``,
+                '- six runtime invariants passed before deployment',
+                '- deployment: GitHub Pages artifact release',
+              ].join('\n'),
+            });


### PR DESCRIPTION
Adds a post-deployment receipt to the DMVX Pages workflow so the exact live URL and deployed commit are recorded on merged PR #70 after a successful release.