### PR TITLE
docs: define the Dr Moagi 3D recursive and unified field runtime

### DIFF
--- a/docs/DR_MOAGI_3D_RECURSIVE_RUNTIME_ENGINE.md
+++ b/docs/DR_MOAGI_3D_RECURSIVE_RUNTIME_ENGINE.md
@@ -1,0 +1,779 @@
+# Dr Moagi 3D Recursive Auto-Encoding/Decoding Runtime Engine
+
+## Status and capability boundary
+
+**Status:** proposed mathematical specification.
+
+This document records the proposed three-dimensional, multimodal, recursively self-consistent auto-encoding and decoding runtime supplied by Dr Matladi Moagi. It defines a candidate mathematical architecture; it does **not** by itself establish that the architecture is implemented, convergent, translation-invariant, physically calibrated, or production-ready.
+
+The specification is intentionally separated from the canonical Jarvis-X VM. A future implementation must enter as an optional bounded research layer and satisfy the repository's deterministic, validation, transaction, provenance, and capability-boundary requirements.
+
+The proposed system is intended to support:
+
+- modality-specific projection into a canonical 3D field;
+- recursive latent-state refinement;
+- volumetric decoding;
+- reconstruction and temporal-consistency losses;
+- divergence-free latent projection;
+- bounded meta-optimization of arithmetic parameters;
+- streaming state transitions across discrete time.
+
+---
+
+## 1. Domains, state, and notation
+
+Let the spatial domain be
+
+\[
+\Omega \subset \mathbb{R}^{3},
+\qquad
+\mathbf r=(x,y,z)\in\Omega,
+\]
+
+with discrete external time
+
+\[
+t\in\mathbb N_0
+\]
+
+and recursive internal iteration
+
+\[
+k\in\mathbb N_0.
+\]
+
+For a practical implementation, \(\Omega\) must be replaced by a finite grid
+
+\[
+\Omega_h=\{0,\ldots,N_x-1\}\times\{0,\ldots,N_y-1\}\times\{0,\ldots,N_z-1\},
+\]
+
+with explicitly declared spacing, boundary conditions, channel count, numeric dtype, resident-memory bound, and serialization order.
+
+The principal fields are:
+
+- \(\mathbf X_t^{(m)}\): input in modality \(m\);
+- \(\Phi_t(\mathbf r)\): canonical 3D observation field;
+- \(Z_t^{(k)}(\mathbf r)\): recursive latent vector field;
+- \(Z_t^*(\mathbf r)\): accepted fixed-point latent field;
+- \(\widehat\Phi_t(\mathbf r)\): decoded reconstruction;
+- \(\theta_t=\{\alpha_t,\beta_t,\gamma_t,\mathbf M_t\}\): proposed arithmetic gauge parameters.
+
+Unless otherwise specified, \(Z\) is a three-component vector field so that curl, divergence, and cross products are defined.
+
+---
+
+## 2. Multimodal projection into canonical 3D space
+
+For each input modality \(m\), define an adapter
+
+\[
+\mathcal P_m:\mathcal X_m\rightarrow\mathcal F(\Omega,\mathbb R^{C_\Phi}).
+\]
+
+The observation field is
+
+\[
+\boxed{
+\Phi_t(\mathbf r)=\mathcal P_m\!\left(\mathbf X_t^{(m)}\right),
+\qquad \mathbf r\in\Omega.
+}
+\]
+
+Examples of adapter families include:
+
+- images or video: convolutional lifting, depth estimation, camera calibration, or multi-view voxelization;
+- audio: spectral/time-frequency encoding followed by spatial placement or learned volumetric lifting;
+- point clouds: point/set transformer followed by sparse voxelization;
+- text: token embeddings mapped to a declared 3D coordinate or sparse geometric support.
+
+### Required implementation contract
+
+Every \(\mathcal P_m\) must define:
+
+1. input schema and normalization;
+2. output shape and channel semantics;
+3. spatial reference frame;
+4. treatment of missing geometry;
+5. interpolation and aliasing behavior;
+6. deterministic behavior under a fixed model version and seed;
+7. bounded memory and execution cost.
+
+A projection into 3D does not imply that the source modality intrinsically possesses Euclidean 3D geometry. The adapter's geometric assumptions must be explicit.
+
+---
+
+## 3. Generalized arithmetic operators
+
+The source formulation proposes trainable scalar operations
+
+\[
+\boxed{
+a\oplus b=\alpha a+\beta b
+}
+\]
+
+and
+
+\[
+\boxed{
+a\odot b=\gamma(a\cdot b),
+}
+\]
+
+with
+
+\[
+\alpha,\beta,\gamma\in\mathbb R.
+\]
+
+For vector fields, addition is interpreted componentwise. The source generalized cross product is
+
+\[
+\boxed{
+\mathbf A\times_{\odot}\mathbf B
+=
+\gamma\left((\mathbf M\mathbf A)\times(\mathbf M\mathbf B)\right),
+\qquad
+\mathbf M\in\mathbb R^{3\times3}.
+}
+\]
+
+### Important algebraic consequence
+
+Under the definition above,
+
+\[
+Z\times_{\odot}Z
+=
+\gamma\left((\mathbf M Z)\times(\mathbf M Z)\right)
+=\mathbf 0
+\]
+
+for every \(Z\), because the ordinary cross product of a vector with itself is identically zero. Therefore the proposed self-interaction term does **not** produce non-commutative dynamics as written.
+
+A non-zero asymmetric self-interaction would require a separately specified bilinear operator, for example
+
+\[
+\boxed{
+\mathcal B_\theta(Z,Z)
+=
+\gamma\left((\mathbf M_L Z)\times(\mathbf M_R Z)\right),
+\qquad \mathbf M_L\ne\mathbf M_R,
+}
+\]
+
+or an interaction between distinct channels, delayed states, neighboring states, or independently transformed copies. This alternative is recorded as an implementation option, not as a silent replacement of the source equation.
+
+### Generalized curl
+
+The notation \(\nabla_{\odot}\times Z\) requires a component-level definition before implementation. Until one is accepted, the conservative interpretation is the ordinary spatial curl followed by a trainable linear map:
+
+\[
+\mathcal C_\theta[Z]
+=
+\gamma_C\mathbf M_C(\nabla\times Z).
+\]
+
+Any different definition must state its discrete stencil or spectral multiplier and its boundary conditions.
+
+---
+
+## 4. Non-local external geometry
+
+The source formulation uses the kernel
+
+\[
+\mathcal K(\mathbf r)=\frac{1}{\|\mathbf r\|}
+\]
+
+and the three-dimensional convolution
+
+\[
+(\mathcal K*\Phi_t)(\mathbf r)
+=
+\int_\Omega
+\mathcal K(\mathbf r-\mathbf q)\Phi_t(\mathbf q)\,d\mathbf q.
+\]
+
+### Discrete and numerical boundary
+
+The kernel is singular at \(\mathbf r=\mathbf 0\). A numerical implementation must define one of:
+
+- a regularized kernel
+  \[
+  \mathcal K_\varepsilon(\mathbf r)
+  =\frac{1}{\sqrt{\|\mathbf r\|^2+\varepsilon_K^2}};
+  \]
+- an analytically integrated cell-center value;
+- a masked origin with a declared replacement value;
+- a Green function matching a specifically declared PDE and boundary condition.
+
+FFT acceleration computes circular convolution unless padding or an alternative boundary construction is used. The implementation must therefore declare periodic, zero-padded, reflective, or other boundary behavior.
+
+For a grid with \(N=N_xN_yN_z\) sites, dense FFT convolution has approximate complexity
+
+\[
+O(N\log N)
+\]
+
+and resident memory proportional to the transformed fields. Sparse or block-spectral alternatives require their own error and complexity contracts.
+
+---
+
+## 5. Recursive inward-turn encoder
+
+The proposed recursive update is
+
+\[
+\boxed{
+Z_t^{(k+1)}
+=
+Z_t^{(k)}
+\oplus
+\left(\nabla_{\odot}\times Z_t^{(k)}\right)
+\oplus
+\left(Z_t^{(k)}\times_{\odot}Z_t^{(k)}\right)
+\oplus
+\left(\mathcal K*\Phi_t\right).
+}
+\]
+
+Using the source scalar grouping, this is summarized as the fixed-point map
+
+\[
+\boxed{
+F_{\theta_t,\Phi_t}(Z)
+=
+\alpha_t Z
++
+\beta_t\left[
+\nabla_{\odot}\times Z
++
+Z\times_{\odot}Z
++
+\mathcal K*\Phi_t
+\right].
+}
+\]
+
+The recursive sequence is
+
+\[
+Z_t^{(k+1)}=F_{\theta_t,\Phi_t}(Z_t^{(k)}).
+\]
+
+### Initialization
+
+The source text refers to the previous latent state but does not define initialization. A practical contract must select one of:
+
+\[
+Z_t^{(0)}=Z_{t-1}^*,
+\]
+
+\[
+Z_t^{(0)}=\mathcal E_0(\Phi_t),
+\]
+
+or a gated combination
+
+\[
+Z_t^{(0)}=g_t\odot Z_{t-1}^*+(1-g_t)\odot\mathcal E_0(\Phi_t).
+\]
+
+The selected initialization is part of the model version and must be journaled.
+
+---
+
+## 6. Fixed-point acceptance and bounded execution
+
+The source convergence criterion is
+
+\[
+\boxed{
+\left\|Z_t^{(k+1)}-Z_t^{(k)}\right\|<\varepsilon.
+}
+\]
+
+A production-safe runtime must also impose
+
+\[
+0\le k<K_{\max},
+\]
+
+finite-value checks, a norm definition, and an explicit failure path.
+
+Define the residual
+
+\[
+R_t^{(k)}
+=
+\left\|F_{\theta_t,\Phi_t}(Z_t^{(k)})-Z_t^{(k)}\right\|.
+\]
+
+The accepted state is
+
+\[
+\boxed{
+Z_t^*=Z_t^{(k_*)}
+}
+\]
+
+only if
+
+\[
+R_t^{(k_*)}\le\varepsilon_{\mathrm{abs}}
++
+\varepsilon_{\mathrm{rel}}\|Z_t^{(k_*)}\|,
+\]
+
+and all policy, resource, and finite-value predicates pass.
+
+If the criterion is not satisfied by \(K_{\max}\), the runtime must reject, roll back, or emit a declared degraded result. It must not silently label the final iterate a fixed point.
+
+### Convergence requirement
+
+The stopping criterion detects a small local update; it does not prove convergence. A sufficient local condition is that \(F\) is a contraction on an invariant admissible set \(\mathcal A\):
+
+\[
+\|F(Z_1)-F(Z_2)\|
+\le q\|Z_1-Z_2\|,
+\qquad 0\le q<1.
+\]
+
+The current equations do not establish such a bound. Any claim of guaranteed convergence requires either an analytic Lipschitz bound or measured bounded behavior under a stated domain and parameter envelope.
+
+---
+
+## 7. Divergence-free latent projection
+
+The source imposes
+
+\[
+\boxed{
+\nabla_{\mathbf r}\cdot Z_t^*=0.
+}
+\]
+
+This must be implemented as an operator, not merely asserted as a loss or postcondition. For periodic boundaries, a spectral Helmholtz-Hodge projection may be defined by
+
+\[
+\widehat{\Pi_{\mathrm{div0}}Z}(\mathbf k)
+=
+\left(
+\mathbf I-
+\frac{\mathbf k\mathbf k^\top}{\|\mathbf k\|^2}
+\right)
+\widehat Z(\mathbf k),
+\qquad \mathbf k\ne\mathbf 0,
+\]
+
+with an explicit convention at \(\mathbf k=\mathbf0\).
+
+The recursive update then becomes
+
+\[
+\boxed{
+Z_t^{(k+1)}
+=
+\Pi_{\mathrm{div0}}
+\left[
+F_{\theta_t,\Phi_t}(Z_t^{(k)})
+\right].
+}
+\]
+
+Non-periodic domains require a boundary-aware Poisson solve or another declared projection method.
+
+A divergence-free constraint controls local source/sink behavior. It does **not** by itself prove invariance under translations, rotations, changes of reference frame, or modality projection.
+
+---
+
+## 8. Decoder and temporal prediction boundary
+
+The decoded reconstruction is
+
+\[
+\boxed{
+\widehat\Phi_t(\mathbf r)
+=
+\mathcal D_{\vartheta_t}[Z_t^*(\mathbf r)],
+}
+\]
+
+where \(\vartheta_t\) denotes decoder parameters. The source text later writes \(\widehat\Phi_{t+1}=\mathcal D(Z_t^*)\). A decoder alone reconstructs the time index represented by its latent state; prediction of \(t+1\) requires an explicit temporal transition model.
+
+A separated predictive formulation is
+
+\[
+\widetilde Z_{t+1}
+=
+\mathcal T_\rho(Z_t^*,u_t),
+\]
+
+\[
+\boxed{
+\widehat\Phi_{t+1}
+=
+\mathcal D_{\vartheta_t}(\widetilde Z_{t+1}).
+}
+\]
+
+Without \(\mathcal T_\rho\), the specification should claim reconstruction of \(\Phi_t\), not forecast of \(\Phi_{t+1}\).
+
+---
+
+## 9. Loss landscape
+
+The proposed total loss is
+
+\[
+\boxed{
+\mathcal L_{\mathrm{total}}
+=
+\|\widehat\Phi_t-\Phi_t\|_\Omega^2
++
+\lambda_1\|Z_t^*-Z_{t-1}^*\|_\Omega^2
++
+\lambda_2
+\left(
+|\alpha|+|\beta|+|\gamma|+\|\mathbf M\|_F
+\right).
+}
+\]
+
+The three terms are interpreted as:
+
+1. reconstruction fidelity;
+2. temporal latent consistency;
+3. arithmetic-gauge regularization.
+
+### Required definitions
+
+The notation \(\|\cdot\|_\Omega\) must be disambiguated from the spatial domain \(\Omega\) and from Jarvis-X correction memory \(\Omega\). A weighted spatial norm can be written as
+
+\[
+\|A\|_{W}^2
+=
+\sum_{\mathbf r\in\Omega_h}
+A(\mathbf r)^\top W(\mathbf r)A(\mathbf r).
+\]
+
+The temporal term penalizes legitimate changes as well as instability. A motion- or control-conditioned alternative may compare against a predicted latent:
+
+\[
+\|Z_t^*-\mathcal T_\rho(Z_{t-1}^*,u_{t-1})\|_W^2.
+\]
+
+The regularizer must declare whether \(\mathbf M\) is expected to approach zero, identity, orthogonality, bounded condition number, or another geometric class. Penalizing \(\|\mathbf M\|_F\) alone encourages collapse toward zero.
+
+If a non-degenerate mixing geometry is intended, possible constraints include
+
+\[
+\|\mathbf M^\top\mathbf M-\mathbf I\|_F^2
+\]
+
+or an explicit spectral/condition-number bound. Such alternatives require an accepted design decision.
+
+---
+
+## 10. Gauge-parameter optimization
+
+The source parameter update is
+
+\[
+\boxed{
+\theta_{t+1}
+=
+\theta_t-\eta_t\nabla_{\theta_t}\mathcal L_{\mathrm{total}}.
+}
+\]
+
+This is a first-order parameter update when the fixed-point solver and decoder are differentiable or supplied with implicit gradients.
+
+The proposed learning-rate update is
+
+\[
+\boxed{
+\eta_{t+1}
+=
+\eta_t-
+\mu\nabla_\eta
+\left(\nabla_\theta\mathcal L_{\mathrm{total}}\right)^2.
+}
+\]
+
+As written, the squared gradient and its variance are not fully defined. A deployable meta-objective must specify the aggregation domain, for example
+
+\[
+V_t(\eta)
+=
+\operatorname{Var}_{b\in\mathcal B_t}
+\left[
+\nabla_\theta\mathcal L_b(\theta_t-\eta\nabla_\theta\mathcal L_b)
+\right],
+\]
+
+followed by a bounded hypergradient update.
+
+To preserve a positive bounded learning rate, one option is
+
+\[
+\eta_t
+=
+\eta_{\min}
++
+(\eta_{\max}-\eta_{\min})\sigma(\xi_t),
+\]
+
+\[
+\xi_{t+1}
+=
+\operatorname{clip}
+\left(
+\xi_t-\mu\nabla_{\xi_t}V_t,
+\xi_{\min},
+\xi_{\max}
+\right).
+\]
+
+This bounded form is an implementation recommendation; it does not replace the source formulation unless adopted by a later architecture decision.
+
+---
+
+## 11. Unified runtime operator
+
+The source unified mapping is
+
+\[
+\boxed{
+\Psi_{3D}:
+\left(
+\Phi_t;\mathbf r_0,\theta_t,Z_{t-1}^*
+\right)
+\xrightarrow{\mathrm{Auto\mbox{-}Evolve}}
+\left(
+\widehat\Phi_{t+1};
+\mathbf r_0^{\mathrm{new}},
+\theta_{t+1},
+Z_t^*
+\right).
+}
+\]
+
+A reality-grounded operational decomposition is
+
+\[
+\Phi_t=\mathcal P_m(\mathbf X_t^{(m)}),
+\]
+
+\[
+Z_t^{(0)}=\mathcal I(\Phi_t,Z_{t-1}^*),
+\]
+
+\[
+Z_t^{(k+1)}
+=
+\Pi_{\mathrm{div0}}
+F_{\theta_t,\Phi_t}(Z_t^{(k)}),
+\]
+
+\[
+Z_t^*=\operatorname{AcceptFixedPoint}
+\left(
+\{Z_t^{(k)}\}_{k=0}^{K_{\max}},
+\varepsilon,
+\Lambda_t
+\right),
+\]
+
+\[
+\widehat\Phi_t=\mathcal D_{\vartheta_t}(Z_t^*),
+\]
+
+\[
+\theta_{t+1}
+=
+\operatorname{Project}_{\Theta_{\mathrm{safe}}}
+\left(
+\theta_t-\eta_t\nabla_{\theta_t}\mathcal L_{\mathrm{total}}
+\right).
+\]
+
+A separate transition operator is required when producing \(\widehat\Phi_{t+1}\).
+
+---
+
+## 12. Reference-frame claims
+
+The source philosophical closure proposes that the reference point \(\mathbf r_0\) is removed by curl and convolution, and that the divergence-free latent constitutes an invariant geometric identity.
+
+The precise mathematical boundary is:
+
+- the ordinary curl is translation-equivariant on a homogeneous domain with compatible boundary conditions;
+- convolution with a translation-invariant kernel is translation-equivariant, not automatically invariant;
+- FFT implementations inherit the selected discrete boundary model;
+- a divergence-free field is not necessarily translation-, rotation-, or gauge-invariant;
+- the modality adapter may introduce an explicit origin, camera frame, token layout, or other reference dependence;
+- a decoder may also break equivariance unless designed and tested to preserve it.
+
+For a translation action \(T_{\mathbf a}\), the operational property to test is
+
+\[
+F(T_{\mathbf a}\Phi,T_{\mathbf a}Z)
+=
+T_{\mathbf a}F(\Phi,Z).
+\]
+
+True output invariance would instead require
+
+\[
+G(T_{\mathbf a}\Phi)=G(\Phi),
+\]
+
+which discards location information and is a different design objective.
+
+The specification therefore treats reference-frame invariance as a hypothesis requiring architectural constraints and tests, not as proven by the current equations.
+
+---
+
+## 13. Transactional runtime integration
+
+The recursive engine must not directly mutate canonical VM state. It should execute as a proposed-state subsystem:
+
+```text
+Acquire modality
+  → validate and project to Φ_t
+  → initialize recursive latent state
+  → bounded fixed-point iterations
+  → divergence projection
+  → decode
+  → compute loss and diagnostics
+  → propose θ/Z/output update
+  → Λ policy and resource validation
+  → transaction buffer
+  → commit or rollback
+  → Ω provenance journal
+```
+
+A candidate transaction contains at minimum:
+
+```json
+{
+  "engine_version": "dr-moagi-3d-recursive-runtime/0.1",
+  "input_hash": "sha256",
+  "adapter_version": "string",
+  "grid_contract": {},
+  "parameter_hash_before": "sha256",
+  "latent_hash_before": "sha256",
+  "iterations": 0,
+  "fixed_point_residual": 0.0,
+  "divergence_residual": 0.0,
+  "loss_terms": {},
+  "policy_decision": "ALLOW | DENY | REVIEW",
+  "parameter_hash_after": "sha256",
+  "latent_hash_after": "sha256",
+  "output_hash": "sha256"
+}
+```
+
+Rejected updates must leave authoritative parameters, latent state, journal head, and cycle counter unchanged except for an append-only rejected-candidate diagnostic record.
+
+---
+
+## 14. Minimal reference implementation plan
+
+### Stage A — deterministic numerical kernel
+
+Implement a small periodic grid with:
+
+- one vector observation modality;
+- fixed \(\mathcal P_m\);
+- regularized Green kernel;
+- NumPy or equivalent FFT convolution;
+- ordinary curl;
+- explicit Helmholtz-Hodge projection;
+- bounded fixed-point iteration;
+- fixed decoder;
+- no online parameter update.
+
+### Stage B — differentiable model
+
+Add:
+
+- learned adapter;
+- learned decoder;
+- accepted asymmetric bilinear interaction if required;
+- differentiable or implicit-gradient fixed-point solver;
+- constrained parameter projection;
+- deterministic training fixtures.
+
+### Stage C — streaming temporal system
+
+Add:
+
+- explicit transition operator \(\mathcal T_\rho\);
+- timestamp and frame contracts;
+- state checkpointing;
+- temporal evaluation datasets;
+- drift and failure monitoring.
+
+### Stage D — bounded meta-optimization
+
+Add only after the base system is validated:
+
+- held-out meta-objective;
+- bounded positive learning-rate parameterization;
+- shadow evaluation;
+- rollback on regression;
+- reproducible promotion criteria.
+
+---
+
+## 15. Validation matrix
+
+An implementation is not considered operational until the following are demonstrated.
+
+| Property | Required evidence |
+|---|---|
+| Shape correctness | adapters, fields, kernels, decoder, and state transitions reject incompatible shapes |
+| Determinism | identical input, seed, parameters, and runtime version yield identical committed outputs |
+| Boundedness | hard limits on grid size, iterations, memory, wall time, and parameter magnitude |
+| Fixed-point integrity | residual reported; non-convergence fails closed or follows a declared degraded path |
+| Divergence projection | measured post-projection divergence below a declared tolerance |
+| Round-trip quality | reconstruction metrics on declared datasets and baselines |
+| Temporal validity | future prediction evaluated separately from same-time reconstruction |
+| Equivariance | translated/rotated fixtures with explicit numerical tolerances |
+| Gradient validity | finite-difference or automatic-differentiation checks |
+| Meta-update safety | learning-rate and parameter updates remain within accepted bounds |
+| Transactionality | injected failures do not partially mutate authoritative state |
+| Provenance | every accepted and rejected proposal is hash-linked and replayable |
+| Adversarial handling | NaN, Inf, singular kernels, malformed shapes, extreme amplitudes, and resource exhaustion |
+
+---
+
+## 16. Canonical conclusion
+
+This specification defines a substantive research direction for a three-dimensional recursive auto-encoding and decoding layer:
+
+\[
+\text{multimodal input}
+\rightarrow
+\text{3D projection}
+\rightarrow
+\text{bounded inward recursion}
+\rightarrow
+\text{divergence projection}
+\rightarrow
+\text{fixed-point acceptance}
+\rightarrow
+\text{decoding}
+\rightarrow
+\text{loss and constrained update}
+\rightarrow
+\text{verified transaction}.
+\]
+
+The core proposal is mathematically expressible and implementable in stages. The current equations do not yet prove convergence, absolute invariance, non-commutative self-interaction, temporal prediction, or operational completeness. Those properties must be established through corrected operator definitions, bounded algorithms, tests, empirical evaluation, and integration with the Jarvis-X policy and provenance boundaries.
+
+The architecture should therefore be treated as a **proposed recursive 3D field engine** until a reference implementation and validation suite satisfy the acceptance matrix above.

--- a/docs/DR_MOAGI_3D_UNIFIED_FIELD_EQUATION.md
+++ b/docs/DR_MOAGI_3D_UNIFIED_FIELD_EQUATION.md
@@ -1,0 +1,964 @@
+# Dr Moagi 3D Unified Field Equation
+
+## Status
+
+**Proposed mathematical and runtime specification.**
+
+This document records the 3D Dr Moagi unified auto-encoding/decoding field model and translates it into a dimensionally typed, bounded, testable form compatible with the Jarvis-X architecture.
+
+It is a companion to:
+
+- `DR_MOAGI_3D_RECURSIVE_RUNTIME_ENGINE.md`;
+- `DR_MOAGI_3D_BILLION_INSTANCE_AUTOENCODER_EQUATION.md`;
+- `ARCHITECTURE.md`.
+
+The equations below define a research model. They do not, by themselves, establish:
+
+- exact reconstruction of arbitrary data from a smaller seed;
+- a measured 1000 GB-to-1 KB compression ratio;
+- conservation of the proposed energy in the presence of damping or learning;
+- existence or stability of a soliton solution;
+- physical equivalence between an informational field and a material field;
+- production implementation or validated forecasting capability.
+
+Those properties require explicit assumptions, executable kernels and reproducible validation.
+
+---
+
+## 1. Spatial-temporal domain and type contract
+
+Let
+
+\[
+V\subset\mathbb R^3,
+\qquad
+\mathbf r=(x,y,z)\in V,
+\qquad
+t\in[0,T].
+\]
+
+The operational field is represented as a vector-valued field
+
+\[
+\boxed{
+\Psi:V\times[0,T]\rightarrow\mathbb R^{d_\Psi}
+}
+\]
+
+with the canonical geometric realization \(d_\Psi=3\).
+
+The latent seed must be time-dependent if it obeys an evolution equation:
+
+\[
+\boxed{
+\Theta:V\times[0,T]\rightarrow\mathbb R^{d_\Theta}.
+}
+\]
+
+The query/context field is
+
+\[
+\mathcal Q:V\times[0,T]\rightarrow\mathbb R.
+\]
+
+The decoder is a map
+
+\[
+\mathcal D_\vartheta:
+\Theta\mapsto\widehat\Psi,
+\]
+
+where \(\vartheta\) denotes decoder parameters and
+
+\[
+\mathcal D_\vartheta[\Theta](\mathbf r,t)
+\in\mathbb R^{d_\Psi}.
+\]
+
+To keep the encoder term in the same codomain as \(\Psi\), define the encoder flux as a rank-2 tensor field:
+
+\[
+\mathcal A_\varphi[\Psi](\mathbf r,t)
+\in\mathbb R^{d_\Psi\times3}.
+\]
+
+Its row-wise divergence is vector-valued:
+
+\[
+\left(\nabla\cdot\mathcal A_\varphi[\Psi]\right)_i
+=
+\sum_{j=1}^{3}
+\frac{\partial (\mathcal A_\varphi[\Psi])_{ij}}{\partial r_j}.
+\]
+
+For the contextual cross-product term, the canonical 3D realization requires
+
+\[
+d_\Psi=d_\Theta=3.
+\]
+
+If a different channel dimension is used, the cross product must be replaced by a declared bilinear map
+
+\[
+B_\chi:\mathbb R^{d_\Theta}\times\mathbb R^3
+\rightarrow\mathbb R^{d_\Psi}.
+\]
+
+---
+
+## 2. Submitted unified field equation
+
+The intended hyperbolic-parabolic coupling is represented as
+
+\[
+\boxed{
+\frac{\partial^2\Psi}{\partial t^2}
+=
+c^2\nabla^2\Psi
+-
+\alpha\left(\Psi-\mathcal D_\vartheta[\Theta]\right)
+-
+\beta\nabla\cdot\mathcal A_\varphi[\Psi]
++
+\gamma\left(\Theta\times\nabla\mathcal Q\right).
+}
+\]
+
+The terms have the following operational interpretations:
+
+1. **Wave propagation**
+
+   \[
+   c^2\nabla^2\Psi
+   \]
+
+   transports local field variation through the declared 3D domain.
+
+2. **Decoder restoring force**
+
+   \[
+   -\alpha(\Psi-\mathcal D_\vartheta[\Theta])
+   \]
+
+   pulls the operational field toward the current decoded seed field.
+
+3. **Encoder-flux coupling**
+
+   \[
+   -\beta\nabla\cdot\mathcal A_\varphi[\Psi]
+   \]
+
+   injects the divergence of a learned vector-valued flux into the field dynamics.
+   It is not automatically a compression operator; compression is established only by the latent representation, rate constraint and measured reconstruction trade-off.
+
+4. **Contextual rotational forcing**
+
+   \[
+   \gamma(\Theta\times\nabla\mathcal Q)
+   \]
+
+   is orthogonal to both the local latent vector and query gradient in the canonical 3D realization.
+   It is a rotational forcing term, not a proof of creativity or novelty.
+
+A damped form is preferred for bounded numerical evolution:
+
+\[
+\boxed{
+\frac{\partial^2\Psi}{\partial t^2}
++
+\lambda_\Psi\frac{\partial\Psi}{\partial t}
+=
+c^2\nabla^2\Psi
+-
+\alpha\left(\Psi-\mathcal D_\vartheta[\Theta]\right)
+-
+\beta\nabla\cdot\mathcal A_\varphi[\Psi]
++
+\gamma\left(\Theta\times\nabla\mathcal Q\right),
+}
+\]
+
+with \(\lambda_\Psi\ge0\).
+
+---
+
+## 3. Latent-seed evolution
+
+Define the reconstruction functional
+
+\[
+\boxed{
+\mathcal J_{\mathrm{rec}}(\Theta;\Psi)
+=
+\frac12
+\iiint_V
+\left\|
+\Psi(\mathbf r,t)
+-
+\mathcal D_\vartheta[\Theta](\mathbf r,t)
+\right\|_2^2
+\,dV.
+}
+\]
+
+The submitted auto-encoding constraint is a functional gradient flow:
+
+\[
+\boxed{
+\frac{\partial\Theta}{\partial t}
+=
+-\eta_\Theta
+\frac{\delta\mathcal J_{\mathrm{rec}}}{\delta\Theta}.
+}
+\]
+
+The variational derivative, rather than an ordinary finite-dimensional gradient, is required because \(\Theta\) is a spatial field.
+
+A regularized operational form is
+
+\[
+\boxed{
+\frac{\partial\Theta}{\partial t}
+=
+D_\Theta\nabla^2\Theta
+-
+\eta_\Theta
+\frac{\delta}{\delta\Theta}
+\left[
+\mathcal J_{\mathrm{rec}}
++
+\lambda_R\mathcal R(\Theta)
++
+\lambda_T\mathcal J_{\mathrm{temporal}}
+\right]
+-
+\kappa_\Theta\Theta,
+}
+\]
+
+where
+
+- \(D_\Theta\ge0\) is latent diffusion;
+- \(\mathcal R\) is a declared capacity, sparsity or smoothness regularizer;
+- \(\mathcal J_{\mathrm{temporal}}\) penalizes uncontrolled temporal drift;
+- \(\kappa_\Theta\ge0\) is latent decay.
+
+Without the \(D_\Theta\nabla^2\Theta\) term, the equation is a local reaction/relaxation flow rather than a reaction-diffusion equation.
+
+---
+
+## 4. Explicit 3D decoder
+
+Let \(K_\vartheta\) be a learned or fixed kernel. Define
+
+\[
+\boxed{
+\mathcal D_{3D,\vartheta}[\Theta](\mathbf p,t)
+=
+\int_V
+K_\vartheta(\mathbf p,\mathbf p')
+\Theta(\mathbf p',t)
+\,d\mathbf p'
+\odot
+\mathcal F_\vartheta
+\left(
+q(\mathbf p,t),d(\mathbf p),s_t
+\right).
+}
+\]
+
+Here:
+
+- \(\mathbf p=(x,y,z)\);
+- \(K_\vartheta\) controls spatial support and coupling;
+- \(q\) is query/context data;
+- \(d\) is an explicitly defined depth coordinate or metadata value;
+- \(s_t\) is optional side information;
+- \(\odot\) must be defined as scalar, channelwise or tensor contraction.
+
+For a translation-invariant convolution,
+
+\[
+K_\vartheta(\mathbf p,\mathbf p')
+=
+kappa_\vartheta(\mathbf p-\mathbf p').
+\]
+
+A Gaussian kernel spreads influence but does not create independent information. A fractal or learned generator may expand a compact latent seed into a large structured output, but exact recovery requires that the target lie in the decoder's image and that all necessary conditioning information be available.
+
+---
+
+## 5. Encoder: flux features, Hodge projection and digest
+
+The submitted surface and volume summaries are useful features:
+
+\[
+F_{\partial V}(\Psi)
+=
+\oint_{\partial V}
+\Psi\cdot\mathbf n\,dS,
+\]
+
+\[
+M_V(\Psi)
+=
+\iiint_V
+\Psi\,dV.
+\]
+
+By the divergence theorem,
+
+\[
+F_{\partial V}(\Psi)
+=
+\iiint_V
+\nabla\cdot\Psi\,dV
+\]
+
+when the regularity assumptions hold.
+
+These integrals are global summaries. They are not, by themselves, a Helmholtz decomposition and cannot uniquely encode an arbitrary field.
+
+The divergence-free component of a sufficiently regular vector field is obtained using the Hodge/Helmholtz projection
+
+\[
+\boxed{
+\mathcal P_{\mathrm{df}}\Psi
+=
+\Psi
+-
+\nabla\Delta^{-1}(\nabla\cdot\Psi),
+}
+\]
+
+subject to declared boundary conditions and treatment of harmonic components.
+
+A typed encoder can therefore be written as
+
+\[
+\boxed{
+\mathcal A_{3D,\varphi}[\Psi]
+=
+E_\varphi
+\left(
+\mathcal P_{\mathrm{df}}\Psi,
+F_{\partial V}(\Psi),
+M_V(\Psi),
+\operatorname{features}(\Psi)
+\right).
+}
+\]
+
+A cryptographic digest may be attached for integrity:
+
+\[
+h_t
+=
+\operatorname{Hash}
+\left(
+\operatorname{Canon}(\Psi_t)
+\right).
+\]
+
+However,
+
+\[
+\boxed{
+\operatorname{Hash}(\Psi)
+\text{ is not an invertible encoding of }\Psi.
+}
+\]
+
+Bitwise XOR of summaries can produce a fixed-width identifier or sketch, but it cannot support exact arbitrary reconstruction. It must not be described as a reversible compressed seed unless an external content-addressed store, codebook, deterministic generator or other side information supplies the missing information.
+
+---
+
+## 6. Compression and expansion boundary
+
+Suppose an input contains \(N\) bits and the seed contains \(M<N\) bits. A deterministic lossless encoder
+
+\[
+E:\{0,1\}^N\rightarrow\{0,1\}^M
+\]
+
+cannot be injective over all possible inputs because
+
+\[
+2^N>2^M.
+\]
+
+Therefore exact universal compression from 1000 GB to 1 KB is impossible without restricting the source family or retaining side information.
+
+The system can legitimately implement one or more of the following:
+
+1. **Lossy representation**
+
+   \[
+   \Theta=E(\Psi),
+   \qquad
+   \widehat\Psi=D(\Theta),
+   \qquad
+   \|\Psi-\widehat\Psi\|\le\varepsilon.
+   \]
+
+2. **Generative expansion**
+
+   a small seed selects or generates a large structured output, which need not reproduce an arbitrary original input.
+
+3. **Content-addressed reference**
+
+   the seed is a digest or key identifying data stored elsewhere.
+
+4. **Programmatic description**
+
+   the seed is executable logic that generates a compressible target family.
+
+5. **Model-plus-residual coding**
+
+   \[
+   \Psi
+   =
+   D(\Theta)+R,
+   \]
+
+   where the total bit cost includes the model, seed, residual and metadata.
+
+The reported compression rate must therefore use
+
+\[
+\boxed{
+R
+=
+\frac{
+B_{\Theta}
++B_{\mathrm{side}}
++B_{\mathrm{model\ share}}
++B_{\mathrm{residual}}
+}{B_{\Psi}}.
+}
+\]
+
+Reconstruction quality must be reported separately.
+
+---
+
+## 7. Dual-phase field system
+
+Define the d'Alembert operator under the convention
+
+\[
+\square_c
+=
+\frac{1}{c^2}\frac{\partial^2}{\partial t^2}
+-
+\nabla^2.
+\]
+
+### Phase A: decoder wave
+
+A dimensionally explicit decoder wave is
+
+\[
+\boxed{
+\square_c\Psi
++
+\frac{\lambda_\Psi}{c^2}
+\frac{\partial\Psi}{\partial t}
+=
+S_D[\Theta]
++S_A[\Psi]
++S_Q[\Theta,\mathcal Q],
+}
+\]
+
+where
+
+\[
+S_D[\Theta]
+=-\frac{\alpha}{c^2}
+(\Psi-\mathcal D_\vartheta[\Theta]),
+\]
+
+\[
+S_A[\Psi]
+=-\frac{\beta}{c^2}
+\nabla\cdot\mathcal A_\varphi[\Psi],
+\]
+
+\[
+S_Q[\Theta,\mathcal Q]
+=
+\frac{\gamma}{c^2}
+(\Theta\times\nabla\mathcal Q).
+\]
+
+### Phase B: encoder flow
+
+\[
+\boxed{
+\frac{\partial\Theta}{\partial t}
+=
+D_\Theta\nabla^2\Theta
+-
+\eta_\Theta
+\frac{\delta\mathcal J}{\delta\Theta}
+-
+\kappa_\Theta\Theta.
+}
+\]
+
+The coupled state is
+
+\[
+\mathcal S_t
+=
+\left(
+\Psi_t,
+\partial_t\Psi_t,
+\Theta_t,
+\vartheta_t,
+\varphi_t,
+\Omega_t,
+\Lambda_t
+\right).
+\]
+
+---
+
+## 8. Energy and dissipation law
+
+The proposed field energy is
+
+\[
+\mathcal H[\Psi,\Theta]
+=
+\int_V
+\left[
+\frac12\|\partial_t\Psi\|^2
++
+\frac{c^2}{2}\|\nabla\Psi\|_F^2
++
+\frac{\alpha}{2}
+\|\Psi-\mathcal D_\vartheta[\Theta]\|^2
++
+\frac{\beta}{2}
+\|\nabla\cdot\mathcal A_\varphi[\Psi]\|^2
+\right]dV
++
+\mathcal R_\Theta[\Theta].
+\]
+
+This functional is not generally constant under:
+
+- damping \(\lambda_\Psi\partial_t\Psi\);
+- latent decay \(-\kappa_\Theta\Theta\);
+- gradient descent in \(\Theta\);
+- time-varying queries or external forcing;
+- time-varying encoder/decoder parameters.
+
+The appropriate invariant is therefore normally an energy balance or Lyapunov inequality, not strict conservation.
+
+Under compatible boundary conditions, no external forcing and exact gradient-flow coupling, the target property is
+
+\[
+\boxed{
+\frac{d\mathcal H}{dt}
+=
+-\lambda_\Psi
+\int_V\|\partial_t\Psi\|^2dV
+-
+\eta_\Theta
+\int_V
+\left\|
+\frac{\delta\mathcal H}{\delta\Theta}
+\right\|^2dV
+-
+\mathcal D_{\mathrm{latent}}
+\le0,
+}
+\]
+
+where \(\mathcal D_{\mathrm{latent}}\ge0\) contains diffusion and decay dissipation terms.
+
+Strict conservation is recovered only in a conservative special case, for example:
+
+\[
+\lambda_\Psi=0,
+\qquad
+\eta_\Theta=0,
+\qquad
+\kappa_\Theta=0,
+\]
+
+with time-independent parameters, no external forcing and energy-compatible boundary conditions.
+
+---
+
+## 9. Candidate traveling-wave ansatz
+
+The submitted field
+
+\[
+\Psi^*(x,y,z,t)
+=
+\Theta_0
+\operatorname{sech}
+\left(
+\frac{x+y+z-vt}{\sigma}
+\right)
+\exp(i\mathcal Q(x,y,z))
+\]
+
+is a candidate traveling-wave ansatz.
+
+It is not automatically an eigensolution or soliton of the coupled system.
+
+A localized soliton requires a balance between dispersion and nonlinearity and must satisfy the PDE after substitution. The submitted wave equation is primarily linear in \(\Psi\) unless \(\mathcal A\), \(\mathcal D\) or the coupling terms introduce a specifically defined nonlinearity.
+
+Validation requires:
+
+1. substitute the ansatz into both coupled equations;
+2. calculate the residual fields
+
+   \[
+   R_\Psi
+   =
+   \partial_{tt}\Psi^*
+   -
+   \operatorname{RHS}_\Psi(\Psi^*,\Theta^*),
+   \]
+
+   \[
+   R_\Theta
+   =
+   \partial_t\Theta^*
+   -
+   \operatorname{RHS}_\Theta(\Psi^*,\Theta^*);
+   \]
+
+3. prove \(R_\Psi=0\) and \(R_\Theta=0\), or report their numerical norms;
+4. perturb the solution and test orbital or asymptotic stability;
+5. specify the boundary conditions and admissible parameter regime.
+
+Until those checks pass, the field is designated a visualization or initialization profile rather than a proven soliton.
+
+---
+
+## 10. Query localization
+
+A point query can be represented distributionally as
+
+\[
+\mathcal Q(\mathbf r)
+=
+q_0\delta(\mathbf r-\mathbf r_q).
+\]
+
+Then \(\nabla\mathcal Q\) is the derivative of a distribution. This is mathematically valid in a weak formulation but unsuitable for direct pointwise numerical evaluation.
+
+On a grid, use a normalized mollifier:
+
+\[
+\boxed{
+\delta_\varepsilon(\mathbf r-\mathbf r_q)
+=
+\frac{1}{(2\pi\varepsilon^2)^{3/2}}
+\exp
+\left(
+-\frac{\|\mathbf r-\mathbf r_q\|^2}{2\varepsilon^2}
+\right).
+}
+\]
+
+The discretized support width must be recorded in the runtime configuration and provenance ledger.
+
+---
+
+## 11. Boundary and initial conditions
+
+The coupled PDE is incomplete until it declares:
+
+\[
+\Psi(\mathbf r,0)=\Psi_0(\mathbf r),
+\]
+
+\[
+\partial_t\Psi(\mathbf r,0)=V_0(\mathbf r),
+\]
+
+\[
+\Theta(\mathbf r,0)=\Theta_0(\mathbf r).
+\]
+
+One boundary family must be selected:
+
+- periodic;
+- homogeneous Dirichlet;
+- homogeneous Neumann;
+- absorbing/radiation;
+- mixed, with each boundary face specified.
+
+FFT convolution naturally implies periodic extension unless padding or another transform is used. The implementation must not describe the solver as free-space while silently using periodic wraparound.
+
+---
+
+## 12. Bounded discrete runtime
+
+Let the grid be
+
+\[
+N_x\times N_y\times N_z
+\]
+
+with spacings \(\Delta x,\Delta y,\Delta z\) and time step \(\Delta t\).
+
+A reference staggered update is
+
+\[
+V^{n+1/2}
+=
+V^{n-1/2}
++
+\Delta t\,
+F_\Psi(\Psi^n,\Theta^n,\mathcal Q^n),
+\]
+
+\[
+\Psi^{n+1}
+=
+\Psi^n+\Delta t\,V^{n+1/2},
+\]
+
+\[
+\Theta^{n+1}
+=
+\Theta^n
++
+\Delta t\,
+F_\Theta(\Psi^n,\Theta^n).
+\]
+
+For an explicit 3D wave stencil, the Courant condition must be enforced. For equal grid spacing \(h\), a standard sufficient condition is
+
+\[
+\boxed{
+\frac{c\Delta t}{h}
+\le
+\frac{1}{\sqrt3}
+}
+\]
+
+before additional stiffness from decoder, encoder and coupling terms is considered.
+
+Each cycle must enforce:
+
+- finite-value checks;
+- state and parameter bounds;
+- memory limits;
+- maximum iteration count;
+- residual thresholds;
+- CFL/stability checks;
+- transaction rollback on violation.
+
+---
+
+## 13. Integration with the Jarvis-X transactional model
+
+A proposed cycle is
+
+```text
+acquire multimodal input
+  -> project to 3D observation field
+  -> stage query/context field
+  -> evolve decoder wave candidate
+  -> evolve latent seed candidate
+  -> compute reconstruction and PDE residuals
+  -> compute energy balance
+  -> apply Lambda admissibility projection
+  -> write candidate state to transaction buffer
+  -> verify bounds, hashes and provenance
+  -> commit Psi, Theta and Omega together
+     or roll back the complete candidate state
+```
+
+Let
+
+\[
+\widetilde{\mathcal S}_{t+1}
+=
+\operatorname{Step}(\mathcal S_t,X_t,U_t).
+\]
+
+The policy projection returns
+
+\[
+\Lambda_t
+=
+\operatorname{Validate}
+(\widetilde{\mathcal S}_{t+1}).
+\]
+
+The commit is
+
+\[
+\boxed{
+\mathcal S_{t+1}
+=
+\begin{cases}
+\widetilde{\mathcal S}_{t+1},&\Lambda_t=1,\\
+\mathcal S_t,&\Lambda_t=0.
+\end{cases}
+}
+\]
+
+The Ω journal records:
+
+- configuration and discretization hash;
+- input and query hashes;
+- prior-state hash;
+- proposed-state hash;
+- reconstruction residual;
+- PDE residuals;
+- energy change;
+- policy decision;
+- committed-state hash.
+
+---
+
+## 14. Operational validation matrix
+
+### 14.1 Shape and type tests
+
+- every field operator returns its declared codomain;
+- scalar, vector and tensor contractions are explicit;
+- no implicit broadcasting changes the mathematics.
+
+### 14.2 Decoder tests
+
+- zero seed behavior;
+- impulse response;
+- translation-equivariance where claimed;
+- finite output under bounded input;
+- gradient correctness.
+
+### 14.3 Encoder tests
+
+- Hodge projection reduces divergence within tolerance;
+- boundary flux and volume summary match reference quadrature;
+- digest is treated only as integrity metadata;
+- latent bit cost is measured.
+
+### 14.4 PDE tests
+
+- manufactured solutions;
+- spatial convergence under grid refinement;
+- temporal convergence under step refinement;
+- CFL rejection;
+- boundary-condition fixtures;
+- deterministic replay.
+
+### 14.5 Energy tests
+
+- conservative configuration preserves energy within numerical tolerance;
+- damped configuration has non-increasing energy absent forcing;
+- external forcing accounts for measured energy injection.
+
+### 14.6 Compression tests
+
+Report jointly:
+
+- input bit count;
+- seed bit count;
+- model and side-information cost;
+- residual bit count;
+- reconstruction error;
+- runtime and peak resident memory.
+
+### 14.7 Traveling-wave tests
+
+- symbolic or automatic-differentiation residual;
+- numerical propagation error;
+- perturbation response;
+- parameter regime for stability.
+
+---
+
+## 15. Canonical formal signature
+
+The proposed unified operator is
+
+\[
+\boxed{
+\mathfrak M_{3D}:
+\left(
+\Psi_t,
+\partial_t\Psi_t,
+\Theta_t,
+\mathcal Q_t,
+\vartheta_t,
+\varphi_t,
+\Omega_t
+\right)
+\mapsto
+\left(
+\widehat\Psi_{t+1},
+\partial_t\widehat\Psi_{t+1},
+\Theta_{t+1},
+\vartheta_{t+1},
+\varphi_{t+1},
+\Omega_{t+1}
+\right),
+}
+\]
+
+subject to:
+
+\[
+\text{bounded numerical evolution},
+\]
+
+\[
+\text{explicit compression accounting},
+\]
+
+\[
+\text{typed field operators},
+\]
+
+\[
+\text{Λ-gated transactional commit},
+\]
+
+\[
+\text{Ω-linked deterministic provenance}.
+\]
+
+In compact coupled form:
+
+\[
+\boxed{
+\begin{aligned}
+\partial_{tt}\Psi
++
+\lambda_\Psi\partial_t\Psi
+&=
+ c^2\nabla^2\Psi
+-
+\alpha(\Psi-\mathcal D_\vartheta[\Theta])
+-
+\beta\nabla\cdot\mathcal A_\varphi[\Psi]
++
+\gamma B_\chi(\Theta,\nabla\mathcal Q),\\[4pt]
+\partial_t\Theta
+&=
+D_\Theta\nabla^2\Theta
+-
+\eta_\Theta
+\frac{\delta\mathcal J}{\delta\Theta}
+-
+\kappa_\Theta\Theta.
+\end{aligned}
+}
+\]
+
+This is the operational mathematical target. It becomes an implemented runtime only when a finite discretization, typed operators, bounded parameters, deterministic fixtures and transaction semantics are supplied and tested.


### PR DESCRIPTION
## Summary

Adds two proposed mathematical specifications for the Dr Moagi 3D auto-encoding/decoding runtime:

1. `docs/DR_MOAGI_3D_RECURSIVE_RUNTIME_ENGINE.md`
   - multimodal projection into a declared 3D field;
   - recursive latent fixed-point refinement;
   - Green-kernel convolution;
   - divergence-free latent projection;
   - temporal transition and bounded meta-optimization;
   - transactional integration with Λ policy and Ω provenance.

2. `docs/DR_MOAGI_3D_UNIFIED_FIELD_EQUATION.md`
   - coupled hyperbolic-parabolic field model for Ψ and Θ;
   - typed vector/tensor operator contracts;
   - 3D decoder convolution and encoder/Hodge projection;
   - explicit compression-accounting boundary;
   - conservative versus dissipative energy law;
   - candidate traveling-wave validation requirements;
   - mollified point-query representation;
   - bounded discretization, CFL checks and rollback semantics.

## Material mathematical findings recorded

### Recursive fixed-point model

- `Z ×_⊙ Z` is identically zero under the submitted same-transform cross-product definition.
- A small fixed-point update is a stopping test, not a convergence proof.
- `1/|r|` requires singularity handling and explicit boundary conditions.
- Divergence-free does not by itself prove translation, rotation or reference-frame invariance.
- A decoder reconstructs the latent time index; forecasting `t+1` requires a temporal transition operator.
- The learning-rate hypergradient needs a defined variance objective and bounded positive parameterization.

### Unified field model

- The submitted PDE mixes scalar, vector and tensor terms unless explicit codomains are declared. The companion specification provides a typed vector-field realization and rank-2 encoder flux.
- Θ must depend on time if `∂Θ/∂t` is defined.
- A surface flux and volume integral are summaries, not a Helmholtz decomposition; the divergence-free projection requires a Hodge operator.
- A cryptographic hash or XOR digest is not an invertible compressed representation.
- Universal exact compression from 1000 GB to 1 KB is impossible without source restrictions or side information; the document separates lossy, generative, content-addressed and model-plus-residual modes.
- Damping and gradient-flow learning make the proposed Hamiltonian dissipative rather than constant. Strict conservation applies only to a conservative special case.
- The submitted sech profile is a candidate ansatz, not a proven soliton, until the coupled PDE residual and stability conditions are verified.
- A Dirac-delta query requires weak/distributional treatment or grid regularization.

## Scope

Documentation/specification only. No canonical VM semantics are changed. The PR remains draft until executable reference kernels and deterministic validation fixtures are added or tracked separately.