### PR TITLE
Operationalize RIOF-3D volumetric self-optimization runtime

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -160,3 +160,12 @@ jarvisx_harden(jarvisx-riof3d-tests)
 
 add_test(NAME riof3d-regressions COMMAND jarvisx-riof3d-tests)
 set_tests_properties(riof3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-riof-permeation-tests
+    tests/riof_permeation_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-riof-permeation-tests)
+jarvisx_harden(jarvisx-riof-permeation-tests)
+
+add_test(NAME riof-permeation-regressions COMMAND jarvisx-riof-permeation-tests)
+set_tests_properties(riof-permeation-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-riof3d
+    src/riof3d_main.cpp
+)
+jarvisx_include_runtime(jarvisx-riof3d)
+jarvisx_harden(jarvisx-riof3d)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -109,6 +115,16 @@ add_test(
 )
 set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME riof3d-runtime-smoke
+    COMMAND jarvisx-riof3d
+        --cycles 4
+        --edge 8
+        --pattern sphere
+        --quiet
+)
+set_tests_properties(riof3d-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -135,3 +151,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-riof3d-tests
+    tests/riof3d_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-riof3d-tests)
+jarvisx_harden(jarvisx-riof3d-tests)
+
+add_test(NAME riof3d-regressions COMMAND jarvisx-riof3d-tests)
+set_tests_properties(riof3d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/riof3d.hpp
+++ b/cpp_runtime/include/jarvisx/riof3d.hpp
@@ -1,0 +1,364 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace jarvisx {
+
+struct Riof3DConfig {
+    std::size_t edge{16U};
+    double smoothness_weight{0.18};
+    double bending_weight{0.015};
+    double prediction_weight{0.30};
+    double refinement_gain{0.08};
+    double enhancement_gain{0.015};
+    double memory_gain{0.025};
+    double base_damping{0.20};
+    double cfl{0.12};
+    double min_timestep{0.001};
+    double max_timestep{0.035};
+    double projection_limit{1.5};
+    std::size_t adjoint_iterations{8U};
+    std::uint64_t seed{0x52494F463344ULL};
+
+    void validate() const {
+        if (edge < 4U || edge > 128U) {
+            throw std::invalid_argument("RIOF edge must be in [4, 128]");
+        }
+        const double weights[] = {smoothness_weight, bending_weight, prediction_weight,
+                                  refinement_gain, enhancement_gain, memory_gain,
+                                  base_damping, cfl, min_timestep, max_timestep,
+                                  projection_limit};
+        for (double value : weights) {
+            if (!std::isfinite(value) || value < 0.0) {
+                throw std::invalid_argument("RIOF configuration values must be finite and non-negative");
+            }
+        }
+        if (smoothness_weight == 0.0 && bending_weight == 0.0 &&
+            prediction_weight == 0.0) {
+            throw std::invalid_argument("RIOF requires at least one objective term");
+        }
+        if (cfl <= 0.0 || min_timestep <= 0.0 || max_timestep <= 0.0 ||
+            min_timestep > max_timestep) {
+            throw std::invalid_argument("RIOF timestep bounds are invalid");
+        }
+        if (projection_limit <= 0.0 || projection_limit > 100.0) {
+            throw std::invalid_argument("RIOF projection limit must be in (0, 100]");
+        }
+        if (adjoint_iterations == 0U || adjoint_iterations > 256U) {
+            throw std::invalid_argument("RIOF adjoint iterations must be in [1, 256]");
+        }
+    }
+};
+
+struct Riof3DMetrics {
+    std::uint64_t step{};
+    double total_energy{};
+    double gradient_energy{};
+    double bending_energy{};
+    double prediction_energy{};
+    double kinetic_energy{};
+    double mean_abs_residual{};
+    double max_abs_value{};
+    double timestep{};
+    double damping{};
+    double enhancement{};
+};
+
+class Riof3D {
+public:
+    explicit Riof3D(Riof3DConfig config)
+        : config_(config),
+          field_(checked_volume(config.edge), 0.0),
+          momentum_(field_.size(), 0.0),
+          adjoint_(field_.size(), 0.0),
+          memory_(field_.size(), 0.0),
+          residual_(field_.size(), 0.0),
+          laplacian_(field_.size(), 0.0),
+          bilaplacian_(field_.size(), 0.0),
+          force_(field_.size(), 0.0) {
+        config_.validate();
+    }
+
+    const Riof3DConfig& config() const noexcept { return config_; }
+    const std::vector<double>& field() const noexcept { return field_; }
+    const std::vector<double>& momentum() const noexcept { return momentum_; }
+    const std::vector<double>& adjoint() const noexcept { return adjoint_; }
+    const std::vector<double>& memory() const noexcept { return memory_; }
+    std::uint64_t steps() const noexcept { return step_; }
+
+    void initialize(const std::string& pattern = "sphere") {
+        const double n = static_cast<double>(config_.edge);
+        const double center = 0.5 * (n - 1.0);
+        for (std::size_t z = 0; z < config_.edge; ++z) {
+            for (std::size_t y = 0; y < config_.edge; ++y) {
+                for (std::size_t x = 0; x < config_.edge; ++x) {
+                    const double dx = (static_cast<double>(x) - center) / n;
+                    const double dy = (static_cast<double>(y) - center) / n;
+                    const double dz = (static_cast<double>(z) - center) / n;
+                    const double radius = std::sqrt(dx * dx + dy * dy + dz * dz);
+                    double value = 0.0;
+                    if (pattern == "sphere") {
+                        value = std::tanh((0.28 - radius) * 12.0);
+                    } else if (pattern == "shell") {
+                        value = std::exp(-180.0 * (radius - 0.27) * (radius - 0.27)) * 2.0 - 1.0;
+                    } else if (pattern == "wave") {
+                        value = 0.55 * std::sin(12.0 * dx) * std::cos(10.0 * dy) * std::sin(8.0 * dz);
+                    } else if (pattern == "noise") {
+                        value = signed_noise(index(x, y, z), 0U);
+                    } else {
+                        throw std::invalid_argument("unknown RIOF pattern: " + pattern);
+                    }
+                    field_[index(x, y, z)] = value;
+                }
+            }
+        }
+        std::fill(momentum_.begin(), momentum_.end(), 0.0);
+        std::fill(adjoint_.begin(), adjoint_.end(), 0.0);
+        std::fill(memory_.begin(), memory_.end(), 0.0);
+        std::fill(residual_.begin(), residual_.end(), 0.0);
+        step_ = 0U;
+        last_timestep_ = config_.max_timestep;
+        update_geometry();
+        solve_adjoint();
+    }
+
+    Riof3DMetrics step() {
+        update_geometry();
+        solve_adjoint();
+        const Dynamics first = compute_force();
+        const double dt = adaptive_timestep(first.max_force);
+
+        for (std::size_t i = 0; i < field_.size(); ++i) {
+            momentum_[i] += 0.5 * dt * force_[i];
+            field_[i] += dt * momentum_[i];
+            project(field_[i], momentum_[i]);
+        }
+
+        update_geometry();
+        solve_adjoint();
+        const Dynamics second = compute_force();
+        for (std::size_t i = 0; i < field_.size(); ++i) {
+            momentum_[i] += 0.5 * dt * force_[i];
+            project(field_[i], momentum_[i]);
+            memory_[i] = 0.97 * memory_[i] + 0.03 * residual_[i];
+        }
+
+        ++step_;
+        last_timestep_ = dt;
+        last_damping_ = second.damping;
+        last_enhancement_ = second.enhancement;
+        return metrics();
+    }
+
+    Riof3DMetrics metrics() {
+        update_geometry();
+        double gradient_sum = 0.0;
+        double bending_sum = 0.0;
+        double prediction_sum = 0.0;
+        double kinetic_sum = 0.0;
+        double residual_sum = 0.0;
+        double max_abs = 0.0;
+
+        for (std::size_t z = 0; z < config_.edge; ++z) {
+            for (std::size_t y = 0; y < config_.edge; ++y) {
+                for (std::size_t x = 0; x < config_.edge; ++x) {
+                    const std::size_t i = index(x, y, z);
+                    const double dx = field_[index(wrap_plus(x), y, z)] - field_[i];
+                    const double dy = field_[index(x, wrap_plus(y), z)] - field_[i];
+                    const double dz = field_[index(x, y, wrap_plus(z))] - field_[i];
+                    gradient_sum += dx * dx + dy * dy + dz * dz;
+                    bending_sum += laplacian_[i] * laplacian_[i];
+                    prediction_sum += residual_[i] * residual_[i];
+                    kinetic_sum += momentum_[i] * momentum_[i];
+                    residual_sum += std::abs(residual_[i]);
+                    max_abs = std::max(max_abs, std::abs(field_[i]));
+                }
+            }
+        }
+
+        const double inv = 1.0 / static_cast<double>(field_.size());
+        Riof3DMetrics result;
+        result.step = step_;
+        result.gradient_energy = 0.5 * config_.smoothness_weight * gradient_sum * inv;
+        result.bending_energy = 0.5 * config_.bending_weight * bending_sum * inv;
+        result.prediction_energy = 0.5 * config_.prediction_weight * prediction_sum * inv;
+        result.kinetic_energy = 0.5 * kinetic_sum * inv;
+        result.total_energy = result.gradient_energy + result.bending_energy +
+                              result.prediction_energy + result.kinetic_energy;
+        result.mean_abs_residual = residual_sum * inv;
+        result.max_abs_value = max_abs;
+        result.timestep = last_timestep_;
+        result.damping = last_damping_;
+        result.enhancement = last_enhancement_;
+        return result;
+    }
+
+private:
+    struct Dynamics {
+        double max_force{};
+        double damping{};
+        double enhancement{};
+    };
+
+    Riof3DConfig config_;
+    std::vector<double> field_;
+    std::vector<double> momentum_;
+    std::vector<double> adjoint_;
+    std::vector<double> memory_;
+    std::vector<double> residual_;
+    std::vector<double> laplacian_;
+    std::vector<double> bilaplacian_;
+    std::vector<double> force_;
+    std::uint64_t step_{0U};
+    double last_timestep_{0.0};
+    double last_damping_{0.0};
+    double last_enhancement_{0.0};
+
+    static std::size_t checked_volume(std::size_t edge) {
+        if (edge == 0U) return 0U;
+        const std::size_t max = std::numeric_limits<std::size_t>::max();
+        if (edge > max / edge || edge * edge > max / edge) {
+            throw std::overflow_error("RIOF volume size overflow");
+        }
+        return edge * edge * edge;
+    }
+
+    std::size_t index(std::size_t x, std::size_t y, std::size_t z) const noexcept {
+        return x + config_.edge * (y + config_.edge * z);
+    }
+
+    std::size_t wrap_plus(std::size_t value) const noexcept {
+        return (value + 1U == config_.edge) ? 0U : value + 1U;
+    }
+
+    std::size_t wrap_minus(std::size_t value) const noexcept {
+        return (value == 0U) ? config_.edge - 1U : value - 1U;
+    }
+
+    double neighbor_mean(const std::vector<double>& values,
+                         std::size_t x, std::size_t y, std::size_t z) const noexcept {
+        return (values[index(wrap_plus(x), y, z)] +
+                values[index(wrap_minus(x), y, z)] +
+                values[index(x, wrap_plus(y), z)] +
+                values[index(x, wrap_minus(y), z)] +
+                values[index(x, y, wrap_plus(z))] +
+                values[index(x, y, wrap_minus(z))]) / 6.0;
+    }
+
+    double laplacian_at(const std::vector<double>& values,
+                        std::size_t x, std::size_t y, std::size_t z) const noexcept {
+        const std::size_t i = index(x, y, z);
+        return 6.0 * (neighbor_mean(values, x, y, z) - values[i]);
+    }
+
+    void update_geometry() {
+        for (std::size_t z = 0; z < config_.edge; ++z) {
+            for (std::size_t y = 0; y < config_.edge; ++y) {
+                for (std::size_t x = 0; x < config_.edge; ++x) {
+                    const std::size_t i = index(x, y, z);
+                    const double prediction = neighbor_mean(field_, x, y, z);
+                    residual_[i] = field_[i] - prediction;
+                    laplacian_[i] = laplacian_at(field_, x, y, z);
+                }
+            }
+        }
+        for (std::size_t z = 0; z < config_.edge; ++z) {
+            for (std::size_t y = 0; y < config_.edge; ++y) {
+                for (std::size_t x = 0; x < config_.edge; ++x) {
+                    bilaplacian_[index(x, y, z)] = laplacian_at(laplacian_, x, y, z);
+                }
+            }
+        }
+    }
+
+    void solve_adjoint() {
+        std::vector<double> next(adjoint_.size(), 0.0);
+        for (std::size_t iteration = 0; iteration < config_.adjoint_iterations; ++iteration) {
+            for (std::size_t z = 0; z < config_.edge; ++z) {
+                for (std::size_t y = 0; y < config_.edge; ++y) {
+                    for (std::size_t x = 0; x < config_.edge; ++x) {
+                        const std::size_t i = index(x, y, z);
+                        next[i] = neighbor_mean(adjoint_, x, y, z) - residual_[i] / 6.0;
+                    }
+                }
+            }
+            adjoint_.swap(next);
+        }
+        double mean = 0.0;
+        for (double value : adjoint_) mean += value;
+        mean /= static_cast<double>(adjoint_.size());
+        for (double& value : adjoint_) value -= mean;
+    }
+
+    Dynamics compute_force() {
+        double residual_mean = 0.0;
+        double curvature_mean = 0.0;
+        for (std::size_t i = 0; i < field_.size(); ++i) {
+            residual_mean += std::abs(residual_[i]);
+            curvature_mean += std::abs(laplacian_[i]);
+        }
+        const double inv = 1.0 / static_cast<double>(field_.size());
+        residual_mean *= inv;
+        curvature_mean *= inv;
+
+        const double disagreement = residual_mean / (curvature_mean + 1.0e-9);
+        const double enhancement = config_.enhancement_gain *
+            std::clamp(disagreement, 0.0, 2.0);
+        const double damping = config_.base_damping *
+            (1.0 + std::clamp(residual_mean, 0.0, 2.0));
+
+        double max_force = 0.0;
+        for (std::size_t i = 0; i < field_.size(); ++i) {
+            const double curvature_scale = std::abs(laplacian_[i]) /
+                (curvature_mean + 1.0e-9);
+            const double high_frequency = signed_noise(i, step_ + 1U) *
+                std::clamp(curvature_scale, 0.0, 3.0);
+            const double conservative =
+                config_.smoothness_weight * laplacian_[i] -
+                config_.bending_weight * bilaplacian_[i] -
+                config_.prediction_weight * residual_[i];
+            const double refinement = -config_.refinement_gain * adjoint_[i];
+            const double history = -config_.memory_gain * memory_[i];
+            const double spectral_surrogate = enhancement * high_frequency;
+            force_[i] = conservative + refinement + history +
+                        spectral_surrogate - damping * momentum_[i];
+            max_force = std::max(max_force, std::abs(force_[i]));
+        }
+        return Dynamics{max_force, damping, enhancement};
+    }
+
+    double adaptive_timestep(double max_force) const noexcept {
+        double max_momentum = 0.0;
+        for (double value : momentum_) max_momentum = std::max(max_momentum, std::abs(value));
+        const double scale = 1.0 + std::sqrt(std::max(0.0, max_force)) + max_momentum;
+        return std::clamp(config_.cfl / scale, config_.min_timestep, config_.max_timestep);
+    }
+
+    void project(double& value, double& momentum) const noexcept {
+        value = std::clamp(value, -config_.projection_limit, config_.projection_limit);
+        const double momentum_limit = 4.0 * config_.projection_limit;
+        momentum = std::clamp(momentum, -momentum_limit, momentum_limit);
+    }
+
+    double signed_noise(std::size_t cell, std::uint64_t epoch) const noexcept {
+        std::uint64_t x = config_.seed;
+        x ^= static_cast<std::uint64_t>(cell) + 0x9E3779B97F4A7C15ULL + (x << 6U) + (x >> 2U);
+        x ^= epoch + 0xBF58476D1CE4E5B9ULL + (x << 6U) + (x >> 2U);
+        x ^= x >> 30U;
+        x *= 0xBF58476D1CE4E5B9ULL;
+        x ^= x >> 27U;
+        x *= 0x94D049BB133111EBULL;
+        x ^= x >> 31U;
+        const double unit = static_cast<double>(x >> 11U) * (1.0 / 9007199254740992.0);
+        return unit * 2.0 - 1.0;
+    }
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/riof_permeation.hpp
+++ b/cpp_runtime/include/jarvisx/riof_permeation.hpp
@@ -1,0 +1,385 @@
+#pragma once
+
+#include "jarvisx/autoencoder3d.hpp"
+#include "jarvisx/riof3d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+
+namespace jarvisx {
+
+struct RiofPermeationConfig {
+    std::size_t cycles{4U};
+    Riof3DConfig dynamics{};
+
+    void validate() const {
+        if (cycles > 4096U) {
+            throw std::invalid_argument("RIOF permeation cycles must be <= 4096");
+        }
+        if (dynamics.edge < 4U || dynamics.edge > 128U) {
+            throw std::invalid_argument("RIOF permeation edge must be in [4, 128]");
+        }
+        if (dynamics.adjoint_iterations == 0U || dynamics.adjoint_iterations > 256U) {
+            throw std::invalid_argument("RIOF permeation adjoint iterations must be in [1, 256]");
+        }
+        const double scalars[] = {
+            dynamics.smoothness_weight, dynamics.bending_weight,
+            dynamics.prediction_weight, dynamics.refinement_gain,
+            dynamics.enhancement_gain, dynamics.memory_gain,
+            dynamics.base_damping, dynamics.cfl, dynamics.min_timestep,
+            dynamics.max_timestep, dynamics.projection_limit
+        };
+        for (double value : scalars) {
+            if (!std::isfinite(value) || value < 0.0) {
+                throw std::invalid_argument("RIOF permeation parameters must be finite and non-negative");
+            }
+        }
+        if (dynamics.cfl <= 0.0 || dynamics.min_timestep <= 0.0 ||
+            dynamics.max_timestep <= 0.0 ||
+            dynamics.min_timestep > dynamics.max_timestep) {
+            throw std::invalid_argument("RIOF permeation timestep bounds are invalid");
+        }
+        if (dynamics.projection_limit <= 0.0 || dynamics.projection_limit > 100.0) {
+            throw std::invalid_argument("RIOF permeation projection limit must be in (0, 100]");
+        }
+    }
+};
+
+struct RiofPermeationMetrics {
+    std::size_t cycles{};
+    double initial_mean_abs_residual{};
+    double final_mean_abs_residual{};
+    double mean_abs_delta{};
+    double max_abs_delta{};
+    double last_timestep{};
+    double last_damping{};
+    double last_enhancement{};
+};
+
+struct RiofPermeationResult {
+    Tensor4D latent;
+    RiofPermeationMetrics metrics;
+};
+
+struct RiofAutoencodingResult {
+    Tensor4D latent;
+    Tensor4D reconstruction;
+    RiofPermeationMetrics metrics;
+};
+
+class RiofLatentPermeator {
+public:
+    explicit RiofLatentPermeator(RiofPermeationConfig config)
+        : config_(config) {
+        config_.validate();
+    }
+
+    const RiofPermeationConfig& config() const noexcept { return config_; }
+
+    RiofPermeationResult permeate(const Tensor4D& latent) const {
+        validate_latent(latent);
+        Tensor4D state = latent;
+        Tensor4D velocity(latent.shape(), 0.0F);
+        Tensor4D memory(latent.shape(), 0.0F);
+        Tensor4D residual(latent.shape(), 0.0F);
+        Tensor4D laplacian(latent.shape(), 0.0F);
+        Tensor4D bilaplacian(latent.shape(), 0.0F);
+        Tensor4D adjoint(latent.shape(), 0.0F);
+        Tensor4D force(latent.shape(), 0.0F);
+
+        RiofPermeationMetrics metrics;
+        metrics.cycles = config_.cycles;
+        update_geometry(state, residual, laplacian, bilaplacian);
+        metrics.initial_mean_abs_residual = mean_abs(residual);
+
+        for (std::size_t cycle = 0; cycle < config_.cycles; ++cycle) {
+            update_geometry(state, residual, laplacian, bilaplacian);
+            solve_adjoint(residual, adjoint);
+            const Control first = compute_force(
+                velocity, memory, residual, laplacian,
+                bilaplacian, adjoint, force, cycle);
+            const double dt = adaptive_timestep(first.max_force, velocity);
+
+            integrate_half_step(state, velocity, force, dt, true);
+
+            update_geometry(state, residual, laplacian, bilaplacian);
+            solve_adjoint(residual, adjoint);
+            const Control second = compute_force(
+                velocity, memory, residual, laplacian,
+                bilaplacian, adjoint, force, cycle + 1U);
+            integrate_half_step(state, velocity, force, dt, false);
+            update_memory(memory, residual);
+
+            metrics.last_timestep = dt;
+            metrics.last_damping = second.damping;
+            metrics.last_enhancement = second.enhancement;
+        }
+
+        update_geometry(state, residual, laplacian, bilaplacian);
+        metrics.final_mean_abs_residual = mean_abs(residual);
+        measure_delta(latent, state, metrics);
+        return RiofPermeationResult{state, metrics};
+    }
+
+private:
+    struct Control {
+        double max_force{};
+        double damping{};
+        double enhancement{};
+    };
+
+    RiofPermeationConfig config_;
+
+    static std::size_t wrap_plus(std::size_t value, std::size_t edge) noexcept {
+        return value + 1U == edge ? 0U : value + 1U;
+    }
+
+    static std::size_t wrap_minus(std::size_t value, std::size_t edge) noexcept {
+        return value == 0U ? edge - 1U : value - 1U;
+    }
+
+    void validate_latent(const Tensor4D& latent) const {
+        const TensorShape4D& shape = latent.shape();
+        if (shape.channels == 0U || shape.depth != shape.height ||
+            shape.depth != shape.width) {
+            throw std::invalid_argument("RIOF permeation requires non-empty cubic latent channels");
+        }
+        if (shape.width != config_.dynamics.edge) {
+            throw std::invalid_argument("RIOF permeation edge must match latent spatial edge");
+        }
+    }
+
+    static double neighbor_mean(const Tensor4D& field, std::size_t channel,
+                                std::size_t z, std::size_t y, std::size_t x) {
+        const std::size_t edge = field.shape().width;
+        return (static_cast<double>(field(channel, z, y, wrap_plus(x, edge))) +
+                static_cast<double>(field(channel, z, y, wrap_minus(x, edge))) +
+                static_cast<double>(field(channel, z, wrap_plus(y, edge), x)) +
+                static_cast<double>(field(channel, z, wrap_minus(y, edge), x)) +
+                static_cast<double>(field(channel, wrap_plus(z, edge), y, x)) +
+                static_cast<double>(field(channel, wrap_minus(z, edge), y, x))) / 6.0;
+    }
+
+    static double laplacian_at(const Tensor4D& field, std::size_t channel,
+                               std::size_t z, std::size_t y, std::size_t x) {
+        const double center = static_cast<double>(field(channel, z, y, x));
+        return 6.0 * (neighbor_mean(field, channel, z, y, x) - center);
+    }
+
+    static void update_geometry(const Tensor4D& state, Tensor4D& residual,
+                                Tensor4D& laplacian, Tensor4D& bilaplacian) {
+        const TensorShape4D& shape = state.shape();
+        for (std::size_t c = 0; c < shape.channels; ++c) {
+            for (std::size_t z = 0; z < shape.depth; ++z) {
+                for (std::size_t y = 0; y < shape.height; ++y) {
+                    for (std::size_t x = 0; x < shape.width; ++x) {
+                        const double center = static_cast<double>(state(c, z, y, x));
+                        const double prediction = neighbor_mean(state, c, z, y, x);
+                        residual(c, z, y, x) = static_cast<float>(center - prediction);
+                        laplacian(c, z, y, x) = static_cast<float>(
+                            6.0 * (prediction - center));
+                    }
+                }
+            }
+        }
+        for (std::size_t c = 0; c < shape.channels; ++c) {
+            for (std::size_t z = 0; z < shape.depth; ++z) {
+                for (std::size_t y = 0; y < shape.height; ++y) {
+                    for (std::size_t x = 0; x < shape.width; ++x) {
+                        bilaplacian(c, z, y, x) = static_cast<float>(
+                            laplacian_at(laplacian, c, z, y, x));
+                    }
+                }
+            }
+        }
+    }
+
+    void solve_adjoint(const Tensor4D& residual, Tensor4D& adjoint) const {
+        Tensor4D next(adjoint.shape(), 0.0F);
+        const TensorShape4D& shape = adjoint.shape();
+        for (std::size_t iteration = 0;
+             iteration < config_.dynamics.adjoint_iterations; ++iteration) {
+            for (std::size_t c = 0; c < shape.channels; ++c) {
+                for (std::size_t z = 0; z < shape.depth; ++z) {
+                    for (std::size_t y = 0; y < shape.height; ++y) {
+                        for (std::size_t x = 0; x < shape.width; ++x) {
+                            const double relaxed = neighbor_mean(adjoint, c, z, y, x) -
+                                static_cast<double>(residual(c, z, y, x)) / 6.0;
+                            next(c, z, y, x) = static_cast<float>(relaxed);
+                        }
+                    }
+                }
+            }
+            adjoint = next;
+        }
+
+        for (std::size_t c = 0; c < shape.channels; ++c) {
+            double mean = 0.0;
+            for (std::size_t z = 0; z < shape.depth; ++z)
+                for (std::size_t y = 0; y < shape.height; ++y)
+                    for (std::size_t x = 0; x < shape.width; ++x)
+                        mean += static_cast<double>(adjoint(c, z, y, x));
+            const double count = static_cast<double>(shape.depth * shape.height * shape.width);
+            mean /= count;
+            for (std::size_t z = 0; z < shape.depth; ++z)
+                for (std::size_t y = 0; y < shape.height; ++y)
+                    for (std::size_t x = 0; x < shape.width; ++x)
+                        adjoint(c, z, y, x) = static_cast<float>(
+                            static_cast<double>(adjoint(c, z, y, x)) - mean);
+        }
+    }
+
+    Control compute_force(const Tensor4D& velocity,
+                          const Tensor4D& memory, const Tensor4D& residual,
+                          const Tensor4D& laplacian, const Tensor4D& bilaplacian,
+                          const Tensor4D& adjoint, Tensor4D& force,
+                          std::size_t epoch) const {
+        const double residual_mean = mean_abs(residual);
+        const double curvature_mean = mean_abs(laplacian);
+        const double disagreement = residual_mean / (curvature_mean + 1.0e-9);
+        const double enhancement = config_.dynamics.enhancement_gain *
+            std::clamp(disagreement, 0.0, 2.0);
+        const double damping = config_.dynamics.base_damping *
+            (1.0 + std::clamp(residual_mean, 0.0, 2.0));
+
+        const TensorShape4D& shape = force.shape();
+        double max_force = 0.0;
+        for (std::size_t c = 0; c < shape.channels; ++c) {
+            for (std::size_t z = 0; z < shape.depth; ++z) {
+                for (std::size_t y = 0; y < shape.height; ++y) {
+                    for (std::size_t x = 0; x < shape.width; ++x) {
+                        const double curvature = std::abs(
+                            static_cast<double>(laplacian(c, z, y, x)));
+                        const double curvature_scale = curvature /
+                            (curvature_mean + 1.0e-9);
+                        const double high_frequency = signed_noise(c, z, y, x, epoch) *
+                            std::clamp(curvature_scale, 0.0, 3.0);
+                        const double value =
+                            config_.dynamics.smoothness_weight *
+                                static_cast<double>(laplacian(c, z, y, x)) -
+                            config_.dynamics.bending_weight *
+                                static_cast<double>(bilaplacian(c, z, y, x)) -
+                            config_.dynamics.prediction_weight *
+                                static_cast<double>(residual(c, z, y, x)) -
+                            config_.dynamics.refinement_gain *
+                                static_cast<double>(adjoint(c, z, y, x)) -
+                            config_.dynamics.memory_gain *
+                                static_cast<double>(memory(c, z, y, x)) +
+                            enhancement * high_frequency -
+                            damping * static_cast<double>(velocity(c, z, y, x));
+                        force(c, z, y, x) = static_cast<float>(value);
+                        max_force = std::max(max_force, std::abs(value));
+                    }
+                }
+            }
+        }
+        return Control{max_force, damping, enhancement};
+    }
+
+    double adaptive_timestep(double max_force, const Tensor4D& velocity) const {
+        double max_velocity = 0.0;
+        for (float value : velocity.values()) {
+            max_velocity = std::max(max_velocity, std::abs(static_cast<double>(value)));
+        }
+        const double scale = 1.0 + std::sqrt(std::max(0.0, max_force)) + max_velocity;
+        return std::clamp(config_.dynamics.cfl / scale,
+                          config_.dynamics.min_timestep,
+                          config_.dynamics.max_timestep);
+    }
+
+    void integrate_half_step(Tensor4D& state, Tensor4D& velocity,
+                             const Tensor4D& force, double dt,
+                             bool advance_position) const {
+        const TensorShape4D& shape = state.shape();
+        const double value_limit = config_.dynamics.projection_limit;
+        const double velocity_limit = 4.0 * value_limit;
+        for (std::size_t c = 0; c < shape.channels; ++c) {
+            for (std::size_t z = 0; z < shape.depth; ++z) {
+                for (std::size_t y = 0; y < shape.height; ++y) {
+                    for (std::size_t x = 0; x < shape.width; ++x) {
+                        double v = static_cast<double>(velocity(c, z, y, x)) +
+                            0.5 * dt * static_cast<double>(force(c, z, y, x));
+                        v = std::clamp(v, -velocity_limit, velocity_limit);
+                        double q = static_cast<double>(state(c, z, y, x));
+                        if (advance_position) q += dt * v;
+                        q = std::clamp(q, -value_limit, value_limit);
+                        velocity(c, z, y, x) = static_cast<float>(v);
+                        state(c, z, y, x) = static_cast<float>(q);
+                    }
+                }
+            }
+        }
+    }
+
+    static void update_memory(Tensor4D& memory, const Tensor4D& residual) {
+        const TensorShape4D& shape = memory.shape();
+        for (std::size_t c = 0; c < shape.channels; ++c)
+            for (std::size_t z = 0; z < shape.depth; ++z)
+                for (std::size_t y = 0; y < shape.height; ++y)
+                    for (std::size_t x = 0; x < shape.width; ++x)
+                        memory(c, z, y, x) = static_cast<float>(
+                            0.97 * static_cast<double>(memory(c, z, y, x)) +
+                            0.03 * static_cast<double>(residual(c, z, y, x)));
+    }
+
+    static double mean_abs(const Tensor4D& field) {
+        if (field.size() == 0U) return 0.0;
+        double sum = 0.0;
+        for (float value : field.values()) sum += std::abs(static_cast<double>(value));
+        return sum / static_cast<double>(field.size());
+    }
+
+    static void measure_delta(const Tensor4D& before, const Tensor4D& after,
+                              RiofPermeationMetrics& metrics) {
+        double sum = 0.0;
+        double max_delta = 0.0;
+        for (std::size_t i = 0; i < before.size(); ++i) {
+            const double delta = std::abs(
+                static_cast<double>(after.values().at(i)) -
+                static_cast<double>(before.values().at(i)));
+            sum += delta;
+            max_delta = std::max(max_delta, delta);
+        }
+        metrics.mean_abs_delta = before.size() == 0U ? 0.0 :
+            sum / static_cast<double>(before.size());
+        metrics.max_abs_delta = max_delta;
+    }
+
+    double signed_noise(std::size_t channel, std::size_t z,
+                        std::size_t y, std::size_t x,
+                        std::size_t epoch) const noexcept {
+        const std::size_t edge = config_.dynamics.edge;
+        const std::size_t cell = x + edge * (y + edge * (z + edge * channel));
+        std::uint64_t hash = config_.dynamics.seed;
+        hash ^= static_cast<std::uint64_t>(cell) + 0x9E3779B97F4A7C15ULL +
+                (hash << 6U) + (hash >> 2U);
+        hash ^= static_cast<std::uint64_t>(epoch) + 0xBF58476D1CE4E5B9ULL +
+                (hash << 6U) + (hash >> 2U);
+        hash ^= hash >> 30U;
+        hash *= 0xBF58476D1CE4E5B9ULL;
+        hash ^= hash >> 27U;
+        hash *= 0x94D049BB133111EBULL;
+        hash ^= hash >> 31U;
+        const double unit = static_cast<double>(hash >> 11U) *
+            (1.0 / 9007199254740992.0);
+        return unit * 2.0 - 1.0;
+    }
+};
+
+inline RiofAutoencodingResult reconstruct_with_riof(
+    const Autoencoder3D& model, const Tensor4D& input,
+    RiofPermeationConfig config, bool quantize = false) {
+    Tensor4D latent = model.encode(input, quantize);
+    config.dynamics.edge = latent.shape().width;
+    RiofLatentPermeator permeator(config);
+    RiofPermeationResult refined = permeator.permeate(latent);
+    Tensor4D reconstruction = model.decode(refined.latent);
+    return RiofAutoencodingResult{
+        refined.latent, reconstruction, refined.metrics
+    };
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/src/riof3d_main.cpp
+++ b/cpp_runtime/src/riof3d_main.cpp
@@ -1,0 +1,99 @@
+#include "jarvisx/riof3d.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+std::size_t parse_size(const char* text, const char* name) {
+    try {
+        const unsigned long long value = std::stoull(text);
+        if (value == 0ULL) throw std::invalid_argument("zero");
+        return static_cast<std::size_t>(value);
+    } catch (...) {
+        throw std::invalid_argument(std::string("invalid ") + name + ": " + text);
+    }
+}
+
+std::uint64_t parse_u64(const char* text, const char* name) {
+    try {
+        return static_cast<std::uint64_t>(std::stoull(text));
+    } catch (...) {
+        throw std::invalid_argument(std::string("invalid ") + name + ": " + text);
+    }
+}
+
+void print_usage() {
+    std::cout << "jarvisx-riof3d [--cycles N] [--edge N] [--pattern sphere|shell|wave|noise] "
+                 "[--seed N] [--quiet]\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        jarvisx::Riof3DConfig config;
+        std::size_t cycles = 64U;
+        std::string pattern = "sphere";
+        bool quiet = false;
+
+        for (int i = 1; i < argc; ++i) {
+            const std::string arg = argv[i];
+            if (arg == "--cycles" && i + 1 < argc) {
+                cycles = parse_size(argv[++i], "cycle count");
+            } else if (arg == "--edge" && i + 1 < argc) {
+                config.edge = parse_size(argv[++i], "edge");
+            } else if (arg == "--pattern" && i + 1 < argc) {
+                pattern = argv[++i];
+            } else if (arg == "--seed" && i + 1 < argc) {
+                config.seed = parse_u64(argv[++i], "seed");
+            } else if (arg == "--quiet") {
+                quiet = true;
+            } else if (arg == "--help" || arg == "-h") {
+                print_usage();
+                return 0;
+            } else {
+                throw std::invalid_argument("unknown or incomplete argument: " + arg);
+            }
+        }
+
+        jarvisx::Riof3D engine(config);
+        engine.initialize(pattern);
+        const jarvisx::Riof3DMetrics initial = engine.metrics();
+
+        if (!quiet) {
+            std::cout << "Jarvis X RIOF-3D | edge=" << config.edge
+                      << " | voxels=" << engine.field().size()
+                      << " | pattern=" << pattern << '\n';
+            std::cout << "step,total_energy,residual,dt,damping,enhancement,max_abs\n";
+            std::cout << std::setprecision(9) << initial.step << ',' << initial.total_energy
+                      << ',' << initial.mean_abs_residual << ',' << initial.timestep
+                      << ',' << initial.damping << ',' << initial.enhancement
+                      << ',' << initial.max_abs_value << '\n';
+        }
+
+        jarvisx::Riof3DMetrics current = initial;
+        for (std::size_t cycle = 0; cycle < cycles; ++cycle) {
+            current = engine.step();
+            if (!quiet && (cycle + 1U == cycles || (cycle + 1U) % 8U == 0U)) {
+                std::cout << current.step << ',' << current.total_energy
+                          << ',' << current.mean_abs_residual << ',' << current.timestep
+                          << ',' << current.damping << ',' << current.enhancement
+                          << ',' << current.max_abs_value << '\n';
+            }
+        }
+
+        if (!std::isfinite(current.total_energy) || !std::isfinite(current.max_abs_value)) {
+            std::cerr << "RIOF-3D became non-finite\n";
+            return 2;
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RIOF-3D error: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/riof3d_tests.cpp
+++ b/cpp_runtime/tests/riof3d_tests.cpp
@@ -1,0 +1,90 @@
+#include "jarvisx/riof3d.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void deterministic_replay() {
+    jarvisx::Riof3DConfig config;
+    config.edge = 8U;
+    config.seed = 42U;
+    jarvisx::Riof3D first(config);
+    jarvisx::Riof3D second(config);
+    first.initialize("wave");
+    second.initialize("wave");
+    for (std::size_t i = 0; i < 12U; ++i) {
+        first.step();
+        second.step();
+    }
+    require(first.field() == second.field(), "same seed and state must replay bit-identically");
+    require(first.momentum() == second.momentum(), "momentum replay must be deterministic");
+}
+
+void projection_and_finiteness() {
+    jarvisx::Riof3DConfig config;
+    config.edge = 8U;
+    config.seed = 99U;
+    jarvisx::Riof3D engine(config);
+    engine.initialize("noise");
+    for (std::size_t i = 0; i < 80U; ++i) {
+        const auto metrics = engine.step();
+        require(std::isfinite(metrics.total_energy), "RIOF energy must remain finite");
+        require(std::isfinite(metrics.mean_abs_residual), "RIOF residual must remain finite");
+        require(metrics.timestep >= config.min_timestep && metrics.timestep <= config.max_timestep,
+                "intrinsic timestep must remain inside stability bounds");
+        require(metrics.max_abs_value <= config.projection_limit + 1.0e-12,
+                "Lambda projection must bound the volumetric field");
+    }
+}
+
+void damped_objective_relaxes() {
+    jarvisx::Riof3DConfig config;
+    config.edge = 10U;
+    config.seed = 7U;
+    config.enhancement_gain = 0.0;
+    config.refinement_gain = 0.0;
+    config.memory_gain = 0.0;
+    config.base_damping = 0.35;
+    jarvisx::Riof3D engine(config);
+    engine.initialize("wave");
+    const double before = engine.metrics().total_energy;
+    for (std::size_t i = 0; i < 160U; ++i) engine.step();
+    const double after = engine.metrics().total_energy;
+    require(after < before, "damped conservative RIOF must reduce total objective energy");
+}
+
+void intrinsic_controls_respond() {
+    jarvisx::Riof3DConfig config;
+    config.edge = 8U;
+    config.seed = 123U;
+    jarvisx::Riof3D engine(config);
+    engine.initialize("noise");
+    const auto metrics = engine.step();
+    require(metrics.damping >= config.base_damping,
+            "damping must be derived from volumetric disagreement");
+    require(metrics.enhancement >= 0.0 &&
+            metrics.enhancement <= config.enhancement_gain * 2.0 + 1.0e-12,
+            "enhancement must be self-bounded by local disagreement");
+}
+
+} // namespace
+
+int main() {
+    try {
+        deterministic_replay();
+        projection_and_finiteness();
+        damped_objective_relaxes();
+        intrinsic_controls_respond();
+        std::cout << "RIOF-3D tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RIOF-3D test failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/riof_permeation_tests.cpp
+++ b/cpp_runtime/tests/riof_permeation_tests.cpp
@@ -1,0 +1,107 @@
+#include "jarvisx/riof_permeation.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+jarvisx::RiofPermeationConfig config_for(const jarvisx::Tensor4D& latent,
+                                         std::size_t cycles = 4U) {
+    jarvisx::RiofPermeationConfig config;
+    config.cycles = cycles;
+    config.dynamics.edge = latent.shape().width;
+    config.dynamics.seed = 42U;
+    config.dynamics.projection_limit = 1.25;
+    return config;
+}
+
+void deterministic_replay() {
+    jarvisx::Autoencoder3D model({8U, 3U, 0.02F, 1.0e-4F, 1.0F, 42U});
+    const auto input = jarvisx::make_volume(8U, "sphere", 42U);
+    const auto latent = model.encode(input);
+    const auto config = config_for(latent, 6U);
+
+    const auto first = jarvisx::RiofLatentPermeator(config).permeate(latent);
+    const auto second = jarvisx::RiofLatentPermeator(config).permeate(latent);
+
+    require(first.latent.values() == second.latent.values(),
+            "same latent/config must replay exactly");
+    require(first.metrics.mean_abs_delta == second.metrics.mean_abs_delta,
+            "permeation metrics must replay exactly");
+}
+
+void zero_cycles_are_identity() {
+    jarvisx::Autoencoder3D model({8U, 2U, 0.02F, 0.0F, 1.0F, 9U});
+    const auto input = jarvisx::make_volume(8U, "wave", 9U);
+    const auto latent = model.encode(input);
+    const auto result = jarvisx::RiofLatentPermeator(
+        config_for(latent, 0U)).permeate(latent);
+
+    require(result.latent.values() == latent.values(),
+            "zero-cycle permeation must be an exact identity");
+    require(result.metrics.mean_abs_delta == 0.0,
+            "zero-cycle permeation delta must be zero");
+}
+
+void projection_and_shape_are_preserved() {
+    jarvisx::Autoencoder3D model({8U, 4U, 0.02F, 1.0e-4F, 1.0F, 17U});
+    const auto input = jarvisx::make_volume(8U, "shell", 17U);
+    const auto latent = model.encode(input);
+    const auto config = config_for(latent, 8U);
+    const auto result = jarvisx::RiofLatentPermeator(config).permeate(latent);
+
+    require(result.latent.shape().channels == latent.shape().channels,
+            "permeation must preserve channel count");
+    require(result.latent.shape().depth == latent.shape().depth &&
+            result.latent.shape().height == latent.shape().height &&
+            result.latent.shape().width == latent.shape().width,
+            "permeation must preserve spatial shape");
+
+    for (float value : result.latent.values()) {
+        require(std::isfinite(value), "permeated latent must remain finite");
+        require(std::abs(static_cast<double>(value)) <=
+                    config.dynamics.projection_limit + 1.0e-6,
+                "Lambda projection must bound the latent field");
+    }
+    require(result.metrics.mean_abs_delta > 0.0,
+            "non-zero permeation cycles must evolve the latent field");
+}
+
+void autoencoder_bridge_decodes() {
+    jarvisx::Autoencoder3D model({8U, 3U, 0.02F, 1.0e-4F, 1.0F, 123U});
+    const auto input = jarvisx::make_volume(8U, "sphere", 123U);
+    jarvisx::RiofPermeationConfig config;
+    config.cycles = 3U;
+    config.dynamics.seed = 123U;
+
+    const auto result = jarvisx::reconstruct_with_riof(model, input, config);
+
+    require(result.reconstruction.shape().channels == input.shape().channels &&
+            result.reconstruction.shape().depth == input.shape().depth &&
+            result.reconstruction.shape().height == input.shape().height &&
+            result.reconstruction.shape().width == input.shape().width,
+            "RIOF bridge reconstruction must match input shape");
+    require(std::isfinite(result.metrics.final_mean_abs_residual),
+            "RIOF bridge telemetry must remain finite");
+}
+
+} // namespace
+
+int main() {
+    try {
+        deterministic_replay();
+        zero_cycles_are_identity();
+        projection_and_shape_are_preserved();
+        autoencoder_bridge_decodes();
+        std::cout << "RIOF latent permeation tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "RIOF latent permeation test failure: " << error.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## What changed

- adds `jarvisx::Riof3D`, a dependency-free C++17 reference implementation of the Recursive Inward Optimization Framework (RIOF)
- represents the volume as intrinsic field, conjugate momentum, adjoint, residual, curvature and persistent memory state
- implements periodic 3D finite-difference geometry, local self-prediction, Jacobi adjoint relaxation, variational smoothness/bending/prediction forces, deterministic curvature-weighted enhancement, intrinsic damping, adaptive CFL-style timesteps and bounded Lambda projection
- adds `jarvisx-riof3d`, a headless CLI for deterministic sphere/shell/wave/noise experiments with live energy/residual/control telemetry
- adds `jarvisx::RiofLatentPermeator`, which inserts the same inward dynamics directly between the existing 3D encoder and decoder without mutating model weights
- adds `reconstruct_with_riof(...)` as the reversible encode → permeate latent → decode bridge; zero permeation cycles are an exact identity path
- adds regression coverage for deterministic replay, finiteness/projection invariants, damped objective relaxation, intrinsic control bounds, latent shape preservation, exact zero-cycle rollback and decoder interoperability
- wires both standalone RIOF and latent permeation into the existing CMake/CTest graph so the existing GCC, Clang+sanitizer and MSVC workflow validates them automatically

## Why

This converts the RIOF research formulation from a conceptual optimizer-inside-the-volume description into a benchmarkable numerical runtime and then permeates it into the repository's existing 3D autoencoding path. The encoder/decoder weights remain authoritative; RIOF evolves only the volumetric latent state and returns it to the existing decoder.

## Operational mapping

- **Refinement**: self-prediction residual + iterative adjoint field
- **Enhancement**: curvature-weighted deterministic high-frequency injection whose gain is derived from volumetric disagreement
- **Optimization**: second-order/leapfrog-style field evolution with conjugate momentum
- **Inward backprop**: Jacobi relaxation of the discrete Poisson adjoint equation
- **Omega persistence**: exponentially retained local residual memory inside the latent evolution
- **Self-control**: damping and enhancement derived from current field statistics; timestep adapts to force/momentum magnitude
- **Lambda guard**: bounded projection of field and momentum after each integration stage
- **Permeation bridge**: `encode(X) → RIOF(latent) → decode(latent*)`, with no model-weight mutation

## Validation

The standalone RIOF implementation was compiled locally as C++17 with `-Wall -Wextra -Wpedantic -Wconversion -Wshadow`, and its regression and smoke targets passed. The latent-permeation header was also syntax/warning-checked against the same public tensor interface. Repository-level GCC, Clang+sanitizer, MSVC, general CI and CodeQL runs are triggered from this branch and remain the authoritative cross-platform validation before merge.

## Capability boundary

This PR is the deterministic CPU/reference layer. It does not claim infinite geometric detail, single-cycle global Poisson convergence, guaranteed escape from all local minima, or GPU-resident FFT execution. Those are acceleration/research layers to add only after the numerical invariants are stable.