### PR TITLE
Add transactional photonic pixel-field runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,11 +49,9 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
-          src/jarvisx/photonic_rendering.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
-          tests/test_photonic_rendering.py
 
       - name: Check canonical import order
         run: >-
@@ -63,11 +61,9 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
-          src/jarvisx/photonic_rendering.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
-          tests/test_photonic_rendering.py
 
       - name: Type-check package
         run: mypy src/jarvisx --ignore-missing-imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,11 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/photonic_rendering.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_photonic_rendering.py
 
       - name: Check canonical import order
         run: >-
@@ -61,9 +63,11 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/photonic_rendering.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_photonic_rendering.py
 
       - name: Type-check package
         run: mypy src/jarvisx --ignore-missing-imports

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 **Jarvis-X is a deterministic, auditable bytecode virtual machine and sparse-computing research platform.**
 
-The project investigates how large virtual state spaces, geometric representations, residual memory and bounded adaptation can be implemented as reproducible software without confusing virtual extent with physical allocation or simulation with deployed intelligence.
+The project investigates how large virtual state spaces, geometric and physical representations, residual memory and bounded adaptation can be implemented as reproducible software without confusing virtual extent with physical allocation, numerical approximation with calibrated physics, or simulation with deployed intelligence.
 
-> **Current status:** alpha research software. The repository contains a stable reference VM foundation, validated sparse and numerical components, a bounded C++ processor laboratory and experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
+> **Current status:** alpha research software. The repository contains a stable reference VM foundation, transactional sparse systems, numerical references, a bounded C++ processor laboratory and experimental integration tracks. See [Project Status](docs/PROJECT_STATUS.md) for the authoritative capability boundary.
 
 ## Why Jarvis-X exists
 
@@ -21,7 +21,8 @@ Jarvis-X develops one coherent systems thesis:
 3. measure prediction or reconstruction error explicitly;
 4. retain bounded correction memory;
 5. verify proposed state transitions before commit;
-6. journal enough information to audit and replay decisions.
+6. journal enough information to audit and replay decisions;
+7. keep physical, numerical and visual claims tied to explicit models and evidence.
 
 The symbolic vocabulary used in the research documents maps to ordinary engineering mechanisms:
 
@@ -34,18 +35,20 @@ The symbolic vocabulary used in the research documents maps to ordinary engineer
 | Π | projection into a valid state set |
 | Ξ | integrated runtime state |
 
-## Capabilities on `main`
+## Capabilities
 
 | Area | Implemented capability | Maturity |
 |---|---|---|
 | Bytecode VM | parser, assembler, decoder, registers and minimal 64-bit instruction execution | Alpha |
 | Core ISA | `SET`, `ADD`, `SUB`, `HALT` | Alpha |
-| Runtime controls | policy check, cycle sandbox, tracing and verifiable ledger integration | Reference foundation |
+| Runtime controls | transactional cycle, policy check, cycle sandbox, tracing and verifiable ledger integration | Reference foundation |
+| Sparse 3D systems | billion-address field and bounded transactional decimal-1-PB BitVM | Stable references |
 | C++ processor laboratory | sparse virtual `8192³` lattice, signed 3-bit latent cycle, deterministic bounded genome/schedule search | Reference laboratory |
 | Fractional 3D smoothing | periodic spectral fractional diffusion, analytic forcing and multiresolution fusion | Numerical reference |
 | Sparse geometry | deterministic inward-folding fractal octree with closed-form invariants | Reference |
+| Photonic pixel field | spectral detector integration, deterministic tiling, frame digest, rollback and `1000³` lattice projection | Integration candidate |
 | Model packaging | Hugging Face-compatible configuration, model and safetensors exporter | Reference |
-| Research specifications | reality-grounded observer dynamics, spatial bytecode and bounded optimization documents | Proposed / reference |
+| Research specifications | observer dynamics, spatial bytecode, bounded optimization and agentic orchestration boundaries | Proposed / reference |
 
 Experimental engines remain in draft pull requests until their tests, interfaces and capability claims are reconciled with the canonical core.
 
@@ -121,6 +124,50 @@ assert result.field.variance < field.variance
 
 The solver uses a dependency-free separable direct DFT for small correctness fixtures. See [Hierarchical 3D Fractional Smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md) for the equations, complexity and production boundary.
 
+### Render a photonic reference frame
+
+```python
+from jarvisx.photonic_rendering import (
+    Camera,
+    Material,
+    PhotonicRenderer,
+    PhotonicScene,
+    PointEmitter,
+    RenderConfig,
+    Sphere,
+    Spectrum,
+)
+
+scene = PhotonicScene(
+    spheres=(
+        Sphere(
+            center=(0.0, 0.0, -3.5),
+            radius=1.2,
+            material=Material(reflectance=(0.8, 0.32, 0.14), roughness=0.35),
+        ),
+    ),
+    emitters=(
+        PointEmitter(
+            position=(-2.5, 3.0, 0.0),
+            spectrum=Spectrum.white_reference(),
+            intensity=120.0,
+        ),
+    ),
+)
+
+frame, state, receipt = PhotonicRenderer().cycle(
+    scene,
+    Camera(width=32, height=18),
+    RenderConfig(samples_per_axis=2, tile_edge=8),
+)
+
+assert receipt.committed
+assert frame is not None
+assert state.frame_digest == frame.digest
+```
+
+The photonic path is a deterministic geometric/radiometric reference. It does not solve the full Maxwell equations and does not claim production GPU performance. See [Electromagnetic-Photonic Pixel-Field Runtime](docs/PHOTONIC_RENDERING_RUNTIME.md).
+
 ### Build the C++ processor laboratory
 
 ```bash
@@ -142,26 +189,20 @@ See [`cpp_runtime/README.md`](cpp_runtime/README.md) for its state artifacts, de
 ## Architecture
 
 ```text
-Source assembly
-      │
-      ▼
-Parser → Assembler → 64-bit bytecode
-                         │
-                         ▼
-             ┌─────────────────────┐
-             │      CodexVM        │
-             │ decode → authorize  │
-             │ execute → trace     │
-             │ journal → constrain │
-             └─────────────────────┘
-                         │
-              ┌──────────┴──────────┐
-              ▼                     ▼
-      authoritative state    isolated research layers
-      registers / memory     C++ / numerical / visual
+physical or digital input
+          |
+          v
+representation -> validation -> transactional execution -> observation -> journal
+          |                         |
+          |                         +-> authoritative VM state
+          |
+          +-> sparse coordinates / numerical fields / photonic detector tiles
+                                      |
+                                      +-> bounded CPU, GPU or cloud backend
+                                      +-> verified output or rollback
 ```
 
-The canonical design rules are documented in [Architecture](docs/ARCHITECTURE.md).
+The canonical design rules are documented in [Architecture](docs/ARCHITECTURE.md). The integrated ten-stage workflow, 3D coordinate conventions and authority boundaries are documented in [System Operational Framework](docs/SYSTEM_OPERATIONAL_FRAMEWORK.md).
 
 ## Sparse fractal octree
 
@@ -190,6 +231,7 @@ At depth `D`:
 | Backlog consolidation | select canonical implementations and close superseded research branches | Issue #48 |
 | Repository protection | required checks, secret scanning and private vulnerability reporting | Issue #49 |
 | Public profile | account-level profile README and pinned-project cleanup | Issue #50 |
+| Photonic pixel field | establish detector semantics before GPU acceleration | Integration candidate |
 | Browser engines | bounded interactive 3D visual-computing demonstrations | Separate repository |
 
 Draft status is intentional: experimental subsystems are not represented as canonical until CI, review and integration boundaries are satisfied.
@@ -220,12 +262,14 @@ Every canonical subsystem should provide:
 - reproducible tests and examples;
 - honest implemented-versus-proposed boundaries;
 - transaction, rollback or failure semantics where state is mutated;
-- no performance or intelligence claim without measurement.
+- no performance, physical or intelligence claim without measurement.
 
 ## Documentation
 
 - [Architecture](docs/ARCHITECTURE.md)
+- [System operational framework](docs/SYSTEM_OPERATIONAL_FRAMEWORK.md)
 - [Project status](docs/PROJECT_STATUS.md)
+- [Electromagnetic-photonic pixel-field runtime](docs/PHOTONIC_RENDERING_RUNTIME.md)
 - [Hierarchical 3D fractional smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md)
 - [Roadmap](ROADMAP.md)
 - [Governance](GOVERNANCE.md)
@@ -235,7 +279,7 @@ Every canonical subsystem should provide:
 
 ## Contributing
 
-Jarvis-X welcomes focused improvements in VM correctness, bytecode formats, sparse spatial computation, deterministic testing, performance measurement and documentation. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
+Jarvis-X welcomes focused improvements in VM correctness, bytecode formats, sparse spatial computation, deterministic numerical methods, performance measurement and documentation. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
 Large architectural proposals should begin as an issue or specification. Production claims must include reproducible evidence.
 
@@ -243,7 +287,7 @@ Large architectural proposals should begin as an issue or specification. Product
 
 Jarvis-X is an experimental software and mathematical research project. It does not claim consciousness, unrestricted autonomous self-modification, lossless compression of arbitrary high-dimensional inputs into smaller states, or production safety merely because a policy layer is present.
 
-Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility. The C++ processor mutates bounded parameters and schedules; it does not rewrite arbitrary native code. The fractional solver is a small-grid CPU reference, not a calibrated physical model or production FFT implementation.
+Virtual address-space size is not resident memory. A deterministic simulation is not evidence of general intelligence. A cryptographic digest provides integrity, not reversibility. A geometric or radiometric rendering model is not a full electromagnetic solver. The C++ processor mutates bounded parameters and schedules; it does not rewrite arbitrary native code. The fractional solver is a small-grid CPU reference, not a calibrated physical model or production FFT implementation.
 
 ## Citation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,17 +6,20 @@ This document defines the canonical architectural boundaries for code merged int
 
 ## 1. Architectural objective
 
-Jarvis-X is a deterministic bytecode virtual machine surrounded by auditable research layers. The core must remain understandable without requiring the speculative layers.
+Jarvis-X is a deterministic bytecode virtual machine surrounded by auditable, bounded research layers. The core must remain understandable without requiring the numerical, photonic, visual or adaptive layers.
 
-The architecture follows this dependency direction:
+The dependency direction is:
 
 ```text
-representation → validation → execution → observation → journaling
-                                     │
-                                     └→ optional bounded adaptation
+representation -> validation -> execution -> observation -> journaling
+                                      |
+                                      +-> sparse/numerical/photonic adapters
+                                      +-> optional bounded adaptation
 ```
 
-Optional layers may depend on the core. The core must not depend on a specific visualizer, neural model, spatial engine or self-optimization strategy.
+Optional layers may depend on the core. The core must not depend on a particular renderer, neural model, spatial engine, GPU backend, cloud provider or self-optimization strategy.
+
+The system-wide pipeline and coordinate conventions are documented in [`SYSTEM_OPERATIONAL_FRAMEWORK.md`](SYSTEM_OPERATIONAL_FRAMEWORK.md).
 
 ## 2. Canonical layers
 
@@ -28,7 +31,8 @@ Responsibilities:
 - typed instruction objects;
 - fixed-width bytecode encoding;
 - deterministic decoding;
-- register and memory representation.
+- register and memory representation;
+- versioned persistent envelopes.
 
 Required properties:
 
@@ -58,12 +62,13 @@ Required properties:
 
 Responsibilities:
 
-- instruction admissibility;
+- instruction and capability admissibility;
 - precondition checks;
+- whole-cycle state snapshots;
 - proposed-state validation;
-- commit or rollback where operations span multiple state domains.
+- commit or rollback across every authoritative state component.
 
-The current core provides a minimal policy check. Experimental transactional engines must not be represented as canonical until rollback covers every authoritative state component.
+A subsystem that cannot restore all authoritative state after failure must not claim atomic rollback. External API side effects require explicit compensation or idempotency contracts.
 
 ### Layer 3 — Observation and provenance
 
@@ -73,7 +78,8 @@ Responsibilities:
 - append-only journal entries;
 - hash-chain verification;
 - persistent state checkpoints;
-- deterministic replay fixtures.
+- deterministic replay fixtures;
+- machine-readable evidence artifacts.
 
 Journal entries must contain JSON-native data. Cryptographic digests establish integrity; they are not reversible encodings.
 
@@ -85,63 +91,123 @@ Responsibilities:
 - sparse blocks, bricks, tiles or octrees;
 - exact logical-to-physical addressing;
 - bounded materialization;
-- topology and geometry validation.
+- topology and geometry validation;
+- deterministic serialization and checkpoint recovery.
 
-A large virtual extent never implies dense allocation. Every implementation must state its resident working-set bound.
+A large virtual extent never implies dense allocation. Every implementation must state logical capacity, resident working-set bounds and materialization rules separately.
 
-### Layer 5 — Adaptive research systems
+### Layer 5 — Numerical field systems
+
+Responsibilities:
+
+- finite-dimensional field representations;
+- discretization and boundary conditions;
+- stable solver steps;
+- conservation, dissipation or error metrics;
+- reference comparisons and tolerance declarations.
+
+A numerical field is an approximation under an explicit model. It must not be represented as a physically calibrated simulation without units, validation data and error bounds.
+
+### Layer 6 — Physical transduction and photonic rendering
+
+Responsibilities:
+
+- physical-to-digital signal contracts;
+- wavelength-dependent source and detector models;
+- finite-area pixel integration;
+- optical/radiometric transport approximations;
+- deterministic detector tiling;
+- exposure, transfer and quantization;
+- optional pixel/depth projection into sparse 3D coordinates.
+
+The reference photonic renderer uses geometric optics and bounded spectral integration. It is not a full-wave Maxwell solver. CPU, GPU and cloud implementations are interchangeable execution backends only when they preserve the declared pixel, digest and transaction semantics.
+
+### Layer 7 — Adaptive and agentic research systems
 
 Responsibilities may include:
 
 - residual correction memory;
 - parameter candidate generation;
+- task decomposition and routing;
 - shadow evaluation;
 - bounded schedule search;
 - coherence projection;
-- commit and rollback decisions.
+- commit and rollback recommendations.
 
-Adaptive systems must optimize constrained representations, not rewrite arbitrary native instructions. Fitness must exclude uncontrolled nondeterministic signals unless repeated statistical evaluation is explicitly part of the contract.
+Adaptive and agentic systems produce proposals. They must not silently mutate authoritative VM or spatial state. They optimize constrained representations, not arbitrary native instructions.
 
-### Layer 6 — Interfaces and visualization
+### Layer 8 — Interfaces and visualization
 
 Responsibilities:
 
 - CLI, API and browser interfaces;
 - 2D or 3D visualization;
 - telemetry presentation;
-- snapshot export.
+- snapshot and artifact export.
 
-A visualization is not an authoritative compute substrate unless the architecture and tests demonstrate that role.
+A visualization is not an authoritative compute substrate unless its numerical and transaction contracts are documented and tested. Interactive demonstrations must not be described as production renderers solely because they display a plausible animation.
 
-## 3. Canonical VM cycle
+## 3. Canonical operational cycles
+
+### VM instruction cycle
 
 ```text
 fetch
-  → bounds check
-  → decode
-  → policy check
-  → execute
-  → snapshot
-  → journal
-  → trace
-  → optional reflex correction
-  → advance IP
-  → enforce cycle limit
-  → continue or halt
+-> bounds check
+-> decode
+-> policy check
+-> checkpoint authoritative state
+-> execute into a proposed state
+-> verify complete state and persistence
+-> commit or rollback
+-> trace and journal the outcome
+-> advance IP on commit
+-> enforce cycle limit
+-> continue or halt
 ```
 
-Reflex correction is opt-in. It must never silently change normal assembly semantics.
+Reflex correction is opt-in. It must never silently change ordinary assembly semantics.
+
+### System workflow cycle
+
+```text
+event ingestion
+-> authenticate/capability
+-> validate schema and dimensions
+-> route workflow
+-> load state
+-> plan bounded tasks
+-> execute VM instructions, kernels or APIs
+-> verify results
+-> persist and emit
+-> complete, halt or wait
+```
+
+### Photonic frame cycle
+
+```text
+validate scene, camera and resource bounds
+-> partition detector into deterministic tiles
+-> transport spectral energy
+-> integrate finite pixel samples
+-> apply exposure and quantization
+-> compute canonical frame digest
+-> verify every output
+-> commit frame and Omega digest, or rollback
+```
 
 ## 4. Core invariants
 
-1. **Determinism:** identical authoritative inputs produce identical VM state, excluding explicitly recorded environmental values such as production timestamps.
-2. **Bounded execution:** every run has an enforceable cycle limit.
-3. **Explicit persistence:** ordinary VM runs do not write files unless a persistence path is supplied.
-4. **Integrity:** a valid journal hash binds its timestamp, opcode, state and previous hash.
-5. **Fail-closed validation:** malformed bytecode, invalid program counters and corrupt journals are rejected.
-6. **Separation of authority:** visual, predictive and adaptive layers cannot silently mutate the canonical VM state.
+1. **Determinism:** identical authoritative inputs produce identical declared outputs, excluding explicitly recorded environmental values and documented floating-point tolerance profiles.
+2. **Bounded execution:** every run has enforceable cycle, memory and work-unit limits.
+3. **Explicit persistence:** ordinary runs do not write files unless a persistence path is supplied.
+4. **Integrity:** journal and checkpoint digests bind canonical serialized state.
+5. **Fail-closed validation:** malformed bytecode, dimensions, coordinates, models and journals are rejected.
+6. **Separation of authority:** visual, predictive, numerical and adaptive layers cannot silently mutate canonical VM state.
 7. **Honest scale:** virtual geometry is reported separately from resident memory and measured throughput.
-8. **No claim by naming:** terms such as intelligence, cognition, self-evolution or neural do not establish those capabilities without operational tests.
+8. **Physical-model honesty:** geometric or radiometric approximations are not represented as full electromagnetic solvers.
+9. **Backend equivalence:** acceleration may replace execution strategy, not semantic contracts.
+10. **No claim by naming:** terms such as intelligence, cognition, self-evolution, photonic or neural do not establish those capabilities without operational evidence.
 
 ## 5. Data contracts
 
@@ -158,7 +224,7 @@ Canonical bytecode words are unsigned 64-bit integers. Persistent binary formats
 
 ### Journal
 
-A canonical journal entry contains exactly:
+A canonical VM journal entry contains exactly:
 
 ```json
 {
@@ -172,6 +238,8 @@ A canonical journal entry contains exactly:
 
 The digest is SHA-256 over canonical JSON of every field except `hash`.
 
+Deterministic research journals may replace environmental timestamps with explicit sequence numbers, but the chosen schema must be versioned and documented.
+
 ### Spatial state
 
 Every spatial subsystem must define:
@@ -184,6 +252,33 @@ Every spatial subsystem must define:
 - serialization order;
 - neighborhood topology.
 
+### Numerical and photonic state
+
+Every numerical or photonic subsystem must define:
+
+- coordinate and unit conventions;
+- discrete sampling scheme;
+- source, detector and boundary assumptions;
+- numerical precision profile;
+- resource limits;
+- output quantization;
+- canonical digest inputs;
+- validation references and tolerance boundaries.
+
+### Agent proposal
+
+Every agent or scheduler proposal must define:
+
+- role and capability;
+- input-state digest;
+- requested operation and coordinates;
+- resource budget;
+- expected output schema;
+- evidence and provenance;
+- expiry or replay behavior.
+
+A proposal is never equivalent to a committed transition.
+
 ## 6. Integration rule
 
 A research subsystem may enter the canonical package only when it provides:
@@ -191,17 +286,19 @@ A research subsystem may enter the canonical package only when it provides:
 - a narrow public API;
 - executable tests;
 - input and state validation;
-- deterministic fixtures;
+- deterministic fixtures or a documented stochastic protocol;
 - capability boundaries;
+- transaction or explicit failure semantics;
+- complexity and memory bounds;
 - documentation;
 - CI coverage on supported platforms;
 - no unresolved conflict with existing authoritative state.
 
-Large pull requests should be decomposed into infrastructure, kernel, integration and demonstration stages.
+Large pull requests should be decomposed into infrastructure, reference kernel, integration, acceleration and demonstration stages.
 
 ## 7. Decision records
 
-Material architecture changes should add an Architecture Decision Record under `docs/adr/` using:
+Material architecture changes must add an Architecture Decision Record under `docs/adr/` using:
 
 ```text
 # ADR-NNN: Decision title
@@ -212,8 +309,8 @@ Consequences
 Validation
 ```
 
-A newer accepted ADR may supersede an older one, but historical records should remain available.
+A newer accepted ADR may supersede an older one, but historical records remain available.
 
 ## 8. Security boundary
 
-The policy layer is an application-level guard, not a complete security sandbox. Untrusted bytecode, native plugins, model files and browser content require dedicated threat models. See [`SECURITY.md`](../SECURITY.md).
+The policy layer is an application-level guard, not a complete security sandbox. Untrusted bytecode, native plugins, scene files, model files, cloud-worker results and browser content require dedicated threat models. Physical emitters, cameras and actuators additionally require device-level permission, rate, power and fail-safe controls. See [`SECURITY.md`](../SECURITY.md).

--- a/docs/PHOTONIC_RENDERING_RUNTIME.md
+++ b/docs/PHOTONIC_RENDERING_RUNTIME.md
@@ -1,0 +1,164 @@
+# Electromagnetic-Photonic Pixel-Field Runtime
+
+## Status
+
+**Numerical reference / integration candidate.** The implementation in `src/jarvisx/photonic_rendering.py` defines a deterministic, bounded rendering contract in which a pixel is a finite-area spectral detector. It is intended for small correctness fixtures and architectural integration, not production rendering or full-wave electromagnetic simulation.
+
+## 1. System interpretation
+
+The subsystem separates the physical phenomenon from its digital representation:
+
+```text
+electromagnetic emission
+→ wavelength-dependent propagation
+→ material interaction
+→ camera projection
+→ finite-area detector integration
+→ exposure and transfer function
+→ integer RGB quantization
+→ verification
+→ commit or rollback
+```
+
+A pixel is not treated as an isolated coloured square. It is the result of a bounded measurement operator applied to a continuous spatial light field:
+
+```text
+p[i,j,c] = Q_b[
+    integral over exposure time
+    integral over wavelength
+    integral over pixel aperture
+    S_c(lambda) L(x, y, lambda, t)
+]
+```
+
+The reference implementation evaluates this integral by deterministic finite sampling and a small ordered wavelength set.
+
+## 2. Physical approximation boundary
+
+The implementation includes:
+
+- geometric camera rays;
+- ray/sphere intersection;
+- inverse-square emitter attenuation;
+- wavelength-dependent RGB detector response;
+- Lambertian diffuse reflection;
+- one bounded roughness-controlled specular term;
+- hard visibility tests;
+- exposure, tone mapping, gamma transfer and 8-bit quantization.
+
+It does **not** include:
+
+- time-domain Maxwell integration;
+- diffraction, polarisation or near-field coupling;
+- calibrated BRDF or sensor spectral data;
+- recursive global illumination;
+- participating media;
+- production acceleration structures;
+- stochastic Monte Carlo claims;
+- hardware GPU acceleration on the reference path.
+
+The phrase electromagnetic-photonic therefore describes the physical interpretation and spectral measurement model, not a claim that the code solves Maxwell's equations.
+
+## 3. Authoritative state transition
+
+The runtime cycle is:
+
+```text
+observe scene and camera
+→ validate dimensional and resource contracts
+→ partition the detector into deterministic tiles
+→ transport spectral energy to each surface sample
+→ integrate each pixel aperture
+→ quantize the detector response
+→ compute the canonical frame digest
+→ verify every output bound
+→ commit frame and Omega digest, or rollback the entire cycle
+```
+
+The transition is represented as:
+
+```text
+(frame, state, receipt) = renderer.cycle(scene, camera, config)
+```
+
+A failed cycle returns `frame=None`, preserves the previous authoritative runtime state and emits a rollback receipt with a reason.
+
+## 4. Deterministic orchestration contract
+
+The detector is partitioned into row-major `WorkTile` records. Tile order, pixel order, wavelength order and digest serialization are fixed. A future CPU thread pool, GPU kernel or distributed worker fabric may replace physical execution only if it preserves:
+
+- pixel semantics;
+- tile and pixel coordinate identity;
+- configured resource bounds;
+- quantized RGB results for the declared numerical profile;
+- canonical frame digest;
+- whole-cycle commit and rollback behavior.
+
+This creates an implementation boundary between **what a pixel means** and **where the computation runs**.
+
+## 5. Pixel-to-3D lattice projection
+
+A rendered detector sample can be projected into the canonical sparse `1000^3` spatial domain:
+
+```text
+X = floor((pixel_x + 0.5) * side / image_width)
+Y = floor((pixel_y + 0.5) * side / image_height)
+Z = floor((depth / (1 + depth)) * (side - 1))
+```
+
+A miss uses the far plane (`Z = side - 1`). This projection is an address mapping, not a claim that a 2D image uniquely reconstructs physical 3D reality.
+
+## 6. Minimal use
+
+```python
+from jarvisx.photonic_rendering import (
+    Camera,
+    Material,
+    PhotonicRenderer,
+    PhotonicScene,
+    PointEmitter,
+    RenderConfig,
+    Sphere,
+    Spectrum,
+)
+
+scene = PhotonicScene(
+    spheres=(
+        Sphere(
+            center=(0.0, 0.0, -3.5),
+            radius=1.2,
+            material=Material(reflectance=(0.8, 0.32, 0.14), roughness=0.35),
+        ),
+    ),
+    emitters=(
+        PointEmitter(
+            position=(-2.5, 3.0, 0.0),
+            spectrum=Spectrum.white_reference(),
+            intensity=120.0,
+        ),
+    ),
+)
+
+renderer = PhotonicRenderer()
+frame, state, receipt = renderer.cycle(
+    scene,
+    Camera(width=32, height=18),
+    RenderConfig(samples_per_axis=2, tile_edge=8),
+)
+
+assert receipt.committed
+assert frame is not None
+assert state.frame_digest == frame.digest
+```
+
+## 7. Promotion requirements
+
+Before this layer is represented as an accelerated or physically calibrated renderer, it requires:
+
+1. independent spectral and radiometric reference comparisons;
+2. a declared floating-point reproducibility profile;
+3. CPU baseline benchmarks;
+4. GPU tile-kernel equivalence tests;
+5. image fixtures with retained machine-readable metrics;
+6. explicit energy-accounting tolerances;
+7. a threat model for untrusted scene and model inputs.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-01  
+**Last reviewed:** 2026-08-04  
 **Release line:** `0.1.x` alpha
 
 This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
@@ -26,6 +26,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | 64-bit bytecode decode | Alpha | `decoder.py`, `instruction.py` | versioned external byte envelope is not yet canonical |
 | Register VM | Alpha | `core.py`, `executor.py` | canonical ISA currently has a small instruction surface |
 | Lambda instruction policy | Alpha | `ethics.py` | application-level guard, not a security sandbox |
+| Transactional instruction cycle | Stable reference | `core.py`, ledger-store integration and regression tests | rollback covers canonical VM state and configured ledger persistence, not arbitrary external APIs |
 | Cycle sandbox | Stable reference | `sandbox.py` | cycle bound only; no process isolation |
 | Trace and Omega journal | Stable reference | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
 | Consolidated empirical validation | Stable reference | `empirical_validation.py`, focused tests, JSON artifact workflow | verifies bounded software invariants only; no AGI, safety or production-performance inference |
@@ -33,9 +34,18 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Fractional 3D smoothing | Numerical reference | `fractional_smoothing_3d.py`, independent DFT/stencil/semigroup tests | dense periodic scalar grids and separable `O(N⁴)` cubic DFT; not a production FFT or calibrated physical model |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
+| Sparse transactional 3D 1 PB BitVM | Stable reference | `bitvm_3d_1pb.py`, documentation, adversarial and recovery tests | virtual decimal 1 PB address space; bounded sparse materialization; no GPU or hostile-code sandbox claim |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
+
+## Current integration candidate
+
+| Capability | Status | Evidence on branch | Boundary |
+|---|---|---|---|
+| Electromagnetic-photonic pixel-field runtime | Integration candidate | `photonic_rendering.py`, focused tests, example, ADR and runtime specification | deterministic geometric/radiometric reference; not a full-wave Maxwell solver or production GPU renderer |
+
+The photonic candidate adds finite-area spectral pixel measurement, inverse-square transport, wavelength-dependent detector response, deterministic tile orchestration, frame digests, transactional commit/rollback and bounded projection into the canonical sparse `1000³` lattice.
 
 ## Empirical evidence gate
 
@@ -48,13 +58,15 @@ python -m jarvisx.empirical_validation \
   --output artifacts/empirical-validation.json
 ```
 
-The gate currently tests five falsifiable properties:
+The gate currently tests five established properties:
 
 1. deterministic VM state and trace replay;
 2. Omega journal tamper detection;
 3. sparse-field insertion-order invariance, checkpoint replay and atomic rollback;
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
+
+The photonic reference initially enters through focused pytest coverage. It must be added to the machine-readable empirical gate only after stable image fixtures and tolerance metrics are accepted.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -72,7 +84,7 @@ Other long-lived draft pull requests are research branches until explicitly clas
 
 `Lord-Xido/3D-Virtual-AI-Interactive-Interface` contains browser and native visual demonstrations. Its merged `2048³` voxel-video machine is a bounded sparse renderer over a large virtual address space. It does not allocate or display every virtual voxel.
 
-Open visual-engine pull requests remain demonstrations or integration candidates until merged.
+The photonic numerical reference in this repository establishes detector and transaction semantics; it does not make browser demonstrations authoritative compute substrates.
 
 ## Claims not made
 
@@ -86,8 +98,9 @@ Jarvis-X does not currently claim:
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
 - safety certification from the presence of a policy or coherence gate;
-- bit-exact cross-platform floating-point results from the C++ research processor;
-- production-scale fractional PDE performance or physical validity from the numerical reference solver;
+- bit-exact cross-platform floating-point results from numerical research processors;
+- production-scale fractional PDE or photonic rendering performance;
+- full electromagnetic-field validity from geometric/radiometric approximations;
 - empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines.
 
 ## Canonical promotion checklist
@@ -120,16 +133,19 @@ A capability moves to `main` only when all applicable items are satisfied:
 - isolated C++ processor laboratory with cross-platform validation;
 - independently validated fractional smoothing reference for small periodic grids.
 
-### `0.3.0` — Sparse spatial runtime
+### `0.3.0` — Sparse spatial and detector runtime
 
 - one canonical sparse coordinate API;
 - durable block storage;
 - deterministic serialization;
 - transactional concurrency;
-- benchmark corpus with named baselines and uncertainty reporting.
+- stable photonic pixel/frame contracts;
+- CPU reference fixtures and named radiometric baselines;
+- benchmark corpus with uncertainty reporting.
 
-### `0.4.0` — Bounded adaptive laboratory
+### `0.4.0` — Bounded accelerated and adaptive laboratory
 
+- GPU tile-kernel equivalence against reference outputs;
 - shadow evaluation API;
 - reproducible candidate generation;
 - rollback-complete state transitions;

--- a/docs/SYSTEM_OPERATIONAL_FRAMEWORK.md
+++ b/docs/SYSTEM_OPERATIONAL_FRAMEWORK.md
@@ -1,0 +1,217 @@
+# Jarvis-X System Operational Framework
+
+## Status
+
+This document unifies the VM, sparse spatial, numerical, photonic, adaptive and interface layers into one operational model. It describes architecture and contracts; individual subsystem maturity remains authoritative in [`PROJECT_STATUS.md`](PROJECT_STATUS.md).
+
+## 1. Coordinate system
+
+Jarvis-X uses two complementary coordinate systems.
+
+### Physical or logical coordinates
+
+```text
+r = (x, y, z)
+```
+
+These identify a spatial location, sparse brick, voxel, detector projection or logical address.
+
+### Operational coordinates
+
+```text
+X = workflow progression
+Y = time and persisted state
+Z = control and abstraction depth
+```
+
+A runtime event can therefore be identified by both where it acts and how it is controlled:
+
+```text
+Event = (x, y, z, X, Y, Z)
+```
+
+The coordinate model is descriptive. It does not imply dense allocation or additional physical hardware.
+
+## 2. Integrated state
+
+The system state is represented by:
+
+```text
+Xi_t = (
+    input_t,
+    authoritative_vm_t,
+    sparse_state_t,
+    numerical_state_t,
+    proposals_t,
+    Omega_t,
+    Lambda_t,
+    journal_t,
+    outputs_t
+)
+```
+
+Where:
+
+- `input_t` is an explicitly acquired external or synthetic input;
+- `authoritative_vm_t` is canonical register, memory and instruction state;
+- `sparse_state_t` contains bounded materialized coordinates and bricks;
+- `numerical_state_t` contains isolated solver or rendering state;
+- `proposals_t` contains non-authoritative adaptive or agent outputs;
+- `Omega_t` is residual correction and provenance memory;
+- `Lambda_t` contains policy, resource and admissibility constraints;
+- `journal_t` is the append-only audit trail;
+- `outputs_t` contains verified digital or physical-interface outputs.
+
+## 3. Canonical ten-stage pipeline
+
+Every system-level workflow maps to the following order:
+
+```text
+1. Event ingestion
+2. Authenticate or establish capability
+3. Validate schema and dimensions
+4. Route workflow
+5. Load authoritative and auxiliary state
+6. Plan bounded tasks
+7. Execute VM instructions, kernels or APIs
+8. Verify proposed results
+9. Persist state and emit outputs
+10. Complete, halt or wait for the next event
+```
+
+The compact runtime loop is:
+
+```text
+observe -> route -> execute -> verify -> repeat
+```
+
+Subsystems may omit stages that do not apply, but they must not bypass validation, authority or verification when authoritative state is mutated.
+
+## 4. Layer mapping
+
+| Stage | VM | Sparse spatial | Photonic rendering | Adaptive/agent layer |
+|---|---|---|---|---|
+| Ingest | bytecode word | coordinate/range | scene, camera, spectrum | observation/task |
+| Authenticate | policy/capability | ASID and address class | trusted local call | bounded role/capability |
+| Validate | decode and bounds | coordinate and residency | dimensions and optical bounds | proposal schema |
+| Route | opcode dispatch | brick/tile selection | detector tile partition | task graph |
+| Load | registers/memory | sparse bricks | scene/runtime state | Omega/context |
+| Plan | next instruction | bounded range operations | deterministic work tiles | candidate actions |
+| Execute | instruction semantics | bit/vector operation | spectral transport/integration | shadow execution |
+| Verify | state invariant | digest/budget | frame and quantization | independent verifier |
+| Persist/emit | ledger/checkpoint | sparse checkpoint | frame/Omega digest | approved proposal only |
+| Complete/wait | halt/advance | commit/rollback | commit/rollback | reschedule/wait |
+
+## 5. Authoritative transition
+
+A general transition has three distinct states:
+
+```text
+current authoritative state
+-> proposed next state
+-> verified committed state or rollback
+```
+
+Formally:
+
+```text
+proposal_t = Execute(Plan(Observe(Xi_t)))
+verified_t = Verify(proposal_t, Lambda_t)
+
+Xi_(t+1) = Commit(Project_Lambda(proposal_t))  when verified_t
+Xi_(t+1) = Rollback(checkpoint_t)              otherwise
+```
+
+The compact research notation is:
+
+```text
+Xi_(t+1) = Pi_Lambda[
+    Xi_t + P(Xi_t) - E_t + Omega_t + U_t
+]
+```
+
+This notation is valid only when every term is mapped to an explicit data contract and the projection is implemented as ordinary validation and bounded state transition logic.
+
+## 6. Physical-to-digital transduction
+
+The photonic path adds an explicit physical interpretation:
+
+```text
+electromagnetic source
+-> spectral radiance field
+-> material interaction
+-> optical projection
+-> finite-area pixel integration
+-> quantized detector state
+-> sparse 3D address projection
+-> optional VM or numerical processing
+-> verified digital output
+```
+
+The pixel measurement is:
+
+```text
+p[i,j,c] = Q_b[
+    integral over exposure time
+    integral over wavelength
+    integral over pixel aperture
+    S_c(lambda) L(x, y, lambda, t)
+]
+```
+
+The reference renderer approximates this expression with deterministic finite samples. It does not solve the full electromagnetic field equations.
+
+## 7. GPU and cloud execution boundary
+
+GPU and cloud workers are execution backends, not independent authorities. They may receive bounded tiles or sparse bricks and return proposals plus evidence:
+
+```text
+work_unit = (input_digest, coordinates, parameters, budget, version)
+result = (output, metrics, output_digest, provenance)
+```
+
+The controller must verify version, dimensions, digest, resource use and semantic invariants before commit. Worker count and physical placement must not alter logical coordinates or transaction semantics.
+
+## 8. Agentic orchestration boundary
+
+An agent is a bounded proposal generator:
+
+```text
+agent_i = (role, policy, local_state, inbox, outbox, budget, capability)
+proposal_i = policy_i(observation_i)
+```
+
+Agent consensus selects a candidate; it does not authorize it. Only the canonical verifier and transaction layer may commit authoritative state.
+
+## 9. System-wide invariants
+
+1. **Authority is explicit.** Predictive, visual, numerical and agent layers produce proposals unless a documented adapter grants narrower mutation rights.
+2. **Every mutation is bounded.** Cycle, coordinate, memory, tile, pixel, optical-path and task limits are enforceable.
+3. **Virtual extent is not residency.** Sparse address spaces report logical capacity separately from materialized payload.
+4. **Encoding is not guaranteed compression.** Smaller representations may be lossy or depend on side information.
+5. **Integrity is not reversibility.** Digests establish tamper evidence, not decoding.
+6. **Simulation is not deployment evidence.** A rendered or deterministic demonstration does not establish physical accuracy, intelligence or production readiness.
+7. **Physical claims require calibration.** A physically interpreted model must state approximations, units, tolerances and reference data.
+8. **Execution strategy is replaceable.** CPU, GPU and cloud backends must preserve declared semantic and transaction contracts.
+9. **Failure is visible.** Rejected inputs and rollbacks are recorded without silently mutating state.
+10. **Every capability has an evidence boundary.** Names and diagrams never substitute for tests.
+
+## 10. Promotion sequence
+
+Subsystems progress in this order:
+
+```text
+working -> robust -> portable -> elegant -> advanced
+```
+
+A promotion requires:
+
+- a narrow public API;
+- deterministic fixtures or a documented stochastic protocol;
+- malformed-input and resource-bound tests;
+- transaction and rollback semantics;
+- serialization and versioning where persistent;
+- explicit complexity and resident-memory bounds;
+- CI evidence on supported platforms;
+- benchmark or reference comparison before performance claims;
+- security analysis before accepting untrusted inputs.

--- a/docs/adr/ADR-009-photonic-pixel-field-runtime.md
+++ b/docs/adr/ADR-009-photonic-pixel-field-runtime.md
@@ -1,0 +1,58 @@
+# ADR-009: Photonic pixel-field runtime boundary
+
+Status: proposed
+
+## Context
+
+Jarvis-X already distinguishes deterministic VM authority, transactional state transitions, sparse spatial domains and non-authoritative visualization. The graphics discussion introduces a stronger interpretation: a pixel is a measurement function over space, wavelength, direction and time, while graphics rendering is a physical-to-digital transduction pipeline.
+
+Without an explicit boundary, three different claims can be conflated:
+
+1. a browser animation of light;
+2. a radiometric numerical model;
+3. a full electromagnetic field solver.
+
+Only the second is introduced by this decision.
+
+## Decision
+
+Add a dependency-free electromagnetic-photonic rendering reference above the canonical VM and transaction layers.
+
+The subsystem shall:
+
+- define pixels as bounded spectral detector measurements;
+- preserve scene, camera, tile, frame and receipt data contracts;
+- separate deterministic pixel semantics from CPU/GPU/cloud execution strategy;
+- commit a frame only after complete verification;
+- project optional pixel/depth samples into the canonical sparse `1000^3` address domain;
+- remain non-authoritative with respect to canonical VM register and memory state unless an explicit adapter submits a separately validated transaction.
+
+The subsystem shall not claim to solve Maxwell's equations or provide production GPU rendering.
+
+## Consequences
+
+Positive consequences:
+
+- the visual layer gains a falsifiable numerical substrate;
+- pixel, voxel and sparse-address concepts share one coordinate contract;
+- GPU acceleration can be evaluated against a stable reference;
+- rendering errors and state updates become transactionally auditable.
+
+Costs and constraints:
+
+- physically richer behavior requires independent validation data;
+- floating-point cross-platform identity is not assumed;
+- full-wave phenomena remain outside scope;
+- large images remain bounded by explicit `max_pixels` and sampling limits.
+
+## Validation
+
+The integration candidate must provide tests for:
+
+- wavelength and sensor-response bounds;
+- deterministic tile partitioning;
+- deterministic frame digest and replay;
+- inverse-square attenuation behavior;
+- quantization bounds;
+- full-cycle rollback on invalid resource requests;
+- bounded pixel-to-lattice mapping.

--- a/examples/photonic_rendering_demo.py
+++ b/examples/photonic_rendering_demo.py
@@ -1,0 +1,49 @@
+"""Render a small deterministic electromagnetic-photonic reference frame."""
+
+from jarvisx.photonic_rendering import (
+    Camera,
+    Material,
+    PhotonicRenderer,
+    PhotonicScene,
+    PointEmitter,
+    RenderConfig,
+    Sphere,
+    Spectrum,
+    mean_irradiance,
+)
+
+
+def main() -> None:
+    scene = PhotonicScene(
+        spheres=(
+            Sphere(
+                center=(0.0, 0.0, -3.5),
+                radius=1.2,
+                material=Material(reflectance=(0.8, 0.32, 0.14), roughness=0.35),
+            ),
+        ),
+        emitters=(
+            PointEmitter(
+                position=(-2.5, 3.0, 0.0),
+                spectrum=Spectrum.white_reference(),
+                intensity=120.0,
+            ),
+        ),
+    )
+    camera = Camera(width=32, height=18)
+    config = RenderConfig(samples_per_axis=2, tile_edge=8)
+    renderer = PhotonicRenderer()
+
+    frame, state, receipt = renderer.cycle(scene, camera, config)
+    if frame is None:
+        raise SystemExit(receipt.reason)
+
+    print("committed:", receipt.committed)
+    print("cycle:", state.cycle)
+    print("frame digest:", frame.digest)
+    print("mean irradiance:", mean_irradiance(frame))
+    print("centre pixel:", frame.at(camera.width // 2, camera.height // 2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/photonic_rendering.py
+++ b/src/jarvisx/photonic_rendering.py
@@ -1,0 +1,774 @@
+"""Deterministic electromagnetic-photonic rendering reference.
+
+This module treats a rendered pixel as a finite-area spectral detector. It is a
+bounded, dependency-free correctness reference: light transport is represented
+with geometric optics, inverse-square attenuation, wavelength-dependent sensor
+response, Lambertian reflection and a bounded specular term. It is not a
+full-wave Maxwell solver, a production path tracer or a calibrated camera model.
+
+The authoritative transition is transactional::
+
+    observe -> partition -> transport -> integrate -> quantize
+            -> verify -> commit or rollback -> journal
+
+Tile scheduling is deliberately separated from pixel semantics so a future CPU,
+GPU or distributed backend can replace the execution strategy without changing
+frame digests, bounds, quantization or transaction behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable, Sequence
+
+Vec3 = tuple[float, float, float]
+RGB = tuple[float, float, float]
+RGB8 = tuple[int, int, int]
+
+_EPSILON = 1.0e-12
+_VISIBLE_MIN_NM = 380.0
+_VISIBLE_MAX_NM = 700.0
+
+
+def _finite(value: float, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be a real number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _vec3(value: Sequence[float], name: str) -> Vec3:
+    if len(value) != 3:
+        raise ValueError(f"{name} must have exactly three components")
+    return tuple(
+        _finite(component, f"{name}[{index}]") for index, component in enumerate(value)
+    )  # type: ignore[return-value]
+
+
+def _rgb(value: Sequence[float], name: str) -> RGB:
+    result = _vec3(value, name)
+    if any(component < 0.0 or component > 1.0 for component in result):
+        raise ValueError(f"{name} components must be in [0, 1]")
+    return result
+
+
+def _add(a: Vec3, b: Vec3) -> Vec3:
+    return a[0] + b[0], a[1] + b[1], a[2] + b[2]
+
+
+def _sub(a: Vec3, b: Vec3) -> Vec3:
+    return a[0] - b[0], a[1] - b[1], a[2] - b[2]
+
+
+def _mul(a: Vec3, scalar: float) -> Vec3:
+    return a[0] * scalar, a[1] * scalar, a[2] * scalar
+
+
+def _dot(a: Vec3, b: Vec3) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def _length(value: Vec3) -> float:
+    return math.sqrt(_dot(value, value))
+
+
+def _normalise(value: Vec3, name: str = "vector") -> Vec3:
+    magnitude = _length(value)
+    if magnitude <= _EPSILON:
+        raise ValueError(f"{name} must have non-zero length")
+    return _mul(value, 1.0 / magnitude)
+
+
+def _clamp01(value: float) -> float:
+    return min(1.0, max(0.0, value))
+
+
+def _gaussian(value: float, mean: float, sigma: float) -> float:
+    return math.exp(-0.5 * ((value - mean) / sigma) ** 2)
+
+
+def wavelength_to_linear_rgb(wavelength_nm: float) -> RGB:
+    """Approximate a visible wavelength with a bounded linear RGB triplet."""
+
+    wavelength = _finite(wavelength_nm, "wavelength_nm")
+    if not _VISIBLE_MIN_NM <= wavelength <= _VISIBLE_MAX_NM:
+        raise ValueError("wavelength_nm must be in [380, 700]")
+
+    red = _gaussian(wavelength, 610.0, 48.0)
+    green = _gaussian(wavelength, 545.0, 42.0)
+    blue = _gaussian(wavelength, 455.0, 36.0)
+    peak = max(red, green, blue, _EPSILON)
+    return red / peak, green / peak, blue / peak
+
+
+def sensor_response(wavelength_nm: float) -> RGB:
+    """Return a simple three-channel photodetector response."""
+
+    wavelength = _finite(wavelength_nm, "wavelength_nm")
+    if not _VISIBLE_MIN_NM <= wavelength <= _VISIBLE_MAX_NM:
+        raise ValueError("wavelength_nm must be in [380, 700]")
+    return (
+        _gaussian(wavelength, 610.0, 52.0),
+        _gaussian(wavelength, 545.0, 46.0),
+        _gaussian(wavelength, 455.0, 40.0),
+    )
+
+
+@dataclass(frozen=True, order=True)
+class SpectralSample:
+    wavelength_nm: float
+    power: float
+
+    def __post_init__(self) -> None:
+        wavelength = _finite(self.wavelength_nm, "wavelength_nm")
+        power = _finite(self.power, "power")
+        if not _VISIBLE_MIN_NM <= wavelength <= _VISIBLE_MAX_NM:
+            raise ValueError("wavelength_nm must be in [380, 700]")
+        if power < 0.0:
+            raise ValueError("power must be non-negative")
+        object.__setattr__(self, "wavelength_nm", wavelength)
+        object.__setattr__(self, "power", power)
+
+
+@dataclass(frozen=True)
+class Spectrum:
+    samples: tuple[SpectralSample, ...]
+
+    def __post_init__(self) -> None:
+        if not self.samples:
+            raise ValueError("spectrum must contain at least one sample")
+        wavelengths = [sample.wavelength_nm for sample in self.samples]
+        if wavelengths != sorted(wavelengths):
+            raise ValueError("spectrum samples must be ordered by wavelength")
+        if len(set(wavelengths)) != len(wavelengths):
+            raise ValueError("spectrum wavelengths must be unique")
+
+    @classmethod
+    def monochromatic(cls, wavelength_nm: float, power: float = 1.0) -> "Spectrum":
+        return cls((SpectralSample(wavelength_nm, power),))
+
+    @classmethod
+    def white_reference(cls, power: float = 1.0) -> "Spectrum":
+        value = _finite(power, "power")
+        if value < 0.0:
+            raise ValueError("power must be non-negative")
+        wavelengths = (420.0, 460.0, 500.0, 540.0, 580.0, 620.0, 660.0)
+        per_sample = value / len(wavelengths)
+        return cls(
+            tuple(SpectralSample(wavelength, per_sample) for wavelength in wavelengths)
+        )
+
+    @property
+    def total_power(self) -> float:
+        return sum(sample.power for sample in self.samples)
+
+
+@dataclass(frozen=True)
+class Material:
+    reflectance: RGB = (0.7, 0.7, 0.7)
+    roughness: float = 0.5
+    emission: Spectrum | None = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "reflectance", _rgb(self.reflectance, "reflectance"))
+        roughness = _finite(self.roughness, "roughness")
+        if not 0.0 <= roughness <= 1.0:
+            raise ValueError("roughness must be in [0, 1]")
+        object.__setattr__(self, "roughness", roughness)
+
+
+@dataclass(frozen=True)
+class Sphere:
+    center: Vec3
+    radius: float
+    material: Material = Material()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "center", _vec3(self.center, "center"))
+        radius = _finite(self.radius, "radius")
+        if radius <= 0.0:
+            raise ValueError("radius must be positive")
+        object.__setattr__(self, "radius", radius)
+
+
+@dataclass(frozen=True)
+class PointEmitter:
+    position: Vec3
+    spectrum: Spectrum
+    intensity: float = 1.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "position", _vec3(self.position, "position"))
+        intensity = _finite(self.intensity, "intensity")
+        if intensity < 0.0:
+            raise ValueError("intensity must be non-negative")
+        object.__setattr__(self, "intensity", intensity)
+
+
+@dataclass(frozen=True)
+class PhotonicScene:
+    spheres: tuple[Sphere, ...]
+    emitters: tuple[PointEmitter, ...]
+    background: RGB = (0.01, 0.02, 0.04)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "background", _rgb(self.background, "background"))
+        if not self.emitters:
+            raise ValueError("scene must contain at least one emitter")
+
+
+@dataclass(frozen=True)
+class Camera:
+    width: int
+    height: int
+    origin: Vec3 = (0.0, 0.0, 3.5)
+    forward: Vec3 = (0.0, 0.0, -1.0)
+    up: Vec3 = (0.0, 1.0, 0.0)
+    vertical_fov_degrees: float = 52.0
+
+    def __post_init__(self) -> None:
+        for name in ("width", "height"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        object.__setattr__(self, "origin", _vec3(self.origin, "origin"))
+        forward = _normalise(_vec3(self.forward, "forward"), "forward")
+        up = _normalise(_vec3(self.up, "up"), "up")
+        if abs(_dot(forward, up)) >= 1.0 - 1.0e-9:
+            raise ValueError("forward and up must not be parallel")
+        object.__setattr__(self, "forward", forward)
+        object.__setattr__(self, "up", up)
+        fov = _finite(self.vertical_fov_degrees, "vertical_fov_degrees")
+        if not 1.0 <= fov < 179.0:
+            raise ValueError("vertical_fov_degrees must be in [1, 179)")
+        object.__setattr__(self, "vertical_fov_degrees", fov)
+
+
+@dataclass(frozen=True)
+class RenderConfig:
+    exposure: float = 1.0
+    gamma: float = 2.2
+    samples_per_axis: int = 1
+    tile_edge: int = 16
+    max_pixels: int = 1_000_000
+    max_optical_path: float = 1_000_000.0
+
+    def __post_init__(self) -> None:
+        exposure = _finite(self.exposure, "exposure")
+        gamma = _finite(self.gamma, "gamma")
+        max_path = _finite(self.max_optical_path, "max_optical_path")
+        if exposure < 0.0:
+            raise ValueError("exposure must be non-negative")
+        if gamma <= 0.0:
+            raise ValueError("gamma must be positive")
+        if max_path <= 0.0:
+            raise ValueError("max_optical_path must be positive")
+        for name in ("samples_per_axis", "tile_edge", "max_pixels"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.samples_per_axis > 8:
+            raise ValueError("samples_per_axis must not exceed 8 in the reference renderer")
+        object.__setattr__(self, "exposure", exposure)
+        object.__setattr__(self, "gamma", gamma)
+        object.__setattr__(self, "max_optical_path", max_path)
+
+
+@dataclass(frozen=True)
+class PixelMeasurement:
+    linear_rgb: RGB
+    quantized_rgb: RGB8
+    irradiance: float
+    optical_path_length: float
+    depth: float | None
+
+
+@dataclass(frozen=True)
+class WorkTile:
+    tile_id: int
+    x0: int
+    y0: int
+    x1: int
+    y1: int
+
+    @property
+    def pixel_count(self) -> int:
+        return (self.x1 - self.x0) * (self.y1 - self.y0)
+
+
+@dataclass(frozen=True)
+class PhotonicFrame:
+    width: int
+    height: int
+    pixels: tuple[PixelMeasurement, ...]
+    digest: str
+
+    def at(self, x: int, y: int) -> PixelMeasurement:
+        if not 0 <= x < self.width or not 0 <= y < self.height:
+            raise IndexError("pixel coordinate out of range")
+        return self.pixels[x + self.width * y]
+
+
+class RuntimeStage(str, Enum):
+    OBSERVE = "observe"
+    PARTITION = "partition"
+    TRANSPORT = "transport"
+    INTEGRATE = "integrate"
+    QUANTIZE = "quantize"
+    VERIFY = "verify"
+    COMMIT = "commit"
+    ROLLBACK = "rollback"
+
+
+@dataclass(frozen=True)
+class PhotonicRuntimeState:
+    cycle: int = 0
+    frame_digest: str = "0" * 64
+    omega_digest: str = "0" * 64
+
+
+@dataclass(frozen=True)
+class RuntimeReceipt:
+    cycle: int
+    committed: bool
+    stage: RuntimeStage
+    frame_digest: str
+    previous_state_digest: str
+    state_digest: str
+    reason: str | None
+    tile_count: int
+    pixel_count: int
+
+
+@dataclass(frozen=True)
+class _Hit:
+    distance: float
+    point: Vec3
+    normal: Vec3
+    material: Material
+
+
+def partition_tiles(width: int, height: int, tile_edge: int) -> tuple[WorkTile, ...]:
+    """Partition a frame deterministically in row-major tile order."""
+
+    for name, value in (("width", width), ("height", height), ("tile_edge", tile_edge)):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+        if value <= 0:
+            raise ValueError(f"{name} must be positive")
+    tiles: list[WorkTile] = []
+    tile_id = 0
+    for y0 in range(0, height, tile_edge):
+        for x0 in range(0, width, tile_edge):
+            tiles.append(
+                WorkTile(
+                    tile_id=tile_id,
+                    x0=x0,
+                    y0=y0,
+                    x1=min(width, x0 + tile_edge),
+                    y1=min(height, y0 + tile_edge),
+                )
+            )
+            tile_id += 1
+    return tuple(tiles)
+
+
+def pixel_to_lattice_coordinate(
+    x: int,
+    y: int,
+    depth: float | None,
+    width: int,
+    height: int,
+    side: int = 1000,
+) -> tuple[int, int, int]:
+    """Encode a 2D detector sample and normalised depth into a bounded 3D lattice."""
+
+    fields = (("x", x), ("y", y), ("width", width), ("height", height), ("side", side))
+    for name, value in fields:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{name} must be an integer")
+    if width <= 0 or height <= 0 or side <= 0:
+        raise ValueError("width, height and side must be positive")
+    if not 0 <= x < width or not 0 <= y < height:
+        raise ValueError("pixel coordinate lies outside the frame")
+    if depth is None:
+        normalised_depth = 1.0
+    else:
+        depth_value = _finite(depth, "depth")
+        if depth_value < 0.0:
+            raise ValueError("depth must be non-negative")
+        normalised_depth = depth_value / (1.0 + depth_value)
+    lattice_x = min(side - 1, int((x + 0.5) * side / width))
+    lattice_y = min(side - 1, int((y + 0.5) * side / height))
+    lattice_z = min(side - 1, int(normalised_depth * (side - 1)))
+    return lattice_x, lattice_y, lattice_z
+
+
+class PhotonicRenderer:
+    """Bounded deterministic renderer with transactional runtime state."""
+
+    def __init__(self, state: PhotonicRuntimeState | None = None) -> None:
+        self._state = state or PhotonicRuntimeState()
+
+    @property
+    def state(self) -> PhotonicRuntimeState:
+        return self._state
+
+    @staticmethod
+    def _camera_basis(camera: Camera) -> tuple[Vec3, Vec3, Vec3]:
+        forward = camera.forward
+        right = _normalise(_cross(forward, camera.up), "camera right")
+        up = _normalise(_cross(right, forward), "camera up")
+        return right, up, forward
+
+    @staticmethod
+    def _ray_sphere(origin: Vec3, direction: Vec3, sphere: Sphere) -> _Hit | None:
+        offset = _sub(origin, sphere.center)
+        half_b = _dot(offset, direction)
+        c = _dot(offset, offset) - sphere.radius * sphere.radius
+        discriminant = half_b * half_b - c
+        if discriminant < 0.0:
+            return None
+        root = math.sqrt(discriminant)
+        distance = -half_b - root
+        if distance <= 1.0e-9:
+            distance = -half_b + root
+        if distance <= 1.0e-9:
+            return None
+        point = _add(origin, _mul(direction, distance))
+        normal = _normalise(_sub(point, sphere.center), "surface normal")
+        return _Hit(distance, point, normal, sphere.material)
+
+    def _nearest_hit(self, scene: PhotonicScene, origin: Vec3, direction: Vec3) -> _Hit | None:
+        nearest: _Hit | None = None
+        for sphere in scene.spheres:
+            hit = self._ray_sphere(origin, direction, sphere)
+            if hit is not None and (nearest is None or hit.distance < nearest.distance):
+                nearest = hit
+        return nearest
+
+    def _visible(
+        self,
+        scene: PhotonicScene,
+        point: Vec3,
+        normal: Vec3,
+        emitter: PointEmitter,
+    ) -> bool:
+        origin = _add(point, _mul(normal, 1.0e-7))
+        to_emitter = _sub(emitter.position, origin)
+        distance = _length(to_emitter)
+        direction = _normalise(to_emitter, "shadow direction")
+        hit = self._nearest_hit(scene, origin, direction)
+        return hit is None or hit.distance >= distance - 1.0e-7
+
+    @staticmethod
+    def _emission_rgb(spectrum: Spectrum) -> RGB:
+        result = [0.0, 0.0, 0.0]
+        for sample in spectrum.samples:
+            detector = sensor_response(sample.wavelength_nm)
+            colour = wavelength_to_linear_rgb(sample.wavelength_nm)
+            for channel in range(3):
+                result[channel] += sample.power * detector[channel] * colour[channel]
+        return result[0], result[1], result[2]
+
+    def _shade(
+        self,
+        scene: PhotonicScene,
+        hit: _Hit,
+        view_direction: Vec3,
+    ) -> tuple[RGB, float, float]:
+        accumulated = [0.0, 0.0, 0.0]
+        irradiance = 0.0
+        optical_path = 0.0
+        visible_emitters = 0
+
+        if hit.material.emission is not None:
+            emitted = self._emission_rgb(hit.material.emission)
+            for channel in range(3):
+                accumulated[channel] += emitted[channel]
+
+        for emitter in scene.emitters:
+            if not self._visible(scene, hit.point, hit.normal, emitter):
+                continue
+            to_emitter = _sub(emitter.position, hit.point)
+            distance = _length(to_emitter)
+            if distance <= _EPSILON:
+                continue
+            light_direction = _mul(to_emitter, 1.0 / distance)
+            cosine = max(0.0, _dot(hit.normal, light_direction))
+            if cosine <= 0.0:
+                continue
+            attenuation = emitter.intensity / (4.0 * math.pi * distance * distance)
+            half_vector = _normalise(
+                _sub(light_direction, view_direction),
+                "half vector",
+            )
+            shininess = 2.0 + 254.0 * (1.0 - hit.material.roughness) ** 2
+            specular = max(0.0, _dot(hit.normal, half_vector)) ** shininess
+            specular_weight = (1.0 - hit.material.roughness) * 0.35
+
+            for sample in emitter.spectrum.samples:
+                incident = sample.power * attenuation * cosine
+                detector = sensor_response(sample.wavelength_nm)
+                colour = wavelength_to_linear_rgb(sample.wavelength_nm)
+                for channel in range(3):
+                    diffuse = hit.material.reflectance[channel] * incident / math.pi
+                    glossy = specular_weight * sample.power * attenuation * specular
+                    accumulated[channel] += detector[channel] * colour[channel] * (
+                        diffuse + glossy
+                    )
+                irradiance += incident
+            optical_path += distance
+            visible_emitters += 1
+
+        mean_path = optical_path / visible_emitters if visible_emitters else 0.0
+        return (accumulated[0], accumulated[1], accumulated[2]), irradiance, mean_path
+
+    @staticmethod
+    def _tone_map(linear: RGB, config: RenderConfig) -> tuple[RGB, RGB8]:
+        exposed = tuple(
+            1.0 - math.exp(-max(0.0, channel) * config.exposure) for channel in linear
+        )
+        encoded = tuple(_clamp01(channel) ** (1.0 / config.gamma) for channel in exposed)
+        quantized = tuple(
+            min(255, max(0, int(round(channel * 255.0)))) for channel in encoded
+        )
+        return encoded, quantized  # type: ignore[return-value]
+
+    def _sample_pixel(
+        self,
+        scene: PhotonicScene,
+        camera: Camera,
+        config: RenderConfig,
+        x: int,
+        y: int,
+    ) -> PixelMeasurement:
+        right, up, forward = self._camera_basis(camera)
+        aspect = camera.width / camera.height
+        half_height = math.tan(math.radians(camera.vertical_fov_degrees) / 2.0)
+        samples = config.samples_per_axis
+        linear_sum = [0.0, 0.0, 0.0]
+        irradiance_sum = 0.0
+        path_sum = 0.0
+        depth_sum = 0.0
+        hit_count = 0
+
+        for sample_y_index in range(samples):
+            for sample_x_index in range(samples):
+                sample_x = x + (sample_x_index + 0.5) / samples
+                sample_y = y + (sample_y_index + 0.5) / samples
+                ndc_x = (2.0 * sample_x / camera.width - 1.0) * aspect * half_height
+                ndc_y = (1.0 - 2.0 * sample_y / camera.height) * half_height
+                direction = _normalise(
+                    _add(forward, _add(_mul(right, ndc_x), _mul(up, ndc_y))),
+                    "camera ray",
+                )
+                hit = self._nearest_hit(scene, camera.origin, direction)
+                if hit is None:
+                    for channel in range(3):
+                        linear_sum[channel] += scene.background[channel]
+                    continue
+                shaded, irradiance, light_path = self._shade(scene, hit, direction)
+                total_path = hit.distance + light_path
+                if total_path > config.max_optical_path:
+                    raise ValueError("optical path exceeds configured bound")
+                for channel in range(3):
+                    linear_sum[channel] += shaded[channel]
+                irradiance_sum += irradiance
+                path_sum += total_path
+                depth_sum += hit.distance
+                hit_count += 1
+
+        sample_count = samples * samples
+        linear = tuple(channel / sample_count for channel in linear_sum)
+        encoded, quantized = self._tone_map(linear, config)  # type: ignore[arg-type]
+        depth = depth_sum / hit_count if hit_count else None
+        return PixelMeasurement(
+            linear_rgb=encoded,
+            quantized_rgb=quantized,
+            irradiance=irradiance_sum / sample_count,
+            optical_path_length=path_sum / hit_count if hit_count else 0.0,
+            depth=depth,
+        )
+
+    @staticmethod
+    def _frame_digest(
+        width: int,
+        height: int,
+        pixels: Sequence[PixelMeasurement],
+    ) -> str:
+        payload = {
+            "height": height,
+            "pixels": [
+                {
+                    "depth": None if pixel.depth is None else format(pixel.depth, ".17g"),
+                    "irradiance": format(pixel.irradiance, ".17g"),
+                    "optical_path_length": format(pixel.optical_path_length, ".17g"),
+                    "rgb": list(pixel.quantized_rgb),
+                }
+                for pixel in pixels
+            ],
+            "width": width,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    @staticmethod
+    def _state_digest(state: PhotonicRuntimeState) -> str:
+        payload = json.dumps(
+            {
+                "cycle": state.cycle,
+                "frame_digest": state.frame_digest,
+                "omega_digest": state.omega_digest,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def _verify_frame(frame: PhotonicFrame, camera: Camera) -> None:
+        if frame.width != camera.width or frame.height != camera.height:
+            raise ValueError("frame dimensions do not match camera")
+        if len(frame.pixels) != camera.width * camera.height:
+            raise ValueError("frame pixel count is invalid")
+        if len(frame.digest) != 64:
+            raise ValueError("frame digest is invalid")
+        for pixel in frame.pixels:
+            if any(not 0 <= channel <= 255 for channel in pixel.quantized_rgb):
+                raise ValueError("quantized channel lies outside [0, 255]")
+            if pixel.irradiance < 0.0 or not math.isfinite(pixel.irradiance):
+                raise ValueError("pixel irradiance is invalid")
+
+    def render(
+        self,
+        scene: PhotonicScene,
+        camera: Camera,
+        config: RenderConfig,
+    ) -> PhotonicFrame:
+        """Render one deterministic frame without mutating runtime state."""
+
+        pixel_count = camera.width * camera.height
+        if pixel_count > config.max_pixels:
+            raise ValueError("frame exceeds max_pixels")
+        pixels: list[PixelMeasurement | None] = [None] * pixel_count
+        for tile in partition_tiles(camera.width, camera.height, config.tile_edge):
+            for y in range(tile.y0, tile.y1):
+                for x in range(tile.x0, tile.x1):
+                    pixels[x + camera.width * y] = self._sample_pixel(
+                        scene,
+                        camera,
+                        config,
+                        x,
+                        y,
+                    )
+        completed = tuple(pixel for pixel in pixels if pixel is not None)
+        if len(completed) != pixel_count:
+            raise RuntimeError("renderer left incomplete pixels")
+        digest = self._frame_digest(camera.width, camera.height, completed)
+        return PhotonicFrame(camera.width, camera.height, completed, digest)
+
+    def cycle(
+        self,
+        scene: PhotonicScene,
+        camera: Camera,
+        config: RenderConfig,
+    ) -> tuple[PhotonicFrame | None, PhotonicRuntimeState, RuntimeReceipt]:
+        """Render, verify and commit one complete transactional frame cycle."""
+
+        previous_state = self._state
+        previous_digest = self._state_digest(previous_state)
+        tile_count = len(partition_tiles(camera.width, camera.height, config.tile_edge))
+        pixel_count = camera.width * camera.height
+        try:
+            frame = self.render(scene, camera, config)
+            self._verify_frame(frame, camera)
+            omega_payload = (
+                f"{previous_state.omega_digest}:{frame.digest}:{previous_state.cycle + 1}"
+            )
+            next_state = PhotonicRuntimeState(
+                cycle=previous_state.cycle + 1,
+                frame_digest=frame.digest,
+                omega_digest=hashlib.sha256(omega_payload.encode("utf-8")).hexdigest(),
+            )
+            self._state = next_state
+            state_digest = self._state_digest(next_state)
+            receipt = RuntimeReceipt(
+                cycle=next_state.cycle,
+                committed=True,
+                stage=RuntimeStage.COMMIT,
+                frame_digest=frame.digest,
+                previous_state_digest=previous_digest,
+                state_digest=state_digest,
+                reason=None,
+                tile_count=tile_count,
+                pixel_count=pixel_count,
+            )
+            return frame, next_state, receipt
+        except (TypeError, ValueError, RuntimeError) as error:
+            self._state = previous_state
+            receipt = RuntimeReceipt(
+                cycle=previous_state.cycle,
+                committed=False,
+                stage=RuntimeStage.ROLLBACK,
+                frame_digest=previous_state.frame_digest,
+                previous_state_digest=previous_digest,
+                state_digest=previous_digest,
+                reason=str(error),
+                tile_count=tile_count,
+                pixel_count=pixel_count,
+            )
+            return None, previous_state, receipt
+
+
+def frame_rgb_bytes(frame: PhotonicFrame) -> bytes:
+    """Serialize quantized RGB pixels in row-major order."""
+
+    output = bytearray()
+    for pixel in frame.pixels:
+        output.extend(pixel.quantized_rgb)
+    return bytes(output)
+
+
+def mean_irradiance(frame: PhotonicFrame) -> float:
+    if not frame.pixels:
+        return 0.0
+    return sum(pixel.irradiance for pixel in frame.pixels) / len(frame.pixels)
+
+
+def iter_lattice_samples(
+    frame: PhotonicFrame,
+    side: int = 1000,
+) -> Iterable[tuple[tuple[int, int, int], PixelMeasurement]]:
+    """Yield deterministic 3D lattice coordinates for every rendered pixel."""
+
+    for y in range(frame.height):
+        for x in range(frame.width):
+            pixel = frame.at(x, y)
+            coordinate = pixel_to_lattice_coordinate(
+                x,
+                y,
+                pixel.depth,
+                frame.width,
+                frame.height,
+                side,
+            )
+            yield coordinate, pixel

--- a/tests/test_photonic_rendering.py
+++ b/tests/test_photonic_rendering.py
@@ -1,0 +1,190 @@
+import math
+
+import pytest
+
+from jarvisx.photonic_rendering import (
+    Camera,
+    Material,
+    PhotonicRenderer,
+    PhotonicScene,
+    PointEmitter,
+    RenderConfig,
+    Sphere,
+    Spectrum,
+    frame_rgb_bytes,
+    iter_lattice_samples,
+    mean_irradiance,
+    partition_tiles,
+    pixel_to_lattice_coordinate,
+    sensor_response,
+    wavelength_to_linear_rgb,
+)
+
+
+def reference_scene(light_z: float = 0.0, intensity: float = 120.0) -> PhotonicScene:
+    return PhotonicScene(
+        spheres=(
+            Sphere(
+                center=(0.0, 0.0, -3.5),
+                radius=1.2,
+                material=Material(reflectance=(0.8, 0.32, 0.14), roughness=0.35),
+            ),
+        ),
+        emitters=(
+            PointEmitter(
+                position=(-2.5, 3.0, light_z),
+                spectrum=Spectrum.white_reference(),
+                intensity=intensity,
+            ),
+        ),
+    )
+
+
+def test_wavelength_and_sensor_response_are_bounded() -> None:
+    for wavelength in (380.0, 455.0, 540.0, 610.0, 700.0):
+        colour = wavelength_to_linear_rgb(wavelength)
+        response = sensor_response(wavelength)
+        assert all(0.0 <= value <= 1.0 for value in colour)
+        assert all(0.0 <= value <= 1.0 for value in response)
+        assert max(colour) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("wavelength", [379.99, 700.01, float("nan")])
+def test_wavelength_validation_fails_closed(wavelength: float) -> None:
+    with pytest.raises(ValueError):
+        wavelength_to_linear_rgb(wavelength)
+
+
+def test_tile_partition_is_complete_and_deterministic() -> None:
+    first = partition_tiles(17, 9, 8)
+    second = partition_tiles(17, 9, 8)
+    assert first == second
+    assert sum(tile.pixel_count for tile in first) == 17 * 9
+    assert [tile.tile_id for tile in first] == list(range(len(first)))
+
+
+def test_frame_render_is_deterministic_and_quantized() -> None:
+    camera = Camera(width=12, height=8)
+    config = RenderConfig(samples_per_axis=2, tile_edge=5, max_pixels=200)
+    renderer = PhotonicRenderer()
+
+    first = renderer.render(reference_scene(), camera, config)
+    second = renderer.render(reference_scene(), camera, config)
+
+    assert first.digest == second.digest
+    assert frame_rgb_bytes(first) == frame_rgb_bytes(second)
+    assert len(first.pixels) == 96
+    assert len(frame_rgb_bytes(first)) == 96 * 3
+    assert all(
+        0 <= channel <= 255 for pixel in first.pixels for channel in pixel.quantized_rgb
+    )
+    assert mean_irradiance(first) > 0.0
+
+
+def test_inverse_square_attenuation_reduces_mean_irradiance() -> None:
+    camera = Camera(width=9, height=7)
+    config = RenderConfig(samples_per_axis=1, max_pixels=100)
+    renderer = PhotonicRenderer()
+
+    near = renderer.render(reference_scene(light_z=0.0), camera, config)
+    far = renderer.render(reference_scene(light_z=8.0), camera, config)
+
+    assert mean_irradiance(near) > mean_irradiance(far)
+
+
+def test_transaction_commit_and_replay() -> None:
+    camera = Camera(width=8, height=6)
+    config = RenderConfig(samples_per_axis=1, tile_edge=4, max_pixels=100)
+    first_renderer = PhotonicRenderer()
+    second_renderer = PhotonicRenderer()
+
+    first_frame, first_state, first_receipt = first_renderer.cycle(
+        reference_scene(), camera, config
+    )
+    second_frame, second_state, second_receipt = second_renderer.cycle(
+        reference_scene(), camera, config
+    )
+
+    assert first_receipt.committed
+    assert second_receipt.committed
+    assert first_frame is not None and second_frame is not None
+    assert first_frame.digest == second_frame.digest
+    assert first_state == second_state
+    assert first_receipt.state_digest == second_receipt.state_digest
+    assert first_state.cycle == 1
+
+
+def test_transaction_rolls_back_on_resource_bound() -> None:
+    camera = Camera(width=11, height=10)
+    renderer = PhotonicRenderer()
+    previous = renderer.state
+
+    frame, state, receipt = renderer.cycle(
+        reference_scene(),
+        camera,
+        RenderConfig(max_pixels=100),
+    )
+
+    assert frame is None
+    assert not receipt.committed
+    assert receipt.reason == "frame exceeds max_pixels"
+    assert state == previous
+    assert renderer.state == previous
+
+
+def test_pixel_to_lattice_coordinate_is_bounded() -> None:
+    assert pixel_to_lattice_coordinate(0, 0, 0.0, 100, 50) == (5, 10, 0)
+    x, y, z = pixel_to_lattice_coordinate(99, 49, 10.0, 100, 50)
+    assert 0 <= x < 1000
+    assert 0 <= y < 1000
+    assert 0 <= z < 1000
+    assert x == 995
+    assert y == 990
+    assert z > 900
+
+
+def test_lattice_projection_covers_every_pixel_once() -> None:
+    renderer = PhotonicRenderer()
+    frame = renderer.render(
+        reference_scene(),
+        Camera(width=7, height=5),
+        RenderConfig(max_pixels=100),
+    )
+    samples = tuple(iter_lattice_samples(frame))
+    assert len(samples) == 35
+    assert len({coordinate for coordinate, _ in samples}) == 35
+
+
+def test_camera_and_config_validation() -> None:
+    with pytest.raises(ValueError, match="parallel"):
+        Camera(
+            width=2,
+            height=2,
+            forward=(0.0, 1.0, 0.0),
+            up=(0.0, 1.0, 0.0),
+        )
+    with pytest.raises(ValueError, match="samples_per_axis"):
+        RenderConfig(samples_per_axis=9)
+    with pytest.raises(ValueError, match="positive"):
+        Sphere(center=(0.0, 0.0, 0.0), radius=0.0)
+
+
+def test_background_only_pixels_remain_finite() -> None:
+    scene = PhotonicScene(
+        spheres=(),
+        emitters=(
+            PointEmitter(
+                position=(0.0, 2.0, 0.0),
+                spectrum=Spectrum.monochromatic(540.0),
+                intensity=1.0,
+            ),
+        ),
+        background=(0.02, 0.03, 0.04),
+    )
+    frame = PhotonicRenderer().render(
+        scene,
+        Camera(width=3, height=2),
+        RenderConfig(),
+    )
+    assert all(math.isfinite(value) for pixel in frame.pixels for value in pixel.linear_rgb)
+    assert len({pixel.quantized_rgb for pixel in frame.pixels}) == 1


### PR DESCRIPTION
## What changed

- adds a dependency-free electromagnetic-photonic rendering reference where each pixel is a finite-area spectral detector;
- implements wavelength-dependent source and sensor response, inverse-square attenuation, Lambertian reflection, bounded specular response, visibility, exposure, gamma transfer and RGB8 quantization;
- partitions frames into deterministic work tiles so future CPU, GPU or cloud backends can replace execution strategy without changing pixel or transaction semantics;
- adds whole-frame verification, SHA-256 frame/state digests, Omega progression and complete commit-or-rollback receipts;
- projects detector coordinates and depth into the canonical sparse `1000^3` lattice;
- adds 13 focused tests, a runnable example, a subsystem specification and ADR;
- upgrades the repository-wide architecture, system operational framework, capability matrix and README.

## Why

The existing architecture correctly separates VM authority, sparse virtual scale, numerical references and visual demonstrations. The new pixel-as-a-function-of-space model needs a falsifiable numerical boundary between a browser animation, a radiometric renderer and a full electromagnetic solver. This PR establishes that boundary and makes photonic rendering auditable and transactionally compatible with the rest of Jarvis-X.

## Operational framework

The unified system pipeline is now:

```text
event ingestion
-> capability/authentication
-> schema and dimensional validation
-> workflow routing
-> state loading
-> bounded task planning
-> VM/kernel/API execution
-> result verification
-> persistence and output emission
-> complete, halt or wait
```

Agent and GPU layers remain proposal/execution backends. They cannot silently mutate authoritative VM state.

## Validation

Locally validated before publication:

- Python compilation for the new module, tests and example;
- 13/13 focused photonic tests passing;
- 85% statement/branch coverage on the new reference module;
- deterministic frame replay and digest equality;
- inverse-square attenuation behavior;
- quantization and lattice bounds;
- full-cycle rollback under resource-limit violation.

The environment used to author this PR could not clone GitHub directly for a full repository run because outbound DNS was unavailable. GitHub Actions remains the authoritative full-suite validation gate.

## Capability boundary

This is a bounded geometric/radiometric numerical reference. It does **not** claim:

- full-wave Maxwell simulation;
- calibrated physical optics;
- production path-tracing performance;
- current GPU acceleration;
- cross-platform bit-identical floating-point output;
- intelligence or autonomous authority from agentic naming.
