### PR TITLE
Operationalize 6,400-GiB sparse 3D volumetric AE/AD runtime + live dashboard

### DIFF
--- a/.github/workflows/volumetric-ae.yml
+++ b/.github/workflows/volumetric-ae.yml
@@ -6,6 +6,7 @@ on:
       - "src/jarvisx/volumetric_ae.py"
       - "src/jarvisx/volumetric_cli.py"
       - "src/jarvisx/volumetric_api.py"
+      - "src/jarvisx/volumetric_dashboard.html"
       - "tests/test_volumetric_ae.py"
       - "pyproject.toml"
       - ".github/workflows/volumetric-ae.yml"
@@ -15,6 +16,7 @@ on:
       - "src/jarvisx/volumetric_ae.py"
       - "src/jarvisx/volumetric_cli.py"
       - "src/jarvisx/volumetric_api.py"
+      - "src/jarvisx/volumetric_dashboard.html"
       - "tests/test_volumetric_ae.py"
       - "pyproject.toml"
 
@@ -36,3 +38,49 @@ jobs:
         run: pytest tests/test_volumetric_ae.py --no-cov -q
       - name: Runtime self-test
         run: jarvisx-volumetric --chunk-bytes 4096 selftest
+      - name: Live API and dashboard smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m uvicorn jarvisx.volumetric_api:app --host 127.0.0.1 --port 8090 > /tmp/jarvisx-volumetric.log 2>&1 &
+          api_pid=$!
+          trap 'kill ${api_pid} 2>/dev/null || true' EXIT
+          python - <<'PY'
+          import json
+          import time
+          import urllib.error
+          import urllib.request
+
+          base = "http://127.0.0.1:8090"
+          for _ in range(40):
+              try:
+                  with urllib.request.urlopen(base + "/health", timeout=1) as response:
+                      if response.status == 200:
+                          break
+              except (OSError, urllib.error.URLError):
+                  time.sleep(0.25)
+          else:
+              raise SystemExit("volumetric API did not become ready")
+
+          with urllib.request.urlopen(base + "/", timeout=2) as response:
+              dashboard = response.read().decode("utf-8")
+          assert "Live Runtime Telemetry" in dashboard
+          assert "/v1/volumetric/cycle" in dashboard
+
+          payload = (b"JARVIS-X-LIVE-CI-CYCLE|" * 4096)
+          request = urllib.request.Request(
+              base + "/v1/volumetric/cycle",
+              data=payload,
+              method="POST",
+              headers={"Content-Type": "application/octet-stream"},
+          )
+          with urllib.request.urlopen(request, timeout=5) as response:
+              report = json.load(response)
+          assert report["verified"] is True
+          assert report["decode"]["verified"] is True
+          print(json.dumps({
+              "verified": report["verified"],
+              "ratio": report["encode"]["compression_ratio"],
+              "artifact_bytes": report["encode"]["artifact_bytes"],
+          }, sort_keys=True))
+          PY

--- a/.github/workflows/volumetric-ae.yml
+++ b/.github/workflows/volumetric-ae.yml
@@ -1,0 +1,38 @@
+name: Volumetric AE Runtime
+
+on:
+  pull_request:
+    paths:
+      - "src/jarvisx/volumetric_ae.py"
+      - "src/jarvisx/volumetric_cli.py"
+      - "src/jarvisx/volumetric_api.py"
+      - "tests/test_volumetric_ae.py"
+      - "pyproject.toml"
+      - ".github/workflows/volumetric-ae.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/volumetric_ae.py"
+      - "src/jarvisx/volumetric_cli.py"
+      - "src/jarvisx/volumetric_api.py"
+      - "tests/test_volumetric_ae.py"
+      - "pyproject.toml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install
+        run: python -m pip install -e '.[test]'
+      - name: Unit tests
+        run: pytest tests/test_volumetric_ae.py --no-cov -q
+      - name: Runtime self-test
+        run: jarvisx-volumetric --chunk-bytes 4096 selftest

--- a/docs/volumetric_ae.md
+++ b/docs/volumetric_ae.md
@@ -42,7 +42,7 @@ jarvisx-volumetric decode state.jx3d restored.bin
 
 The final command verifies that the reconstructed bytes match the hash committed in the artifact.
 
-## HTTP API
+## HTTP API and live 3D dashboard
 
 Start the service:
 
@@ -56,14 +56,29 @@ or:
 uvicorn jarvisx.volumetric_api:app --host 0.0.0.0 --port 8090
 ```
 
+Open `http://127.0.0.1:8090/` in a browser. The packaged Three.js dashboard is served by the API process itself. It continuously performs real encode -> artifact -> decode -> verification cycles and renders measured telemetry from those executions.
+
+Dashboard telemetry includes:
+
+- sparse virtual capacity and logical cube dimensions;
+- measured compression ratio from the generated artifact;
+- actual artifact byte size and chunk count;
+- encode/decode latency;
+- committed payload SHA-256;
+- end-to-end bit-exact verification state.
+
+The 3D node lattice is a visualization of runtime activity; it does not pretend that all 1.7 trillion logical cells are resident GPU objects.
+
 Endpoints:
 
+- `GET /` — live Three.js operational dashboard
 - `GET /health`
 - `GET /v1/volumetric/metrics`
 - `POST /v1/volumetric/encode` with raw request bytes
 - `POST /v1/volumetric/decode` with raw `.jx3d` artifact bytes
+- `POST /v1/volumetric/cycle` with raw request bytes for a complete verified encode/decode cycle
 
-The encode endpoint returns the artifact as Base64 plus an execution receipt. The decode endpoint returns the reconstructed bytes and verification headers.
+The encode endpoint returns the artifact as Base64 plus an execution receipt. The decode endpoint returns the reconstructed bytes and verification headers. The cycle endpoint intentionally omits the artifact body and returns encode/decode receipts plus a final `verified` boolean, making it appropriate for live telemetry.
 
 ## Verification invariants
 
@@ -76,3 +91,7 @@ SHA256(decoded_chunk_i) == committed_chunk_sha256_i
 ```
 
 A corrupt or truncated artifact raises `ArtifactError` and does not produce reconstructed output.
+
+## Dashboard provenance
+
+The dashboard is derived from the Universal 3D Bit ANN Matrix visualization and preserves its interactive Three.js lattice, drag rotation, zoom, auto-cycle control, and substrate log presentation. Its former randomized compression/fidelity telemetry has been replaced with values returned by the operational API.

--- a/docs/volumetric_ae.md
+++ b/docs/volumetric_ae.md
@@ -1,0 +1,78 @@
+# Jarvis-X 3D Volumetric Auto-Encoding/Decoding Runtime
+
+This module operationalizes the 6,400-GiB 3D tensor concept as a **sparse virtual address space**. It does not allocate 6.4 TiB of RAM. Only active payload chunks are materialized.
+
+## Numerical substrate
+
+The default storage cell is 32 bits, matching Q16.16 representation.
+
+- Logical capacity: `6400 * 1024^3 = 6,871,947,673,600` bytes
+- Bytes per Q16.16 cell: `4`
+- Logical cells: `1,717,986,918,400`
+- Minimum cubic side containing those cells: `11,977`
+- Allocation mode: sparse virtual
+
+The virtual field is addressed by mapping each active chunk onto a linear cell index and then into `(x, y, z)` coordinates.
+
+## What is operational
+
+`Universal3DAutoEncoder` performs a real reversible transform:
+
+1. split payload bytes into chunks;
+2. map each chunk onto the virtual 3D field;
+3. compress each chunk with zlib;
+4. record chunk size, coordinate, and SHA-256 metadata;
+5. serialize a self-contained `.jx3d` latent artifact;
+6. decode every chunk;
+7. verify per-chunk hashes and the end-to-end payload hash;
+8. reject corruption or malformed artifacts.
+
+The implementation is an operational storage/transport codec, not a trained neural network. Compression ratio is measured from the actual output artifact rather than fixed to a simulated value.
+
+## CLI
+
+After installing the package:
+
+```bash
+jarvisx-volumetric metrics
+jarvisx-volumetric selftest
+jarvisx-volumetric encode input.bin state.jx3d
+jarvisx-volumetric decode state.jx3d restored.bin
+```
+
+The final command verifies that the reconstructed bytes match the hash committed in the artifact.
+
+## HTTP API
+
+Start the service:
+
+```bash
+jarvisx-volumetric-api
+```
+
+or:
+
+```bash
+uvicorn jarvisx.volumetric_api:app --host 0.0.0.0 --port 8090
+```
+
+Endpoints:
+
+- `GET /health`
+- `GET /v1/volumetric/metrics`
+- `POST /v1/volumetric/encode` with raw request bytes
+- `POST /v1/volumetric/decode` with raw `.jx3d` artifact bytes
+
+The encode endpoint returns the artifact as Base64 plus an execution receipt. The decode endpoint returns the reconstructed bytes and verification headers.
+
+## Verification invariants
+
+The runtime enforces:
+
+```text
+SHA256(decoded_payload) == committed_payload_sha256
+len(decoded_payload)    == committed_payload_bytes
+SHA256(decoded_chunk_i) == committed_chunk_sha256_i
+```
+
+A corrupt or truncated artifact raises `ArtifactError` and does not produce reconstructed output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ jarvisx-volumetric-api = "jarvisx.volumetric_api:main"
 [tool.setuptools]
 package-dir = {"" = "src"}
 
+[tool.setuptools.package-data]
+jarvisx = ["*.html"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ Changelog = "https://github.com/Lord-Xido/Jarvis-X/blob/main/CHANGELOG.md"
 [project.scripts]
 jarvisx = "jarvisx.cli:main"
 jarvisx-hyperion = "jarvisx.hyperion_cli:main"
+jarvisx-volumetric = "jarvisx.volumetric_cli:main"
+jarvisx-volumetric-api = "jarvisx.volumetric_api:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/volumetric_ae.py
+++ b/src/jarvisx/volumetric_ae.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import struct
+import time
+import zlib
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Iterator, Tuple
+
+MAGIC = b"JX3DVAE1"
+FORMAT_VERSION = 1
+_HEADER_LEN = struct.Struct(">Q")
+_CHUNK_LEN = struct.Struct(">I")
+
+
+class ArtifactError(ValueError):
+    """Raised when a volumetric latent artifact is malformed or fails verification."""
+
+
+@dataclass(frozen=True)
+class VirtualVolumeSpec:
+    """Logical 3D tensor substrate; capacity is virtual and is never eagerly allocated."""
+
+    capacity_gib: int = 6400
+    cell_bits: int = 32
+    chunk_bytes: int = 1 << 20
+
+    def __post_init__(self) -> None:
+        if self.capacity_gib <= 0:
+            raise ValueError("capacity_gib must be positive")
+        if self.cell_bits <= 0 or self.cell_bits % 8:
+            raise ValueError("cell_bits must be a positive multiple of 8")
+        if self.chunk_bytes <= 0:
+            raise ValueError("chunk_bytes must be positive")
+
+    @property
+    def capacity_bytes(self) -> int:
+        return self.capacity_gib * (1024**3)
+
+    @property
+    def bytes_per_cell(self) -> int:
+        return self.cell_bits // 8
+
+    @property
+    def total_cells(self) -> int:
+        return self.capacity_bytes // self.bytes_per_cell
+
+    @property
+    def cubic_side_cells(self) -> int:
+        side = max(1, int(round(self.total_cells ** (1.0 / 3.0))))
+        while side**3 < self.total_cells:
+            side += 1
+        while (side - 1) ** 3 >= self.total_cells:
+            side -= 1
+        return side
+
+    def linear_cell_to_xyz(self, cell_index: int) -> Tuple[int, int, int]:
+        if not 0 <= cell_index < self.total_cells:
+            raise ValueError("cell index is outside the virtual substrate")
+        side = self.cubic_side_cells
+        plane = side * side
+        z, rem = divmod(cell_index, plane)
+        y, x = divmod(rem, side)
+        return x, y, z
+
+    def metrics(self) -> Dict[str, Any]:
+        side = self.cubic_side_cells
+        return {
+            "capacity_gib": self.capacity_gib,
+            "capacity_bytes": self.capacity_bytes,
+            "cell_bits": self.cell_bits,
+            "bytes_per_cell": self.bytes_per_cell,
+            "total_cells": self.total_cells,
+            "logical_cube_side_cells": side,
+            "logical_cube_cells": side**3,
+            "chunk_bytes": self.chunk_bytes,
+            "allocation_mode": "sparse_virtual",
+            "resident_bytes_at_idle": 0,
+        }
+
+
+@dataclass(frozen=True)
+class EncodingReceipt:
+    operation: str
+    format_version: int
+    payload_bytes: int
+    artifact_bytes: int
+    chunk_count: int
+    compression_ratio: float
+    payload_sha256: str
+    artifact_sha256: str
+    virtual_capacity_gib: int
+    cell_bits: int
+    logical_cube_side_cells: int
+    first_chunk_xyz: Tuple[int, int, int] | None
+    last_chunk_xyz: Tuple[int, int, int] | None
+    latency_ms: float
+    status: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DecodeReceipt:
+    operation: str
+    payload_bytes: int
+    chunk_count: int
+    payload_sha256: str
+    verified: bool
+    latency_ms: float
+    status: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class Universal3DAutoEncoder:
+    """Reversible chunked encoder mapped onto a sparse virtual 3D Q16.16 substrate.
+
+    This is an operational storage/transport codec, not a trained neural network. The
+    virtual 6400-GiB field describes the address space; only active payload chunks are
+    materialized in memory or artifacts.
+    """
+
+    def __init__(self, spec: VirtualVolumeSpec | None = None, *, compression_level: int = 9):
+        self.spec = spec or VirtualVolumeSpec()
+        if not 0 <= compression_level <= 9:
+            raise ValueError("compression_level must be between 0 and 9")
+        self.compression_level = compression_level
+
+    def _chunks(self, data: bytes) -> Iterator[bytes]:
+        size = self.spec.chunk_bytes
+        for offset in range(0, len(data), size):
+            yield data[offset : offset + size]
+
+    def _chunk_cell_index(self, chunk_index: int) -> int:
+        cells_per_chunk = math.ceil(self.spec.chunk_bytes / self.spec.bytes_per_cell)
+        cell_index = chunk_index * cells_per_chunk
+        if cell_index >= self.spec.total_cells:
+            raise ValueError("payload exceeds the configured virtual substrate")
+        return cell_index
+
+    def encode(self, payload: bytes) -> tuple[bytes, EncodingReceipt]:
+        if not isinstance(payload, (bytes, bytearray, memoryview)):
+            raise TypeError("payload must be bytes-like")
+        payload = bytes(payload)
+        if len(payload) > self.spec.capacity_bytes:
+            raise ValueError("payload exceeds the configured virtual capacity")
+
+        started = time.perf_counter()
+        payload_hash = hashlib.sha256(payload).hexdigest()
+        chunks = list(self._chunks(payload))
+
+        chunk_meta = []
+        encoded_chunks = []
+        for index, raw in enumerate(chunks):
+            cell_index = self._chunk_cell_index(index)
+            xyz = self.spec.linear_cell_to_xyz(cell_index)
+            compressed = zlib.compress(raw, self.compression_level)
+            encoded_chunks.append(compressed)
+            chunk_meta.append(
+                {
+                    "index": index,
+                    "xyz": xyz,
+                    "raw_bytes": len(raw),
+                    "encoded_bytes": len(compressed),
+                    "sha256": hashlib.sha256(raw).hexdigest(),
+                }
+            )
+
+        header = {
+            "format": "jarvisx-3d-volumetric-latent",
+            "version": FORMAT_VERSION,
+            "codec": "zlib",
+            "compression_level": self.compression_level,
+            "payload_bytes": len(payload),
+            "payload_sha256": payload_hash,
+            "virtual_volume": self.spec.metrics(),
+            "chunks": chunk_meta,
+        }
+        header_bytes = json.dumps(header, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+        artifact = bytearray(MAGIC)
+        artifact.extend(_HEADER_LEN.pack(len(header_bytes)))
+        artifact.extend(header_bytes)
+        for compressed in encoded_chunks:
+            artifact.extend(_CHUNK_LEN.pack(len(compressed)))
+            artifact.extend(compressed)
+        artifact_bytes = bytes(artifact)
+
+        artifact_hash = hashlib.sha256(artifact_bytes).hexdigest()
+        ratio = (len(payload) / len(artifact_bytes)) if artifact_bytes else 0.0
+        first_xyz = tuple(chunk_meta[0]["xyz"]) if chunk_meta else None
+        last_xyz = tuple(chunk_meta[-1]["xyz"]) if chunk_meta else None
+        receipt = EncodingReceipt(
+            operation="ENCODE_3D_VOLUMETRIC",
+            format_version=FORMAT_VERSION,
+            payload_bytes=len(payload),
+            artifact_bytes=len(artifact_bytes),
+            chunk_count=len(chunk_meta),
+            compression_ratio=ratio,
+            payload_sha256=payload_hash,
+            artifact_sha256=artifact_hash,
+            virtual_capacity_gib=self.spec.capacity_gib,
+            cell_bits=self.spec.cell_bits,
+            logical_cube_side_cells=self.spec.cubic_side_cells,
+            first_chunk_xyz=first_xyz,
+            last_chunk_xyz=last_xyz,
+            latency_ms=(time.perf_counter() - started) * 1000.0,
+            status="ENCODED_VERIFIABLE",
+        )
+        return artifact_bytes, receipt
+
+    def decode(self, artifact: bytes) -> tuple[bytes, DecodeReceipt]:
+        if not isinstance(artifact, (bytes, bytearray, memoryview)):
+            raise TypeError("artifact must be bytes-like")
+        artifact = bytes(artifact)
+        started = time.perf_counter()
+
+        if len(artifact) < len(MAGIC) + _HEADER_LEN.size or not artifact.startswith(MAGIC):
+            raise ArtifactError("invalid volumetric artifact magic")
+
+        cursor = len(MAGIC)
+        (header_len,) = _HEADER_LEN.unpack_from(artifact, cursor)
+        cursor += _HEADER_LEN.size
+        header_end = cursor + header_len
+        if header_end > len(artifact):
+            raise ArtifactError("truncated volumetric artifact header")
+
+        try:
+            header = json.loads(artifact[cursor:header_end].decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ArtifactError("invalid volumetric artifact header") from exc
+        cursor = header_end
+
+        if header.get("version") != FORMAT_VERSION or header.get("codec") != "zlib":
+            raise ArtifactError("unsupported volumetric artifact format")
+
+        reconstructed = bytearray()
+        chunk_meta = header.get("chunks")
+        if not isinstance(chunk_meta, list):
+            raise ArtifactError("artifact chunk table is missing")
+
+        for expected_index, meta in enumerate(chunk_meta):
+            if cursor + _CHUNK_LEN.size > len(artifact):
+                raise ArtifactError("truncated chunk length")
+            (encoded_len,) = _CHUNK_LEN.unpack_from(artifact, cursor)
+            cursor += _CHUNK_LEN.size
+            chunk_end = cursor + encoded_len
+            if chunk_end > len(artifact):
+                raise ArtifactError("truncated encoded chunk")
+            encoded = artifact[cursor:chunk_end]
+            cursor = chunk_end
+            try:
+                raw = zlib.decompress(encoded)
+            except zlib.error as exc:
+                raise ArtifactError(f"chunk {expected_index} decompression failed") from exc
+            if meta.get("index") != expected_index:
+                raise ArtifactError("chunk index sequence is invalid")
+            if len(raw) != meta.get("raw_bytes"):
+                raise ArtifactError(f"chunk {expected_index} size mismatch")
+            if hashlib.sha256(raw).hexdigest() != meta.get("sha256"):
+                raise ArtifactError(f"chunk {expected_index} hash mismatch")
+            reconstructed.extend(raw)
+
+        if cursor != len(artifact):
+            raise ArtifactError("artifact contains trailing bytes")
+
+        payload = bytes(reconstructed)
+        expected_size = header.get("payload_bytes")
+        expected_hash = header.get("payload_sha256")
+        payload_hash = hashlib.sha256(payload).hexdigest()
+        if len(payload) != expected_size or payload_hash != expected_hash:
+            raise ArtifactError("reconstructed payload failed end-to-end verification")
+
+        receipt = DecodeReceipt(
+            operation="DECODE_3D_VOLUMETRIC",
+            payload_bytes=len(payload),
+            chunk_count=len(chunk_meta),
+            payload_sha256=payload_hash,
+            verified=True,
+            latency_ms=(time.perf_counter() - started) * 1000.0,
+            status="RECONSTRUCTED_BIT_EXACT",
+        )
+        return payload, receipt
+
+    def self_test(self) -> Dict[str, Any]:
+        sample = b"Codex_vOmegaXi_3D_Matrix_Stream_Simulation_Data" * 128
+        artifact, encoded = self.encode(sample)
+        restored, decoded = self.decode(artifact)
+        return {
+            "ok": restored == sample,
+            "grid": self.spec.metrics(),
+            "encode": encoded.to_dict(),
+            "decode": decoded.to_dict(),
+        }

--- a/src/jarvisx/volumetric_api.py
+++ b/src/jarvisx/volumetric_api.py
@@ -17,6 +17,18 @@ engine = Universal3DAutoEncoder()
 _DASHBOARD_PATH = Path(__file__).with_name("volumetric_dashboard.html")
 
 
+def execute_cycle(payload: bytes) -> dict[str, object]:
+    """Execute encode -> artifact -> decode -> verification for a byte payload."""
+
+    artifact, encoded = engine.encode(payload)
+    restored, decoded = engine.decode(artifact)
+    return {
+        "verified": restored == payload and decoded.verified,
+        "encode": encoded.to_dict(),
+        "decode": decoded.to_dict(),
+    }
+
+
 @app.get("/", response_class=HTMLResponse, include_in_schema=False)
 def dashboard() -> HTMLResponse:
     return HTMLResponse(_DASHBOARD_PATH.read_text(encoding="utf-8"))
@@ -69,20 +81,13 @@ async def decode(request: Request) -> Response:
 
 @app.post("/v1/volumetric/cycle")
 async def cycle(request: Request) -> dict[str, object]:
-    """Execute encode -> artifact -> decode -> verification in one request."""
+    """HTTP wrapper for one verified end-to-end execution cycle."""
 
     payload = await request.body()
     try:
-        artifact, encoded = engine.encode(payload)
-        restored, decoded = engine.decode(artifact)
+        return execute_cycle(payload)
     except (TypeError, ValueError, ArtifactError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-    return {
-        "verified": restored == payload and decoded.verified,
-        "encode": encoded.to_dict(),
-        "decode": decoded.to_dict(),
-    }
 
 
 def main() -> None:

--- a/src/jarvisx/volumetric_api.py
+++ b/src/jarvisx/volumetric_api.py
@@ -1,22 +1,35 @@
 from __future__ import annotations
 
 import base64
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request, Response
+from fastapi.responses import HTMLResponse
 
 from .volumetric_ae import ArtifactError, Universal3DAutoEncoder
 
 app = FastAPI(
     title="Jarvis-X 3D Volumetric Auto-Encoding/Decoding API",
-    version="1.0.0",
+    version="1.1.0",
 )
 engine = Universal3DAutoEncoder()
+_DASHBOARD_PATH = Path(__file__).with_name("volumetric_dashboard.html")
+
+
+@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+def dashboard() -> HTMLResponse:
+    return HTMLResponse(_DASHBOARD_PATH.read_text(encoding="utf-8"))
 
 
 @app.get("/health")
 def health() -> dict[str, object]:
-    return {"status": "ok", "engine": "3d-volumetric-aead", "capacity_gib": 6400}
+    return {
+        "status": "ok",
+        "engine": "3d-volumetric-aead",
+        "capacity_gib": engine.spec.capacity_gib,
+        "dashboard": "/",
+    }
 
 
 @app.get("/v1/volumetric/metrics")
@@ -52,6 +65,24 @@ async def decode(request: Request) -> Response:
             "X-JarvisX-Verified": "true",
         },
     )
+
+
+@app.post("/v1/volumetric/cycle")
+async def cycle(request: Request) -> dict[str, object]:
+    """Execute encode -> artifact -> decode -> verification in one request."""
+
+    payload = await request.body()
+    try:
+        artifact, encoded = engine.encode(payload)
+        restored, decoded = engine.decode(artifact)
+    except (TypeError, ValueError, ArtifactError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "verified": restored == payload and decoded.verified,
+        "encode": encoded.to_dict(),
+        "decode": decoded.to_dict(),
+    }
 
 
 def main() -> None:

--- a/src/jarvisx/volumetric_api.py
+++ b/src/jarvisx/volumetric_api.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import base64
+
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request, Response
+
+from .volumetric_ae import ArtifactError, Universal3DAutoEncoder
+
+app = FastAPI(
+    title="Jarvis-X 3D Volumetric Auto-Encoding/Decoding API",
+    version="1.0.0",
+)
+engine = Universal3DAutoEncoder()
+
+
+@app.get("/health")
+def health() -> dict[str, object]:
+    return {"status": "ok", "engine": "3d-volumetric-aead", "capacity_gib": 6400}
+
+
+@app.get("/v1/volumetric/metrics")
+def metrics() -> dict[str, object]:
+    return engine.spec.metrics()
+
+
+@app.post("/v1/volumetric/encode")
+async def encode(request: Request) -> dict[str, object]:
+    payload = await request.body()
+    try:
+        artifact, receipt = engine.encode(payload)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {
+        "receipt": receipt.to_dict(),
+        "artifact_base64": base64.b64encode(artifact).decode("ascii"),
+    }
+
+
+@app.post("/v1/volumetric/decode")
+async def decode(request: Request) -> Response:
+    artifact = await request.body()
+    try:
+        payload, receipt = engine.decode(artifact)
+    except ArtifactError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return Response(
+        content=payload,
+        media_type="application/octet-stream",
+        headers={
+            "X-JarvisX-SHA256": receipt.payload_sha256,
+            "X-JarvisX-Verified": "true",
+        },
+    )
+
+
+def main() -> None:
+    uvicorn.run("jarvisx.volumetric_api:app", host="0.0.0.0", port=8090)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/volumetric_cli.py
+++ b/src/jarvisx/volumetric_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .volumetric_ae import Universal3DAutoEncoder, VirtualVolumeSpec
+
+
+def _engine(args: argparse.Namespace) -> Universal3DAutoEncoder:
+    return Universal3DAutoEncoder(
+        VirtualVolumeSpec(
+            capacity_gib=args.capacity_gib,
+            cell_bits=args.cell_bits,
+            chunk_bytes=args.chunk_bytes,
+        ),
+        compression_level=args.compression_level,
+    )
+
+
+def _print_json(value: object) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Jarvis-X 3D volumetric AE/AD runtime")
+    parser.add_argument("--capacity-gib", type=int, default=6400)
+    parser.add_argument("--cell-bits", type=int, default=32, help="32 = Q16.16 storage cell")
+    parser.add_argument("--chunk-bytes", type=int, default=1 << 20)
+    parser.add_argument("--compression-level", type=int, default=9)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sub.add_parser("metrics", help="show logical substrate metrics")
+    sub.add_parser("selftest", help="run encode/decode verification")
+
+    enc = sub.add_parser("encode", help="encode a file into a .jx3d latent artifact")
+    enc.add_argument("input", type=Path)
+    enc.add_argument("output", type=Path)
+
+    dec = sub.add_parser("decode", help="decode and verify a .jx3d latent artifact")
+    dec.add_argument("input", type=Path)
+    dec.add_argument("output", type=Path)
+
+    args = parser.parse_args(argv)
+    engine = _engine(args)
+
+    if args.command == "metrics":
+        _print_json(engine.spec.metrics())
+        return 0
+    if args.command == "selftest":
+        report = engine.self_test()
+        _print_json(report)
+        return 0 if report["ok"] else 1
+    if args.command == "encode":
+        artifact, receipt = engine.encode(args.input.read_bytes())
+        args.output.write_bytes(artifact)
+        _print_json(receipt.to_dict())
+        return 0
+    if args.command == "decode":
+        payload, receipt = engine.decode(args.input.read_bytes())
+        args.output.write_bytes(payload)
+        _print_json(receipt.to_dict())
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/volumetric_dashboard.html
+++ b/src/jarvisx/volumetric_dashboard.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jarvis-X Universal 3D Volumetric Runtime</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background: #030712; color: #f3f4f6; overflow: hidden; }
+    .mono { font-family: 'JetBrains Mono', monospace; }
+    canvas { display: block; width: 100vw; height: 100vh; position: fixed; inset: 0; z-index: 0; }
+    .glass-panel { background: rgba(17, 24, 39, 0.78); backdrop-filter: blur(14px); border: 1px solid rgba(255, 255, 255, 0.10); }
+    .metric-value { font-variant-numeric: tabular-nums; }
+  </style>
+</head>
+<body class="selection:bg-indigo-500 selection:text-white">
+  <div id="canvas-container" class="absolute inset-0"></div>
+
+  <header class="relative z-10 flex items-center justify-between px-6 py-4 glass-panel border-b border-gray-800">
+    <div class="flex items-center space-x-3">
+      <div id="status-dot" class="w-3 h-3 bg-amber-400 rounded-full animate-pulse shadow-[0_0_12px_#f59e0b]"></div>
+      <h1 class="text-lg font-bold tracking-wider text-white">JARVIS-X <span class="text-indigo-400 font-light">6400 GiB 3D VOLUMETRIC RUNTIME</span></h1>
+    </div>
+    <div class="hidden md:flex items-center space-x-6 text-xs mono text-gray-400">
+      <div>STATUS: <span id="sys-status" class="text-amber-300 font-semibold">CONNECTING</span></div>
+      <div>ALLOCATION: <span class="text-indigo-300">SPARSE VIRTUAL</span></div>
+      <div>VERIFY: <span id="header-verify" class="text-gray-400">PENDING</span></div>
+    </div>
+  </header>
+
+  <main class="relative z-10 grid grid-cols-1 lg:grid-cols-4 gap-6 p-6 pointer-events-none h-[calc(100vh-73px)]">
+    <section class="lg:col-span-1 flex flex-col space-y-4 pointer-events-auto overflow-y-auto max-h-full pr-1">
+      <div class="glass-panel p-5 rounded-2xl shadow-2xl">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-xs uppercase tracking-widest font-semibold text-gray-400">Live Runtime Telemetry</h2>
+          <span id="api-badge" class="text-[10px] mono px-2 py-1 rounded-full bg-gray-900 text-gray-500 border border-gray-800">API</span>
+        </div>
+
+        <div class="space-y-2.5 text-sm">
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Virtual Capacity</span>
+            <span id="metric-capacity" class="mono metric-value font-semibold text-indigo-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Logical Cube Side</span>
+            <span id="metric-side" class="mono metric-value font-semibold text-cyan-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Logical Cells</span>
+            <span id="metric-cells" class="mono metric-value font-semibold text-cyan-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Measured Ratio</span>
+            <span id="metric-comp" class="mono metric-value font-semibold text-emerald-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Artifact / Chunks</span>
+            <span id="metric-artifact" class="mono metric-value font-semibold text-violet-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Encode / Decode</span>
+            <span id="metric-latency" class="mono metric-value font-semibold text-amber-300">—</span>
+          </div>
+          <div class="flex justify-between items-center bg-gray-900/60 p-2.5 rounded-xl border border-gray-800">
+            <span class="text-gray-400 text-xs">Bit-Exact Verify</span>
+            <span id="metric-verify" class="mono metric-value font-semibold text-gray-400">PENDING</span>
+          </div>
+        </div>
+
+        <div class="mt-4 bg-gray-950/70 border border-gray-900 rounded-xl p-3">
+          <div class="text-[10px] uppercase tracking-widest text-gray-500 mb-1">Payload SHA-256</div>
+          <div id="metric-hash" class="mono text-[10px] text-cyan-300 break-all">—</div>
+        </div>
+
+        <div class="mt-5 pt-4 border-t border-gray-800/80 grid grid-cols-2 gap-2">
+          <button id="toggle-exec" class="py-3 px-3 bg-gradient-to-r from-indigo-600 to-violet-600 hover:from-indigo-500 hover:to-violet-500 text-white font-medium text-xs rounded-xl shadow-lg shadow-indigo-500/20 transition-all active:scale-95">
+            <span id="btn-text">Pause Auto-Cycle</span>
+          </button>
+          <button id="run-once" class="py-3 px-3 bg-gray-800 hover:bg-gray-700 border border-gray-700 text-white font-medium text-xs rounded-xl transition-all active:scale-95">Run Once</button>
+        </div>
+      </div>
+
+      <div class="glass-panel p-5 rounded-2xl shadow-2xl flex-1 flex flex-col min-h-[180px]">
+        <h2 class="text-xs uppercase tracking-widest font-semibold text-gray-400 mb-3">Verified Execution Stream</h2>
+        <div id="log-container" class="mono text-[11px] bg-gray-950/80 p-3 rounded-xl border border-gray-900 flex-1 overflow-y-auto space-y-2 text-gray-300 max-h-52 lg:max-h-none">
+          <div class="text-amber-300">[BOOT] Connecting dashboard to volumetric runtime…</div>
+        </div>
+      </div>
+    </section>
+
+    <section class="lg:col-span-3 flex flex-col justify-between items-end pointer-events-none pb-6 pr-2">
+      <div class="mt-2 glass-panel px-4 py-3 rounded-xl text-[11px] mono text-gray-400 max-w-xl">
+        <div class="text-indigo-300 mb-1">DM–vΩΞ⁺ execution surface</div>
+        <div>Payload → chunk map (x,y,z) → reversible latent artifact → integrity decode → byte-exact verification</div>
+      </div>
+      <div class="glass-panel px-4 py-2 rounded-xl text-xs mono text-gray-400 flex items-center space-x-2">
+        <span class="w-2 h-2 rounded-full bg-indigo-500 animate-ping"></span>
+        <span>Drag to rotate • Scroll to zoom • Live pulses follow API cycles</span>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    let isExecuting = true;
+    let cycleInFlight = false;
+    let frameCount = 0;
+    let cycleCounter = 0;
+    let lastVerified = false;
+
+    const $ = (id) => document.getElementById(id);
+    const formatInt = (value) => Number(value).toLocaleString('en-US');
+    const formatBytes = (value) => {
+      const n = Number(value);
+      if (n < 1024) return `${n} B`;
+      if (n < 1024 ** 2) return `${(n / 1024).toFixed(1)} KiB`;
+      return `${(n / 1024 ** 2).toFixed(2)} MiB`;
+    };
+
+    function setSystemState(state, detail = '') {
+      const status = $('sys-status');
+      const dot = $('status-dot');
+      const badge = $('api-badge');
+      if (state === 'online') {
+        status.textContent = isExecuting ? 'AUTO-EXECUTING' : 'PAUSED';
+        status.className = isExecuting ? 'text-emerald-400 font-semibold' : 'text-amber-300 font-semibold';
+        dot.className = isExecuting
+          ? 'w-3 h-3 bg-emerald-500 rounded-full animate-pulse shadow-[0_0_12px_#10b981]'
+          : 'w-3 h-3 bg-amber-400 rounded-full shadow-[0_0_12px_#f59e0b]';
+        badge.textContent = 'API LIVE';
+        badge.className = 'text-[10px] mono px-2 py-1 rounded-full bg-emerald-950/70 text-emerald-300 border border-emerald-900';
+      } else if (state === 'busy') {
+        status.textContent = 'EXECUTING';
+        status.className = 'text-cyan-300 font-semibold';
+        badge.textContent = 'API BUSY';
+        badge.className = 'text-[10px] mono px-2 py-1 rounded-full bg-cyan-950/70 text-cyan-300 border border-cyan-900';
+      } else {
+        status.textContent = 'OFFLINE';
+        status.className = 'text-rose-400 font-semibold';
+        dot.className = 'w-3 h-3 bg-rose-500 rounded-full shadow-[0_0_12px_#f43f5e]';
+        badge.textContent = detail || 'API ERROR';
+        badge.className = 'text-[10px] mono px-2 py-1 rounded-full bg-rose-950/70 text-rose-300 border border-rose-900';
+      }
+    }
+
+    function appendLog(message, colorClass = 'text-gray-300') {
+      const container = $('log-container');
+      const stamp = new Date().toLocaleTimeString('en-GB', { hour12: false }) + '.' + String(new Date().getMilliseconds()).padStart(3, '0');
+      const div = document.createElement('div');
+      div.className = colorClass;
+      div.textContent = `[${stamp}] ${message}`;
+      container.appendChild(div);
+      container.scrollTop = container.scrollHeight;
+      while (container.children.length > 36) container.removeChild(container.firstChild);
+    }
+
+    function makeCyclePayload() {
+      cycleCounter += 1;
+      const seed = `JARVIS-X|DM-vOmegaXi|cycle=${cycleCounter}|`;
+      const block = `${seed}ENCODE>LATENT>DECODE>VERIFY|`;
+      return new TextEncoder().encode(block.repeat(4096));
+    }
+
+    async function loadMetrics() {
+      const response = await fetch('/v1/volumetric/metrics', { cache: 'no-store' });
+      if (!response.ok) throw new Error(`metrics HTTP ${response.status}`);
+      const m = await response.json();
+      $('metric-capacity').textContent = `${formatInt(m.capacity_gib)} GiB`;
+      $('metric-side').textContent = `${formatInt(m.logical_cube_side_cells)}³`;
+      $('metric-cells').textContent = formatInt(m.total_cells);
+      appendLog(`SUBSTRATE: ${formatInt(m.total_cells)} logical ${m.cell_bits}-bit cells; idle resident allocation ${formatBytes(m.resident_bytes_at_idle)}.`, 'text-indigo-300');
+    }
+
+    async function runCycle(manual = false) {
+      if (cycleInFlight) return;
+      cycleInFlight = true;
+      setSystemState('busy');
+      try {
+        const payload = makeCyclePayload();
+        const response = await fetch('/v1/volumetric/cycle', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/octet-stream' },
+          body: payload,
+        });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`cycle HTTP ${response.status}: ${text.slice(0, 120)}`);
+        }
+        const result = await response.json();
+        const enc = result.encode;
+        const dec = result.decode;
+        lastVerified = Boolean(result.verified && dec.verified);
+
+        $('metric-comp').textContent = `${Number(enc.compression_ratio).toFixed(3)}×`;
+        $('metric-artifact').textContent = `${formatBytes(enc.artifact_bytes)} / ${formatInt(enc.chunk_count)}`;
+        $('metric-latency').textContent = `${Number(enc.latency_ms).toFixed(2)} / ${Number(dec.latency_ms).toFixed(2)} ms`;
+        $('metric-hash').textContent = enc.payload_sha256;
+        $('metric-verify').textContent = lastVerified ? 'BIT-EXACT' : 'FAILED';
+        $('metric-verify').className = lastVerified
+          ? 'mono metric-value font-semibold text-emerald-300'
+          : 'mono metric-value font-semibold text-rose-300';
+        $('header-verify').textContent = lastVerified ? 'BIT-EXACT' : 'FAILED';
+        $('header-verify').className = lastVerified ? 'text-emerald-300' : 'text-rose-300';
+
+        appendLog(`ENCODER: ${formatBytes(enc.payload_bytes)} → ${formatBytes(enc.artifact_bytes)} across ${enc.chunk_count} chunk(s), measured ${Number(enc.compression_ratio).toFixed(3)}×.`, 'text-cyan-300');
+        appendLog(`DECODER: SHA-256 ${dec.payload_sha256.slice(0, 16)}… verified=${dec.verified}; reconstructed bit-exact=${result.verified}.`, lastVerified ? 'text-emerald-300' : 'text-rose-300');
+        if (manual) appendLog('CONTROL: Manual end-to-end cycle completed.', 'text-violet-300');
+        setSystemState('online');
+      } catch (error) {
+        lastVerified = false;
+        $('metric-verify').textContent = 'ERROR';
+        $('metric-verify').className = 'mono metric-value font-semibold text-rose-300';
+        $('header-verify').textContent = 'ERROR';
+        $('header-verify').className = 'text-rose-300';
+        appendLog(`API: ${error.message}`, 'text-rose-300');
+        setSystemState('offline');
+      } finally {
+        cycleInFlight = false;
+      }
+    }
+
+    const container = $('canvas-container');
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x030712, 0.015);
+
+    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+    camera.position.set(0, 15, 35);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    container.appendChild(renderer.domElement);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.78));
+    const pointLight = new THREE.PointLight(0x6366f1, 3, 60);
+    pointLight.position.set(0, 10, 0);
+    scene.add(pointLight);
+
+    const gridGroup = new THREE.Group();
+    scene.add(gridGroup);
+
+    const nodeCountX = 10;
+    const nodeCountY = 6;
+    const nodeCountZ = 10;
+    const spacing = 3.2;
+    const sphereGeo = new THREE.SphereGeometry(0.18, 16, 16);
+    const baseMaterial = new THREE.MeshStandardMaterial({
+      color: 0x818cf8,
+      emissive: 0x4f46e5,
+      emissiveIntensity: 0.6,
+      roughness: 0.2,
+      metalness: 0.8,
+    });
+
+    const nodes = [];
+    for (let x = 0; x < nodeCountX; x++) {
+      for (let y = 0; y < nodeCountY; y++) {
+        for (let z = 0; z < nodeCountZ; z++) {
+          const mesh = new THREE.Mesh(sphereGeo, baseMaterial.clone());
+          mesh.position.set(
+            (x - nodeCountX / 2) * spacing + spacing / 2,
+            (y - nodeCountY / 2) * spacing + spacing / 2,
+            (z - nodeCountZ / 2) * spacing + spacing / 2,
+          );
+          mesh.userData = {
+            origY: mesh.position.y,
+            phase: Math.random() * Math.PI * 2,
+          };
+          gridGroup.add(mesh);
+          nodes.push(mesh);
+        }
+      }
+    }
+
+    const lineMaterial = new THREE.LineBasicMaterial({ color: 0x312e81, transparent: true, opacity: 0.18 });
+    const box = new THREE.BoxGeometry((nodeCountX - 1) * spacing, (nodeCountY - 1) * spacing, (nodeCountZ - 1) * spacing);
+    const edges = new THREE.EdgesGeometry(box);
+    const frame = new THREE.LineSegments(edges, lineMaterial);
+    gridGroup.add(frame);
+
+    const particleCount = 420;
+    const particleGeo = new THREE.BufferGeometry();
+    const particlePositions = new Float32Array(particleCount * 3);
+    for (let i = 0; i < particlePositions.length; i += 3) {
+      particlePositions[i] = (Math.random() - 0.5) * 35;
+      particlePositions[i + 1] = (Math.random() - 0.5) * 20;
+      particlePositions[i + 2] = (Math.random() - 0.5) * 35;
+    }
+    particleGeo.setAttribute('position', new THREE.BufferAttribute(particlePositions, 3));
+    const particleSystem = new THREE.Points(
+      particleGeo,
+      new THREE.PointsMaterial({
+        color: 0x38bdf8,
+        size: 0.25,
+        transparent: true,
+        opacity: 0.8,
+        blending: THREE.AdditiveBlending,
+      }),
+    );
+    scene.add(particleSystem);
+
+    let isDragging = false;
+    let previousPointer = { x: 0, y: 0 };
+    let targetRotationX = 0;
+    let targetRotationY = 0;
+
+    function beginDrag(x, y) {
+      isDragging = true;
+      previousPointer = { x, y };
+    }
+    function dragTo(x, y) {
+      if (!isDragging) return;
+      targetRotationY += (x - previousPointer.x) * 0.005;
+      targetRotationX += (y - previousPointer.y) * 0.005;
+      targetRotationX = Math.max(-1.2, Math.min(1.2, targetRotationX));
+      previousPointer = { x, y };
+    }
+
+    window.addEventListener('mousedown', (e) => beginDrag(e.clientX, e.clientY));
+    window.addEventListener('mousemove', (e) => dragTo(e.clientX, e.clientY));
+    window.addEventListener('mouseup', () => { isDragging = false; });
+    window.addEventListener('touchstart', (e) => {
+      if (e.touches.length === 1) beginDrag(e.touches[0].clientX, e.touches[0].clientY);
+    }, { passive: true });
+    window.addEventListener('touchmove', (e) => {
+      if (e.touches.length === 1) dragTo(e.touches[0].clientX, e.touches[0].clientY);
+    }, { passive: true });
+    window.addEventListener('touchend', () => { isDragging = false; });
+    window.addEventListener('wheel', (e) => {
+      camera.position.z = Math.max(18, Math.min(70, camera.position.z + e.deltaY * 0.02));
+    }, { passive: true });
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    $('toggle-exec').addEventListener('click', () => {
+      isExecuting = !isExecuting;
+      $('btn-text').textContent = isExecuting ? 'Pause Auto-Cycle' : 'Resume Auto-Cycle';
+      appendLog(`CONTROL: Auto-cycle ${isExecuting ? 'resumed' : 'paused'}.`, isExecuting ? 'text-emerald-300' : 'text-amber-300');
+      setSystemState('online');
+      if (isExecuting) runCycle(false);
+    });
+    $('run-once').addEventListener('click', () => runCycle(true));
+
+    function animate() {
+      requestAnimationFrame(animate);
+      frameCount += 1;
+      const time = Date.now() * 0.002;
+
+      if (isExecuting) {
+        gridGroup.rotation.y += 0.0015;
+        gridGroup.rotation.x += (targetRotationX - gridGroup.rotation.x) * 0.05;
+        gridGroup.rotation.y += (targetRotationY - gridGroup.rotation.y) * 0.05;
+
+        nodes.forEach((node, index) => {
+          const pulse = Math.abs(Math.sin(time * 1.8 + node.userData.phase));
+          node.position.y = node.userData.origY + Math.sin(time + node.userData.phase) * 0.55;
+          node.material.emissiveIntensity = (lastVerified ? 0.3 : 0.12) + pulse * (lastVerified ? 0.85 : 0.35);
+          if (cycleInFlight && index % 7 === frameCount % 7) node.scale.setScalar(1.7);
+          else node.scale.lerp(new THREE.Vector3(1, 1, 1), 0.18);
+        });
+
+        const positions = particleGeo.attributes.position.array;
+        for (let i = 0; i < positions.length; i += 3) {
+          positions[i + 1] -= cycleInFlight ? 0.24 : 0.10;
+          if (positions[i + 1] < -12) positions[i + 1] = 12;
+        }
+        particleGeo.attributes.position.needsUpdate = true;
+      } else {
+        gridGroup.rotation.x += (targetRotationX - gridGroup.rotation.x) * 0.03;
+        gridGroup.rotation.y += (targetRotationY - gridGroup.rotation.y) * 0.03;
+      }
+
+      renderer.render(scene, camera);
+    }
+
+    async function boot() {
+      try {
+        await loadMetrics();
+        setSystemState('online');
+        appendLog('API: Live metrics endpoint connected.', 'text-emerald-300');
+        await runCycle(false);
+      } catch (error) {
+        appendLog(`BOOT: ${error.message}`, 'text-rose-300');
+        setSystemState('offline');
+      }
+      setInterval(() => {
+        if (isExecuting) runCycle(false);
+      }, 3000);
+    }
+
+    animate();
+    boot();
+  </script>
+</body>
+</html>

--- a/tests/test_volumetric_ae.py
+++ b/tests/test_volumetric_ae.py
@@ -1,0 +1,52 @@
+import hashlib
+
+import pytest
+
+from jarvisx.volumetric_ae import ArtifactError, Universal3DAutoEncoder, VirtualVolumeSpec
+
+
+def test_6400_gib_q16_16_metrics_are_virtual() -> None:
+    spec = VirtualVolumeSpec(capacity_gib=6400, cell_bits=32, chunk_bytes=1024)
+    metrics = spec.metrics()
+    assert metrics["capacity_bytes"] == 6400 * 1024**3
+    assert metrics["total_cells"] == (6400 * 1024**3) // 4
+    assert metrics["logical_cube_side_cells"] ** 3 >= metrics["total_cells"]
+    assert metrics["allocation_mode"] == "sparse_virtual"
+    assert metrics["resident_bytes_at_idle"] == 0
+
+
+def test_round_trip_is_bit_exact_across_multiple_chunks() -> None:
+    engine = Universal3DAutoEncoder(VirtualVolumeSpec(chunk_bytes=257))
+    payload = (bytes(range(256)) * 20) + b"Jarvis-X"
+    artifact, encode_receipt = engine.encode(payload)
+    restored, decode_receipt = engine.decode(artifact)
+
+    assert restored == payload
+    assert encode_receipt.chunk_count > 1
+    assert encode_receipt.payload_sha256 == hashlib.sha256(payload).hexdigest()
+    assert decode_receipt.verified is True
+    assert decode_receipt.status == "RECONSTRUCTED_BIT_EXACT"
+
+
+def test_empty_payload_round_trip() -> None:
+    engine = Universal3DAutoEncoder(VirtualVolumeSpec(chunk_bytes=64))
+    artifact, receipt = engine.encode(b"")
+    restored, decoded = engine.decode(artifact)
+    assert restored == b""
+    assert receipt.chunk_count == 0
+    assert decoded.chunk_count == 0
+
+
+def test_corruption_is_detected() -> None:
+    engine = Universal3DAutoEncoder(VirtualVolumeSpec(chunk_bytes=64))
+    artifact, _ = engine.encode(b"A" * 512)
+    damaged = bytearray(artifact)
+    damaged[-1] ^= 0xFF
+    with pytest.raises(ArtifactError):
+        engine.decode(bytes(damaged))
+
+
+def test_self_test_reports_success() -> None:
+    report = Universal3DAutoEncoder(VirtualVolumeSpec(chunk_bytes=256)).self_test()
+    assert report["ok"] is True
+    assert report["decode"]["verified"] is True

--- a/tests/test_volumetric_ae.py
+++ b/tests/test_volumetric_ae.py
@@ -3,6 +3,7 @@ import hashlib
 import pytest
 
 from jarvisx.volumetric_ae import ArtifactError, Universal3DAutoEncoder, VirtualVolumeSpec
+from jarvisx.volumetric_api import dashboard, execute_cycle
 
 
 def test_6400_gib_q16_16_metrics_are_virtual() -> None:
@@ -50,3 +51,20 @@ def test_self_test_reports_success() -> None:
     report = Universal3DAutoEncoder(VirtualVolumeSpec(chunk_bytes=256)).self_test()
     assert report["ok"] is True
     assert report["decode"]["verified"] is True
+
+
+def test_api_cycle_executes_real_encode_decode_verification() -> None:
+    payload = b"DM-vOmegaXi-live-cycle" * 2048
+    report = execute_cycle(payload)
+    assert report["verified"] is True
+    assert report["encode"]["payload_bytes"] == len(payload)
+    assert report["decode"]["payload_sha256"] == hashlib.sha256(payload).hexdigest()
+
+
+def test_dashboard_is_packaged_and_targets_live_runtime() -> None:
+    response = dashboard()
+    body = response.body.decode("utf-8")
+    assert "Live Runtime Telemetry" in body
+    assert "/v1/volumetric/metrics" in body
+    assert "/v1/volumetric/cycle" in body
+    assert "Measured Ratio" in body


### PR DESCRIPTION
## What changed

- replaces the simulated fixed compression factor with a real reversible chunked codec
- models the 6,400-GiB Q16.16 substrate as a sparse virtual 3D address space
- serializes self-contained `.jx3d` latent artifacts with per-chunk spatial coordinates and SHA-256 integrity metadata
- verifies byte-exact reconstruction and rejects corrupt/truncated artifacts
- adds CLI commands for metrics, self-test, encode, and decode
- adds a FastAPI service for encode/decode execution
- adds `POST /v1/volumetric/cycle` for one complete encode -> artifact -> decode -> verification transaction
- integrates the supplied Three.js 3D ANN Matrix dashboard and serves it directly at `/`
- replaces randomized dashboard compression/fidelity telemetry with actual runtime receipts: measured ratio, artifact bytes, chunks, encode/decode latency, SHA-256, and bit-exact verification
- adds drag rotation, wheel zoom, live API state, Run Once, and Pause/Resume Auto-Cycle controls
- packages the dashboard HTML with the Python distribution
- adds pytest coverage plus a Python 3.10/3.12 GitHub Actions workflow with a live HTTP dashboard/API smoke test
- registers `jarvisx-volumetric` and `jarvisx-volumetric-api` entry points
- documents the operational model and the distinction between virtual capacity and resident allocation

## Why

The original prototype reported compression and decoding semantics without producing a reconstructable latent representation. The supplied dashboard likewise visualized a 3D matrix but generated compression/fidelity numbers randomly in JavaScript. This PR turns both layers into one executable system: the backend performs a real reversible transform and the Three.js surface visualizes telemetry returned by that backend.

## Numerical correction

Q16.16 is represented as a 32-bit cell. At 6,400 GiB, the logical field contains `1,717,986,918,400` cells and requires a minimum cubic side of `11,977` cells. The field is virtual/sparse and is not eagerly allocated.

## Operational path

```text
Browser 3D dashboard
        |
        v
POST /v1/volumetric/cycle
        |
        v
payload -> chunk/XYZ map -> zlib latent artifact -> SHA-256 guarded decode -> byte-exact verification
        |
        v
execution receipts -> live dashboard telemetry
```

Start it with:

```bash
jarvisx-volumetric-api
```

Then open:

```text
http://127.0.0.1:8090/
```

## Validation

The focused test suite now covers:

- sparse 6,400-GiB numerical substrate invariants
- multi-chunk byte-exact round trip
- empty payload round trip
- corruption detection
- runtime self-test
- API-level verified cycle execution
- packaged dashboard/live endpoint integration

The dedicated GitHub Actions job additionally launches Uvicorn and exercises `/health`, `/`, and `/v1/volumetric/cycle` over HTTP on Python 3.10 and 3.12.

## Scope note

This is an operational storage/transport auto-encoding codec with a live 3D execution surface, not yet a trained neural autoencoder. The reported compression ratio is measured from the actual generated artifact rather than hard-coded or randomized.