### PR TITLE
Add sparse transactional 3D 1PB BitVM reference

### DIFF
--- a/docs/JX_3D_1PB_BITVM.md
+++ b/docs/JX_3D_1PB_BITVM.md
@@ -1,0 +1,141 @@
+# JX-3D-1PB-BitVM
+
+## Status
+
+**Reference implementation / integration candidate.** This subsystem exposes a canonical
+`1000 × 1000 × 1000` lattice of decimal 1 MB bricks while materializing only non-zero active
+bricks. It is a bounded correctness reference, not a one-petabyte resident allocation or a
+production security sandbox.
+
+## Geometry
+
+The default virtual extent is:
+
+```text
+1,000,000,000 bricks × 1,000,000 bytes
+= 1,000,000,000,000,000 bytes
+= 1 PB decimal
+= 8,000,000,000,000,000 addressable bits
+```
+
+A brick coordinate is `(x, y, z)` with each component in `[0, 999]`. The linear brick index is:
+
+```text
+a = x + 1000 * (y + 1000 * z)
+```
+
+The canonical 64-bit address is:
+
+```text
+ASID[8] | CLASS[3] | Z[10] | Y[10] | X[10] | BYTE[20] | BIT[3]
+```
+
+The 20-bit byte field carries decimal offsets `0..999,999`; unused encodings are rejected.
+
+## Sparse storage contract
+
+- Missing bricks read as immutable zero.
+- Reading does not allocate.
+- The first non-zero write copy-on-write materializes one brick.
+- A brick that returns to all-zero state is pruned by default.
+- `max_resident_bricks` bounds committed physical payload.
+- Virtual extent and physical residency are reported separately.
+
+For `k` active bricks, payload residency is approximately:
+
+```text
+resident_payload = k × brick_bytes
+```
+
+rather than one petabyte.
+
+## Transaction cycle
+
+Every instruction follows:
+
+```text
+validate envelope
+→ validate address range
+→ capability check
+→ copy-on-write stage
+→ execute bounded bit operation
+→ enforce accessed/resident brick budgets
+→ calculate deterministic state digest
+→ commit or rollback
+→ append hash-chained journal receipt
+```
+
+Rejected instructions leave authoritative brick state unchanged but remain visible in the audit
+journal.
+
+## Reference ISA
+
+| Opcode | Function |
+|---|---|
+| `BSET` | set a destination bit range |
+| `BCLR` | clear a destination bit range |
+| `BCOPY` | copy one bit range to another |
+| `BNOT` | invert a source range into a destination |
+| `BAND` | bitwise conjunction |
+| `BOR` | bitwise disjunction |
+| `BXOR` | bitwise exclusive-or |
+| `BPOPCNT` | count set bits without mutation |
+| `BHASH` | SHA-256 a canonically packed bit range |
+
+The Python reference executes bit-by-bit and enforces `max_instruction_bits`. Optimized SIMD, GPU,
+and distributed kernels may replace the physical execution strategy only if they preserve the same
+addressing, state digest, transaction, and journal semantics.
+
+## Example
+
+```python
+from jarvisx.bitvm_3d_1pb import (
+    AddressClass,
+    BitAddress,
+    BitInstruction,
+    BitOpcode,
+    Sparse3DBitVM,
+)
+
+vm = Sparse3DBitVM()
+destination = BitAddress(
+    asid=0,
+    access_class=int(AddressClass.WRITE),
+    x=10,
+    y=20,
+    z=30,
+    byte_offset=0,
+    bit_offset=0,
+)
+
+receipt = vm.execute(
+    BitInstruction(BitOpcode.BSET, destination=destination, length_bits=16)
+)
+assert receipt.committed
+assert vm.resident_brick_count == 1
+```
+
+## Determinism and checkpointing
+
+The implementation provides:
+
+- canonical address packing and unpacking;
+- deterministic state hashing over sorted sparse bricks;
+- a deterministic hash-chained instruction journal without wall-clock fields;
+- JSON-serializable checkpoints containing sparse payloads and journal receipts;
+- checkpoint chain, state-digest, payload-length, and resident-budget verification.
+
+## Explicit boundaries
+
+This implementation does **not** establish:
+
+- one petabyte of resident physical memory;
+- fast full-volume scans;
+- secure execution of hostile bytecode;
+- distributed consensus or high availability;
+- external API rollback;
+- GPU or SIMD performance;
+- intelligence, consciousness, or unrestricted self-modification.
+
+The next promotion step is a named benchmark corpus comparing memory, range-operation latency,
+serialization, rollback, and recovery against straightforward dense/sparse baselines.

--- a/examples/jx_3d_1pb_bitvm.py
+++ b/examples/jx_3d_1pb_bitvm.py
@@ -1,0 +1,33 @@
+"""Minimal sparse JX-3D-1PB-BitVM demonstration."""
+
+from jarvisx.bitvm_3d_1pb import (
+    AddressClass,
+    BitAddress,
+    BitInstruction,
+    BitOpcode,
+    Sparse3DBitVM,
+)
+
+
+def main() -> None:
+    vm = Sparse3DBitVM()
+    start = BitAddress(
+        asid=0,
+        access_class=int(AddressClass.WRITE),
+        x=10,
+        y=20,
+        z=30,
+        byte_offset=0,
+        bit_offset=0,
+    )
+    receipt = vm.execute(
+        BitInstruction(BitOpcode.BSET, destination=start, length_bits=16)
+    )
+
+    print(receipt)
+    print("virtual bytes:", vm.virtual_byte_count)
+    print("resident bytes:", vm.resident_payload_bytes)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/bitvm_3d_1pb.py
+++ b/src/jarvisx/bitvm_3d_1pb.py
@@ -616,6 +616,8 @@ class Sparse3DBitVM:
             if operand is not None and not isinstance(operand, BitAddress):
                 raise TypeError("instruction addresses must be BitAddress values")
 
+        required: Tuple[BitAddress | None, ...]
+        forbidden: Tuple[BitAddress | None, ...]
         if instruction.opcode in (BitOpcode.BSET, BitOpcode.BCLR):
             required = (instruction.destination,)
             forbidden = (instruction.source0, instruction.source1)
@@ -763,23 +765,44 @@ class Sparse3DBitVM:
         after_digest: str,
         error: str | None,
     ) -> JournalEntry:
+        sequence = self._sequence + 1
+        opcode = instruction.opcode.value
+        destination = self._serialize_address(instruction.destination)
+        source0 = self._serialize_address(instruction.source0)
+        source1 = self._serialize_address(instruction.source1)
+        previous_hash = self._journal_digest
         payload = {
-            "sequence": self._sequence + 1,
-            "opcode": instruction.opcode.value,
+            "sequence": sequence,
+            "opcode": opcode,
             "committed": committed,
-            "destination": self._serialize_address(instruction.destination),
-            "source0": self._serialize_address(instruction.source0),
-            "source1": self._serialize_address(instruction.source1),
+            "destination": destination,
+            "source0": source0,
+            "source1": source1,
             "length_bits": instruction.length_bits,
             "result": result,
             "touched_bricks": touched,
             "before_state_digest": before_digest,
             "after_state_digest": after_digest,
-            "previous_hash": self._journal_digest,
+            "previous_hash": previous_hash,
             "error": error,
         }
         entry_hash = hashlib.sha256(self._canonical_json(payload)).hexdigest()
-        entry = JournalEntry(hash=entry_hash, **payload)
+        entry = JournalEntry(
+            sequence=sequence,
+            opcode=opcode,
+            committed=committed,
+            destination=destination,
+            source0=source0,
+            source1=source1,
+            length_bits=instruction.length_bits,
+            result=result,
+            touched_bricks=touched,
+            before_state_digest=before_digest,
+            after_state_digest=after_digest,
+            previous_hash=previous_hash,
+            error=error,
+            hash=entry_hash,
+        )
         self._journal.append(entry)
         self._journal_digest = entry_hash
         return entry

--- a/src/jarvisx/bitvm_3d_1pb.py
+++ b/src/jarvisx/bitvm_3d_1pb.py
@@ -1,0 +1,796 @@
+"""Sparse transactional 3D bit virtual machine with a canonical 1 PB address space.
+
+The default geometry is a ``1000 x 1000 x 1000`` lattice of decimal 1 MB bricks:
+
+    1_000_000_000 bricks x 1_000_000 bytes = 1_000_000_000_000_000 bytes
+
+Only bricks containing non-zero committed data are materialized. Missing bricks are an immutable
+zero background. Every mutating instruction is copy-on-write, capability checked, journaled, and
+committed atomically or rejected without changing authoritative state.
+
+This module is a bounded correctness reference. It does not allocate one petabyte, provide process
+isolation for hostile code, or claim production throughput.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from enum import Enum, IntEnum
+from typing import Any, Dict, Iterable, Iterator, Mapping, Sequence, Tuple
+
+DECIMAL_MEGABYTE = 1_000_000
+CANONICAL_SIDE = 1000
+CANONICAL_BRICKS = CANONICAL_SIDE**3
+CANONICAL_VIRTUAL_BYTES = CANONICAL_BRICKS * DECIMAL_MEGABYTE
+CANONICAL_VIRTUAL_BITS = CANONICAL_VIRTUAL_BYTES * 8
+
+BrickKey = Tuple[int, int, int, int]  # (asid, x, y, z)
+
+
+class AddressClass(IntEnum):
+    """Three-bit access-class field carried by every packed virtual address."""
+
+    READ = 0
+    WRITE = 1
+    EXECUTE = 2
+    JOURNAL = 3
+    CONTROL = 4
+
+
+class BitOpcode(str, Enum):
+    """Bounded reference instruction set for bit-addressed operations."""
+
+    BSET = "BSET"
+    BCLR = "BCLR"
+    BCOPY = "BCOPY"
+    BNOT = "BNOT"
+    BAND = "BAND"
+    BOR = "BOR"
+    BXOR = "BXOR"
+    BPOPCNT = "BPOPCNT"
+    BHASH = "BHASH"
+
+
+@dataclass(frozen=True)
+class BitVMConfig:
+    """Geometry and execution bounds for one sparse VM instance."""
+
+    side: int = CANONICAL_SIDE
+    brick_bytes: int = DECIMAL_MEGABYTE
+    max_resident_bricks: int = 64
+    max_instruction_bits: int = 65_536
+    vector_line_bytes: int = 64
+    prune_zero_bricks: bool = True
+
+    def __post_init__(self) -> None:
+        for name in (
+            "side",
+            "brick_bytes",
+            "max_resident_bricks",
+            "max_instruction_bits",
+            "vector_line_bytes",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.side > 1000:
+            raise ValueError("side must fit the canonical 10-bit coordinate field")
+        if self.brick_bytes > DECIMAL_MEGABYTE:
+            raise ValueError("brick_bytes must not exceed the canonical decimal 1 MB brick")
+        if self.vector_line_bytes > self.brick_bytes:
+            raise ValueError("vector_line_bytes must not exceed brick_bytes")
+        if self.brick_bytes % self.vector_line_bytes != 0:
+            raise ValueError("brick_bytes must be divisible by vector_line_bytes")
+        if not isinstance(self.prune_zero_bricks, bool):
+            raise TypeError("prune_zero_bricks must be a boolean")
+
+    @property
+    def virtual_bricks(self) -> int:
+        return self.side**3
+
+    @property
+    def virtual_bytes(self) -> int:
+        return self.virtual_bricks * self.brick_bytes
+
+    @property
+    def virtual_bits(self) -> int:
+        return self.virtual_bytes * 8
+
+    @property
+    def lines_per_brick(self) -> int:
+        return self.brick_bytes // self.vector_line_bytes
+
+
+@dataclass(frozen=True)
+class BitAddress:
+    """Canonical packed 64-bit address.
+
+    Layout, most-significant field first::
+
+        ASID[8] | CLASS[3] | Z[10] | Y[10] | X[10] | BYTE[20] | BIT[3]
+    """
+
+    asid: int
+    access_class: int
+    x: int
+    y: int
+    z: int
+    byte_offset: int
+    bit_offset: int
+
+    def __post_init__(self) -> None:
+        fields = {
+            "asid": (self.asid, 0, 255),
+            "access_class": (self.access_class, 0, 7),
+            "x": (self.x, 0, 999),
+            "y": (self.y, 0, 999),
+            "z": (self.z, 0, 999),
+            "byte_offset": (self.byte_offset, 0, DECIMAL_MEGABYTE - 1),
+            "bit_offset": (self.bit_offset, 0, 7),
+        }
+        for name, (value, minimum, maximum) in fields.items():
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value < minimum or value > maximum:
+                raise ValueError(f"{name} must be in [{minimum}, {maximum}]")
+
+    @property
+    def brick_key(self) -> BrickKey:
+        return self.asid, self.x, self.y, self.z
+
+    def pack(self) -> int:
+        """Pack the address into one unsigned 64-bit integer."""
+
+        return (
+            (self.asid << 56)
+            | (self.access_class << 53)
+            | (self.z << 43)
+            | (self.y << 33)
+            | (self.x << 23)
+            | (self.byte_offset << 3)
+            | self.bit_offset
+        )
+
+    @classmethod
+    def unpack(cls, value: int) -> "BitAddress":
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError("packed address must be an integer")
+        if value < 0 or value >= 1 << 64:
+            raise ValueError("packed address must be an unsigned 64-bit integer")
+        return cls(
+            asid=(value >> 56) & 0xFF,
+            access_class=(value >> 53) & 0x7,
+            z=(value >> 43) & 0x3FF,
+            y=(value >> 33) & 0x3FF,
+            x=(value >> 23) & 0x3FF,
+            byte_offset=(value >> 3) & 0xFFFFF,
+            bit_offset=value & 0x7,
+        )
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Address and opcode authority granted to one VM caller."""
+
+    allowed_asids: Tuple[int, ...] = (0,)
+    allowed_classes: Tuple[int, ...] = tuple(int(item) for item in AddressClass)
+    allowed_opcodes: Tuple[BitOpcode, ...] = tuple(BitOpcode)
+    x_range: Tuple[int, int] = (0, 999)
+    y_range: Tuple[int, int] = (0, 999)
+    z_range: Tuple[int, int] = (0, 999)
+    max_accessed_bricks: int = 64
+
+    def __post_init__(self) -> None:
+        if not self.allowed_asids:
+            raise ValueError("allowed_asids must not be empty")
+        if not self.allowed_classes:
+            raise ValueError("allowed_classes must not be empty")
+        if not self.allowed_opcodes:
+            raise ValueError("allowed_opcodes must not be empty")
+        for asid in self.allowed_asids:
+            if isinstance(asid, bool) or not isinstance(asid, int):
+                raise TypeError("allowed_asids must contain integers")
+            if asid < 0 or asid > 255:
+                raise ValueError("allowed ASID must be in [0, 255]")
+        for access_class in self.allowed_classes:
+            if isinstance(access_class, bool) or not isinstance(access_class, int):
+                raise TypeError("allowed_classes must contain integers")
+            if access_class < 0 or access_class > 7:
+                raise ValueError("allowed access class must be in [0, 7]")
+        for name in ("x_range", "y_range", "z_range"):
+            value = getattr(self, name)
+            if len(value) != 2 or any(
+                isinstance(item, bool) or not isinstance(item, int) for item in value
+            ):
+                raise TypeError(f"{name} must be a two-integer tuple")
+            if value[0] < 0 or value[1] > 999 or value[0] > value[1]:
+                raise ValueError(f"{name} must be an ordered subset of [0, 999]")
+        if isinstance(self.max_accessed_bricks, bool) or not isinstance(
+            self.max_accessed_bricks, int
+        ):
+            raise TypeError("max_accessed_bricks must be an integer")
+        if self.max_accessed_bricks <= 0:
+            raise ValueError("max_accessed_bricks must be positive")
+
+    def authorize(self, opcode: BitOpcode, address: BitAddress) -> None:
+        if opcode not in self.allowed_opcodes:
+            raise PermissionError(f"opcode {opcode.value} is not allowed")
+        if address.asid not in self.allowed_asids:
+            raise PermissionError(f"ASID {address.asid} is not allowed")
+        if address.access_class not in self.allowed_classes:
+            raise PermissionError(f"access class {address.access_class} is not allowed")
+        if not self.x_range[0] <= address.x <= self.x_range[1]:
+            raise PermissionError("X coordinate is outside the capability")
+        if not self.y_range[0] <= address.y <= self.y_range[1]:
+            raise PermissionError("Y coordinate is outside the capability")
+        if not self.z_range[0] <= address.z <= self.z_range[1]:
+            raise PermissionError("Z coordinate is outside the capability")
+
+
+@dataclass(frozen=True)
+class BitInstruction:
+    """One bounded bit-range operation."""
+
+    opcode: BitOpcode
+    destination: BitAddress | None = None
+    source0: BitAddress | None = None
+    source1: BitAddress | None = None
+    length_bits: int = 1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.opcode, BitOpcode):
+            raise TypeError("opcode must be a BitOpcode")
+        if isinstance(self.length_bits, bool) or not isinstance(self.length_bits, int):
+            raise TypeError("length_bits must be an integer")
+        if self.length_bits <= 0:
+            raise ValueError("length_bits must be positive")
+
+
+@dataclass(frozen=True)
+class JournalEntry:
+    sequence: int
+    opcode: str
+    committed: bool
+    destination: int | None
+    source0: int | None
+    source1: int | None
+    length_bits: int
+    result: int | str | None
+    touched_bricks: Tuple[BrickKey, ...]
+    before_state_digest: str
+    after_state_digest: str
+    previous_hash: str
+    error: str | None
+    hash: str
+
+
+@dataclass(frozen=True)
+class ExecutionReceipt:
+    sequence: int
+    committed: bool
+    result: int | str | None
+    touched_bricks: Tuple[BrickKey, ...]
+    state_digest: str
+    journal_digest: str
+
+
+class TransactionRejected(RuntimeError):
+    """Raised after a rejected instruction has been recorded in the journal."""
+
+    def __init__(self, message: str, receipt: ExecutionReceipt) -> None:
+        super().__init__(message)
+        self.receipt = receipt
+
+
+class Sparse3DBitVM:
+    """Sparse, deterministic and transactional bit-addressed virtual machine."""
+
+    CHECKPOINT_VERSION = 1
+
+    def __init__(
+        self,
+        config: BitVMConfig | None = None,
+        capability: Capability | None = None,
+    ) -> None:
+        self.config = config or BitVMConfig()
+        self.capability = capability or Capability(
+            x_range=(0, self.config.side - 1),
+            y_range=(0, self.config.side - 1),
+            z_range=(0, self.config.side - 1),
+            max_accessed_bricks=self.config.max_resident_bricks,
+        )
+        self._bricks: Dict[BrickKey, bytes] = {}
+        self._journal: list[JournalEntry] = []
+        self._sequence = 0
+        self._journal_digest = self._initial_journal_digest()
+
+    @property
+    def virtual_brick_count(self) -> int:
+        return self.config.virtual_bricks
+
+    @property
+    def virtual_byte_count(self) -> int:
+        return self.config.virtual_bytes
+
+    @property
+    def virtual_bit_count(self) -> int:
+        return self.config.virtual_bits
+
+    @property
+    def resident_brick_count(self) -> int:
+        return len(self._bricks)
+
+    @property
+    def resident_payload_bytes(self) -> int:
+        return len(self._bricks) * self.config.brick_bytes
+
+    @property
+    def journal_digest(self) -> str:
+        return self._journal_digest
+
+    @property
+    def journal(self) -> Tuple[JournalEntry, ...]:
+        return tuple(self._journal)
+
+    def estimate_dense_payload_bytes(self) -> int:
+        return self.virtual_byte_count
+
+    def read_bit(self, address: BitAddress) -> int:
+        """Read one bit. An absent brick returns zero without allocation."""
+
+        self._validate_address(address)
+        self.capability.authorize(BitOpcode.BPOPCNT, address)
+        return self._read_bit_from(self._bricks, address)
+
+    def execute(self, instruction: BitInstruction) -> ExecutionReceipt:
+        """Execute one instruction as an atomic copy-on-write transaction."""
+
+        if not isinstance(instruction, BitInstruction):
+            raise TypeError("instruction must be a BitInstruction")
+        before_digest = self.state_digest()
+        staged: Dict[BrickKey, bytearray] = {}
+        accessed: set[BrickKey] = set()
+        result: int | str | None = None
+
+        try:
+            if instruction.length_bits > self.config.max_instruction_bits:
+                raise ValueError("instruction bit length exceeds the configured bound")
+            self._validate_instruction_shape(instruction)
+
+            destination = self._address_stream(instruction.destination, instruction.length_bits)
+            source0 = self._address_stream(instruction.source0, instruction.length_bits)
+            source1 = self._address_stream(instruction.source1, instruction.length_bits)
+
+            if instruction.opcode in (BitOpcode.BSET, BitOpcode.BCLR):
+                bit_value = 1 if instruction.opcode is BitOpcode.BSET else 0
+                for dst in destination:
+                    self._authorize_address(instruction.opcode, dst, accessed)
+                    self._write_bit(staged, dst, bit_value)
+
+            elif instruction.opcode in (BitOpcode.BCOPY, BitOpcode.BNOT):
+                for dst, src in zip(destination, source0):
+                    self._authorize_address(instruction.opcode, dst, accessed)
+                    self._authorize_address(instruction.opcode, src, accessed)
+                    source_bit = self._read_bit_from(self._bricks, src)
+                    value = source_bit if instruction.opcode is BitOpcode.BCOPY else 1 - source_bit
+                    self._write_bit(staged, dst, value)
+
+            elif instruction.opcode in (BitOpcode.BAND, BitOpcode.BOR, BitOpcode.BXOR):
+                for dst, left, right in zip(destination, source0, source1):
+                    self._authorize_address(instruction.opcode, dst, accessed)
+                    self._authorize_address(instruction.opcode, left, accessed)
+                    self._authorize_address(instruction.opcode, right, accessed)
+                    left_bit = self._read_bit_from(self._bricks, left)
+                    right_bit = self._read_bit_from(self._bricks, right)
+                    if instruction.opcode is BitOpcode.BAND:
+                        value = left_bit & right_bit
+                    elif instruction.opcode is BitOpcode.BOR:
+                        value = left_bit | right_bit
+                    else:
+                        value = left_bit ^ right_bit
+                    self._write_bit(staged, dst, value)
+
+            elif instruction.opcode is BitOpcode.BPOPCNT:
+                count = 0
+                for src in source0:
+                    self._authorize_address(instruction.opcode, src, accessed)
+                    count += self._read_bit_from(self._bricks, src)
+                result = count
+
+            elif instruction.opcode is BitOpcode.BHASH:
+                bits: list[int] = []
+                for src in source0:
+                    self._authorize_address(instruction.opcode, src, accessed)
+                    bits.append(self._read_bit_from(self._bricks, src))
+                result = hashlib.sha256(self._pack_bits(bits)).hexdigest()
+
+            else:  # pragma: no cover - Enum exhaustiveness guard
+                raise ValueError(f"unsupported opcode {instruction.opcode.value}")
+
+            if len(accessed) > self.capability.max_accessed_bricks:
+                raise PermissionError("instruction exceeds the capability brick-access bound")
+
+            next_bricks = dict(self._bricks)
+            for key, payload in staged.items():
+                immutable = bytes(payload)
+                if self.config.prune_zero_bricks and not any(immutable):
+                    next_bricks.pop(key, None)
+                else:
+                    next_bricks[key] = immutable
+            if len(next_bricks) > self.config.max_resident_bricks:
+                raise RuntimeError("resident-brick budget exceeded")
+
+            after_digest = self._state_digest_for(next_bricks)
+            touched = tuple(sorted(staged))
+            entry = self._append_journal(
+                instruction=instruction,
+                committed=True,
+                result=result,
+                touched=touched,
+                before_digest=before_digest,
+                after_digest=after_digest,
+                error=None,
+            )
+            self._bricks = next_bricks
+            self._sequence = entry.sequence
+            return ExecutionReceipt(
+                sequence=entry.sequence,
+                committed=True,
+                result=result,
+                touched_bricks=touched,
+                state_digest=after_digest,
+                journal_digest=entry.hash,
+            )
+        except Exception as exc:
+            touched = tuple(sorted(staged))
+            entry = self._append_journal(
+                instruction=instruction,
+                committed=False,
+                result=None,
+                touched=touched,
+                before_digest=before_digest,
+                after_digest=before_digest,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            self._sequence = entry.sequence
+            receipt = ExecutionReceipt(
+                sequence=entry.sequence,
+                committed=False,
+                result=None,
+                touched_bricks=touched,
+                state_digest=before_digest,
+                journal_digest=entry.hash,
+            )
+            raise TransactionRejected(str(exc), receipt) from exc
+
+    def state_digest(self) -> str:
+        return self._state_digest_for(self._bricks)
+
+    def brick_digest(self, key: BrickKey) -> str:
+        self._validate_brick_key(key)
+        payload = self._bricks.get(key, bytes(self.config.brick_bytes))
+        return hashlib.sha256(payload).hexdigest()
+
+    def checkpoint(self) -> Dict[str, Any]:
+        """Return a deterministic JSON-serializable checkpoint including sparse payloads."""
+
+        return {
+            "version": self.CHECKPOINT_VERSION,
+            "config": asdict(self.config),
+            "sequence": self._sequence,
+            "journal_digest": self._journal_digest,
+            "state_digest": self.state_digest(),
+            "bricks": [
+                {
+                    "key": list(key),
+                    "payload_b64": base64.b64encode(payload).decode("ascii"),
+                }
+                for key, payload in sorted(self._bricks.items())
+            ],
+            "journal": [asdict(entry) for entry in self._journal],
+        }
+
+    @classmethod
+    def from_checkpoint(
+        cls,
+        checkpoint: Mapping[str, Any],
+        capability: Capability | None = None,
+    ) -> "Sparse3DBitVM":
+        """Restore and verify a checkpoint, rejecting malformed or tampered state."""
+
+        if not isinstance(checkpoint, Mapping):
+            raise TypeError("checkpoint must be a mapping")
+        if checkpoint.get("version") != cls.CHECKPOINT_VERSION:
+            raise ValueError("unsupported checkpoint version")
+        config_raw = checkpoint.get("config")
+        if not isinstance(config_raw, Mapping):
+            raise ValueError("checkpoint config must be a mapping")
+        vm = cls(BitVMConfig(**dict(config_raw)), capability)
+
+        bricks_raw = checkpoint.get("bricks")
+        if not isinstance(bricks_raw, Sequence) or isinstance(bricks_raw, (str, bytes, bytearray)):
+            raise ValueError("checkpoint bricks must be a sequence")
+        bricks: Dict[BrickKey, bytes] = {}
+        for item in bricks_raw:
+            if not isinstance(item, Mapping):
+                raise ValueError("checkpoint brick entry must be a mapping")
+            raw_key = item.get("key")
+            if not isinstance(raw_key, Sequence) or isinstance(raw_key, (str, bytes, bytearray)):
+                raise ValueError("checkpoint brick key must be a sequence")
+            key = tuple(raw_key)
+            vm._validate_brick_key(key)
+            payload_text = item.get("payload_b64")
+            if not isinstance(payload_text, str):
+                raise ValueError("checkpoint brick payload must be base64 text")
+            try:
+                payload = base64.b64decode(payload_text, validate=True)
+            except Exception as exc:
+                raise ValueError("checkpoint brick payload is not valid base64") from exc
+            if len(payload) != vm.config.brick_bytes:
+                raise ValueError("checkpoint brick payload has the wrong length")
+            if vm.config.prune_zero_bricks and not any(payload):
+                raise ValueError("checkpoint contains a non-canonical zero brick")
+            bricks[key] = payload
+        if len(bricks) > vm.config.max_resident_bricks:
+            raise ValueError("checkpoint exceeds the resident-brick budget")
+        vm._bricks = bricks
+
+        journal_raw = checkpoint.get("journal")
+        if not isinstance(journal_raw, Sequence) or isinstance(
+            journal_raw, (str, bytes, bytearray)
+        ):
+            raise ValueError("checkpoint journal must be a sequence")
+        previous = vm._initial_journal_digest()
+        entries: list[JournalEntry] = []
+        for raw in journal_raw:
+            if not isinstance(raw, Mapping):
+                raise ValueError("checkpoint journal entry must be a mapping")
+            normalized = dict(raw)
+            touched_raw = normalized.get("touched_bricks")
+            if not isinstance(touched_raw, Sequence):
+                raise ValueError("checkpoint touched_bricks must be a sequence")
+            normalized["touched_bricks"] = tuple(tuple(item) for item in touched_raw)
+            entry = JournalEntry(**normalized)
+            if entry.previous_hash != previous:
+                raise ValueError("checkpoint journal chain mismatch")
+            if vm._journal_entry_hash(entry) != entry.hash:
+                raise ValueError("checkpoint journal digest mismatch")
+            previous = entry.hash
+            entries.append(entry)
+        vm._journal = entries
+        vm._journal_digest = previous
+        vm._sequence = len(entries)
+
+        if checkpoint.get("sequence") != vm._sequence:
+            raise ValueError("checkpoint sequence mismatch")
+        if checkpoint.get("journal_digest") != vm._journal_digest:
+            raise ValueError("checkpoint journal digest mismatch")
+        if checkpoint.get("state_digest") != vm.state_digest():
+            raise ValueError("checkpoint state digest mismatch")
+        return vm
+
+    def _validate_instruction_shape(self, instruction: BitInstruction) -> None:
+        mutating = {
+            BitOpcode.BSET,
+            BitOpcode.BCLR,
+            BitOpcode.BCOPY,
+            BitOpcode.BNOT,
+            BitOpcode.BAND,
+            BitOpcode.BOR,
+            BitOpcode.BXOR,
+        }
+        unary_source = {BitOpcode.BCOPY, BitOpcode.BNOT, BitOpcode.BPOPCNT, BitOpcode.BHASH}
+        binary_source = {BitOpcode.BAND, BitOpcode.BOR, BitOpcode.BXOR}
+        if instruction.opcode in mutating and instruction.destination is None:
+            raise ValueError("mutating instruction requires a destination")
+        if instruction.opcode in unary_source and instruction.source0 is None:
+            raise ValueError("instruction requires source0")
+        if instruction.opcode in binary_source and (
+            instruction.source0 is None or instruction.source1 is None
+        ):
+            raise ValueError("binary instruction requires source0 and source1")
+        if instruction.destination is not None and instruction.opcode in mutating:
+            if instruction.destination.access_class not in (
+                int(AddressClass.WRITE),
+                int(AddressClass.JOURNAL),
+                int(AddressClass.CONTROL),
+            ):
+                raise PermissionError("mutating destination must carry a write-capable class")
+        for source in (instruction.source0, instruction.source1):
+            if source is not None and source.access_class not in (
+                int(AddressClass.READ),
+                int(AddressClass.EXECUTE),
+                int(AddressClass.JOURNAL),
+                int(AddressClass.CONTROL),
+            ):
+                raise PermissionError("source must carry a readable class")
+
+    def _validate_address(self, address: BitAddress) -> None:
+        if not isinstance(address, BitAddress):
+            raise TypeError("address must be a BitAddress")
+        if (
+            address.x >= self.config.side
+            or address.y >= self.config.side
+            or address.z >= self.config.side
+        ):
+            raise ValueError("address coordinate is outside the configured lattice")
+        if address.byte_offset >= self.config.brick_bytes:
+            raise ValueError("byte offset is outside the configured brick")
+
+    def _validate_brick_key(self, key: object) -> None:
+        if not isinstance(key, tuple) or len(key) != 4:
+            raise TypeError("brick key must be a four-integer tuple")
+        asid, x, y, z = key
+        for item in key:
+            if isinstance(item, bool) or not isinstance(item, int):
+                raise TypeError("brick key components must be integers")
+        if asid < 0 or asid > 255:
+            raise ValueError("brick ASID is outside [0, 255]")
+        if min(x, y, z) < 0 or max(x, y, z) >= self.config.side:
+            raise ValueError("brick coordinate is outside the configured lattice")
+
+    def _authorize_address(
+        self,
+        opcode: BitOpcode,
+        address: BitAddress,
+        accessed: set[BrickKey],
+    ) -> None:
+        self._validate_address(address)
+        self.capability.authorize(opcode, address)
+        accessed.add(address.brick_key)
+        if len(accessed) > self.capability.max_accessed_bricks:
+            raise PermissionError("instruction exceeds the capability brick-access bound")
+
+    def _address_stream(
+        self,
+        start: BitAddress | None,
+        length_bits: int,
+    ) -> Iterator[BitAddress]:
+        if start is None:
+            return iter(())
+        self._validate_address(start)
+        absolute = self._absolute_bit(start)
+        final = absolute + length_bits
+        if final > self.virtual_bit_count:
+            raise ValueError("bit range exceeds the configured virtual lattice")
+
+        def iterator() -> Iterator[BitAddress]:
+            for offset in range(length_bits):
+                yield self._address_from_absolute(absolute + offset, start)
+
+        return iterator()
+
+    def _absolute_bit(self, address: BitAddress) -> int:
+        brick_index = address.x + self.config.side * (
+            address.y + self.config.side * address.z
+        )
+        return (
+            (brick_index * self.config.brick_bytes + address.byte_offset) * 8
+            + address.bit_offset
+        )
+
+    def _address_from_absolute(self, absolute: int, template: BitAddress) -> BitAddress:
+        byte_index, bit_offset = divmod(absolute, 8)
+        brick_index, byte_offset = divmod(byte_index, self.config.brick_bytes)
+        x = brick_index % self.config.side
+        y = (brick_index // self.config.side) % self.config.side
+        z = brick_index // (self.config.side * self.config.side)
+        return BitAddress(
+            asid=template.asid,
+            access_class=template.access_class,
+            x=x,
+            y=y,
+            z=z,
+            byte_offset=byte_offset,
+            bit_offset=bit_offset,
+        )
+
+    def _read_bit_from(self, mapping: Mapping[BrickKey, bytes], address: BitAddress) -> int:
+        payload = mapping.get(address.brick_key)
+        if payload is None:
+            return 0
+        return (payload[address.byte_offset] >> address.bit_offset) & 1
+
+    def _write_bit(
+        self,
+        staged: Dict[BrickKey, bytearray],
+        address: BitAddress,
+        value: int,
+    ) -> None:
+        payload = staged.get(address.brick_key)
+        if payload is None:
+            payload = bytearray(
+                self._bricks.get(address.brick_key, bytes(self.config.brick_bytes))
+            )
+            staged[address.brick_key] = payload
+        mask = 1 << address.bit_offset
+        if value:
+            payload[address.byte_offset] |= mask
+        else:
+            payload[address.byte_offset] &= ~mask & 0xFF
+
+    def _state_digest_for(self, mapping: Mapping[BrickKey, bytes]) -> str:
+        digest = hashlib.sha256()
+        digest.update(b"jarvisx-jx-3d-1pb-bitvm-state-v1\0")
+        digest.update(self._canonical_json(asdict(self.config)))
+        for key, payload in sorted(mapping.items()):
+            digest.update(bytes((key[0],)))
+            for component in key[1:]:
+                digest.update(component.to_bytes(2, "big"))
+            digest.update(payload)
+        return digest.hexdigest()
+
+    def _initial_journal_digest(self) -> str:
+        digest = hashlib.sha256()
+        digest.update(b"jarvisx-jx-3d-1pb-bitvm-journal-v1\0")
+        digest.update(self._canonical_json(asdict(self.config)))
+        return digest.hexdigest()
+
+    def _append_journal(
+        self,
+        *,
+        instruction: BitInstruction,
+        committed: bool,
+        result: int | str | None,
+        touched: Tuple[BrickKey, ...],
+        before_digest: str,
+        after_digest: str,
+        error: str | None,
+    ) -> JournalEntry:
+        payload = {
+            "sequence": self._sequence + 1,
+            "opcode": instruction.opcode.value,
+            "committed": committed,
+            "destination": (
+                instruction.destination.pack() if instruction.destination is not None else None
+            ),
+            "source0": instruction.source0.pack() if instruction.source0 is not None else None,
+            "source1": instruction.source1.pack() if instruction.source1 is not None else None,
+            "length_bits": instruction.length_bits,
+            "result": result,
+            "touched_bricks": touched,
+            "before_state_digest": before_digest,
+            "after_state_digest": after_digest,
+            "previous_hash": self._journal_digest,
+            "error": error,
+        }
+        entry_hash = hashlib.sha256(self._canonical_json(payload)).hexdigest()
+        entry = JournalEntry(hash=entry_hash, **payload)
+        self._journal.append(entry)
+        self._journal_digest = entry_hash
+        return entry
+
+    def _journal_entry_hash(self, entry: JournalEntry) -> str:
+        payload = asdict(entry)
+        payload.pop("hash")
+        return hashlib.sha256(self._canonical_json(payload)).hexdigest()
+
+    @staticmethod
+    def _canonical_json(value: object) -> bytes:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+
+    @staticmethod
+    def _pack_bits(bits: Iterable[int]) -> bytes:
+        packed = bytearray()
+        value = 0
+        width = 0
+        for bit in bits:
+            value |= (bit & 1) << width
+            width += 1
+            if width == 8:
+                packed.append(value)
+                value = 0
+                width = 0
+        if width:
+            packed.append(value)
+        return bytes(packed)

--- a/src/jarvisx/bitvm_3d_1pb.py
+++ b/src/jarvisx/bitvm_3d_1pb.py
@@ -28,6 +28,9 @@ CANONICAL_VIRTUAL_BYTES = CANONICAL_BRICKS * DECIMAL_MEGABYTE
 CANONICAL_VIRTUAL_BITS = CANONICAL_VIRTUAL_BYTES * 8
 
 BrickKey = Tuple[int, int, int, int]  # (asid, x, y, z)
+_READABLE_CLASSES = frozenset((0, 2, 3, 4))
+_WRITABLE_CLASSES = frozenset((1, 3, 4))
+_HEX_DIGEST_LENGTH = 64
 
 
 class AddressClass(IntEnum):
@@ -78,7 +81,7 @@ class BitVMConfig:
                 raise TypeError(f"{name} must be an integer")
             if value <= 0:
                 raise ValueError(f"{name} must be positive")
-        if self.side > 1000:
+        if self.side > CANONICAL_SIDE:
             raise ValueError("side must fit the canonical 10-bit coordinate field")
         if self.brick_bytes > DECIMAL_MEGABYTE:
             raise ValueError("brick_bytes must not exceed the canonical decimal 1 MB brick")
@@ -144,8 +147,6 @@ class BitAddress:
         return self.asid, self.x, self.y, self.z
 
     def pack(self) -> int:
-        """Pack the address into one unsigned 64-bit integer."""
-
         return (
             (self.asid << 56)
             | (self.access_class << 53)
@@ -192,15 +193,18 @@ class Capability:
             raise ValueError("allowed_classes must not be empty")
         if not self.allowed_opcodes:
             raise ValueError("allowed_opcodes must not be empty")
+        for opcode in self.allowed_opcodes:
+            if not isinstance(opcode, BitOpcode):
+                raise TypeError("allowed_opcodes must contain BitOpcode values")
         for asid in self.allowed_asids:
             if isinstance(asid, bool) or not isinstance(asid, int):
                 raise TypeError("allowed_asids must contain integers")
-            if asid < 0 or asid > 255:
+            if not 0 <= asid <= 255:
                 raise ValueError("allowed ASID must be in [0, 255]")
         for access_class in self.allowed_classes:
             if isinstance(access_class, bool) or not isinstance(access_class, int):
                 raise TypeError("allowed_classes must contain integers")
-            if access_class < 0 or access_class > 7:
+            if not 0 <= access_class <= 7:
                 raise ValueError("allowed access class must be in [0, 7]")
         for name in ("x_range", "y_range", "z_range"):
             value = getattr(self, name)
@@ -256,9 +260,9 @@ class JournalEntry:
     sequence: int
     opcode: str
     committed: bool
-    destination: int | None
-    source0: int | None
-    source1: int | None
+    destination: int | str | None
+    source0: int | str | None
+    source1: int | str | None
     length_bits: int
     result: int | str | None
     touched_bricks: Tuple[BrickKey, ...]
@@ -344,6 +348,8 @@ class Sparse3DBitVM:
         """Read one bit. An absent brick returns zero without allocation."""
 
         self._validate_address(address)
+        if address.access_class not in _READABLE_CLASSES:
+            raise PermissionError("read_bit requires a readable address class")
         self.capability.authorize(BitOpcode.BPOPCNT, address)
         return self._read_bit_from(self._bricks, address)
 
@@ -407,13 +413,10 @@ class Sparse3DBitVM:
                 for src in source0:
                     self._authorize_address(instruction.opcode, src, accessed)
                     bits.append(self._read_bit_from(self._bricks, src))
-                result = hashlib.sha256(self._pack_bits(bits)).hexdigest()
+                result = hashlib.sha256(self._pack_bits_lsb_first(bits)).hexdigest()
 
-            else:  # pragma: no cover - Enum exhaustiveness guard
+            else:  # pragma: no cover
                 raise ValueError(f"unsupported opcode {instruction.opcode.value}")
-
-            if len(accessed) > self.capability.max_accessed_bricks:
-                raise PermissionError("instruction exceeds the capability brick-access bound")
 
             next_bricks = dict(self._bricks)
             for key, payload in staged.items():
@@ -477,8 +480,6 @@ class Sparse3DBitVM:
         return hashlib.sha256(payload).hexdigest()
 
     def checkpoint(self) -> Dict[str, Any]:
-        """Return a deterministic JSON-serializable checkpoint including sparse payloads."""
-
         return {
             "version": self.CHECKPOINT_VERSION,
             "config": asdict(self.config),
@@ -486,10 +487,7 @@ class Sparse3DBitVM:
             "journal_digest": self._journal_digest,
             "state_digest": self.state_digest(),
             "bricks": [
-                {
-                    "key": list(key),
-                    "payload_b64": base64.b64encode(payload).decode("ascii"),
-                }
+                {"key": list(key), "payload_b64": base64.b64encode(payload).decode("ascii")}
                 for key, payload in sorted(self._bricks.items())
             ],
             "journal": [asdict(entry) for entry in self._journal],
@@ -524,6 +522,8 @@ class Sparse3DBitVM:
                 raise ValueError("checkpoint brick key must be a sequence")
             key = tuple(raw_key)
             vm._validate_brick_key(key)
+            if key in bricks:
+                raise ValueError("checkpoint contains a duplicate brick key")
             payload_text = item.get("payload_b64")
             if not isinstance(payload_text, str):
                 raise ValueError("checkpoint brick payload must be base64 text")
@@ -545,33 +545,60 @@ class Sparse3DBitVM:
             journal_raw, (str, bytes, bytearray)
         ):
             raise ValueError("checkpoint journal must be a sequence")
-        previous = vm._initial_journal_digest()
+        previous_hash = vm._initial_journal_digest()
+        expected_before = vm._state_digest_for({})
         entries: list[JournalEntry] = []
-        for raw in journal_raw:
+        for expected_sequence, raw in enumerate(journal_raw, start=1):
             if not isinstance(raw, Mapping):
                 raise ValueError("checkpoint journal entry must be a mapping")
             normalized = dict(raw)
             touched_raw = normalized.get("touched_bricks")
-            if not isinstance(touched_raw, Sequence):
+            if not isinstance(touched_raw, Sequence) or isinstance(
+                touched_raw, (str, bytes, bytearray)
+            ):
                 raise ValueError("checkpoint touched_bricks must be a sequence")
-            normalized["touched_bricks"] = tuple(tuple(item) for item in touched_raw)
-            entry = JournalEntry(**normalized)
-            if entry.previous_hash != previous:
+            touched: list[BrickKey] = []
+            for raw_key in touched_raw:
+                if not isinstance(raw_key, Sequence) or isinstance(
+                    raw_key, (str, bytes, bytearray)
+                ):
+                    raise ValueError("checkpoint touched brick key must be a sequence")
+                key = tuple(raw_key)
+                vm._validate_brick_key(key)
+                touched.append(key)
+            if tuple(touched) != tuple(sorted(set(touched))):
+                raise ValueError("checkpoint touched_bricks must be sorted and unique")
+            normalized["touched_bricks"] = tuple(touched)
+            try:
+                entry = JournalEntry(**normalized)
+            except TypeError as exc:
+                raise ValueError("checkpoint journal entry schema mismatch") from exc
+            vm._validate_journal_entry(entry, expected_sequence)
+            if entry.previous_hash != previous_hash:
                 raise ValueError("checkpoint journal chain mismatch")
+            if entry.before_state_digest != expected_before:
+                raise ValueError("checkpoint journal state continuity mismatch")
+            if not entry.committed and entry.after_state_digest != entry.before_state_digest:
+                raise ValueError("rejected journal entry must preserve state")
             if vm._journal_entry_hash(entry) != entry.hash:
                 raise ValueError("checkpoint journal digest mismatch")
-            previous = entry.hash
+            previous_hash = entry.hash
+            expected_before = entry.after_state_digest
             entries.append(entry)
+
         vm._journal = entries
-        vm._journal_digest = previous
+        vm._journal_digest = previous_hash
         vm._sequence = len(entries)
+        restored_state_digest = vm.state_digest()
 
         if checkpoint.get("sequence") != vm._sequence:
             raise ValueError("checkpoint sequence mismatch")
         if checkpoint.get("journal_digest") != vm._journal_digest:
             raise ValueError("checkpoint journal digest mismatch")
-        if checkpoint.get("state_digest") != vm.state_digest():
+        if checkpoint.get("state_digest") != restored_state_digest:
             raise ValueError("checkpoint state digest mismatch")
+        if expected_before != restored_state_digest:
+            raise ValueError("checkpoint journal tip does not match restored state")
         return vm
 
     def _validate_instruction_shape(self, instruction: BitInstruction) -> None:
@@ -584,40 +611,42 @@ class Sparse3DBitVM:
             BitOpcode.BOR,
             BitOpcode.BXOR,
         }
-        unary_source = {BitOpcode.BCOPY, BitOpcode.BNOT, BitOpcode.BPOPCNT, BitOpcode.BHASH}
-        binary_source = {BitOpcode.BAND, BitOpcode.BOR, BitOpcode.BXOR}
-        if instruction.opcode in mutating and instruction.destination is None:
-            raise ValueError("mutating instruction requires a destination")
-        if instruction.opcode in unary_source and instruction.source0 is None:
-            raise ValueError("instruction requires source0")
-        if instruction.opcode in binary_source and (
-            instruction.source0 is None or instruction.source1 is None
-        ):
-            raise ValueError("binary instruction requires source0 and source1")
-        if instruction.destination is not None and instruction.opcode in mutating:
-            if instruction.destination.access_class not in (
-                int(AddressClass.WRITE),
-                int(AddressClass.JOURNAL),
-                int(AddressClass.CONTROL),
-            ):
+        operands = (instruction.destination, instruction.source0, instruction.source1)
+        for operand in operands:
+            if operand is not None and not isinstance(operand, BitAddress):
+                raise TypeError("instruction addresses must be BitAddress values")
+
+        if instruction.opcode in (BitOpcode.BSET, BitOpcode.BCLR):
+            required = (instruction.destination,)
+            forbidden = (instruction.source0, instruction.source1)
+        elif instruction.opcode in (BitOpcode.BCOPY, BitOpcode.BNOT):
+            required = (instruction.destination, instruction.source0)
+            forbidden = (instruction.source1,)
+        elif instruction.opcode in (BitOpcode.BAND, BitOpcode.BOR, BitOpcode.BXOR):
+            required = (instruction.destination, instruction.source0, instruction.source1)
+            forbidden = ()
+        elif instruction.opcode in (BitOpcode.BPOPCNT, BitOpcode.BHASH):
+            required = (instruction.source0,)
+            forbidden = (instruction.destination, instruction.source1)
+        else:  # pragma: no cover
+            raise ValueError("unsupported opcode")
+        if any(item is None for item in required):
+            raise ValueError("instruction is missing a required operand")
+        if any(item is not None for item in forbidden):
+            raise ValueError("instruction contains an extraneous operand")
+
+        if instruction.opcode in mutating:
+            assert instruction.destination is not None
+            if instruction.destination.access_class not in _WRITABLE_CLASSES:
                 raise PermissionError("mutating destination must carry a write-capable class")
         for source in (instruction.source0, instruction.source1):
-            if source is not None and source.access_class not in (
-                int(AddressClass.READ),
-                int(AddressClass.EXECUTE),
-                int(AddressClass.JOURNAL),
-                int(AddressClass.CONTROL),
-            ):
+            if source is not None and source.access_class not in _READABLE_CLASSES:
                 raise PermissionError("source must carry a readable class")
 
     def _validate_address(self, address: BitAddress) -> None:
         if not isinstance(address, BitAddress):
             raise TypeError("address must be a BitAddress")
-        if (
-            address.x >= self.config.side
-            or address.y >= self.config.side
-            or address.z >= self.config.side
-        ):
+        if max(address.x, address.y, address.z) >= self.config.side:
             raise ValueError("address coordinate is outside the configured lattice")
         if address.byte_offset >= self.config.brick_bytes:
             raise ValueError("byte offset is outside the configured brick")
@@ -629,16 +658,13 @@ class Sparse3DBitVM:
         for item in key:
             if isinstance(item, bool) or not isinstance(item, int):
                 raise TypeError("brick key components must be integers")
-        if asid < 0 or asid > 255:
+        if not 0 <= asid <= 255:
             raise ValueError("brick ASID is outside [0, 255]")
         if min(x, y, z) < 0 or max(x, y, z) >= self.config.side:
             raise ValueError("brick coordinate is outside the configured lattice")
 
     def _authorize_address(
-        self,
-        opcode: BitOpcode,
-        address: BitAddress,
-        accessed: set[BrickKey],
+        self, opcode: BitOpcode, address: BitAddress, accessed: set[BrickKey]
     ) -> None:
         self._validate_address(address)
         self.capability.authorize(opcode, address)
@@ -647,9 +673,7 @@ class Sparse3DBitVM:
             raise PermissionError("instruction exceeds the capability brick-access bound")
 
     def _address_stream(
-        self,
-        start: BitAddress | None,
-        length_bits: int,
+        self, start: BitAddress | None, length_bits: int
     ) -> Iterator[BitAddress]:
         if start is None:
             return iter(())
@@ -697,10 +721,7 @@ class Sparse3DBitVM:
         return (payload[address.byte_offset] >> address.bit_offset) & 1
 
     def _write_bit(
-        self,
-        staged: Dict[BrickKey, bytearray],
-        address: BitAddress,
-        value: int,
+        self, staged: Dict[BrickKey, bytearray], address: BitAddress, value: int
     ) -> None:
         payload = staged.get(address.brick_key)
         if payload is None:
@@ -746,11 +767,9 @@ class Sparse3DBitVM:
             "sequence": self._sequence + 1,
             "opcode": instruction.opcode.value,
             "committed": committed,
-            "destination": (
-                instruction.destination.pack() if instruction.destination is not None else None
-            ),
-            "source0": instruction.source0.pack() if instruction.source0 is not None else None,
-            "source1": instruction.source1.pack() if instruction.source1 is not None else None,
+            "destination": self._serialize_address(instruction.destination),
+            "source0": self._serialize_address(instruction.source0),
+            "source1": self._serialize_address(instruction.source1),
             "length_bits": instruction.length_bits,
             "result": result,
             "touched_bricks": touched,
@@ -764,6 +783,58 @@ class Sparse3DBitVM:
         self._journal.append(entry)
         self._journal_digest = entry_hash
         return entry
+
+    @staticmethod
+    def _serialize_address(value: object) -> int | str | None:
+        if value is None:
+            return None
+        if isinstance(value, BitAddress):
+            return value.pack()
+        return f"<invalid:{type(value).__module__}.{type(value).__qualname__}>"
+
+    def _validate_journal_entry(self, entry: JournalEntry, expected_sequence: int) -> None:
+        if isinstance(entry.sequence, bool) or entry.sequence != expected_sequence:
+            raise ValueError("checkpoint journal sequence mismatch")
+        if entry.opcode not in {opcode.value for opcode in BitOpcode}:
+            raise ValueError("checkpoint journal opcode is invalid")
+        if not isinstance(entry.committed, bool):
+            raise ValueError("checkpoint journal committed flag is invalid")
+        if isinstance(entry.length_bits, bool) or not isinstance(entry.length_bits, int):
+            raise ValueError("checkpoint journal length_bits is invalid")
+        if entry.length_bits <= 0 or entry.length_bits > self.config.max_instruction_bits:
+            raise ValueError("checkpoint journal length_bits is outside bounds")
+        for value in (entry.destination, entry.source0, entry.source1):
+            if value is not None and not isinstance(value, (int, str)):
+                raise ValueError("checkpoint journal address encoding is invalid")
+            if isinstance(value, int) and not 0 <= value < 1 << 64:
+                raise ValueError("checkpoint journal packed address is outside bounds")
+            if isinstance(value, str) and not value.startswith("<invalid:"):
+                raise ValueError("checkpoint journal invalid-address marker is malformed")
+        for digest in (
+            entry.before_state_digest,
+            entry.after_state_digest,
+            entry.previous_hash,
+            entry.hash,
+        ):
+            self._validate_digest(digest)
+        if entry.committed and entry.error is not None:
+            raise ValueError("committed journal entry must not contain an error")
+        if not entry.committed and not isinstance(entry.error, str):
+            raise ValueError("rejected journal entry must contain an error")
+        if entry.committed and any(
+            isinstance(value, str)
+            for value in (entry.destination, entry.source0, entry.source1)
+        ):
+            raise ValueError("committed journal entry cannot contain invalid addresses")
+
+    @staticmethod
+    def _validate_digest(value: object) -> None:
+        if not isinstance(value, str) or len(value) != _HEX_DIGEST_LENGTH:
+            raise ValueError("checkpoint digest must be 64 hexadecimal characters")
+        try:
+            bytes.fromhex(value)
+        except ValueError as exc:
+            raise ValueError("checkpoint digest must be hexadecimal") from exc
 
     def _journal_entry_hash(self, entry: JournalEntry) -> str:
         payload = asdict(entry)
@@ -780,7 +851,9 @@ class Sparse3DBitVM:
         ).encode("utf-8")
 
     @staticmethod
-    def _pack_bits(bits: Iterable[int]) -> bytes:
+    def _pack_bits_lsb_first(bits: Iterable[int]) -> bytes:
+        """Pack the first addressed bit into bit 0 of the first output byte."""
+
         packed = bytearray()
         value = 0
         width = 0

--- a/tests/test_bitvm_3d_1pb.py
+++ b/tests/test_bitvm_3d_1pb.py
@@ -1,0 +1,252 @@
+"""Invariant tests for the sparse transactional 3D 1 PB BitVM reference."""
+
+import copy
+
+import pytest
+
+from jarvisx.bitvm_3d_1pb import (
+    CANONICAL_VIRTUAL_BITS,
+    CANONICAL_VIRTUAL_BYTES,
+    AddressClass,
+    BitAddress,
+    BitInstruction,
+    BitOpcode,
+    BitVMConfig,
+    Capability,
+    Sparse3DBitVM,
+    TransactionRejected,
+)
+
+
+def address(
+    *,
+    access: AddressClass,
+    x: int = 0,
+    y: int = 0,
+    z: int = 0,
+    byte: int = 0,
+    bit: int = 0,
+    asid: int = 0,
+) -> BitAddress:
+    return BitAddress(asid, int(access), x, y, z, byte, bit)
+
+
+def test_default_geometry_is_one_petabyte_without_allocation() -> None:
+    vm = Sparse3DBitVM()
+
+    assert vm.virtual_brick_count == 1_000_000_000
+    assert vm.virtual_byte_count == CANONICAL_VIRTUAL_BYTES == 1_000_000_000_000_000
+    assert vm.virtual_bit_count == CANONICAL_VIRTUAL_BITS == 8_000_000_000_000_000
+    assert vm.config.lines_per_brick == 15_625
+    assert vm.resident_brick_count == 0
+    assert vm.resident_payload_bytes == 0
+
+
+def test_address_pack_unpack_round_trip() -> None:
+    values = (
+        address(access=AddressClass.READ),
+        address(
+            access=AddressClass.CONTROL,
+            asid=255,
+            x=999,
+            y=998,
+            z=997,
+            byte=999_999,
+            bit=7,
+        ),
+    )
+
+    for item in values:
+        assert BitAddress.unpack(item.pack()) == item
+        assert 0 <= item.pack() < 1 << 64
+
+    with pytest.raises(ValueError, match="byte_offset"):
+        BitAddress(0, 0, 0, 0, 0, 1_000_000, 0)
+
+
+def test_absent_read_is_zero_and_does_not_materialize_a_brick() -> None:
+    vm = Sparse3DBitVM()
+
+    assert vm.read_bit(address(access=AddressClass.READ, x=500, y=500, z=500)) == 0
+    assert vm.resident_brick_count == 0
+
+
+def test_set_clear_and_zero_brick_pruning() -> None:
+    vm = Sparse3DBitVM(BitVMConfig(brick_bytes=64))
+    target = address(access=AddressClass.WRITE, byte=3, bit=6)
+
+    set_receipt = vm.execute(BitInstruction(BitOpcode.BSET, destination=target, length_bits=3))
+
+    assert set_receipt.committed is True
+    assert vm.resident_brick_count == 1
+    assert vm.read_bit(address(access=AddressClass.READ, byte=3, bit=6)) == 1
+    assert vm.read_bit(address(access=AddressClass.READ, byte=3, bit=7)) == 1
+    assert vm.read_bit(address(access=AddressClass.READ, byte=4, bit=0)) == 1
+
+    vm.execute(BitInstruction(BitOpcode.BCLR, destination=target, length_bits=3))
+
+    assert vm.resident_brick_count == 0
+    assert vm.read_bit(address(access=AddressClass.READ, byte=4, bit=0)) == 0
+
+
+def test_copy_and_xor_across_a_brick_boundary() -> None:
+    vm = Sparse3DBitVM(
+        BitVMConfig(
+            side=3,
+            brick_bytes=8,
+            vector_line_bytes=8,
+            max_resident_bricks=8,
+        )
+    )
+    source = address(access=AddressClass.WRITE, byte=7, bit=6)
+    vm.execute(BitInstruction(BitOpcode.BSET, destination=source, length_bits=4))
+
+    destination = address(access=AddressClass.WRITE, x=2, byte=7, bit=6)
+    readable_source = address(access=AddressClass.READ, byte=7, bit=6)
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BCOPY,
+            destination=destination,
+            source0=readable_source,
+            length_bits=4,
+        )
+    )
+
+    assert vm.read_bit(address(access=AddressClass.READ, x=2, byte=7, bit=6)) == 1
+    assert vm.read_bit(address(access=AddressClass.READ, y=1, byte=0, bit=0)) == 1
+
+    xor_destination = address(access=AddressClass.WRITE, x=1, byte=0, bit=0)
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BXOR,
+            destination=xor_destination,
+            source0=address(access=AddressClass.READ, x=0, byte=7, bit=6),
+            source1=address(access=AddressClass.READ, x=2, byte=7, bit=6),
+            length_bits=1,
+        )
+    )
+    assert vm.read_bit(address(access=AddressClass.READ, x=1, byte=0, bit=0)) == 0
+
+
+def test_popcount_and_hash_are_deterministic_and_non_mutating() -> None:
+    vm = Sparse3DBitVM(BitVMConfig(brick_bytes=64))
+    target = address(access=AddressClass.WRITE, byte=0, bit=0)
+    vm.execute(BitInstruction(BitOpcode.BSET, destination=target, length_bits=5))
+    before = vm.state_digest()
+
+    pop = vm.execute(
+        BitInstruction(
+            BitOpcode.BPOPCNT,
+            source0=address(access=AddressClass.READ),
+            length_bits=8,
+        )
+    )
+    hashed = vm.execute(
+        BitInstruction(
+            BitOpcode.BHASH,
+            source0=address(access=AddressClass.READ),
+            length_bits=8,
+        )
+    )
+
+    assert pop.result == 5
+    assert isinstance(hashed.result, str) and len(hashed.result) == 64
+    assert vm.state_digest() == before
+
+
+def test_rejected_instruction_rolls_back_state_but_advances_journal() -> None:
+    capability = Capability(x_range=(0, 0), y_range=(0, 0), z_range=(0, 0))
+    vm = Sparse3DBitVM(BitVMConfig(side=2, brick_bytes=64), capability)
+    before_state = vm.state_digest()
+    before_journal = vm.journal_digest
+
+    with pytest.raises(TransactionRejected, match="outside the capability") as rejected:
+        vm.execute(
+            BitInstruction(
+                BitOpcode.BSET,
+                destination=address(access=AddressClass.WRITE, x=1),
+            )
+        )
+
+    assert rejected.value.receipt.committed is False
+    assert vm.state_digest() == before_state
+    assert vm.journal_digest != before_journal
+    assert vm.resident_brick_count == 0
+    assert vm.journal[-1].after_state_digest == before_state
+
+
+def test_resident_budget_failure_is_atomic() -> None:
+    vm = Sparse3DBitVM(
+        BitVMConfig(
+            side=2,
+            brick_bytes=8,
+            vector_line_bytes=8,
+            max_resident_bricks=1,
+        ),
+        Capability(x_range=(0, 1), y_range=(0, 1), z_range=(0, 1), max_accessed_bricks=2),
+    )
+    before = vm.state_digest()
+
+    with pytest.raises(TransactionRejected, match="resident-brick budget exceeded"):
+        vm.execute(
+            BitInstruction(
+                BitOpcode.BSET,
+                destination=address(access=AddressClass.WRITE, byte=7, bit=7),
+                length_bits=2,
+            )
+        )
+
+    assert vm.state_digest() == before
+    assert vm.resident_brick_count == 0
+
+
+def test_checkpoint_round_trip_and_tamper_detection() -> None:
+    vm = Sparse3DBitVM(BitVMConfig(side=4, brick_bytes=64, max_resident_bricks=4))
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE, x=2, byte=1, bit=3),
+            length_bits=7,
+        )
+    )
+    checkpoint = vm.checkpoint()
+
+    restored = Sparse3DBitVM.from_checkpoint(checkpoint)
+
+    assert restored.config == vm.config
+    assert restored.state_digest() == vm.state_digest()
+    assert restored.journal_digest == vm.journal_digest
+    assert restored.read_bit(address(access=AddressClass.READ, x=2, byte=1, bit=3)) == 1
+
+    tampered = copy.deepcopy(checkpoint)
+    payload = tampered["bricks"][0]["payload_b64"]
+    tampered["bricks"][0]["payload_b64"] = ("A" if payload[0] != "A" else "B") + payload[1:]
+    with pytest.raises(ValueError, match="digest mismatch|base64"):
+        Sparse3DBitVM.from_checkpoint(tampered)
+
+
+def test_same_instruction_stream_produces_identical_state_and_journal() -> None:
+    config = BitVMConfig(side=4, brick_bytes=64, max_resident_bricks=4)
+    first = Sparse3DBitVM(config)
+    second = Sparse3DBitVM(config)
+    program = (
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE, x=1, byte=2, bit=1),
+            length_bits=9,
+        ),
+        BitInstruction(
+            BitOpcode.BNOT,
+            destination=address(access=AddressClass.WRITE, x=2, byte=0, bit=0),
+            source0=address(access=AddressClass.READ, x=1, byte=2, bit=1),
+            length_bits=9,
+        ),
+    )
+
+    for instruction in program:
+        first.execute(instruction)
+        second.execute(instruction)
+
+    assert first.state_digest() == second.state_digest()
+    assert first.journal_digest == second.journal_digest
+    assert first.checkpoint() == second.checkpoint()

--- a/tests/test_bitvm_3d_1pb_hardening.py
+++ b/tests/test_bitvm_3d_1pb_hardening.py
@@ -1,0 +1,163 @@
+"""Adversarial hardening tests for the 3D 1 PB BitVM."""
+
+import base64
+import copy
+import hashlib
+
+import pytest
+
+from jarvisx.bitvm_3d_1pb import (
+    AddressClass,
+    BitAddress,
+    BitInstruction,
+    BitOpcode,
+    BitVMConfig,
+    Capability,
+    Sparse3DBitVM,
+    TransactionRejected,
+)
+
+
+def address(*, access: AddressClass, x=0, y=0, z=0, byte=0, bit=0, asid=0):
+    return BitAddress(asid, int(access), x, y, z, byte, bit)
+
+
+def tiny_config(**overrides):
+    values = dict(side=4, brick_bytes=64, vector_line_bytes=64, max_resident_bricks=8)
+    values.update(overrides)
+    return BitVMConfig(**values)
+
+
+def rehash_journal(checkpoint):
+    vm = Sparse3DBitVM(BitVMConfig(**checkpoint["config"]))
+    previous = vm._initial_journal_digest()
+    for raw in checkpoint["journal"]:
+        raw["previous_hash"] = previous
+        payload = dict(raw)
+        payload.pop("hash", None)
+        raw["hash"] = hashlib.sha256(vm._canonical_json(payload)).hexdigest()
+        previous = raw["hash"]
+    checkpoint["journal_digest"] = previous
+
+
+def test_read_bit_rejects_write_class_even_when_capability_allows_it():
+    capability = Capability(
+        allowed_classes=(int(AddressClass.WRITE),),
+        allowed_opcodes=(BitOpcode.BPOPCNT,),
+    )
+    vm = Sparse3DBitVM(tiny_config(), capability)
+
+    with pytest.raises(PermissionError, match="readable"):
+        vm.read_bit(address(access=AddressClass.WRITE))
+
+
+def test_malformed_address_is_rejected_and_journaled_safely():
+    vm = Sparse3DBitVM(tiny_config())
+    malformed = BitInstruction(
+        BitOpcode.BSET,
+        destination="not-an-address",  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(TransactionRejected, match="BitAddress"):
+        vm.execute(malformed)
+
+    assert len(vm.journal) == 1
+    assert vm.journal[0].destination == "<invalid:builtins.str>"
+    assert vm.journal[0].committed is False
+
+
+def test_extraneous_operands_are_rejected():
+    vm = Sparse3DBitVM(tiny_config())
+    instruction = BitInstruction(
+        BitOpcode.BSET,
+        destination=address(access=AddressClass.WRITE),
+        source0=address(access=AddressClass.READ),
+    )
+
+    with pytest.raises(TransactionRejected, match="extraneous"):
+        vm.execute(instruction)
+
+
+def test_checkpoint_rejects_duplicate_brick_keys():
+    vm = Sparse3DBitVM(tiny_config())
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE),
+        )
+    )
+    checkpoint = vm.checkpoint()
+    checkpoint["bricks"].append(copy.deepcopy(checkpoint["bricks"][0]))
+
+    with pytest.raises(ValueError, match="duplicate brick"):
+        Sparse3DBitVM.from_checkpoint(checkpoint)
+
+
+def test_checkpoint_rejects_non_monotonic_sequence_even_when_rehashed():
+    vm = Sparse3DBitVM(tiny_config())
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE),
+        )
+    )
+    checkpoint = vm.checkpoint()
+    checkpoint["journal"][0]["sequence"] = 999
+    rehash_journal(checkpoint)
+    checkpoint["sequence"] = 1
+
+    with pytest.raises(ValueError, match="sequence"):
+        Sparse3DBitVM.from_checkpoint(checkpoint)
+
+
+def test_checkpoint_rejects_broken_state_continuity_even_when_rehashed():
+    vm = Sparse3DBitVM(tiny_config())
+    target = address(access=AddressClass.WRITE)
+    vm.execute(BitInstruction(BitOpcode.BSET, destination=target))
+    vm.execute(BitInstruction(BitOpcode.BCLR, destination=target))
+    checkpoint = vm.checkpoint()
+    checkpoint["journal"][1]["before_state_digest"] = "0" * 64
+    rehash_journal(checkpoint)
+
+    with pytest.raises(ValueError, match="continuity"):
+        Sparse3DBitVM.from_checkpoint(checkpoint)
+
+
+def test_checkpoint_rejects_state_not_produced_by_journal_tip():
+    vm = Sparse3DBitVM(tiny_config())
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE),
+        )
+    )
+    checkpoint = vm.checkpoint()
+    raw = bytearray(64)
+    raw[0] = 2
+    checkpoint["bricks"][0]["payload_b64"] = base64.b64encode(raw).decode("ascii")
+
+    probe = Sparse3DBitVM(tiny_config())
+    probe._bricks[(0, 0, 0, 0)] = bytes(raw)
+    checkpoint["state_digest"] = probe.state_digest()
+
+    with pytest.raises(ValueError, match="journal tip"):
+        Sparse3DBitVM.from_checkpoint(checkpoint)
+
+
+def test_checkpoint_rejects_malformed_touched_bricks():
+    vm = Sparse3DBitVM(tiny_config())
+    vm.execute(
+        BitInstruction(
+            BitOpcode.BSET,
+            destination=address(access=AddressClass.WRITE),
+        )
+    )
+    checkpoint = vm.checkpoint()
+    checkpoint["journal"][0]["touched_bricks"] = [
+        [0, 0, 0, 0],
+        [0, 0, 0, 0],
+    ]
+    rehash_journal(checkpoint)
+
+    with pytest.raises(ValueError, match="sorted and unique"):
+        Sparse3DBitVM.from_checkpoint(checkpoint)


### PR DESCRIPTION
## Summary

Operationalize the proposed `1000 × 1000 × 1000` MB-axis architecture as a bounded sparse bit virtual machine:

- canonical `1000³` lattice of decimal 1 MB bricks;
- 1 PB virtual extent and `8 × 10^15` addressable bits;
- packed 64-bit address: `ASID | CLASS | Z | Y | X | BYTE | BIT`;
- zero-background sparse materialization and zero-brick pruning;
- capability-bounded address and opcode access;
- copy-on-write commit/rollback for state-changing instructions;
- deterministic state digests and hash-chained journal receipts;
- checkpoint export, replay, and tamper detection;
- bounded reference ISA: `BSET`, `BCLR`, `BCOPY`, `BNOT`, `BAND`, `BOR`, `BXOR`, `BPOPCNT`, `BHASH`.

## Review hardening

The review findings have been addressed:

- direct reads now enforce readable address classes;
- malformed instruction addresses are rejected and journaled safely;
- extraneous operands are rejected;
- checkpoint brick keys must be unique;
- journal sequences must be monotonic and one-based;
- journal state transitions must be continuous;
- rejected entries must preserve authoritative state;
- the journal tip must equal the restored state digest;
- touched-brick metadata must be validated, sorted, and unique;
- `BHASH` bit packing is explicitly LSB-first.

## Validation

The original 10 invariant tests remain, with 8 additional adversarial recovery and authorization tests. The focused combined suite was executed locally:

```text
18 passed
```

CI, CodeQL, and empirical validation are required before merge.

## Capability boundary

This is a correctness-oriented sparse reference implementation. It does not claim one petabyte of resident memory, hostile-bytecode isolation, distributed consensus, GPU/SIMD performance, or production readiness. Optimized backends must preserve the canonical address, transaction, digest, and journal semantics.