### PR TITLE
Operationalize DMSO 3D inward runtime and autonomous OS environment

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-dmso-fused-benchmark
+    src/dmso_fused_main.cpp
+)
+jarvisx_include_runtime(jarvisx-dmso-fused-benchmark)
+jarvisx_harden(jarvisx-dmso-fused-benchmark)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -135,3 +141,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-dmso-fused-tests
+    tests/dmso_fused_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-dmso-fused-tests)
+jarvisx_harden(jarvisx-dmso-fused-tests)
+
+add_test(NAME dmso-fused-regressions COMMAND jarvisx-dmso-fused-tests)
+set_tests_properties(dmso-fused-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -50,6 +50,12 @@ add_executable(jarvisx-dmso-fused-benchmark
 jarvisx_include_runtime(jarvisx-dmso-fused-benchmark)
 jarvisx_harden(jarvisx-dmso-fused-benchmark)
 
+add_executable(jarvisx-dmso-os
+    src/dmso_os_main.cpp
+)
+jarvisx_include_runtime(jarvisx-dmso-os)
+jarvisx_harden(jarvisx-dmso-os)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -115,6 +121,12 @@ add_test(
 )
 set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME dmso-os-runtime-smoke
+    COMMAND jarvisx-dmso-os 8 2
+)
+set_tests_properties(dmso-os-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -150,3 +162,12 @@ jarvisx_harden(jarvisx-dmso-fused-tests)
 
 add_test(NAME dmso-fused-regressions COMMAND jarvisx-dmso-fused-tests)
 set_tests_properties(dmso-fused-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-dmso-os-tests
+    tests/dmso_os_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-dmso-os-tests)
+jarvisx_harden(jarvisx-dmso-os-tests)
+
+add_test(NAME dmso-os-regressions COMMAND jarvisx-dmso-os-tests)
+set_tests_properties(dmso-os-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/dmso_fused.hpp
+++ b/cpp_runtime/include/jarvisx/dmso_fused.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+namespace jarvisx::dmso {
+
+enum class Opcode : std::uint8_t {
+    load_self,
+    aggregate_26,
+    decode_front,
+    load_input,
+    affine,
+    tanh,
+    relax,
+};
+
+inline constexpr std::array<Opcode, 7> canonical_program{
+    Opcode::load_self,
+    Opcode::aggregate_26,
+    Opcode::decode_front,
+    Opcode::load_input,
+    Opcode::affine,
+    Opcode::tanh,
+    Opcode::relax,
+};
+
+struct Parameters {
+    double self_gain{0.75};
+    double neighbour_gain{0.20};
+    double projection_gain{0.05};
+    double input_gain{0.50};
+    double bias{0.0};
+};
+
+struct Context {
+    std::vector<double> current;
+    std::vector<double> neighbour_mean;
+    std::vector<double> projected;
+    std::vector<double> stimulus;
+    double alpha{0.25};
+};
+
+struct ExecutionResult {
+    std::vector<double> value;
+    std::uint64_t dispatches{0};
+};
+
+inline void validate(const Context& context) {
+    const auto channels = context.current.size();
+    if (channels == 0 || context.neighbour_mean.size() != channels ||
+        context.projected.size() != channels || context.stimulus.size() != channels) {
+        throw std::invalid_argument("DMSO context vectors must have one equal non-zero size");
+    }
+    if (!std::isfinite(context.alpha) || context.alpha <= 0.0 || context.alpha > 1.0) {
+        throw std::invalid_argument("DMSO alpha must be finite and in (0, 1]");
+    }
+    const auto check = [](const std::vector<double>& values) {
+        for (const double value : values) {
+            if (!std::isfinite(value)) {
+                throw std::invalid_argument("DMSO context contains a non-finite value");
+            }
+        }
+    };
+    check(context.current);
+    check(context.neighbour_mean);
+    check(context.projected);
+    check(context.stimulus);
+}
+
+inline ExecutionResult execute_primitive(const Context& context, const Parameters& parameters) {
+    validate(context);
+    const auto channels = context.current.size();
+    std::vector<double> current(channels, 0.0);
+    std::vector<double> neighbours(channels, 0.0);
+    std::vector<double> projected(channels, 0.0);
+    std::vector<double> stimulus(channels, 0.0);
+    std::vector<double> affine(channels, 0.0);
+    std::vector<double> mapped(channels, 0.0);
+    std::vector<double> output = context.current;
+    std::uint64_t dispatches = 0;
+
+    for (const Opcode opcode : canonical_program) {
+        ++dispatches;
+        switch (opcode) {
+            case Opcode::load_self:
+                current = context.current;
+                break;
+            case Opcode::aggregate_26:
+                neighbours = context.neighbour_mean;
+                break;
+            case Opcode::decode_front:
+                projected = context.projected;
+                break;
+            case Opcode::load_input:
+                stimulus = context.stimulus;
+                break;
+            case Opcode::affine:
+                for (std::size_t channel = 0; channel < channels; ++channel) {
+                    affine[channel] = parameters.self_gain * current[channel] +
+                                      parameters.neighbour_gain * neighbours[channel] +
+                                      parameters.projection_gain * projected[channel] +
+                                      parameters.input_gain * stimulus[channel] + parameters.bias;
+                }
+                break;
+            case Opcode::tanh:
+                for (std::size_t channel = 0; channel < channels; ++channel) {
+                    mapped[channel] = std::tanh(affine[channel]);
+                }
+                break;
+            case Opcode::relax:
+                for (std::size_t channel = 0; channel < channels; ++channel) {
+                    output[channel] = current[channel] +
+                                      context.alpha * (mapped[channel] - current[channel]);
+                }
+                break;
+        }
+    }
+    return ExecutionResult{output, dispatches};
+}
+
+inline ExecutionResult execute_fused(const Context& context, const Parameters& parameters) {
+    validate(context);
+    const auto channels = context.current.size();
+    std::vector<double> output(channels, 0.0);
+    for (std::size_t channel = 0; channel < channels; ++channel) {
+        const double activation = parameters.self_gain * context.current[channel] +
+                                  parameters.neighbour_gain * context.neighbour_mean[channel] +
+                                  parameters.projection_gain * context.projected[channel] +
+                                  parameters.input_gain * context.stimulus[channel] + parameters.bias;
+        const double mapped = std::tanh(activation);
+        output[channel] = context.current[channel] +
+                          context.alpha * (mapped - context.current[channel]);
+    }
+    return ExecutionResult{output, 1};
+}
+
+inline double max_abs_error(const ExecutionResult& left, const ExecutionResult& right) {
+    if (left.value.size() != right.value.size()) {
+        throw std::invalid_argument("DMSO result channel counts differ");
+    }
+    double error = 0.0;
+    for (std::size_t channel = 0; channel < left.value.size(); ++channel) {
+        error = std::max(error, std::abs(left.value[channel] - right.value[channel]));
+    }
+    return error;
+}
+
+}  // namespace jarvisx::dmso

--- a/cpp_runtime/include/jarvisx/dmso_os.hpp
+++ b/cpp_runtime/include/jarvisx/dmso_os.hpp
@@ -1,0 +1,422 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+namespace jarvisx::dmso {
+
+struct Instruction {
+    std::uint8_t opcode{};
+    std::uint16_t alpha{};
+    std::uint16_t beta{};
+};
+
+class BinaryBytecodeCompiler {
+public:
+    static constexpr std::uint8_t RECURSE_SPACE = 0x80U;
+    static constexpr std::uint8_t EVAL_FIELD_GEO = 0x90U;
+    static constexpr std::uint8_t EVAL_FIELD_TEX = 0xA0U;
+
+    static std::uint64_t compile_instruction(
+        const std::uint8_t opcode,
+        const std::uint16_t alpha,
+        const std::uint16_t beta
+    ) noexcept {
+        return (static_cast<std::uint64_t>(opcode) << 56U)
+            | (static_cast<std::uint64_t>(alpha) << 40U)
+            | (static_cast<std::uint64_t>(beta) << 24U);
+    }
+
+    static Instruction decompile_raw_chunk(const std::uint64_t word) noexcept {
+        Instruction result{};
+        result.opcode = static_cast<std::uint8_t>((word >> 56U) & 0xFFU);
+        result.alpha = static_cast<std::uint16_t>((word >> 40U) & 0xFFFFU);
+        result.beta = static_cast<std::uint16_t>((word >> 24U) & 0xFFFFU);
+        return result;
+    }
+
+    static bool is_supported(const std::uint8_t opcode) noexcept {
+        return opcode == RECURSE_SPACE || opcode == EVAL_FIELD_GEO || opcode == EVAL_FIELD_TEX;
+    }
+};
+
+struct VirtualVRAMRegisters {
+    explicit VirtualVRAMRegisters(const std::size_t resolution)
+        : res(validate_resolution(resolution)),
+          reg_f(res * res * 3U, 0.0),
+          z_buf(res * res, 10.0) {}
+
+    std::size_t res;
+    std::size_t reg_pc{0U};
+    std::vector<double> reg_f;
+    std::vector<double> z_buf;
+    std::array<double, 3U> theta_g{{0.55, 4.0, 0.25}};
+    std::array<double, 3U> theta_t{{0.60, 2.5, 0.10}};
+
+private:
+    static std::size_t validate_resolution(const std::size_t value) {
+        if (value == 0U || value > 512U) {
+            throw std::invalid_argument("resolution must be in [1, 512]");
+        }
+        return value;
+    }
+};
+
+struct OptimizationStep {
+    double baseline_loss{0.0};
+    double candidate_loss{0.0};
+    double committed_loss{0.0};
+    bool accepted{false};
+};
+
+struct LifecycleReport {
+    std::size_t epochs_executed{0U};
+    std::size_t accepted_updates{0U};
+    std::size_t rejected_updates{0U};
+    double initial_loss{0.0};
+    double final_loss{0.0};
+    double elapsed_seconds{0.0};
+    bool converged{false};
+    std::array<double, 3U> theta_g{};
+    std::array<double, 3U> theta_t{};
+};
+
+class ExecutionEngineKernel {
+public:
+    explicit ExecutionEngineKernel(VirtualVRAMRegisters& registers)
+        : vram_(registers),
+          x_coords_(registers.res * registers.res),
+          y_coords_(registers.res * registers.res) {
+        const double denom = registers.res > 1U ? static_cast<double>(registers.res - 1U) : 1.0;
+        for (std::size_t row = 0U; row < registers.res; ++row) {
+            for (std::size_t col = 0U; col < registers.res; ++col) {
+                const std::size_t index = row * registers.res + col;
+                x_coords_[index] = -1.0 + (2.0 * static_cast<double>(col) / denom);
+                y_coords_[index] = -1.0 + (2.0 * static_cast<double>(row) / denom);
+            }
+        }
+    }
+
+    const std::vector<double>& dispatch_forward_pass(const std::vector<std::uint64_t>& program) {
+        validate_program(program);
+        std::fill(vram_.reg_f.begin(), vram_.reg_f.end(), 0.0);
+        std::fill(vram_.z_buf.begin(), vram_.z_buf.end(), 10.0);
+        vram_.reg_pc = 0U;
+        double spatial_scale = 1.0;
+
+        while (vram_.reg_pc < program.size()) {
+            const Instruction instr = BinaryBytecodeCompiler::decompile_raw_chunk(program[vram_.reg_pc]);
+            switch (instr.opcode) {
+            case BinaryBytecodeCompiler::RECURSE_SPACE:
+                spatial_scale = (static_cast<double>(instr.alpha) / 65535.0)
+                    * static_cast<double>(instr.beta);
+                break;
+            case BinaryBytecodeCompiler::EVAL_FIELD_GEO:
+                execute_geometry(spatial_scale);
+                break;
+            case BinaryBytecodeCompiler::EVAL_FIELD_TEX:
+                execute_shading(spatial_scale);
+                break;
+            default:
+                throw std::invalid_argument("unsupported opcode");
+            }
+            ++vram_.reg_pc;
+        }
+        return vram_.reg_f;
+    }
+
+    OptimizationStep dispatch_backward_optimization(
+        const std::vector<std::uint64_t>& program,
+        const std::vector<double>& target_pixels,
+        const double learning_rate = 0.12
+    ) {
+        validate_target(target_pixels);
+        if (!std::isfinite(learning_rate) || learning_rate < 0.0 || learning_rate > 1.0) {
+            throw std::invalid_argument("learning_rate must be finite and in [0, 1]");
+        }
+
+        const auto original_g = vram_.theta_g;
+        const auto original_t = vram_.theta_t;
+        const double base_loss = mse(dispatch_forward_pass(program), target_pixels);
+        constexpr double eps = 1.0e-5;
+        std::array<double, 3U> grad_g{};
+        std::array<double, 3U> grad_t{};
+
+        for (std::size_t i = 0U; i < vram_.theta_g.size(); ++i) {
+            const double original = vram_.theta_g[i];
+            vram_.theta_g[i] = original + eps;
+            const double high = mse(dispatch_forward_pass(program), target_pixels);
+            vram_.theta_g[i] = original - eps;
+            const double low = mse(dispatch_forward_pass(program), target_pixels);
+            vram_.theta_g[i] = original;
+            grad_g[i] = (high - low) / (2.0 * eps);
+        }
+
+        for (std::size_t i = 0U; i < vram_.theta_t.size(); ++i) {
+            const double original = vram_.theta_t[i];
+            vram_.theta_t[i] = original + eps;
+            const double high = mse(dispatch_forward_pass(program), target_pixels);
+            vram_.theta_t[i] = original - eps;
+            const double low = mse(dispatch_forward_pass(program), target_pixels);
+            vram_.theta_t[i] = original;
+            grad_t[i] = (high - low) / (2.0 * eps);
+        }
+
+        for (std::size_t i = 0U; i < vram_.theta_g.size(); ++i) {
+            vram_.theta_g[i] -= learning_rate * std::clamp(grad_g[i], -1.0, 1.0);
+            vram_.theta_t[i] -= learning_rate * std::clamp(grad_t[i], -1.0, 1.0);
+        }
+        sanitize_parameters();
+
+        const double candidate_loss = mse(dispatch_forward_pass(program), target_pixels);
+        const bool accepted = std::isfinite(candidate_loss) && candidate_loss <= base_loss;
+        if (!accepted) {
+            vram_.theta_g = original_g;
+            vram_.theta_t = original_t;
+            dispatch_forward_pass(program);
+        }
+        return OptimizationStep{
+            base_loss,
+            candidate_loss,
+            accepted ? candidate_loss : base_loss,
+            accepted,
+        };
+    }
+
+    static double mse(const std::vector<double>& lhs, const std::vector<double>& rhs) {
+        if (lhs.size() != rhs.size() || lhs.empty()) {
+            throw std::invalid_argument("mse vectors must be non-empty and equal length");
+        }
+        double total = 0.0;
+        for (std::size_t i = 0U; i < lhs.size(); ++i) {
+            const double diff = lhs[i] - rhs[i];
+            total += diff * diff;
+        }
+        return total / static_cast<double>(lhs.size());
+    }
+
+private:
+    VirtualVRAMRegisters& vram_;
+    std::vector<double> x_coords_;
+    std::vector<double> y_coords_;
+
+    double query_geometry_field(const double x, const double y, const double z) const noexcept {
+        const double r = std::sqrt((x * x) + (y * y) + (z * z));
+        const double base = r - vram_.theta_g[0U];
+        const double freq = vram_.theta_g[1U];
+        const double amplitude = vram_.theta_g[2U];
+        const double noise = std::sin(x * freq) * std::cos(y * freq)
+            * std::sin(z * freq) * amplitude;
+        return base + noise;
+    }
+
+    std::array<double, 3U> query_shading_field(
+        const double x,
+        const double y,
+        const double z
+    ) const noexcept {
+        const double r = vram_.theta_t[0U] + 0.3 * std::sin(x * vram_.theta_t[1U]);
+        const double g = 0.5 * (std::cos((y * vram_.theta_t[1U]) + vram_.theta_t[2U]) + 1.0);
+        const double b = (0.4 * std::sin(z + 2.0)) + 0.5;
+        return {{
+            std::clamp(r, 0.0, 1.0),
+            std::clamp(g, 0.0, 1.0),
+            std::clamp(b, 0.0, 1.0),
+        }};
+    }
+
+    void execute_geometry(const double spatial_scale) {
+        constexpr double ray_origin_z = -2.0;
+        constexpr std::size_t depth_steps = 16U;
+        constexpr double step = 0.25;
+        for (std::size_t depth_index = 0U; depth_index < depth_steps; ++depth_index) {
+            const double z = ray_origin_z + (static_cast<double>(depth_index) * step);
+            for (std::size_t pixel = 0U; pixel < vram_.z_buf.size(); ++pixel) {
+                const double x = x_coords_[pixel] * spatial_scale;
+                const double y = y_coords_[pixel] * spatial_scale;
+                const double distance = query_geometry_field(x, y, z);
+                if (distance <= 0.0 && z < vram_.z_buf[pixel]) {
+                    vram_.z_buf[pixel] = z;
+                }
+            }
+        }
+    }
+
+    void execute_shading(const double spatial_scale) {
+        for (std::size_t pixel = 0U; pixel < vram_.z_buf.size(); ++pixel) {
+            const double z = vram_.z_buf[pixel];
+            if (z >= 10.0) {
+                continue;
+            }
+            const double x = x_coords_[pixel] * spatial_scale;
+            const double y = y_coords_[pixel] * spatial_scale;
+            const auto colour = query_shading_field(x, y, z);
+            const std::size_t base = pixel * 3U;
+            vram_.reg_f[base] = colour[0U];
+            vram_.reg_f[base + 1U] = colour[1U];
+            vram_.reg_f[base + 2U] = colour[2U];
+        }
+    }
+
+    static void validate_program(const std::vector<std::uint64_t>& program) {
+        if (program.empty() || program.size() > 1024U) {
+            throw std::invalid_argument("program must contain between 1 and 1024 instructions");
+        }
+        for (const auto word : program) {
+            const auto instr = BinaryBytecodeCompiler::decompile_raw_chunk(word);
+            if (!BinaryBytecodeCompiler::is_supported(instr.opcode)) {
+                throw std::invalid_argument("program contains unsupported opcode");
+            }
+        }
+    }
+
+    void validate_target(const std::vector<double>& target) const {
+        if (target.size() != vram_.reg_f.size()) {
+            throw std::invalid_argument("target buffer size mismatch");
+        }
+        for (const double value : target) {
+            if (!std::isfinite(value) || value < 0.0 || value > 1.0) {
+                throw std::invalid_argument("target values must be finite and in [0, 1]");
+            }
+        }
+    }
+
+    void sanitize_parameters() {
+        for (double& value : vram_.theta_g) {
+            if (!std::isfinite(value)) {
+                throw std::runtime_error("non-finite geometry parameter");
+            }
+            value = std::clamp(value, -8.0, 8.0);
+        }
+        for (double& value : vram_.theta_t) {
+            if (!std::isfinite(value)) {
+                throw std::runtime_error("non-finite shading parameter");
+            }
+            value = std::clamp(value, -8.0, 8.0);
+        }
+    }
+};
+
+class AutonomousSystemOS {
+public:
+    explicit AutonomousSystemOS(const std::size_t surface_resolution = 32U)
+        : registers_(surface_resolution),
+          kernel_(registers_),
+          target_(surface_resolution * surface_resolution * 3U, 0.0) {
+        program_ = {
+            BinaryBytecodeCompiler::compile_instruction(
+                BinaryBytecodeCompiler::RECURSE_SPACE,
+                45000U,
+                1U
+            ),
+            BinaryBytecodeCompiler::compile_instruction(
+                BinaryBytecodeCompiler::EVAL_FIELD_GEO,
+                0U,
+                0U
+            ),
+            BinaryBytecodeCompiler::compile_instruction(
+                BinaryBytecodeCompiler::EVAL_FIELD_TEX,
+                0U,
+                0U
+            ),
+        };
+        seed_default_target();
+    }
+
+    LifecycleReport execute_system_lifecycle(
+        const std::size_t operational_epochs = 20U,
+        const double learning_rate = 0.15,
+        const double convergence_threshold = 1.0e-6
+    ) {
+        const std::lock_guard<std::mutex> lifecycle_guard(lifecycle_mutex_);
+        if (operational_epochs == 0U || operational_epochs > 10000U) {
+            throw std::invalid_argument("operational_epochs must be in [1, 10000]");
+        }
+        if (!std::isfinite(convergence_threshold) || convergence_threshold < 0.0) {
+            throw std::invalid_argument("convergence_threshold must be finite and non-negative");
+        }
+
+        const auto started = std::chrono::steady_clock::now();
+        LifecycleReport report{};
+        double loss = ExecutionEngineKernel::mse(kernel_.dispatch_forward_pass(program_), target_);
+        report.initial_loss = loss;
+
+        for (std::size_t epoch = 0U; epoch < operational_epochs; ++epoch) {
+            const OptimizationStep step = kernel_.dispatch_backward_optimization(
+                program_,
+                target_,
+                learning_rate
+            );
+            report.epochs_executed = epoch + 1U;
+            if (step.accepted) {
+                ++report.accepted_updates;
+            } else {
+                ++report.rejected_updates;
+            }
+            loss = step.committed_loss;
+            if (loss <= convergence_threshold) {
+                report.converged = true;
+                break;
+            }
+        }
+
+        const auto ended = std::chrono::steady_clock::now();
+        report.elapsed_seconds = std::chrono::duration<double>(ended - started).count();
+        report.final_loss = loss;
+        report.theta_g = registers_.theta_g;
+        report.theta_t = registers_.theta_t;
+        return report;
+    }
+
+    std::future<LifecycleReport> execute_system_lifecycle_async(
+        const std::size_t operational_epochs = 20U,
+        const double learning_rate = 0.15,
+        const double convergence_threshold = 1.0e-6
+    ) {
+        return std::async(
+            std::launch::async,
+            [this, operational_epochs, learning_rate, convergence_threshold]() {
+                return execute_system_lifecycle(
+                    operational_epochs,
+                    learning_rate,
+                    convergence_threshold
+                );
+            }
+        );
+    }
+
+    const VirtualVRAMRegisters& registers() const noexcept { return registers_; }
+    const std::vector<std::uint64_t>& program() const noexcept { return program_; }
+    const std::vector<double>& target() const noexcept { return target_; }
+
+private:
+    VirtualVRAMRegisters registers_;
+    ExecutionEngineKernel kernel_;
+    std::vector<std::uint64_t> program_;
+    std::vector<double> target_;
+    std::mutex lifecycle_mutex_;
+
+    void seed_default_target() {
+        const std::size_t side = registers_.res;
+        const std::size_t margin = side / 5U;
+        const std::size_t end = side - margin;
+        for (std::size_t row = margin; row < end; ++row) {
+            for (std::size_t col = margin; col < end; ++col) {
+                const std::size_t base = ((row * side) + col) * 3U;
+                target_[base] = 0.90;
+                target_[base + 1U] = 0.15;
+                target_[base + 2U] = 0.35;
+            }
+        }
+    }
+};
+
+} // namespace jarvisx::dmso

--- a/cpp_runtime/src/dmso_fused_main.cpp
+++ b/cpp_runtime/src/dmso_fused_main.cpp
@@ -1,0 +1,102 @@
+#include "jarvisx/dmso_fused.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+std::uint64_t parse_repetitions(int argc, char** argv) {
+    std::uint64_t repetitions = 500000;
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--repetitions") {
+            if (index + 1 >= argc) {
+                throw std::invalid_argument("--repetitions requires a value");
+            }
+            const std::string value = argv[++index];
+            const auto parsed = std::stoull(value);
+            if (parsed == 0) {
+                throw std::invalid_argument("repetitions must be positive");
+            }
+            repetitions = parsed;
+        } else {
+            throw std::invalid_argument("unknown argument: " + argument);
+        }
+    }
+    return repetitions;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        using jarvisx::dmso::Context;
+        using jarvisx::dmso::Parameters;
+        using jarvisx::dmso::execute_fused;
+        using jarvisx::dmso::execute_primitive;
+        using jarvisx::dmso::max_abs_error;
+
+        const auto repetitions = parse_repetitions(argc, argv);
+        const Context context{
+            {0.25, -0.5, 0.125, -0.25},
+            {0.1, 0.2, -0.15, 0.05},
+            {0.25, -0.5, 0.125, -0.25},
+            {0.7, -0.1, 0.3, 0.2},
+            0.25,
+        };
+        const Parameters parameters{};
+        const auto primitive_reference = execute_primitive(context, parameters);
+        const auto fused_reference = execute_fused(context, parameters);
+        const double error = max_abs_error(primitive_reference, fused_reference);
+        if (error != 0.0) {
+            throw std::runtime_error("fused semantic verification failed");
+        }
+
+        volatile double checksum = 0.0;
+        const auto primitive_start = std::chrono::steady_clock::now();
+        for (std::uint64_t index = 0; index < repetitions; ++index) {
+            checksum += execute_primitive(context, parameters).value[0];
+        }
+        const auto primitive_end = std::chrono::steady_clock::now();
+
+        const auto fused_start = std::chrono::steady_clock::now();
+        for (std::uint64_t index = 0; index < repetitions; ++index) {
+            checksum += execute_fused(context, parameters).value[0];
+        }
+        const auto fused_end = std::chrono::steady_clock::now();
+
+        const auto primitive_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                      primitive_end - primitive_start)
+                                      .count();
+        const auto fused_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                  fused_end - fused_start)
+                                  .count();
+        const double primitive_per_call = static_cast<double>(primitive_ns) /
+                                          static_cast<double>(repetitions);
+        const double fused_per_call = static_cast<double>(fused_ns) /
+                                      static_cast<double>(repetitions);
+        const double speedup = primitive_per_call / fused_per_call;
+
+        std::cout << std::fixed << std::setprecision(6)
+                  << "{\n"
+                  << "  \"repetitions\": " << repetitions << ",\n"
+                  << "  \"primitive_dispatches\": 7,\n"
+                  << "  \"fused_dispatches\": 1,\n"
+                  << "  \"dispatch_reduction_ratio\": 7.0,\n"
+                  << "  \"primitive_ns_per_call\": " << primitive_per_call << ",\n"
+                  << "  \"fused_ns_per_call\": " << fused_per_call << ",\n"
+                  << "  \"measured_speedup\": " << speedup << ",\n"
+                  << "  \"output_max_abs_error\": " << error << ",\n"
+                  << "  \"checksum\": " << checksum << "\n"
+                  << "}\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "dmso fused benchmark error: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/cpp_runtime/src/dmso_os_main.cpp
+++ b/cpp_runtime/src/dmso_os_main.cpp
@@ -1,0 +1,39 @@
+#include "jarvisx/dmso_os.hpp"
+
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+int main(int argc, char** argv) {
+    try {
+        std::size_t resolution = 32U;
+        std::size_t epochs = 20U;
+        if (argc > 1) {
+            resolution = static_cast<std::size_t>(std::stoul(argv[1]));
+        }
+        if (argc > 2) {
+            epochs = static_cast<std::size_t>(std::stoul(argv[2]));
+        }
+
+        jarvisx::dmso::AutonomousSystemOS runtime(resolution);
+        auto future = runtime.execute_system_lifecycle_async(epochs);
+        const auto report = future.get();
+
+        std::cout << std::fixed << std::setprecision(8)
+                  << "{\n"
+                  << "  \"epochs_executed\": " << report.epochs_executed << ",\n"
+                  << "  \"accepted_updates\": " << report.accepted_updates << ",\n"
+                  << "  \"rejected_updates\": " << report.rejected_updates << ",\n"
+                  << "  \"initial_loss\": " << report.initial_loss << ",\n"
+                  << "  \"final_loss\": " << report.final_loss << ",\n"
+                  << "  \"converged\": " << (report.converged ? "true" : "false") << ",\n"
+                  << "  \"elapsed_seconds\": " << report.elapsed_seconds << "\n"
+                  << "}\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& ex) {
+        std::cerr << "jarvisx-dmso-os: " << ex.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/cpp_runtime/tests/dmso_fused_tests.cpp
+++ b/cpp_runtime/tests/dmso_fused_tests.cpp
@@ -1,0 +1,50 @@
+#include "jarvisx/dmso_fused.hpp"
+
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+}  // namespace
+
+int main() {
+    using jarvisx::dmso::Context;
+    using jarvisx::dmso::Parameters;
+    using jarvisx::dmso::execute_fused;
+    using jarvisx::dmso::execute_primitive;
+    using jarvisx::dmso::max_abs_error;
+
+    const Context context{
+        {0.25, -0.5},
+        {0.1, 0.2},
+        {0.25, -0.5},
+        {0.7, -0.1},
+        0.25,
+    };
+    const Parameters parameters{};
+    const auto primitive = execute_primitive(context, parameters);
+    const auto fused = execute_fused(context, parameters);
+    require(primitive.dispatches == 7, "primitive path must dispatch seven operations");
+    require(fused.dispatches == 1, "fused path must dispatch once");
+    require(max_abs_error(primitive, fused) == 0.0, "fused path must preserve exact output");
+
+    bool rejected = false;
+    try {
+        Context invalid = context;
+        invalid.stimulus[0] = std::numeric_limits<double>::quiet_NaN();
+        static_cast<void>(execute_fused(invalid, parameters));
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    require(rejected, "non-finite input must be rejected");
+
+    std::cout << "DMSO fused native regression tests passed\n";
+    return 0;
+}

--- a/cpp_runtime/tests/dmso_os_tests.cpp
+++ b/cpp_runtime/tests/dmso_os_tests.cpp
@@ -1,0 +1,84 @@
+#include "jarvisx/dmso_os.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+int main() {
+    using namespace jarvisx::dmso;
+
+    const std::uint64_t word = BinaryBytecodeCompiler::compile_instruction(0x80U, 45000U, 3U);
+    const Instruction decoded = BinaryBytecodeCompiler::decompile_raw_chunk(word);
+    assert(decoded.opcode == 0x80U);
+    assert(decoded.alpha == 45000U);
+    assert(decoded.beta == 3U);
+
+    VirtualVRAMRegisters registers(8U);
+    ExecutionEngineKernel kernel(registers);
+    const std::vector<std::uint64_t> program{
+        BinaryBytecodeCompiler::compile_instruction(
+            BinaryBytecodeCompiler::RECURSE_SPACE,
+            45000U,
+            1U
+        ),
+        BinaryBytecodeCompiler::compile_instruction(
+            BinaryBytecodeCompiler::EVAL_FIELD_GEO,
+            0U,
+            0U
+        ),
+        BinaryBytecodeCompiler::compile_instruction(
+            BinaryBytecodeCompiler::EVAL_FIELD_TEX,
+            0U,
+            0U
+        ),
+    };
+
+    const auto& frame = kernel.dispatch_forward_pass(program);
+    assert(frame.size() == 8U * 8U * 3U);
+    for (const double value : frame) {
+        assert(std::isfinite(value));
+        assert(value >= 0.0 && value <= 1.0);
+    }
+
+    bool rejected_opcode = false;
+    try {
+        kernel.dispatch_forward_pass({
+            BinaryBytecodeCompiler::compile_instruction(0x01U, 0U, 0U),
+        });
+    } catch (const std::invalid_argument&) {
+        rejected_opcode = true;
+    }
+    assert(rejected_opcode);
+
+    AutonomousSystemOS os(8U);
+    auto future = os.execute_system_lifecycle_async(2U, 0.05, 0.0);
+    const LifecycleReport report = future.get();
+    assert(report.epochs_executed == 2U);
+    assert(report.accepted_updates + report.rejected_updates == report.epochs_executed);
+    assert(std::isfinite(report.initial_loss));
+    assert(std::isfinite(report.final_loss));
+    assert(report.final_loss >= 0.0);
+    assert(report.final_loss <= report.initial_loss);
+    assert(report.elapsed_seconds >= 0.0);
+    for (const double value : report.theta_g) {
+        assert(std::isfinite(value));
+    }
+    for (const double value : report.theta_t) {
+        assert(std::isfinite(value));
+    }
+
+    bool rejected_resolution = false;
+    try {
+        AutonomousSystemOS invalid(0U);
+        (void)invalid;
+    } catch (const std::invalid_argument&) {
+        rejected_resolution = true;
+    }
+    assert(rejected_resolution);
+
+    std::cout << "dmso-os regressions passed\n";
+    return 0;
+}

--- a/docs/DMSO_AUTONOMOUS_OS.md
+++ b/docs/DMSO_AUTONOMOUS_OS.md
@@ -1,0 +1,201 @@
+# DMSO Autonomous OS-Style Runtime
+
+## Status
+
+Executable C++17 reference subsystem for PR #84.
+
+This layer turns the DMSO research runtime into one self-contained userspace lifecycle environment containing:
+
+- fixed register arrays;
+- a 64-bit instruction format;
+- bytecode compiler/decompiler functions;
+- a procedural geometry field;
+- a shading field;
+- forward execution;
+- numerical reverse optimization;
+- transactional candidate commit/rollback;
+- an asynchronous lifecycle supervisor;
+- bounded convergence and telemetry reporting;
+- CTest regression coverage.
+
+It deliberately uses only the C++ standard library. No NumPy, scripting wrapper, external configuration file, or generated runtime dependency is required.
+
+## Important boundary
+
+`AutonomousSystemOS` is an **OS-style userspace machine environment**, not a bootable operating-system kernel and not a hardware-isolation boundary. Its VRAM, registers, bytecode and scheduler are software abstractions executing inside the host process.
+
+The name describes the lifecycle role: it owns its virtual hardware state, program image, target buffer, execution loop, optimizer, validation gates and shutdown report.
+
+## 64-bit instruction layout
+
+```text
+63                            56 55              40 39              24 23       0
++------------------------------+------------------+------------------+-----------+
+| opcode: 8 bits               | alpha: 16 bits   | beta: 16 bits    | reserved  |
++------------------------------+------------------+------------------+-----------+
+```
+
+The reference instruction set is intentionally small:
+
+```text
+0x80  RECURSE_SPACE
+0x90  EVAL_FIELD_GEO
+0xA0  EVAL_FIELD_TEX
+```
+
+Unsupported opcodes are rejected before execution.
+
+## Virtual registers
+
+`VirtualVRAMRegisters` owns:
+
+```text
+REG_PC   program counter
+REG_F    RGB frame buffer
+Z_BUF    depth surface
+THETA_G  geometry parameters
+THETA_T  shading parameters
+```
+
+Resolution is bounded to `[1, 512]` to prevent accidental unbounded allocation in the reference implementation.
+
+## Forward execution
+
+The default program is assembled internally at boot:
+
+```text
+RECURSE_SPACE -> EVAL_FIELD_GEO -> EVAL_FIELD_TEX
+```
+
+`EVAL_FIELD_GEO` samples a bounded procedural signed-distance-like field over sixteen fixed depth planes. `EVAL_FIELD_TEX` shades occupied samples into the RGB register buffer.
+
+The geometry field is:
+
+```math
+f(x,y,z)
+=
+\sqrt{x^2+y^2+z^2}-r
++
+a\sin(\omega x)\cos(\omega y)\sin(\omega z).
+```
+
+The shading field is a bounded procedural RGB map controlled by `THETA_T`.
+
+## Reverse optimization
+
+The prototype equation used numerical central differences. The operational reference preserves that mechanic but makes it transactional.
+
+For each parameter `theta_i`:
+
+```math
+\frac{\partial L}{\partial \theta_i}
+\approx
+\frac{L(\theta_i+\varepsilon)-L(\theta_i-\varepsilon)}{2\varepsilon}.
+```
+
+A shadow candidate is then formed from clipped gradients.
+
+The update is committed only when:
+
+```text
+candidate loss is finite
+AND
+candidate loss <= baseline loss
+```
+
+Otherwise `THETA_G` and `THETA_T` are restored exactly to the pre-optimization snapshot.
+
+This means the authoritative optimization trajectory is monotone non-worsening with respect to the measured MSE objective for each accepted epoch.
+
+## Lifecycle
+
+The complete machine loop is:
+
+```text
+BOOT
+  -> allocate virtual registers
+  -> assemble internal 64-bit program
+  -> construct internal target frame
+  -> validate program and buffers
+  -> FORWARD
+  -> finite-difference SHADOW OPTIMIZATION
+  -> validate candidate
+  -> COMMIT or ROLLBACK
+  -> check convergence
+  -> repeat within bounded epoch budget
+  -> emit lifecycle report
+  -> HALT
+```
+
+The asynchronous entry point uses `std::async(std::launch::async, ...)`. The authoritative lifecycle method is protected by a mutex so concurrent callers cannot mutate the same virtual register bank simultaneously.
+
+## Telemetry
+
+`LifecycleReport` records:
+
+- epochs executed;
+- accepted optimization updates;
+- rejected updates;
+- initial loss;
+- final committed loss;
+- elapsed host time;
+- convergence status;
+- final geometry parameters;
+- final shading parameters.
+
+Elapsed time is telemetry only. It does not participate in correctness or commit decisions.
+
+The runtime reports `converged=true` only when the committed loss reaches the configured threshold. Exhausting the epoch budget is not mislabeled as convergence.
+
+## Build and run
+
+From the repository root:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --parallel
+ctest --test-dir build/cpp-runtime --output-on-failure
+```
+
+Run the self-contained environment with defaults:
+
+```bash
+./build/cpp-runtime/jarvisx-dmso-os
+```
+
+Or provide resolution and epoch count:
+
+```bash
+./build/cpp-runtime/jarvisx-dmso-os 32 20
+```
+
+The executable prints a compact JSON lifecycle receipt.
+
+## Corrections relative to the Python sketch
+
+The C++ operational form intentionally fixes several prototype hazards:
+
+1. the supplied Python import line was syntactically collapsed;
+2. `asyncio.run(runtime_environment...)` was outside the `if __name__ == "__main__"` guard and would fail when imported;
+3. optimization updated authoritative parameter arrays before proving the candidate improved the objective;
+4. the final diagnostic always printed `FUNCTIONAL / STABLE` even when the convergence threshold had not been reached;
+5. unsupported opcodes and unbounded resolutions/epoch counts were not rejected;
+6. multiple concurrent lifecycle calls could race on shared VRAM state;
+7. NumPy made the claimed self-contained runtime dependent on an external numerical package.
+
+The native reference addresses those issues without changing the central architectural idea.
+
+## Capability boundary
+
+This implementation demonstrates an integrated virtual machine and optimization lifecycle. It does not claim:
+
+- a bootable general-purpose OS;
+- physical GPU/VRAM isolation;
+- exact differentiable rendering through discontinuous hit masks;
+- analytic backpropagation;
+- real-time guarantees;
+- unrestricted self-modifying native code;
+- autonomous safety or correctness beyond its explicit invariants;
+- consciousness or general intelligence.
+
+The current reverse path is numerical finite-difference optimization. A later production acceleration layer could replace it with analytic/automatic differentiation while preserving the same shadow-state commit contract.

--- a/docs/DMSO_FUSED_BYTECODE.md
+++ b/docs/DMSO_FUSED_BYTECODE.md
@@ -1,0 +1,93 @@
+# DMSO Fused Bytecode Execution
+
+## Status
+
+Executable reference backend for PR #84. This layer gives a promoted level-1 DMSO operator an actual execution meaning beyond description compression.
+
+## Canonical primitive trace
+
+The current cell update is represented as seven primitive operations:
+
+```text
+LOAD_SELF
+AGGREGATE_26
+DECODE_FRONT
+LOAD_INPUT
+AFFINE
+TANH
+RELAX
+```
+
+The primitive interpreter dispatches those operations one by one.
+
+After the runtime observes and verifies the complete sequence, it can promote the trace to one `OperatorDefinition`. The fused compiler accepts only a verified operator whose expansion exactly matches the canonical trace and replaces the seven interpreter dispatches with one direct kernel call.
+
+## Semantic contract
+
+For execution context
+
+```text
+(current, neighbour_mean, projected, stimulus, alpha)
+```
+
+and parameters
+
+```text
+(self_gain, neighbour_gain, projection_gain, input_gain, bias)
+```
+
+the fused kernel computes, per channel,
+
+```math
+z = w_s s + w_n n + w_p p + w_u u + b
+```
+
+```math
+m = \tanh(z)
+```
+
+```math
+s' = s + \alpha(m-s)
+```
+
+Before benchmarking, the backend executes both the primitive program and the fused operator and requires exact floating-point equality for the reference formula. If the values differ, the benchmark aborts.
+
+## What is accelerated
+
+The demonstrated optimization is **interpreter dispatch fusion**:
+
+```text
+primitive dispatches per cell update: 7
+fused dispatches per cell update:     1
+structural dispatch reduction:        7x
+```
+
+The benchmark additionally records wall-clock nanoseconds per call and a measured speedup for the specific host and run. Timing is telemetry only; it is never used to prove correctness, select authoritative state, or claim a portable speedup.
+
+Run:
+
+```bash
+python examples/dmso_fused_benchmark.py
+```
+
+The JSON result reports:
+
+- primitive and fused dispatch counts;
+- dispatch-reduction ratio;
+- median primitive and fused nanoseconds per call;
+- measured host-specific speedup;
+- maximum absolute semantic error.
+
+## Current boundary
+
+This backend is still Python. It proves that a promoted operator can move from a symbolic macro to a directly executable fused operation with semantic verification and measurable dispatch reduction.
+
+It does **not** yet provide:
+
+- native machine-code generation;
+- LLVM or JIT compilation;
+- GPU kernel fusion;
+- recursive fusion of arbitrary higher-order operators;
+- cross-platform performance guarantees.
+
+Those are subsequent implementation layers. A native backend should preserve the same rule: compile only verified operator expansions, compare against the primitive reference on bounded fixtures, and treat timing as measured telemetry rather than an authority signal.

--- a/docs/DMSO_FUSED_BYTECODE.md
+++ b/docs/DMSO_FUSED_BYTECODE.md
@@ -4,6 +4,11 @@
 
 Executable reference backend for PR #84. This layer gives a promoted level-1 DMSO operator an actual execution meaning beyond description compression.
 
+Two reference implementations are provided:
+
+- `src/jarvisx/dmso_bytecode.py`: Python primitive interpreter and fused kernel with benchmark telemetry;
+- `cpp_runtime/include/jarvisx/dmso_fused.hpp`: dependency-free C++17 primitive and native fused kernels.
+
 ## Canonical primitive trace
 
 The current cell update is represented as seven primitive operations:
@@ -50,7 +55,7 @@ m = \tanh(z)
 s' = s + \alpha(m-s)
 ```
 
-Before benchmarking, the backend executes both the primitive program and the fused operator and requires exact floating-point equality for the reference formula. If the values differ, the benchmark aborts.
+Before benchmarking, the backend executes both the primitive program and the fused operator and requires exact reference equality. If the values differ, benchmarking aborts.
 
 ## What is accelerated
 
@@ -64,30 +69,62 @@ structural dispatch reduction:        7x
 
 The benchmark additionally records wall-clock nanoseconds per call and a measured speedup for the specific host and run. Timing is telemetry only; it is never used to prove correctness, select authoritative state, or claim a portable speedup.
 
+### Python reference
+
 Run:
 
 ```bash
 python examples/dmso_fused_benchmark.py
 ```
 
-The JSON result reports:
+A local reference run on the development host measured approximately `2.46x` fused-versus-primitive speedup with zero output error. That number is host-specific telemetry, not a guaranteed result.
+
+### C++17 native reference
+
+Build through the existing processor laboratory:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --config Release --parallel
+ctest --test-dir build/cpp-runtime -C Release --output-on-failure
+```
+
+Run the benchmark:
+
+```bash
+./build/cpp-runtime/jarvisx-dmso-fused-benchmark --repetitions 500000
+```
+
+The native benchmark reports JSON containing:
 
 - primitive and fused dispatch counts;
-- dispatch-reduction ratio;
-- median primitive and fused nanoseconds per call;
+- structural dispatch-reduction ratio;
+- primitive and fused nanoseconds per call;
 - measured host-specific speedup;
-- maximum absolute semantic error.
+- maximum absolute semantic error;
+- a checksum that keeps the benchmark result live.
+
+A strict local C++17 build using `-Wall -Wextra -Wpedantic -Wconversion -Wshadow` passed. A 100,000-iteration development run measured approximately `2.59x` on that host with zero semantic error. Repository CI remains authoritative.
+
+## Verification boundary
+
+The C++ regression target `jarvisx-dmso-fused-tests` verifies:
+
+- primitive execution dispatches exactly seven canonical operations;
+- fused execution dispatches once;
+- the primitive and fused reference outputs are exactly equal;
+- non-finite execution inputs are rejected.
+
+No wall-clock threshold appears in CTest because machine timing is not deterministic enough to be a correctness invariant.
 
 ## Current boundary
 
-This backend is still Python. It proves that a promoted operator can move from a symbolic macro to a directly executable fused operation with semantic verification and measurable dispatch reduction.
+This PR now provides both Python-level and C++17 native direct fusion for the canonical level-1 operator. It does **not** yet provide:
 
-It does **not** yet provide:
-
-- native machine-code generation;
-- LLVM or JIT compilation;
+- LLVM or runtime JIT code generation;
 - GPU kernel fusion;
 - recursive fusion of arbitrary higher-order operators;
+- dynamic native code mutation;
 - cross-platform performance guarantees.
 
-Those are subsequent implementation layers. A native backend should preserve the same rule: compile only verified operator expansions, compare against the primitive reference on bounded fixtures, and treat timing as measured telemetry rather than an authority signal.
+Subsequent backends should preserve the same rule: compile only verified operator expansions, compare against the primitive reference on bounded fixtures, and treat performance timing as measured telemetry rather than an authority signal.

--- a/docs/DMSO_OPERATIONAL_RUNTIME.md
+++ b/docs/DMSO_OPERATIONAL_RUNTIME.md
@@ -1,0 +1,92 @@
+# DMSO 3D Operational Runtime
+
+This document defines the executable reference implemented in `jarvisx.dmso_runtime`.
+It operationalizes the inward-facing equations as a bounded sparse 3D state machine; it does
+not claim consciousness, unrestricted self-modification, continuous `SO(3)` invariance, or
+native-code acceleration from symbolic compression alone.
+
+## State and dynamics
+
+The authoritative state is a sparse field
+
+\[
+\mathcal S_t : \mathcal G \to \mathbb R^C,
+\qquad
+\mathcal G=\{0,\ldots,N-1\}^3.
+\]
+
+Each active coordinate reads all 26 Chebyshev neighbours. The front decoder chooses the
+smallest occupied `z` for each `(x,y)` ray. The inward map is
+
+\[
+F_\theta(\mathcal S,\mathcal U)
+=\mathcal E_\theta(\mathcal D(\mathcal S),\mathcal U,\mathcal S),
+\]
+
+and the fast state clock uses relaxed iteration
+
+\[
+\mathcal S_{t+1}
+=(1-\alpha)\mathcal S_t+\alpha F_\theta(\mathcal S_t,\mathcal U_t).
+\]
+
+The fixed-point residual is the RMS norm of `F_theta(S,U)-S`. `settle()` stops when that residual
+is below the configured tolerance or the bounded iteration budget is exhausted.
+
+## Parameter clock
+
+Five scalar mechanics parameters are explicit: self, neighbour, projection and external-input
+gains plus bias. When targets are supplied, `step(..., learn=True)` performs one analytic MSE
+gradient update after computing the state candidate. Parameters are clamped to a configured
+finite range. State and parameter updates therefore remain distinct clocks.
+
+## Exact operator promotion
+
+Every active cell executes the deterministic primitive trace
+
+```text
+LOAD_SELF -> AGGREGATE_26 -> DECODE_FRONT -> LOAD_INPUT
+-> AFFINE -> TANH -> RELAX
+```
+
+Repeated traces can be promoted to exact macro definitions. The macro keeps its complete child
+expansion and is marked verified because promotion aliases the same primitive semantics.
+Reported compression is **description compression**: a promoted trace can be represented by one
+four-byte operator reference instead of seven four-byte primitive references. No claim of runtime
+speedup is made until a compiled or fused backend is measured.
+
+Higher-order abstractions have explicit depth. Depths above `auto_approve_depth` require the
+`human_approved=True` gate and all definitions are bounded by `max_operator_depth`.
+
+## Transaction and verification boundary
+
+`step()` normalizes inputs and computes candidates before authoritative mutation. Invalid or
+non-finite inputs fail before commit. `verify()` checks state finiteness and bounds, parameter
+bounds, operator provenance, abstraction depth and the human gate. `state_digest()` provides a
+canonical SHA-256 digest for deterministic replay comparison.
+
+## Minimal use
+
+```python
+from jarvisx.dmso_runtime import DMSOConfig, DMSORuntime
+
+runtime = DMSORuntime(DMSOConfig(side=8, promotion_repeats=4))
+runtime.seed({(3, 3, 3): 0.25, (4, 3, 3): -0.10})
+
+metrics = runtime.step(
+    external={(3, 3, 3): 0.5},
+    targets={(3, 3, 3): 0.4},
+    learn=True,
+)
+
+assert runtime.verify()
+print(metrics)
+```
+
+## Capability boundary
+
+This is an executable mathematical reference. It demonstrates sparse 3D coordination,
+projection-with-prior recurrence, fixed-point telemetry, bounded parameter adaptation, exact
+macro abstraction and deterministic verification. It does not prove general intelligence or
+state-of-the-art performance. Those claims require workload benchmarks against fixed baselines,
+including the discovery, verification, lookup and memory costs of the abstraction layer.

--- a/examples/dmso_fused_benchmark.py
+++ b/examples/dmso_fused_benchmark.py
@@ -1,0 +1,34 @@
+"""Benchmark a promoted DMSO operator as primitive versus fused bytecode execution."""
+
+from dataclasses import asdict
+import json
+
+from jarvisx.dmso_bytecode import CellExecutionContext, benchmark_operator
+from jarvisx.dmso_runtime import DMSOConfig, DMSOParameters, DMSORuntime
+
+
+def main() -> None:
+    runtime = DMSORuntime(DMSOConfig(side=4, promotion_repeats=1))
+    runtime.seed({(1, 1, 1): 0.1})
+    runtime.step()
+    operator = runtime.operators[0]
+
+    context = CellExecutionContext(
+        current=(0.25, -0.5),
+        neighbour_mean=(0.1, 0.2),
+        projected=(0.25, -0.5),
+        stimulus=(0.7, -0.1),
+        alpha=0.25,
+    )
+    result = benchmark_operator(
+        operator,
+        context,
+        DMSOParameters(),
+        repetitions=10_000,
+        samples=7,
+    )
+    print(json.dumps(asdict(result), indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dmso_inward_runtime.py
+++ b/examples/dmso_inward_runtime.py
@@ -1,0 +1,35 @@
+"""Minimal deterministic DMSO inward-runtime demonstration."""
+
+from jarvisx.dmso_runtime import DMSOConfig, DMSORuntime
+
+
+def main() -> None:
+    runtime = DMSORuntime(
+        DMSOConfig(
+            side=8,
+            channels=1,
+            alpha=0.35,
+            promotion_repeats=4,
+            max_settle_steps=64,
+        )
+    )
+    runtime.seed(
+        {
+            (3, 3, 3): 0.25,
+            (4, 3, 3): -0.10,
+            (3, 4, 3): 0.15,
+            (3, 3, 4): 0.05,
+        }
+    )
+    metrics = runtime.step(
+        external={(3, 3, 3): 0.5},
+        targets={(3, 3, 3): 0.4},
+        learn=True,
+    )
+    print(metrics)
+    print("verified:", runtime.verify())
+    print("operators:", runtime.operators)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/dmso_bytecode.py
+++ b/src/jarvisx/dmso_bytecode.py
@@ -167,7 +167,7 @@ def verify_fused_equivalence(
         raise ValueError("tolerance must be a finite non-negative value")
     primitive = PrimitiveCellInterpreter().execute(context, parameters, definition.expansion)
     fused = FusedOperatorCompiler.compile(definition).execute(context, parameters)
-    error = max(abs(left - right) for left, right in zip(primitive.value, fused.value))
+    error = float(max(abs(left - right) for left, right in zip(primitive.value, fused.value)))
     if error > tolerance:
         raise RuntimeError(f"fused operator failed semantic verification: error={error}")
     return error

--- a/src/jarvisx/dmso_bytecode.py
+++ b/src/jarvisx/dmso_bytecode.py
@@ -1,0 +1,232 @@
+"""Executable primitive-versus-fused bytecode backend for the DMSO reference runtime.
+
+This module gives promoted level-1 operators an execution meaning. The primitive path dispatches
+seven named operations through an interpreter; the fused path executes the same mathematics in
+one direct call. Timing is telemetry only and is never used as a correctness condition.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Callable, Sequence, Tuple
+
+from .dmso_runtime import DMSOParameters, OperatorDefinition, PRIMITIVE_TRACE, Vector
+
+
+@dataclass(frozen=True)
+class CellExecutionContext:
+    current: Vector
+    neighbour_mean: Vector
+    projected: Vector
+    stimulus: Vector
+    alpha: float
+
+    def __post_init__(self) -> None:
+        lengths = {
+            len(self.current),
+            len(self.neighbour_mean),
+            len(self.projected),
+            len(self.stimulus),
+        }
+        if len(lengths) != 1 or not self.current:
+            raise ValueError("all context vectors must have one equal, non-zero channel count")
+        if not 0.0 < self.alpha <= 1.0 or not math.isfinite(self.alpha):
+            raise ValueError("alpha must be finite and in (0, 1]")
+        for vector in (self.current, self.neighbour_mean, self.projected, self.stimulus):
+            if not all(math.isfinite(value) for value in vector):
+                raise ValueError("execution context contains non-finite values")
+
+
+@dataclass(frozen=True)
+class CellExecutionResult:
+    value: Vector
+    dispatches: int
+
+
+@dataclass(frozen=True)
+class FusedOperator:
+    operator_id: str
+    expansion: Tuple[str, ...]
+    execute: Callable[[CellExecutionContext, DMSOParameters], CellExecutionResult]
+
+
+@dataclass(frozen=True)
+class OperatorBenchmark:
+    repetitions: int
+    samples: int
+    primitive_dispatches: int
+    fused_dispatches: int
+    dispatch_reduction_ratio: float
+    primitive_ns_per_call: float
+    fused_ns_per_call: float
+    measured_speedup: float
+    output_max_abs_error: float
+
+
+class PrimitiveCellInterpreter:
+    """Dispatch the canonical cell update one primitive opcode at a time."""
+
+    def execute(
+        self,
+        context: CellExecutionContext,
+        parameters: DMSOParameters,
+        program: Sequence[str] = PRIMITIVE_TRACE,
+    ) -> CellExecutionResult:
+        current: Vector = context.current
+        neighbours: Vector = tuple(0.0 for _ in current)
+        projected: Vector = tuple(0.0 for _ in current)
+        stimulus: Vector = tuple(0.0 for _ in current)
+        affine: Vector = tuple(0.0 for _ in current)
+        mapped: Vector = tuple(0.0 for _ in current)
+        output: Vector = current
+        dispatches = 0
+
+        for opcode in program:
+            dispatches += 1
+            if opcode == "LOAD_SELF":
+                current = context.current
+            elif opcode == "AGGREGATE_26":
+                neighbours = context.neighbour_mean
+            elif opcode == "DECODE_FRONT":
+                projected = context.projected
+            elif opcode == "LOAD_INPUT":
+                stimulus = context.stimulus
+            elif opcode == "AFFINE":
+                affine = tuple(
+                    parameters.self_gain * current[channel]
+                    + parameters.neighbour_gain * neighbours[channel]
+                    + parameters.projection_gain * projected[channel]
+                    + parameters.input_gain * stimulus[channel]
+                    + parameters.bias
+                    for channel in range(len(current))
+                )
+            elif opcode == "TANH":
+                mapped = tuple(math.tanh(value) for value in affine)
+            elif opcode == "RELAX":
+                output = tuple(
+                    current[channel]
+                    + context.alpha * (mapped[channel] - current[channel])
+                    for channel in range(len(current))
+                )
+            else:
+                raise ValueError(f"unknown primitive opcode: {opcode}")
+        return CellExecutionResult(value=output, dispatches=dispatches)
+
+
+class FusedOperatorCompiler:
+    """Compile a verified canonical promoted macro into one direct Python kernel call."""
+
+    @staticmethod
+    def compile(definition: OperatorDefinition) -> FusedOperator:
+        if not definition.verified:
+            raise ValueError("operator must be verified before compilation")
+        if definition.expansion != PRIMITIVE_TRACE:
+            raise ValueError("only the canonical level-1 DMSO trace is currently fusible")
+
+        def execute(
+            context: CellExecutionContext,
+            parameters: DMSOParameters,
+        ) -> CellExecutionResult:
+            value = tuple(
+                context.current[channel]
+                + context.alpha
+                * (
+                    math.tanh(
+                        parameters.self_gain * context.current[channel]
+                        + parameters.neighbour_gain * context.neighbour_mean[channel]
+                        + parameters.projection_gain * context.projected[channel]
+                        + parameters.input_gain * context.stimulus[channel]
+                        + parameters.bias
+                    )
+                    - context.current[channel]
+                )
+                for channel in range(len(context.current))
+            )
+            return CellExecutionResult(value=value, dispatches=1)
+
+        return FusedOperator(
+            operator_id=definition.operator_id,
+            expansion=definition.expansion,
+            execute=execute,
+        )
+
+
+def verify_fused_equivalence(
+    definition: OperatorDefinition,
+    context: CellExecutionContext,
+    parameters: DMSOParameters,
+    *,
+    tolerance: float = 0.0,
+) -> float:
+    """Return max absolute error after comparing primitive and fused execution."""
+
+    if tolerance < 0.0 or not math.isfinite(tolerance):
+        raise ValueError("tolerance must be a finite non-negative value")
+    primitive = PrimitiveCellInterpreter().execute(context, parameters, definition.expansion)
+    fused = FusedOperatorCompiler.compile(definition).execute(context, parameters)
+    error = max(abs(left - right) for left, right in zip(primitive.value, fused.value))
+    if error > tolerance:
+        raise RuntimeError(f"fused operator failed semantic verification: error={error}")
+    return error
+
+
+def benchmark_operator(
+    definition: OperatorDefinition,
+    context: CellExecutionContext,
+    parameters: DMSOParameters,
+    *,
+    repetitions: int = 10_000,
+    samples: int = 7,
+) -> OperatorBenchmark:
+    """Benchmark primitive dispatch against fused dispatch after exact semantic verification."""
+
+    if isinstance(repetitions, bool) or not isinstance(repetitions, int) or repetitions <= 0:
+        raise ValueError("repetitions must be a positive integer")
+    if isinstance(samples, bool) or not isinstance(samples, int) or samples <= 0:
+        raise ValueError("samples must be a positive integer")
+
+    error = verify_fused_equivalence(definition, context, parameters, tolerance=0.0)
+    interpreter = PrimitiveCellInterpreter()
+    fused = FusedOperatorCompiler.compile(definition)
+
+    for _ in range(min(100, repetitions)):
+        interpreter.execute(context, parameters, definition.expansion)
+        fused.execute(context, parameters)
+
+    primitive_times = []
+    fused_times = []
+    checksum = 0.0
+    for _ in range(samples):
+        start = time.perf_counter_ns()
+        for _ in range(repetitions):
+            result = interpreter.execute(context, parameters, definition.expansion)
+            checksum += result.value[0]
+        primitive_times.append((time.perf_counter_ns() - start) / repetitions)
+
+        start = time.perf_counter_ns()
+        for _ in range(repetitions):
+            result = fused.execute(context, parameters)
+            checksum += result.value[0]
+        fused_times.append((time.perf_counter_ns() - start) / repetitions)
+
+    if not math.isfinite(checksum):
+        raise RuntimeError("benchmark checksum became non-finite")
+
+    primitive_ns = float(statistics.median(primitive_times))
+    fused_ns = float(statistics.median(fused_times))
+    primitive_dispatches = len(definition.expansion)
+    fused_dispatches = 1
+    return OperatorBenchmark(
+        repetitions=repetitions,
+        samples=samples,
+        primitive_dispatches=primitive_dispatches,
+        fused_dispatches=fused_dispatches,
+        dispatch_reduction_ratio=primitive_dispatches / fused_dispatches,
+        primitive_ns_per_call=primitive_ns,
+        fused_ns_per_call=fused_ns,
+        measured_speedup=primitive_ns / fused_ns if fused_ns > 0.0 else math.inf,
+        output_max_abs_error=error,
+    )

--- a/src/jarvisx/dmso_runtime.py
+++ b/src/jarvisx/dmso_runtime.py
@@ -1,0 +1,571 @@
+"""Deterministic operational reference for the Dr Moagi inward 3D system.
+
+The runtime implements a bounded sparse voxel field with 26-neighbour message passing,
+front-projection decode, prior-preserving re-encoding, relaxed fixed-point iteration,
+small analytic parameter updates, exact trace-macro promotion, and deterministic
+verification. Operator promotion compresses the execution description and does not imply
+native-code acceleration.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, replace
+from typing import Dict, Iterable, Mapping, Sequence, Tuple
+
+Coordinate = Tuple[int, int, int]
+Pixel = Tuple[int, int]
+Vector = Tuple[float, ...]
+
+PRIMITIVE_TRACE: Tuple[str, ...] = (
+    "LOAD_SELF",
+    "AGGREGATE_26",
+    "DECODE_FRONT",
+    "LOAD_INPUT",
+    "AFFINE",
+    "TANH",
+    "RELAX",
+)
+
+
+@dataclass(frozen=True)
+class DMSOConfig:
+    side: int = 16
+    channels: int = 1
+    alpha: float = 0.25
+    learning_rate: float = 0.025
+    tolerance: float = 1.0e-6
+    max_settle_steps: int = 128
+    max_active_cells: int = 4096
+    promotion_repeats: int = 4
+    max_operator_depth: int = 4
+    auto_approve_depth: int = 1
+    parameter_limit: float = 4.0
+
+    def __post_init__(self) -> None:
+        integer_fields = (
+            "side",
+            "channels",
+            "max_settle_steps",
+            "max_active_cells",
+            "promotion_repeats",
+            "max_operator_depth",
+            "auto_approve_depth",
+        )
+        for name in integer_fields:
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.auto_approve_depth > self.max_operator_depth:
+            raise ValueError("auto_approve_depth cannot exceed max_operator_depth")
+        for name in ("alpha", "learning_rate", "tolerance", "parameter_limit"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if not 0.0 < self.alpha <= 1.0:
+            raise ValueError("alpha must be in (0, 1]")
+        if self.learning_rate < 0.0:
+            raise ValueError("learning_rate must be non-negative")
+        if self.tolerance < 0.0:
+            raise ValueError("tolerance must be non-negative")
+        if self.parameter_limit <= 0.0:
+            raise ValueError("parameter_limit must be positive")
+
+
+@dataclass(frozen=True)
+class DMSOParameters:
+    self_gain: float = 0.75
+    neighbour_gain: float = 0.20
+    projection_gain: float = 0.05
+    input_gain: float = 0.50
+    bias: float = 0.0
+
+
+@dataclass(frozen=True)
+class OperatorDefinition:
+    operator_id: str
+    expansion: Tuple[str, ...]
+    depth: int
+    observed_repeats: int
+    utility: float
+    verified: bool
+    human_approved: bool
+
+
+@dataclass(frozen=True)
+class DMSOMetrics:
+    cycle: int
+    active_cells: int
+    fixed_point_residual: float
+    task_loss: float
+    stable: bool
+    parameter_version: int
+    operator_count: int
+    trace_bytes_raw: int
+    trace_bytes_encoded: int
+    description_compression_ratio: float
+    state_digest: str
+
+
+class DMSORuntime:
+    """Sparse deterministic inward 3D reference runtime."""
+
+    NEIGHBOUR_OFFSETS: Tuple[Coordinate, ...] = tuple(
+        (dx, dy, dz)
+        for dx in (-1, 0, 1)
+        for dy in (-1, 0, 1)
+        for dz in (-1, 0, 1)
+        if (dx, dy, dz) != (0, 0, 0)
+    )
+
+    def __init__(
+        self,
+        config: DMSOConfig | None = None,
+        parameters: DMSOParameters | None = None,
+    ) -> None:
+        self.config = config or DMSOConfig()
+        self.parameters = parameters or DMSOParameters()
+        self._validate_parameters(self.parameters)
+        self._state: Dict[Coordinate, Vector] = {}
+        self._cycle = 0
+        self._parameter_version = 0
+        self._trace_counts: Dict[Tuple[str, ...], int] = {}
+        self._operators: Dict[str, OperatorDefinition] = {}
+        self._raw_trace_occurrences = 0
+        self._encoded_trace_occurrences = 0
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    @property
+    def state(self) -> Dict[Coordinate, Vector]:
+        return dict(self._state)
+
+    @property
+    def operators(self) -> Tuple[OperatorDefinition, ...]:
+        return tuple(self._operators[key] for key in sorted(self._operators))
+
+    @classmethod
+    def neighbour_offsets(cls) -> Tuple[Coordinate, ...]:
+        return cls.NEIGHBOUR_OFFSETS
+
+    def seed(self, values: Mapping[Coordinate, Sequence[float] | float]) -> None:
+        normalized = self._normalize_field(values, "state")
+        if len(normalized) > self.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+        self._state = normalized
+
+    def decode(self, state: Mapping[Coordinate, Vector] | None = None) -> Dict[Pixel, Vector]:
+        """Front-project by selecting the smallest occupied z for each (x, y)."""
+
+        source = self._state if state is None else dict(state)
+        front: Dict[Pixel, Tuple[int, Vector]] = {}
+        for (x, y, z), value in source.items():
+            current = front.get((x, y))
+            if current is None or z < current[0]:
+                front[(x, y)] = (z, value)
+        return {pixel: item[1] for pixel, item in front.items()}
+
+    def encode(
+        self,
+        decoded: Mapping[Pixel, Vector],
+        external: Mapping[Coordinate, Vector],
+        prior: Mapping[Coordinate, Vector],
+        support: Iterable[Coordinate],
+    ) -> Dict[Coordinate, Vector]:
+        """Evaluate E(D(S), U, S) on a bounded support without authoritative mutation."""
+
+        visible_depth = self._visible_depth(prior)
+        candidate: Dict[Coordinate, Vector] = {}
+        for coordinate in support:
+            x, y, z = coordinate
+            current = prior.get(coordinate, self._zero())
+            neighbours = self._neighbour_mean(prior, coordinate)
+            projected = (
+                decoded.get((x, y), self._zero())
+                if visible_depth.get((x, y)) == z
+                else self._zero()
+            )
+            stimulus = external.get(coordinate, self._zero())
+            values = []
+            for channel in range(self.config.channels):
+                preactivation = (
+                    self.parameters.self_gain * current[channel]
+                    + self.parameters.neighbour_gain * neighbours[channel]
+                    + self.parameters.projection_gain * projected[channel]
+                    + self.parameters.input_gain * stimulus[channel]
+                    + self.parameters.bias
+                )
+                values.append(math.tanh(preactivation))
+            candidate[coordinate] = tuple(values)
+        return candidate
+
+    def step(
+        self,
+        external: Mapping[Coordinate, Sequence[float] | float] | None = None,
+        targets: Mapping[Coordinate, Sequence[float] | float] | None = None,
+        *,
+        learn: bool = False,
+    ) -> DMSOMetrics:
+        """Run one transactional relaxed update and optional bounded mechanics-learning step."""
+
+        normalized_external = self._normalize_field(external or {}, "external")
+        normalized_targets = self._normalize_field(targets or {}, "target")
+        support = set(self._state).union(normalized_external).union(normalized_targets)
+        if len(support) > self.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+
+        snapshot = dict(self._state)
+        decoded = self.decode(snapshot)
+        mapped = self.encode(decoded, normalized_external, snapshot, sorted(support))
+        staged: Dict[Coordinate, Vector] = {}
+        squared_delta = 0.0
+        scalar_count = max(1, len(support) * self.config.channels)
+        for coordinate in sorted(support):
+            current = snapshot.get(coordinate, self._zero())
+            mapped_value = mapped[coordinate]
+            relaxed = tuple(
+                current[channel]
+                + self.config.alpha * (mapped_value[channel] - current[channel])
+                for channel in range(self.config.channels)
+            )
+            self._require_finite_vector(relaxed, "candidate")
+            staged[coordinate] = relaxed
+            squared_delta += sum(
+                (relaxed[channel] - current[channel]) ** 2
+                for channel in range(self.config.channels)
+            )
+
+        residual = math.sqrt(squared_delta / scalar_count)
+        task_loss = self._task_loss(staged, normalized_targets)
+        staged_parameters = self.parameters
+        if learn and normalized_targets:
+            staged_parameters = self._learn_parameters(
+                snapshot,
+                decoded,
+                normalized_external,
+                normalized_targets,
+                support,
+            )
+
+        self._validate_parameters(staged_parameters)
+        if not math.isfinite(residual) or not math.isfinite(task_loss):
+            raise RuntimeError("non-finite runtime metric; transaction rolled back")
+
+        self._state = staged
+        if staged_parameters != self.parameters:
+            self.parameters = staged_parameters
+            self._parameter_version += 1
+        self._cycle += 1
+        self._observe_trace(PRIMITIVE_TRACE, max(1, len(support)))
+        return self.metrics(task_loss=task_loss, residual=residual)
+
+    def settle(
+        self,
+        external: Mapping[Coordinate, Sequence[float] | float] | None = None,
+    ) -> DMSOMetrics:
+        """Iterate the fast state clock until the fixed-point residual meets tolerance."""
+
+        metrics = self.metrics()
+        for _ in range(self.config.max_settle_steps):
+            metrics = self.step(external=external)
+            if metrics.stable:
+                return metrics
+        return metrics
+
+    def promote_operator(
+        self,
+        expansion: Sequence[str],
+        *,
+        human_approved: bool = False,
+        observed_repeats: int = 1,
+    ) -> OperatorDefinition:
+        """Register an exact macro after depth, provenance and human-gate checks."""
+
+        normalized = tuple(expansion)
+        if len(normalized) < 2:
+            raise ValueError("composite operator requires at least two children")
+        child_depths = []
+        for child in normalized:
+            if child in PRIMITIVE_TRACE:
+                child_depths.append(0)
+            elif child in self._operators:
+                child_depths.append(self._operators[child].depth)
+            else:
+                raise ValueError(f"unknown operator child: {child}")
+        depth = 1 + max(child_depths)
+        if depth > self.config.max_operator_depth:
+            raise RuntimeError("maximum operator abstraction depth exceeded")
+        if depth > self.config.auto_approve_depth and not human_approved:
+            raise PermissionError("human approval required for this abstraction depth")
+
+        digest = hashlib.sha256("\0".join(normalized).encode("utf-8")).hexdigest()[:12]
+        operator_id = f"DMSO_{depth}_{digest}"
+        repeats = max(1, int(observed_repeats))
+        utility = float((len(normalized) - 1) * repeats - len(normalized))
+        definition = OperatorDefinition(
+            operator_id=operator_id,
+            expansion=normalized,
+            depth=depth,
+            observed_repeats=repeats,
+            utility=utility,
+            verified=True,
+            human_approved=human_approved or depth <= self.config.auto_approve_depth,
+        )
+        current = self._operators.get(operator_id)
+        if current is None or definition.observed_repeats > current.observed_repeats:
+            self._operators[operator_id] = definition
+        return self._operators[operator_id]
+
+    def verify(self) -> bool:
+        """Check bounded state, parameters, operator provenance, and abstraction depth."""
+
+        self._validate_parameters(self.parameters)
+        if len(self._state) > self.config.max_active_cells:
+            return False
+        for coordinate, vector in self._state.items():
+            self._validate_coordinate(coordinate)
+            self._require_finite_vector(vector, "state")
+        known = set(PRIMITIVE_TRACE).union(self._operators)
+        for definition in self._operators.values():
+            if not definition.verified or definition.depth > self.config.max_operator_depth:
+                return False
+            if any(child not in known for child in definition.expansion):
+                return False
+            if definition.depth > self.config.auto_approve_depth and not definition.human_approved:
+                return False
+        return True
+
+    def metrics(
+        self,
+        *,
+        task_loss: float = 0.0,
+        residual: float | None = None,
+    ) -> DMSOMetrics:
+        if residual is None:
+            residual = self._fixed_point_residual()
+        raw = self._raw_trace_occurrences * len(PRIMITIVE_TRACE) * 4
+        encoded = self._encoded_trace_occurrences * 4
+        unresolved = self._raw_trace_occurrences - self._encoded_trace_occurrences
+        encoded += unresolved * len(PRIMITIVE_TRACE) * 4
+        ratio = (raw / encoded) if encoded else 1.0
+        return DMSOMetrics(
+            cycle=self._cycle,
+            active_cells=len(self._state),
+            fixed_point_residual=residual,
+            task_loss=task_loss,
+            stable=residual <= self.config.tolerance,
+            parameter_version=self._parameter_version,
+            operator_count=len(self._operators),
+            trace_bytes_raw=raw,
+            trace_bytes_encoded=encoded,
+            description_compression_ratio=ratio,
+            state_digest=self.state_digest(),
+        )
+
+    def state_digest(self) -> str:
+        payload = {
+            "config": asdict(self.config),
+            "parameters": asdict(self.parameters),
+            "cycle": self._cycle,
+            "state": [
+                [list(coordinate), list(self._state[coordinate])]
+                for coordinate in sorted(self._state)
+            ],
+            "operators": [asdict(item) for item in self.operators],
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(b"jarvisx-dmso-v1\0" + encoded).hexdigest()
+
+    def _fixed_point_residual(self) -> float:
+        if not self._state:
+            return 0.0
+        decoded = self.decode(self._state)
+        mapped = self.encode(decoded, {}, self._state, sorted(self._state))
+        squared = 0.0
+        count = len(self._state) * self.config.channels
+        for coordinate, current in self._state.items():
+            squared += sum(
+                (mapped[coordinate][channel] - current[channel]) ** 2
+                for channel in range(self.config.channels)
+            )
+        return math.sqrt(squared / max(1, count))
+
+    def _learn_parameters(
+        self,
+        snapshot: Mapping[Coordinate, Vector],
+        decoded: Mapping[Pixel, Vector],
+        external: Mapping[Coordinate, Vector],
+        targets: Mapping[Coordinate, Vector],
+        support: Iterable[Coordinate],
+    ) -> DMSOParameters:
+        visible_depth = self._visible_depth(snapshot)
+        gradients = {
+            "self_gain": 0.0,
+            "neighbour_gain": 0.0,
+            "projection_gain": 0.0,
+            "input_gain": 0.0,
+            "bias": 0.0,
+        }
+        scalar_count = max(1, len(targets) * self.config.channels)
+        for coordinate in sorted(support):
+            if coordinate not in targets:
+                continue
+            x, y, z = coordinate
+            current = snapshot.get(coordinate, self._zero())
+            neighbours = self._neighbour_mean(snapshot, coordinate)
+            projected = (
+                decoded.get((x, y), self._zero())
+                if visible_depth.get((x, y)) == z
+                else self._zero()
+            )
+            stimulus = external.get(coordinate, self._zero())
+            target = targets[coordinate]
+            for channel in range(self.config.channels):
+                features = {
+                    "self_gain": current[channel],
+                    "neighbour_gain": neighbours[channel],
+                    "projection_gain": projected[channel],
+                    "input_gain": stimulus[channel],
+                    "bias": 1.0,
+                }
+                preactivation = (
+                    self.parameters.self_gain * features["self_gain"]
+                    + self.parameters.neighbour_gain * features["neighbour_gain"]
+                    + self.parameters.projection_gain * features["projection_gain"]
+                    + self.parameters.input_gain * features["input_gain"]
+                    + self.parameters.bias
+                )
+                mapped_value = math.tanh(preactivation)
+                relaxed = current[channel] + self.config.alpha * (mapped_value - current[channel])
+                dloss = 2.0 * (relaxed - target[channel]) / scalar_count
+                common = dloss * self.config.alpha * (1.0 - mapped_value * mapped_value)
+                for name, feature in features.items():
+                    gradients[name] += common * feature
+
+        updates = {}
+        limit = self.config.parameter_limit
+        for name, gradient in gradients.items():
+            value = getattr(self.parameters, name) - self.config.learning_rate * gradient
+            updates[name] = max(-limit, min(limit, value))
+        return replace(self.parameters, **updates)
+
+    def _observe_trace(self, trace: Tuple[str, ...], occurrences: int) -> None:
+        previous = self._trace_counts.get(trace, 0)
+        total = previous + occurrences
+        self._trace_counts[trace] = total
+        self._raw_trace_occurrences += occurrences
+        existing = self._operator_for_expansion(trace)
+        if existing is None and total >= self.config.promotion_repeats:
+            existing = self.promote_operator(trace, observed_repeats=total)
+        if existing is not None:
+            self._encoded_trace_occurrences += occurrences
+
+    def _operator_for_expansion(self, trace: Tuple[str, ...]) -> OperatorDefinition | None:
+        for definition in self._operators.values():
+            if definition.expansion == trace:
+                return definition
+        return None
+
+    def _task_loss(
+        self,
+        state: Mapping[Coordinate, Vector],
+        targets: Mapping[Coordinate, Vector],
+    ) -> float:
+        if not targets:
+            return 0.0
+        squared = 0.0
+        count = 0
+        for coordinate, target in targets.items():
+            value = state.get(coordinate, self._zero())
+            for channel in range(self.config.channels):
+                squared += (value[channel] - target[channel]) ** 2
+                count += 1
+        return squared / max(1, count)
+
+    def _visible_depth(self, state: Mapping[Coordinate, Vector]) -> Dict[Pixel, int]:
+        visible: Dict[Pixel, int] = {}
+        for x, y, z in state:
+            pixel = (x, y)
+            current = visible.get(pixel)
+            if current is None or z < current:
+                visible[pixel] = z
+        return visible
+
+    def _neighbour_mean(
+        self,
+        state: Mapping[Coordinate, Vector],
+        coordinate: Coordinate,
+    ) -> Vector:
+        x, y, z = coordinate
+        totals = [0.0] * self.config.channels
+        count = 0
+        for dx, dy, dz in self.NEIGHBOUR_OFFSETS:
+            neighbour = (x + dx, y + dy, z + dz)
+            if self._coordinate_in_bounds(neighbour):
+                vector = state.get(neighbour, self._zero())
+                for channel in range(self.config.channels):
+                    totals[channel] += vector[channel]
+                count += 1
+        if count == 0:
+            return self._zero()
+        return tuple(value / count for value in totals)
+
+    def _normalize_field(
+        self,
+        values: Mapping[Coordinate, Sequence[float] | float],
+        name: str,
+    ) -> Dict[Coordinate, Vector]:
+        if not isinstance(values, Mapping):
+            raise TypeError(f"{name} must be a mapping")
+        normalized: Dict[Coordinate, Vector] = {}
+        for coordinate, value in values.items():
+            checked = self._validate_coordinate(coordinate)
+            if self.config.channels == 1 and isinstance(value, (int, float)) and not isinstance(
+                value, bool
+            ):
+                vector = (float(value),)
+            else:
+                if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+                    raise TypeError(f"{name} values must match channel count")
+                vector = tuple(float(item) for item in value)
+            if len(vector) != self.config.channels:
+                raise ValueError(f"{name} values must contain exactly {self.config.channels} channels")
+            self._require_finite_vector(vector, name)
+            normalized[checked] = vector
+        return normalized
+
+    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
+        if not isinstance(coordinate, tuple) or len(coordinate) != 3:
+            raise TypeError("coordinate must be a three-integer tuple")
+        if not all(isinstance(item, int) and not isinstance(item, bool) for item in coordinate):
+            raise TypeError("coordinate components must be integers")
+        if not self._coordinate_in_bounds(coordinate):
+            raise ValueError("coordinate is outside the configured lattice")
+        return coordinate
+
+    def _coordinate_in_bounds(self, coordinate: Coordinate) -> bool:
+        return all(0 <= item < self.config.side for item in coordinate)
+
+    def _validate_parameters(self, parameters: DMSOParameters) -> None:
+        limit = self.config.parameter_limit
+        for name, value in asdict(parameters).items():
+            if not math.isfinite(value):
+                raise ValueError(f"parameter {name} must be finite")
+            if abs(value) > limit:
+                raise ValueError(f"parameter {name} exceeds configured bound")
+
+    @staticmethod
+    def _require_finite_vector(vector: Sequence[float], name: str) -> None:
+        if not all(math.isfinite(float(value)) for value in vector):
+            raise ValueError(f"{name} contains a non-finite value")
+
+    def _zero(self) -> Vector:
+        return (0.0,) * self.config.channels

--- a/src/jarvisx/dmso_runtime.py
+++ b/src/jarvisx/dmso_runtime.py
@@ -2,9 +2,9 @@
 
 The runtime implements a bounded sparse voxel field with 26-neighbour message passing,
 front-projection decode, prior-preserving re-encoding, relaxed fixed-point iteration,
-small analytic parameter updates, exact trace-macro promotion, and deterministic
-verification. Operator promotion compresses the execution description and does not imply
-native-code acceleration.
+bounded analytic parameter updates, exact trace-macro promotion, and deterministic
+verification. Operator promotion compresses execution descriptions; acceleration is measured
+separately by an execution backend.
 """
 
 from __future__ import annotations
@@ -165,7 +165,7 @@ class DMSORuntime:
     def decode(self, state: Mapping[Coordinate, Vector] | None = None) -> Dict[Pixel, Vector]:
         """Front-project by selecting the smallest occupied z for each (x, y)."""
 
-        source = self._state if state is None else dict(state)
+        source = self._state if state is None else state
         front: Dict[Pixel, Tuple[int, Vector]] = {}
         for (x, y, z), value in source.items():
             current = front.get((x, y))
@@ -180,7 +180,7 @@ class DMSORuntime:
         prior: Mapping[Coordinate, Vector],
         support: Iterable[Coordinate],
     ) -> Dict[Coordinate, Vector]:
-        """Evaluate E(D(S), U, S) on a bounded support without authoritative mutation."""
+        """Evaluate E(D(S), U, S) on bounded support without authoritative mutation."""
 
         visible_depth = self._visible_depth(prior)
         candidate: Dict[Coordinate, Vector] = {}
@@ -194,17 +194,16 @@ class DMSORuntime:
                 else self._zero()
             )
             stimulus = external.get(coordinate, self._zero())
-            values = []
-            for channel in range(self.config.channels):
-                preactivation = (
+            candidate[coordinate] = tuple(
+                math.tanh(
                     self.parameters.self_gain * current[channel]
                     + self.parameters.neighbour_gain * neighbours[channel]
                     + self.parameters.projection_gain * projected[channel]
                     + self.parameters.input_gain * stimulus[channel]
                     + self.parameters.bias
                 )
-                values.append(math.tanh(preactivation))
-            candidate[coordinate] = tuple(values)
+                for channel in range(self.config.channels)
+            )
         return candidate
 
     def step(
@@ -228,6 +227,7 @@ class DMSORuntime:
         staged: Dict[Coordinate, Vector] = {}
         squared_delta = 0.0
         scalar_count = max(1, len(support) * self.config.channels)
+
         for coordinate in sorted(support):
             current = snapshot.get(coordinate, self._zero())
             mapped_value = mapped[coordinate]
@@ -271,8 +271,6 @@ class DMSORuntime:
         self,
         external: Mapping[Coordinate, Sequence[float] | float] | None = None,
     ) -> DMSOMetrics:
-        """Iterate the fast state clock until the fixed-point residual meets tolerance."""
-
         metrics = self.metrics()
         for _ in range(self.config.max_settle_steps):
             metrics = self.step(external=external)
@@ -287,8 +285,6 @@ class DMSORuntime:
         human_approved: bool = False,
         observed_repeats: int = 1,
     ) -> OperatorDefinition:
-        """Register an exact macro after depth, provenance and human-gate checks."""
-
         normalized = tuple(expansion)
         if len(normalized) < 2:
             raise ValueError("composite operator requires at least two children")
@@ -325,8 +321,6 @@ class DMSORuntime:
         return self._operators[operator_id]
 
     def verify(self) -> bool:
-        """Check bounded state, parameters, operator provenance, and abstraction depth."""
-
         self._validate_parameters(self.parameters)
         if len(self._state) > self.config.max_active_cells:
             return False
@@ -349,19 +343,18 @@ class DMSORuntime:
         task_loss: float = 0.0,
         residual: float | None = None,
     ) -> DMSOMetrics:
-        if residual is None:
-            residual = self._fixed_point_residual()
+        current_residual = self._fixed_point_residual() if residual is None else residual
         raw = self._raw_trace_occurrences * len(PRIMITIVE_TRACE) * 4
         encoded = self._encoded_trace_occurrences * 4
         unresolved = self._raw_trace_occurrences - self._encoded_trace_occurrences
         encoded += unresolved * len(PRIMITIVE_TRACE) * 4
-        ratio = (raw / encoded) if encoded else 1.0
+        ratio = raw / encoded if encoded else 1.0
         return DMSOMetrics(
             cycle=self._cycle,
             active_cells=len(self._state),
-            fixed_point_residual=residual,
+            fixed_point_residual=current_residual,
             task_loss=task_loss,
-            stable=residual <= self.config.tolerance,
+            stable=current_residual <= self.config.tolerance,
             parameter_version=self._parameter_version,
             operator_count=len(self._operators),
             trace_bytes_raw=raw,
@@ -382,7 +375,7 @@ class DMSORuntime:
             "operators": [asdict(item) for item in self.operators],
         }
         encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-        return hashlib.sha256(b"jarvisx-dmso-v1\0" + encoded).hexdigest()
+        return hashlib.sha256(b"jarvisx-dmso-v2\0" + encoded).hexdigest()
 
     def _fixed_point_residual(self) -> float:
         if not self._state:
@@ -407,7 +400,7 @@ class DMSORuntime:
         support: Iterable[Coordinate],
     ) -> DMSOParameters:
         visible_depth = self._visible_depth(snapshot)
-        gradients = {
+        gradients: Dict[str, float] = {
             "self_gain": 0.0,
             "neighbour_gain": 0.0,
             "projection_gain": 0.0,
@@ -416,7 +409,8 @@ class DMSORuntime:
         }
         scalar_count = max(1, len(targets) * self.config.channels)
         for coordinate in sorted(support):
-            if coordinate not in targets:
+            target = targets.get(coordinate)
+            if target is None:
                 continue
             x, y, z = coordinate
             current = snapshot.get(coordinate, self._zero())
@@ -427,7 +421,6 @@ class DMSORuntime:
                 else self._zero()
             )
             stimulus = external.get(coordinate, self._zero())
-            target = targets[coordinate]
             for channel in range(self.config.channels):
                 features = {
                     "self_gain": current[channel],
@@ -436,21 +429,20 @@ class DMSORuntime:
                     "input_gain": stimulus[channel],
                     "bias": 1.0,
                 }
-                preactivation = (
-                    self.parameters.self_gain * features["self_gain"]
-                    + self.parameters.neighbour_gain * features["neighbour_gain"]
-                    + self.parameters.projection_gain * features["projection_gain"]
-                    + self.parameters.input_gain * features["input_gain"]
-                    + self.parameters.bias
+                preactivation = sum(
+                    getattr(self.parameters, name) * feature
+                    for name, feature in features.items()
                 )
                 mapped_value = math.tanh(preactivation)
-                relaxed = current[channel] + self.config.alpha * (mapped_value - current[channel])
+                relaxed = current[channel] + self.config.alpha * (
+                    mapped_value - current[channel]
+                )
                 dloss = 2.0 * (relaxed - target[channel]) / scalar_count
                 common = dloss * self.config.alpha * (1.0 - mapped_value * mapped_value)
                 for name, feature in features.items():
                     gradients[name] += common * feature
 
-        updates = {}
+        updates: Dict[str, float] = {}
         limit = self.config.parameter_limit
         for name, gradient in gradients.items():
             value = getattr(self.parameters, name) - self.config.learning_rate * gradient
@@ -469,10 +461,10 @@ class DMSORuntime:
             self._encoded_trace_occurrences += occurrences
 
     def _operator_for_expansion(self, trace: Tuple[str, ...]) -> OperatorDefinition | None:
-        for definition in self._operators.values():
-            if definition.expansion == trace:
-                return definition
-        return None
+        return next(
+            (definition for definition in self._operators.values() if definition.expansion == trace),
+            None,
+        )
 
     def _task_loss(
         self,
@@ -490,7 +482,8 @@ class DMSORuntime:
                 count += 1
         return squared / max(1, count)
 
-    def _visible_depth(self, state: Mapping[Coordinate, Vector]) -> Dict[Pixel, int]:
+    @staticmethod
+    def _visible_depth(state: Mapping[Coordinate, Vector]) -> Dict[Pixel, int]:
         visible: Dict[Pixel, int] = {}
         for x, y, z in state:
             pixel = (x, y)
@@ -528,8 +521,11 @@ class DMSORuntime:
         normalized: Dict[Coordinate, Vector] = {}
         for coordinate, value in values.items():
             checked = self._validate_coordinate(coordinate)
-            if self.config.channels == 1 and isinstance(value, (int, float)) and not isinstance(
-                value, bool
+            vector: Vector
+            if (
+                self.config.channels == 1
+                and isinstance(value, (int, float))
+                and not isinstance(value, bool)
             ):
                 vector = (float(value),)
             else:
@@ -537,7 +533,9 @@ class DMSORuntime:
                     raise TypeError(f"{name} values must match channel count")
                 vector = tuple(float(item) for item in value)
             if len(vector) != self.config.channels:
-                raise ValueError(f"{name} values must contain exactly {self.config.channels} channels")
+                raise ValueError(
+                    f"{name} values must contain exactly {self.config.channels} channels"
+                )
             self._require_finite_vector(vector, name)
             normalized[checked] = vector
         return normalized
@@ -557,9 +555,10 @@ class DMSORuntime:
     def _validate_parameters(self, parameters: DMSOParameters) -> None:
         limit = self.config.parameter_limit
         for name, value in asdict(parameters).items():
-            if not math.isfinite(value):
+            numeric_value = float(value)
+            if not math.isfinite(numeric_value):
                 raise ValueError(f"parameter {name} must be finite")
-            if abs(value) > limit:
+            if abs(numeric_value) > limit:
                 raise ValueError(f"parameter {name} exceeds configured bound")
 
     @staticmethod

--- a/tests/test_dmso_bytecode.py
+++ b/tests/test_dmso_bytecode.py
@@ -1,0 +1,73 @@
+import pytest
+
+from jarvisx.dmso_bytecode import (
+    CellExecutionContext,
+    FusedOperatorCompiler,
+    PrimitiveCellInterpreter,
+    benchmark_operator,
+    verify_fused_equivalence,
+)
+from jarvisx.dmso_runtime import DMSOConfig, DMSOParameters, DMSORuntime
+
+
+def _promoted_operator():
+    runtime = DMSORuntime(DMSOConfig(side=4, promotion_repeats=1))
+    runtime.seed({(1, 1, 1): 0.1})
+    runtime.step()
+    return runtime.operators[0]
+
+
+def _context():
+    return CellExecutionContext(
+        current=(0.25, -0.5),
+        neighbour_mean=(0.1, 0.2),
+        projected=(0.25, -0.5),
+        stimulus=(0.7, -0.1),
+        alpha=0.25,
+    )
+
+
+def test_fused_operator_is_semantically_exact_for_canonical_macro():
+    operator = _promoted_operator()
+    params = DMSOParameters()
+    assert verify_fused_equivalence(operator, _context(), params) == 0.0
+
+
+def test_fused_operator_reduces_dispatch_count_from_seven_to_one():
+    operator = _promoted_operator()
+    params = DMSOParameters()
+    primitive = PrimitiveCellInterpreter().execute(_context(), params, operator.expansion)
+    fused = FusedOperatorCompiler.compile(operator).execute(_context(), params)
+    assert primitive.value == fused.value
+    assert primitive.dispatches == 7
+    assert fused.dispatches == 1
+
+
+def test_compiler_rejects_unverified_operator():
+    operator = _promoted_operator()
+    invalid = type(operator)(
+        operator_id=operator.operator_id,
+        expansion=operator.expansion,
+        depth=operator.depth,
+        observed_repeats=operator.observed_repeats,
+        utility=operator.utility,
+        verified=False,
+        human_approved=operator.human_approved,
+    )
+    with pytest.raises(ValueError):
+        FusedOperatorCompiler.compile(invalid)
+
+
+def test_benchmark_reports_equivalence_and_dispatch_reduction():
+    result = benchmark_operator(
+        _promoted_operator(),
+        _context(),
+        DMSOParameters(),
+        repetitions=200,
+        samples=3,
+    )
+    assert result.output_max_abs_error == 0.0
+    assert result.dispatch_reduction_ratio == pytest.approx(7.0)
+    assert result.primitive_ns_per_call > 0.0
+    assert result.fused_ns_per_call > 0.0
+    assert result.measured_speedup > 0.0

--- a/tests/test_dmso_runtime.py
+++ b/tests/test_dmso_runtime.py
@@ -1,0 +1,105 @@
+import math
+
+import pytest
+
+from jarvisx.dmso_runtime import DMSOConfig, DMSOParameters, DMSORuntime
+
+
+def test_neighbourhood_is_exact_26_shell():
+    offsets = DMSORuntime.neighbour_offsets()
+    assert len(offsets) == 26
+    assert len(set(offsets)) == 26
+    assert (0, 0, 0) not in offsets
+    assert all(max(abs(x), abs(y), abs(z)) == 1 for x, y, z in offsets)
+
+
+def test_front_decoder_uses_smallest_depth_and_preserves_channels():
+    runtime = DMSORuntime(DMSOConfig(side=4, channels=2))
+    runtime.seed({(1, 1, 2): (0.2, 0.3), (1, 1, 0): (0.8, 0.9)})
+    assert runtime.decode()[(1, 1)] == (0.8, 0.9)
+
+
+def test_step_is_deterministic_for_equal_state_and_input():
+    config = DMSOConfig(side=4, channels=1)
+    a = DMSORuntime(config)
+    b = DMSORuntime(config)
+    seed = {(1, 1, 1): 0.25, (2, 1, 1): -0.1}
+    control = {(1, 1, 1): 0.5}
+    a.seed(seed)
+    b.seed(seed)
+    assert a.step(control) == b.step(control)
+    assert a.state == b.state
+
+
+def test_zero_state_is_fixed_point():
+    runtime = DMSORuntime(DMSOConfig(side=4, tolerance=1.0e-12))
+    runtime.seed({(1, 1, 1): 0.0})
+    metrics = runtime.settle()
+    assert metrics.stable
+    assert metrics.fixed_point_residual == pytest.approx(0.0)
+
+
+def test_learning_moves_input_gain_toward_target():
+    config = DMSOConfig(side=4, alpha=1.0, learning_rate=0.1)
+    runtime = DMSORuntime(
+        config,
+        DMSOParameters(
+            self_gain=0.0,
+            neighbour_gain=0.0,
+            projection_gain=0.0,
+            input_gain=0.0,
+            bias=0.0,
+        ),
+    )
+    runtime.seed({(1, 1, 1): 0.0})
+    before = runtime.parameters.input_gain
+    first = runtime.step(
+        {(1, 1, 1): 1.0},
+        {(1, 1, 1): 0.5},
+        learn=True,
+    )
+    assert first.task_loss == pytest.approx(0.25)
+    assert runtime.parameters.input_gain > before
+    assert runtime.verify()
+
+
+def test_trace_promotes_exact_macro_and_reports_description_compression():
+    runtime = DMSORuntime(DMSOConfig(side=4, promotion_repeats=2))
+    runtime.seed({(1, 1, 1): 0.1, (2, 1, 1): 0.2})
+    metrics = runtime.step()
+    assert metrics.operator_count == 1
+    assert runtime.operators[0].verified
+    assert runtime.operators[0].depth == 1
+    assert metrics.description_compression_ratio > 1.0
+
+
+def test_higher_order_promotion_requires_human_approval():
+    runtime = DMSORuntime(DMSOConfig(side=4, promotion_repeats=1, auto_approve_depth=1))
+    runtime.seed({(1, 1, 1): 0.1})
+    runtime.step()
+    child = runtime.operators[0].operator_id
+    with pytest.raises(PermissionError):
+        runtime.promote_operator((child, child))
+    promoted = runtime.promote_operator((child, child), human_approved=True)
+    assert promoted.depth == 2
+    assert promoted.human_approved
+    assert runtime.verify()
+
+
+def test_invalid_external_input_does_not_mutate_state():
+    runtime = DMSORuntime(DMSOConfig(side=4))
+    runtime.seed({(1, 1, 1): 0.25})
+    before = runtime.state_digest()
+    with pytest.raises(ValueError):
+        runtime.step({(1, 1, 1): math.nan})
+    assert runtime.state_digest() == before
+
+
+def test_digest_replays_for_equal_execution():
+    config = DMSOConfig(side=4, promotion_repeats=2)
+    runtimes = [DMSORuntime(config), DMSORuntime(config)]
+    for runtime in runtimes:
+        runtime.seed({(1, 1, 1): 0.2, (2, 2, 2): -0.4})
+        runtime.step({(1, 1, 1): 0.1})
+        runtime.step()
+    assert runtimes[0].state_digest() == runtimes[1].state_digest()


### PR DESCRIPTION
## What changed

- add `src/jarvisx/dmso_runtime.py`, a deterministic bounded inward 3D runtime with the exact 26-neighbour Chebyshev shell
- implement front-projection decoding and prior-preserving re-encoding as `F_theta(S,U) = E_theta(D(S),U,S)`
- implement relaxed fixed-point iteration, bounded analytic parameter learning, deterministic state digests, and transaction-before-commit behavior
- add execution-trace macro promotion with provenance, abstraction depth, utility telemetry, and a human approval gate for higher-order composites
- add `src/jarvisx/dmso_bytecode.py` plus `cpp_runtime/include/jarvisx/dmso_fused.hpp` for executable primitive-versus-fused operator paths
- verify exact primitive/fused semantic equality before benchmarking and reduce the canonical seven-op interpreter trace to one fused dispatch
- add `cpp_runtime/include/jarvisx/dmso_os.hpp`, a standard-library-only OS-style lifecycle environment containing virtual registers, 64-bit program storage, field rendering, numerical reverse optimization, asynchronous supervision, telemetry, and transactional rollback
- add `jarvisx-dmso-os`, a self-contained native executable that boots its virtual machine, assembles its own program and target, executes bounded optimization epochs, reports convergence truthfully, and halts with a JSON lifecycle receipt
- wire fused and OS regression/smoke targets into the existing CMake/CTest native matrix
- add engineering specifications and runnable Python/C++ benchmark paths with explicit capability boundaries

## Why

The repository already contains canonical sparse Dr Moagi field mechanics and multiple research tracks. This PR integrates the latest 26-neighbour geometry, decode/re-encode fixed-point law, multi-timescale learning, recursive operator promotion, executable fusion, and an internally managed lifecycle environment without changing the existing canonical VM semantics or claiming unrestricted self-modification.

## Governing dynamics

```math
F_\theta(\mathcal S,\mathcal U)
=\mathcal E_\theta(\mathcal D(\mathcal S),\mathcal U,\mathcal S)
```

```math
\mathcal S_{t+1}
=(1-\alpha)\mathcal S_t+\alpha F_\theta(\mathcal S_t,\mathcal U_t)
```

The mechanics update remains a separate bounded learning clock.

## Operator abstraction and execution

The canonical primitive cell trace is:

```text
LOAD_SELF -> AGGREGATE_26 -> DECODE_FRONT -> LOAD_INPUT
-> AFFINE -> TANH -> RELAX
```

Repeated traces are promoted to exact macros while retaining their complete expansion. Higher-order abstractions require human approval above the configured auto-approval depth.

A verified level-1 macro executes through both Python and C++17 fused reference backends. The primitive path performs seven opcode dispatches; the fused path performs one direct kernel dispatch. Both paths must produce exactly equal reference outputs before timing is accepted.

The structural dispatch-reduction ratio is exactly `7x`. Local development runs measured approximately `2.46x` for the Python reference and `2.59x` for the C++17 reference; these are host-specific telemetry, not portable performance guarantees.

## Autonomous OS-style lifecycle

The native lifecycle layer owns its internal machine state:

```text
BOOT
  -> allocate virtual registers
  -> assemble internal 64-bit bytecode
  -> generate internal objective target
  -> FORWARD render
  -> finite-difference SHADOW optimization
  -> validate candidate
  -> COMMIT or ROLLBACK
  -> convergence check
  -> bounded repeat
  -> JSON lifecycle receipt
  -> HALT
```

The current bytecode layout is:

```text
[ opcode: 8 ][ alpha: 16 ][ beta: 16 ][ reserved: 24 ]
```

with bounded opcodes for spatial scaling, geometry-field evaluation, and texture-field evaluation.

Optimization is transactional. A parameter candidate is authoritative only when its measured loss is finite and no worse than the baseline; otherwise geometry and material registers are restored to the exact pre-candidate snapshot. The lifecycle reports `converged=true` only when the configured threshold is actually reached.

The asynchronous API uses a host thread via `std::async`, while a mutex serializes authoritative lifecycle mutation so concurrent callers cannot race on one virtual register bank.

## Validation

Focused Python reference validation before publication:

```text
13 passed in 0.06s
```

The native fused and autonomous-OS components were separately compiled with:

```text
-std=c++17 -Wall -Wextra -Wpedantic -Wconversion -Wshadow
```

The local autonomous-OS regression fixture verifies:

- exact 64-bit instruction compile/decompile round-trip
- supported-opcode gating and unsupported-opcode rejection
- bounded frame-buffer output with finite RGB values
- asynchronous lifecycle completion
- accepted/rejected update accounting
- finite parameter state
- monotone non-worsening committed lifecycle loss
- invalid-resolution rejection

The updated CMake adds both `dmso-os-runtime-smoke` and `dmso-os-regressions` to the native CI matrix.

Repository CI, CodeQL, empirical validation, and the C++ workflow on the updated head remain authoritative before this draft is marked ready.

## Capability boundary

This is an executable mathematical research reference. `AutonomousSystemOS` is an OS-style userspace machine environment, not a bootable general-purpose operating system or a physical hardware-isolation boundary. The reverse path currently uses finite differences rather than analytic/autodiff gradients. The system does not establish consciousness, general intelligence, continuous `SO(3)` invariance, lossless arbitrary compression, unrestricted native-code self-rewriting, LLVM/JIT generation, GPU acceleration, hard real-time guarantees, or state-of-the-art performance. Those require separate implementation and empirical evidence.