### PR TITLE
Make canonical VM instruction cycles transactional

### DIFF
--- a/docs/CANONICAL_TRANSACTIONAL_VM.md
+++ b/docs/CANONICAL_TRANSACTIONAL_VM.md
@@ -1,0 +1,235 @@
+# Canonical Transactional VM Core
+
+## Status
+
+**Integration candidate.**
+
+This document defines the transaction boundary implemented by the canonical `CodexVM` branch. It narrows the system-wide Jarvis-X operational law into one executable instruction-cycle contract.
+
+The governing rule is:
+
+```text
+checkpoint authoritative state
+→ decode and authorize
+→ enforce the prospective cycle budget
+→ execute the instruction
+→ apply explicitly enabled reflex correction
+→ construct the canonical post-state
+→ persist the ledger entry
+→ record the trace
+→ commit
+```
+
+If any operation after the checkpoint fails, the authoritative checkpoint is restored and the VM stops.
+
+## Authoritative state covered by one instruction transaction
+
+A checkpoint contains:
+
+- the complete register file;
+- the complete VM memory image;
+- the committed cycle count;
+- the running state;
+- the Omega-ledger length;
+- the trace length.
+
+The loaded program is immutable during an instruction cycle and therefore does not require a per-step copy.
+
+The transaction state is:
+
+\[
+S_t=(R_t,M_t,c_t,q_t,J_t,T_t),
+\]
+
+where:
+
+- \(R_t\) is the register file;
+- \(M_t\) is memory;
+- \(c_t\) is the committed cycle count;
+- \(q_t\) is the run-state flag;
+- \(J_t\) is the ledger prefix;
+- \(T_t\) is the trace prefix.
+
+For a decoded and authorized instruction \(i_t\), execution proposes:
+
+\[
+\widetilde S_{t+1}=F(S_t,i_t).
+\]
+
+The candidate commits only if execution, resource enforcement, provenance persistence and tracing all succeed:
+
+\[
+S_{t+1}=
+\begin{cases}
+\widetilde S_{t+1}, & V(\widetilde S_{t+1})=\mathrm{pass},\\
+S_t, & V(\widetilde S_{t+1})=\mathrm{fail}.
+\end{cases}
+\]
+
+A failed transaction stops execution after restoration. The caller must explicitly decide whether to inspect, repair, reload or discard the machine.
+
+## Cycle-budget semantics
+
+The sandbox validates the prospective committed cycle count before instruction execution:
+
+\[
+c' = c_t + 1,
+\qquad
+c' \le c_{\max}.
+\]
+
+This prevents an instruction beyond the configured budget from mutating state and then requiring avoidable rollback.
+
+Exactly `max_cycles` instructions may commit. The next attempted instruction fails closed and preserves the last committed checkpoint.
+
+## Reflex ordering
+
+Reflex correction remains disabled by default.
+
+When enabled, it is part of the same instruction transaction and runs before the canonical snapshot is written to the ledger and trace:
+
+```text
+execute instruction
+→ optional reflex stabilization
+→ advance IP and cycle count
+→ snapshot
+→ ledger
+→ trace
+```
+
+Therefore the recorded post-state is the state that is actually authoritative after the instruction. Reflex changes are not hidden from provenance.
+
+This does not turn reflex correction into autonomous authority. It remains an explicit constructor option and is bounded by the same rollback boundary.
+
+## Invalid instruction behavior
+
+The executor recognizes the canonical instruction surface:
+
+- `SET` (`0x01`);
+- `ADD` (`0x03`);
+- `SUB` (`0x04`);
+- `HALT` (`0x0A`).
+
+Unknown opcodes raise an error. Invalid register indices raise an error. Neither case emits a committed receipt or advances the instruction pointer.
+
+This replaces silent continuation with fail-closed behavior.
+
+## Memory contract
+
+Memory now enforces:
+
+- positive allocation size;
+- integer addresses and lengths;
+- non-negative ranges;
+- complete in-bounds reads and writes;
+- equal-size checkpoint restoration.
+
+A failed access cannot use Python slice behavior to wrap negative indices or silently truncate an out-of-range operation.
+
+## Ledger transactionality
+
+The in-memory Omega ledger exposes prefix checkpoints. Restoration removes every entry after the checkpoint.
+
+The persistent ledger uses the following write transaction:
+
+```text
+remember ledger prefix
+→ append candidate entry in memory
+→ write complete candidate ledger to a temporary file
+→ flush and fsync
+→ atomically replace the destination
+```
+
+If persistence fails, the in-memory candidate entry is removed and the previous on-disk file remains authoritative because replacement is atomic.
+
+If a later VM-stage failure requires restoration after a successful ledger write, the prior ledger prefix is persisted again.
+
+The ledger remains a tamper-evident hash chain. It is not encryption, trusted timestamping, external witnessing or deletion resistance.
+
+## Trace transactionality
+
+The tracer exposes prefix checkpoints and restoration. A rejected instruction cannot leave a trace entry describing state that never committed.
+
+For every committed instruction:
+
+\[
+\text{ledger state}=
+\text{trace state}=
+\text{authoritative register state}.
+\]
+
+## Failure classes covered
+
+The transaction boundary covers failures from:
+
+- cycle-budget enforcement;
+- instruction execution;
+- invalid opcodes or register operands;
+- reflex correction;
+- ledger serialization or persistence;
+- trace recording;
+- checkpoint restoration validation.
+
+A failure during rollback is elevated as `VM transaction rollback failed`, and execution stops. This is deliberately distinct from an ordinary rejected candidate because recoverability could not be established.
+
+## Validation fixtures
+
+Focused tests establish:
+
+1. ordinary arithmetic remains deterministic;
+2. reflex remains explicit and its final state is journalled and traced;
+3. a cycle-budget rejection preserves the last committed registers, instruction pointer, cycle count, ledger and trace;
+4. a receipt failure after instruction execution restores registers and memory and emits no receipt;
+5. an unknown opcode fails closed without state mutation;
+6. ledger prefix restoration preserves chain validity;
+7. a persistent-ledger write failure removes the in-memory candidate entry.
+
+The reconstructed focused harness passes all 15 VM and ledger tests.
+
+Repository CI remains authoritative for:
+
+- the complete regression suite;
+- supported Python versions;
+- branch coverage;
+- formatting and import ordering;
+- static type checking;
+- package builds;
+- dependency audit;
+- CodeQL.
+
+## Compatibility boundary
+
+This change intentionally does not yet:
+
+- expand the four-opcode canonical ISA;
+- define a versioned external bytecode envelope;
+- isolate hostile bytecode at the operating-system process boundary;
+- roll back irreversible network, device or external-service effects;
+- define machine-reset versus program-load lifecycle semantics;
+- unify every research runtime under one cross-language receipt format;
+- provide concurrent multi-VM transactions.
+
+External effects must remain outside the instruction mutation boundary until they use a separate prepare/authorize/commit protocol.
+
+## Next integration sequence
+
+After this transaction core is accepted, the recommended order is:
+
+1. define Canonical ISA v1 and its versioned bytecode envelope;
+2. add explicit machine-reset, execution-reset and checkpoint APIs;
+3. introduce one cross-component receipt schema;
+4. add staged external-effect commands;
+5. bind sparse and numerical candidates through typed VM adapters;
+6. add end-to-end deterministic replay across Python, C++ and browser components.
+
+## Capability statement
+
+This implementation supports the following defensible claim:
+
+\[
+\boxed{
+\text{Each canonical VM instruction either commits one complete recorded state transition or preserves the previous authoritative state.}
+}
+\]
+
+It does not establish production security, general intelligence or unrestricted self-modification.

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from os import PathLike
 
 from .debugger import Debugger
@@ -16,12 +17,23 @@ from .sandbox import Sandbox
 from .tracer import Tracer
 
 
-class CodexVM:
-    """Deterministic Jarvis-X bytecode virtual machine.
+@dataclass(frozen=True)
+class _VMCheckpoint:
+    registers: dict[str, int]
+    memory: bytes
+    cycles: int
+    running: bool
+    ledger_length: int
+    trace_length: int
 
-    Ordinary VM execution is side-effect free outside memory unless a
-    ``ledger_path`` is supplied. Reflex stabilization is opt-in so that basic
-    assembly semantics remain authoritative and reproducible.
+
+class CodexVM:
+    """Deterministic transactional Jarvis-X bytecode virtual machine.
+
+    Each instruction executes against a complete authoritative-state checkpoint.
+    A failed execution, validation, journal write, or trace write restores the
+    checkpoint and stops the VM. Reflex stabilization is opt-in and occurs
+    before the canonical post-instruction snapshot is journalled and traced.
     """
 
     def __init__(
@@ -48,6 +60,24 @@ class CodexVM:
         self.program: list[int] = []
         self.cycles = 0
         self.running = False
+
+    def _checkpoint(self) -> _VMCheckpoint:
+        return _VMCheckpoint(
+            registers=self.regs.snapshot(),
+            memory=self.mem.snapshot(),
+            cycles=self.cycles,
+            running=self.running,
+            ledger_length=self.ledger.checkpoint(),
+            trace_length=self.tracer.checkpoint(),
+        )
+
+    def _restore(self, checkpoint: _VMCheckpoint) -> None:
+        self.regs.restore(checkpoint.registers)
+        self.mem.restore(checkpoint.memory)
+        self.cycles = checkpoint.cycles
+        self.running = checkpoint.running
+        self.ledger.restore(checkpoint.ledger_length)
+        self.tracer.restore(checkpoint.trace_length)
 
     def load(self, bytecode: Iterable[int]) -> None:
         program = list(bytecode)
@@ -78,20 +108,31 @@ class CodexVM:
             self.running = False
             raise RuntimeError("Lambda policy blocked instruction")
 
-        should_continue = bool(self.executor.execute(instruction))
-        snapshot = self.regs.snapshot()
-        self.ledger.log(snapshot, instruction.opcode)
-        self.tracer.record(instruction, snapshot)
+        checkpoint = self._checkpoint()
+        try:
+            next_cycles = self.cycles + 1
+            self.sandbox.enforce(next_cycles)
 
-        if self.enable_reflex:
-            self.reflex.stabilize(self.regs)
+            should_continue = bool(self.executor.execute(instruction))
+            if self.enable_reflex:
+                self.reflex.stabilize(self.regs)
 
-        self.regs["IP"] = ip + 1
-        self.cycles += 1
-        self.sandbox.enforce(self.cycles)
+            self.regs["IP"] = ip + 1
+            self.cycles = next_cycles
+            self.running = should_continue
 
-        if not should_continue:
+            snapshot = self.regs.snapshot()
+            self.ledger.log(snapshot, instruction.opcode)
+            self.tracer.record(instruction, snapshot)
+        except Exception:
+            try:
+                self._restore(checkpoint)
+            except Exception as rollback_error:
+                self.running = False
+                raise RuntimeError("VM transaction rollback failed") from rollback_error
             self.running = False
+            raise
+
         return should_continue
 
     def run(self) -> dict[str, int]:

--- a/src/jarvisx/executor.py
+++ b/src/jarvisx/executor.py
@@ -1,27 +1,39 @@
-REG_NAMES = [
-    "Ξ","Ψ","Φ","Λ","Ω","Θ","𝒮","Π",
-    "A","B","C","D","IP","SP","FLAGS","TMP"
-]
+from __future__ import annotations
+
+from .registers import REGISTER_NAMES
+
+REG_NAMES = list(REGISTER_NAMES)
+SUPPORTED_OPCODES = frozenset({0x01, 0x03, 0x04, 0x0A})
+
 
 class Executor:
     def __init__(self, registers):
         self.regs = registers
 
+    @staticmethod
+    def _register_name(index: int) -> str:
+        if not 0 <= index < len(REG_NAMES):
+            raise RuntimeError(f"register index {index} is outside the register file")
+        return REG_NAMES[index]
+
     def execute(self, instr):
         if instr.opcode == 0x01:  # SET
-            self.regs[REG_NAMES[instr.dst]] = instr.imm
+            self.regs[self._register_name(instr.dst)] = instr.imm
 
         elif instr.opcode == 0x03:  # ADD
-            a = self.regs[REG_NAMES[instr.src1]]
-            b = self.regs[REG_NAMES[instr.src2]]
-            self.regs[REG_NAMES[instr.dst]] = a + b
+            a = self.regs[self._register_name(instr.src1)]
+            b = self.regs[self._register_name(instr.src2)]
+            self.regs[self._register_name(instr.dst)] = a + b
 
         elif instr.opcode == 0x04:  # SUB
-            a = self.regs[REG_NAMES[instr.src1]]
-            b = self.regs[REG_NAMES[instr.src2]]
-            self.regs[REG_NAMES[instr.dst]] = a - b
+            a = self.regs[self._register_name(instr.src1)]
+            b = self.regs[self._register_name(instr.src2)]
+            self.regs[self._register_name(instr.dst)] = a - b
 
         elif instr.opcode == 0x0A:  # HALT
             return False
+
+        else:
+            raise RuntimeError(f"Unsupported opcode 0x{instr.opcode:02X}")
 
         return True

--- a/src/jarvisx/executor.py
+++ b/src/jarvisx/executor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from .registers import REGISTER_NAMES
 
-REG_NAMES = list(REGISTER_NAMES)
+REG_NAMES: list[str] = list(REGISTER_NAMES)
 SUPPORTED_OPCODES = frozenset({0x01, 0x03, 0x04, 0x0A})
 
 

--- a/src/jarvisx/ledger.py
+++ b/src/jarvisx/ledger.py
@@ -33,6 +33,22 @@ class OmegaLedger:
         self.chain: list[dict[str, Any]] = []
         self._clock_ns = clock_ns or time.time_ns
 
+    def checkpoint(self) -> int:
+        return len(self.chain)
+
+    def restore(self, checkpoint: int) -> None:
+        if (
+            not isinstance(checkpoint, int)
+            or isinstance(checkpoint, bool)
+            or checkpoint < 0
+            or checkpoint > len(self.chain)
+        ):
+            raise ValueError("ledger checkpoint is invalid")
+        del self.chain[checkpoint:]
+
+    def reset(self) -> None:
+        self.chain.clear()
+
     def log(self, state: Mapping[str, Any], opcode: int) -> dict[str, Any]:
         if not isinstance(state, Mapping):
             raise TypeError("ledger state must be a mapping")

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -29,9 +29,23 @@ class PersistentLedger(OmegaLedger):
                 raise ValueError("ledger integrity verification failed")
 
     def log(self, state: Mapping[str, Any], opcode: int) -> dict[str, Any]:
-        entry: dict[str, Any] = super().log(state, opcode)
-        self._persist()
+        checkpoint = self.checkpoint()
+        entry = OmegaLedger.log(self, state, opcode)
+        try:
+            self._persist()
+        except Exception:
+            OmegaLedger.restore(self, checkpoint)
+            raise
         return entry
+
+    def restore(self, checkpoint: int) -> None:
+        if checkpoint == len(self.chain):
+            return
+        OmegaLedger.restore(self, checkpoint)
+        self._persist()
+
+    def reset(self) -> None:
+        self.restore(0)
 
     def _persist(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/jarvisx/ledger_store.py
+++ b/src/jarvisx/ledger_store.py
@@ -4,7 +4,7 @@ import json
 import os
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from .ledger import OmegaLedger
 
@@ -30,7 +30,7 @@ class PersistentLedger(OmegaLedger):
 
     def log(self, state: Mapping[str, Any], opcode: int) -> dict[str, Any]:
         checkpoint = self.checkpoint()
-        entry = OmegaLedger.log(self, state, opcode)
+        entry = cast(dict[str, Any], OmegaLedger.log(self, state, opcode))
         try:
             self._persist()
         except Exception:

--- a/src/jarvisx/memory.py
+++ b/src/jarvisx/memory.py
@@ -1,9 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
 class Memory:
-    def __init__(self, size=4096):
+    def __init__(self, size: int = 4096) -> None:
+        if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+            raise ValueError("memory size must be a positive integer")
         self.data = bytearray(size)
 
-    def load(self, address, size):
-        return self.data[address:address+size]
+    def _checked_end(self, address: int, size: int) -> int:
+        if not isinstance(address, int) or isinstance(address, bool):
+            raise TypeError("memory address must be an integer")
+        if not isinstance(size, int) or isinstance(size, bool):
+            raise TypeError("memory size must be an integer")
+        if address < 0 or size < 0 or address + size > len(self.data):
+            raise IndexError("memory access is outside the allocated range")
+        return address + size
 
-    def store(self, address, values):
-        self.data[address:address+len(values)] = values
+    def load(self, address: int, size: int) -> bytearray:
+        end = self._checked_end(address, size)
+        return self.data[address:end]
+
+    def store(self, address: int, values: Iterable[int]) -> None:
+        payload = bytes(values)
+        end = self._checked_end(address, len(payload))
+        self.data[address:end] = payload
+
+    def snapshot(self) -> bytes:
+        return bytes(self.data)
+
+    def restore(self, snapshot: bytes | bytearray) -> None:
+        if len(snapshot) != len(self.data):
+            raise ValueError("memory snapshot size mismatch")
+        self.data[:] = snapshot
+
+    def reset(self) -> None:
+        self.data[:] = b"\x00" * len(self.data)

--- a/src/jarvisx/registers.py
+++ b/src/jarvisx/registers.py
@@ -1,17 +1,44 @@
-class Registers:
-    def __init__(self):
-        self._regs = {
-            "Ξ": 0, "Ψ": 0, "Φ": 0, "Λ": 0, "Ω": 0,
-            "Θ": 0, "𝒮": 0, "Π": 0,
-            "A": 0, "B": 0, "C": 0, "D": 0,
-            "IP": 0, "SP": 0, "FLAGS": 0, "TMP": 0
-        }
+from __future__ import annotations
 
-    def __getitem__(self, key):
+from collections.abc import Mapping
+
+REGISTER_NAMES = (
+    "Ξ",
+    "Ψ",
+    "Φ",
+    "Λ",
+    "Ω",
+    "Θ",
+    "𝒮",
+    "Π",
+    "A",
+    "B",
+    "C",
+    "D",
+    "IP",
+    "SP",
+    "FLAGS",
+    "TMP",
+)
+
+
+class Registers:
+    def __init__(self) -> None:
+        self._regs = {name: 0 for name in REGISTER_NAMES}
+
+    def __getitem__(self, key: str) -> int:
         return self._regs[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: int) -> None:
         self._regs[key] = int(value)
 
-    def snapshot(self):
+    def snapshot(self) -> dict[str, int]:
         return dict(self._regs)
+
+    def restore(self, snapshot: Mapping[str, int]) -> None:
+        if set(snapshot) != set(REGISTER_NAMES):
+            raise ValueError("register snapshot schema mismatch")
+        self._regs = {name: int(snapshot[name]) for name in REGISTER_NAMES}
+
+    def reset(self) -> None:
+        self._regs = {name: 0 for name in REGISTER_NAMES}

--- a/src/jarvisx/tracer.py
+++ b/src/jarvisx/tracer.py
@@ -1,6 +1,28 @@
-class Tracer:
-    def __init__(self):
-        self.log = []
+from __future__ import annotations
 
-    def record(self, instr, regs):
-        self.log.append((instr.opcode, regs.copy()))
+from collections.abc import Mapping
+from typing import Any
+
+
+class Tracer:
+    def __init__(self) -> None:
+        self.log: list[tuple[int, dict[str, Any]]] = []
+
+    def checkpoint(self) -> int:
+        return len(self.log)
+
+    def restore(self, checkpoint: int) -> None:
+        if (
+            not isinstance(checkpoint, int)
+            or isinstance(checkpoint, bool)
+            or checkpoint < 0
+            or checkpoint > len(self.log)
+        ):
+            raise ValueError("trace checkpoint is invalid")
+        del self.log[checkpoint:]
+
+    def reset(self) -> None:
+        self.log.clear()
+
+    def record(self, instr: Any, regs: Mapping[str, Any]) -> None:
+        self.log.append((int(instr.opcode), dict(regs)))

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -33,6 +33,18 @@ def test_ledger_detects_tampering() -> None:
     assert not ledger.verify()
 
 
+def test_ledger_checkpoint_restore() -> None:
+    ledger = OmegaLedger(clock_ns=clock(100, 200))
+    ledger.log({"A": 1}, 1)
+    checkpoint = ledger.checkpoint()
+    ledger.log({"A": 2}, 3)
+
+    ledger.restore(checkpoint)
+
+    assert len(ledger.chain) == 1
+    assert ledger.verify()
+
+
 def test_persistent_ledger_round_trip(tmp_path) -> None:
     path = tmp_path / "state" / "omega.json"
     ledger = PersistentLedger(path, clock_ns=clock(123))
@@ -51,3 +63,19 @@ def test_persistent_ledger_rejects_corruption(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="integrity verification failed"):
         PersistentLedger(path)
+
+
+def test_persistent_ledger_failed_write_rolls_back_chain(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "omega.json"
+    ledger = PersistentLedger(path, clock_ns=clock(123))
+
+    def fail_persist() -> None:
+        raise OSError("disk unavailable")
+
+    monkeypatch.setattr(ledger, "_persist", fail_persist)
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        ledger.log({"A": 1}, 1)
+
+    assert ledger.chain == []
+    assert not path.exists()

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jarvisx.assembler import Assembler
+from jarvisx.assembler import Assembler, encode
 from jarvisx.core import CodexVM
 from jarvisx.parser import Parser
 
@@ -34,6 +34,70 @@ def test_reflex_stabilization_is_explicitly_opt_in() -> None:
 
     assert authoritative.regs["Φ"] == 20
     assert adaptive.regs["Φ"] != authoritative.regs["Φ"]
+
+
+def test_reflex_effect_is_in_authoritative_receipt() -> None:
+    vm = CodexVM(enable_reflex=True)
+    vm.load(assemble("SET Ψ 10\nSET Φ 20\nHALT"))
+
+    final_state = vm.run()
+
+    assert vm.ledger.chain[-1]["state"] == final_state
+    assert vm.tracer.log[-1][1] == final_state
+
+
+def test_sandbox_rejection_preserves_last_committed_state() -> None:
+    vm = CodexVM(max_cycles=1)
+    vm.load(assemble("SET A 1\nSET A 2\nHALT"))
+
+    assert vm.step()
+
+    with pytest.raises(RuntimeError, match="Sandbox limit exceeded"):
+        vm.step()
+
+    assert vm.regs["A"] == 1
+    assert vm.regs["IP"] == 1
+    assert vm.cycles == 1
+    assert len(vm.ledger.chain) == 1
+    assert len(vm.tracer.log) == 1
+    assert vm.running is False
+
+
+def test_post_execution_receipt_failure_rolls_back_authoritative_state(monkeypatch) -> None:
+    vm = CodexVM()
+    vm.load(assemble("SET A 7\nHALT"))
+    before_registers = vm.regs.snapshot()
+    before_memory = vm.mem.snapshot()
+
+    def fail_log(state: object, opcode: int) -> None:
+        raise OSError("receipt unavailable")
+
+    monkeypatch.setattr(vm.ledger, "log", fail_log)
+
+    with pytest.raises(OSError, match="receipt unavailable"):
+        vm.step()
+
+    assert vm.regs.snapshot() == before_registers
+    assert vm.mem.snapshot() == before_memory
+    assert vm.cycles == 0
+    assert len(vm.ledger.chain) == 0
+    assert len(vm.tracer.log) == 0
+    assert vm.running is False
+
+
+def test_unknown_opcode_fails_closed_without_receipt() -> None:
+    vm = CodexVM()
+    vm.load([encode(0xFF)])
+    before_registers = vm.regs.snapshot()
+
+    with pytest.raises(RuntimeError, match="Unsupported opcode 0xFF"):
+        vm.step()
+
+    assert vm.regs.snapshot() == before_registers
+    assert vm.cycles == 0
+    assert not vm.ledger.chain
+    assert not vm.tracer.log
+    assert vm.running is False
 
 
 def test_load_rejects_empty_program() -> None:


### PR DESCRIPTION
## Summary

Hardens the canonical `CodexVM` so every instruction executes as one recoverable authoritative-state transaction.

The new cycle is:

```text
checkpoint registers + memory + counters + ledger + trace
→ decode and authorize
→ enforce prospective cycle budget
→ execute
→ apply explicitly enabled reflex correction
→ advance IP and cycle count
→ persist canonical post-state
→ trace
→ commit
```

Any failure after the checkpoint restores the prior authoritative state and stops the VM.

## Why

The canonical architecture requires candidate transitions to commit atomically or preserve the previous state. The existing VM mutated registers before all postconditions were known, recorded snapshots before optional reflex correction, silently continued on unknown opcodes, and could leave an in-memory persistent-ledger entry after a filesystem write failure.

This PR aligns the executable core with the merged system operational mechanics formula without importing any experimental spatial, neural or visual subsystem into VM authority.

## What changed

### Whole-cycle checkpoint and rollback

- checkpoints the complete register file;
- checkpoints the complete memory image;
- checkpoints committed cycle and run state;
- checkpoints Omega-ledger and trace prefixes;
- restores the complete checkpoint on execution, provenance or trace failure;
- distinguishes ordinary transaction rejection from rollback failure.

### Canonical receipt ordering

Reflex remains opt-in, but when enabled it now runs before the canonical state snapshot. Ledger state, trace state and the actual authoritative post-instruction register state therefore agree.

### Fail-closed execution

- unknown opcodes now raise rather than silently continuing;
- invalid register indices raise explicit errors;
- prospective cycle limits are checked before instruction mutation;
- memory reads and writes reject negative, truncated and out-of-range accesses.

### Transactional persistent ledger

- adds ledger prefix checkpoints and restoration;
- removes a candidate in-memory entry when atomic persistence fails;
- allows VM rollback to restore and persist the prior ledger prefix after a later-stage failure.

### Documentation

Adds `docs/CANONICAL_TRANSACTIONAL_VM.md` with the state contract, equations, failure semantics, compatibility boundary and next integration sequence.

## Validation

A reconstructed focused harness was executed against the exact proposed modules:

```text
15 passed
```

The focused tests cover:

- deterministic arithmetic;
- explicit reflex operation;
- post-reflex ledger/trace agreement;
- sandbox rejection preserving the last committed state;
- receipt failure restoring registers and memory;
- unknown-opcode rejection with no receipt;
- ledger checkpoint restoration;
- persistent-ledger write failure rolling back the in-memory chain.

`compileall` also passed for the reconstructed source and tests. Black, isort and mypy executables were not installed in the local environment; repository CI remains the authoritative full-suite, quality, package, dependency and CodeQL gate.

## Compatibility boundary

This PR does not:

- expand the four-opcode canonical ISA;
- define the versioned external bytecode envelope;
- provide operating-system isolation for hostile bytecode;
- roll back irreversible external network or device effects;
- resolve program-load versus full-machine-reset semantics;
- unify all research engines under one receipt schema.

Those are deliberately left as follow-on stages after the canonical instruction transaction is accepted.

## Review focus

1. Confirm the authoritative checkpoint contents.
2. Confirm fail-closed behavior and stop-after-rollback semantics.
3. Confirm the ordering of reflex, snapshot, ledger and trace.
4. Confirm persistent-ledger restoration behavior.
5. Confirm memory bounds do not conflict with intended future ISA semantics.
