### PR TITLE
Operationalize DM-vΩΞ⁺ SK-3D bytecode manifold

### DIFF
--- a/docs/DM_VOMEGAXI_SPATIAL_KERNEL.md
+++ b/docs/DM_VOMEGAXI_SPATIAL_KERNEL.md
@@ -1,0 +1,146 @@
+# DM-vΩΞ⁺ Spatial Kernel (SK-3D)
+
+## Status
+
+SK-3D is an executable, deterministic research reference for the submitted three-axis Dr Moagi equation. It maps the symbolic geometry into bounded software semantics and a render-neutral tetrahedral manifold. It is **not** a claim that software directly alters physical reality, that recursion is literally infinite, or that a 6.4 GB ROM image must be densely allocated.
+
+## Three-axis geometry
+
+For committed state \(S_t=(\Psi_t,\Theta_t,\Xi_t,\Omega_t)\), the decoded coordinate is
+
+\[
+\mathbf r_t=
+\begin{bmatrix}
+X_t\\Y_t\\Z_t
+\end{bmatrix}
+=
+\begin{bmatrix}
+\Phi\Xi_t\\
+\Psi_t\Theta_t\\
+\Lambda^{\Omega_t}
+\end{bmatrix}.
+\]
+
+The contraction/singularity scalar is
+
+\[
+s_t=\frac{\Psi_t\Phi}{\Lambda^{\Omega_t}}.
+\]
+
+The reference uses finite positive `recursion_base` for \(\Lambda\) and a bounded projection manifold instead of literal infinity.
+
+## Bounded recurrence
+
+One cycle evaluates a concrete form of the canonical recurrence
+
+\[
+\Xi_{t+1}=\Pi_{\rho}
+\left[
+\Xi_t + P_t - E_t + \Omega_{t+1}
++\kappa R_t
+-\eta\nabla_\Theta L_t
+-\zeta\nabla_H C_t
+\right],
+\]
+
+where
+
+\[
+E_t=X_t^{obs}-s_t,
+\]
+
+and the bounded residual memory is
+
+\[
+\Omega_{t+1}=\Pi_{\rho}
+\left[d_\Omega\Omega_t+g_\Omega E_t\right].
+\]
+
+`Πρ` is an explicit clamp to `[-projection_limit, projection_limit]`. This makes every persistent symbolic coordinate finite and machine representable.
+
+## Bytecode
+
+Each micro-instruction is exactly 64 bits:
+
+```text
+[ opcode:8 ][ flags:8 ][ operand:16 ][ immediate:32 ]
+```
+
+The canonical program is:
+
+```text
+ENCODE
+EVOLVE
+PROJECT
+DECODE
+ROTATE
+PULSE
+SEAL
+HALT
+```
+
+Eight instructions therefore occupy 64 physical bytes. The configured `6_400_000_000` byte ROM value is a logical capacity/namespace, not a dense allocation requirement.
+
+## Transaction boundary
+
+Every program executes on a shadow working state. Authoritative state changes only after `HALT` and only if all values remain finite and satisfy the projection manifold. Invalid inputs, malformed bytecode, instruction-budget violations and cycle-budget violations fail before partial state mutation.
+
+## Manifold decoder
+
+`DECODE` emits four semantic vertices:
+
+- Ψ vertex: `(0, Ψ, 0)`;
+- Φ vertex: `(Φ, 0, 0)`;
+- Λ vertex: `(0, 0, Λ^Ω)`;
+- Ω/Θ/Ξ closure vertex: `(-Ω, -Θ, -Ξ)`.
+
+`ROTATE` applies a deterministic Rodrigues rotation around `(1,1,1)/√3`. Angular velocity is
+
+\[
+\omega_t^{rot}=v(\Omega_t\Xi_t),
+\]
+
+and `PULSE` exposes reconstruction mismatch as
+
+\[
+A_t=A_0+\alpha|E_t|.
+\]
+
+The resulting `SpatialFrame` is renderer-neutral and can be consumed by a browser/WebGL, native graphics or telemetry frontend without making rendering part of authoritative execution.
+
+## Integrity
+
+`SEAL` computes a SHA-256 digest over the program image, configuration-defining geometry constants and complete persistent state encoded with deterministic big-endian IEEE-754 values. Equal initial states and equal inputs therefore produce equal state/frame digests.
+
+## Run
+
+```bash
+python -m pip install -e ".[dev]"
+pytest tests/test_dm_spatial_kernel.py
+python examples/dm_spatial_kernel.py
+```
+
+## Implemented versus proposed
+
+Implemented here:
+
+- 64-bit spatial microcode;
+- bounded Ψ/Θ/Ξ/Ω state evolution;
+- exact X/Y/Z projection;
+- residual-memory update;
+- Λ-style projection gate;
+- tetrahedral manifold decoding;
+- rotation and pulse telemetry;
+- deterministic state sealing;
+- cycle/instruction budgets;
+- transaction-before-commit semantics.
+
+Not implemented or claimed here:
+
+- literal infinite recursion;
+- physical 6.4 GB ROM hardware;
+- autonomous modification of arbitrary native code;
+- consciousness or self-awareness;
+- physical-world effects from symbolic execution;
+- learned multimodal encoders/decoders;
+- GPU acceleration or production performance guarantees.

--- a/examples/dm_spatial_kernel.py
+++ b/examples/dm_spatial_kernel.py
@@ -1,0 +1,35 @@
+"""Run the bounded DM-vOmegaXi+ SK-3D bytecode reference."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from jarvisx.dm_spatial_kernel import OME6400SpatialKernel, SpatialInputs
+
+
+def main() -> None:
+    kernel = OME6400SpatialKernel()
+    frame = kernel.run(
+        12,
+        SpatialInputs(
+            observation=0.72,
+            intent=0.45,
+            prediction=0.12,
+            refinement=0.08,
+            grad_theta=-0.02,
+            grad_h=0.01,
+        ),
+    )
+    receipt = {
+        "engine": "OME-6400 / DM-vOmegaXi+ SK-3D",
+        "virtual_rom_bytes": kernel.virtual_rom_bytes,
+        "physical_rom_bytes": kernel.physical_rom_bytes,
+        "state": asdict(kernel.state),
+        "frame": asdict(frame),
+    }
+    print(json.dumps(receipt, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/dm_spatial_kernel.py
+++ b/src/jarvisx/dm_spatial_kernel.py
@@ -1,7 +1,7 @@
 """Deterministic DM-vOmegaXi+ spatial-kernel reference.
 
 The module turns the symbolic three-axis Dr Moagi spatial equation into a bounded,
-auditable bytecode machine. It deliberately distinguishes a logical ROM capacity from
+auditable bytecode machine.  It deliberately distinguishes a logical ROM capacity from
 the tiny physical program image used by the reference implementation.
 """
 
@@ -237,7 +237,7 @@ class _WorkingCycle:
 class OME6400SpatialKernel:
     """Bounded bytecode executor for the DM-vOmegaXi+ SK-3D equation.
 
-    One bytecode program execution is one complete spatial cycle. All work occurs on a
+    One bytecode program execution is one complete spatial cycle.  All work occurs on a
     shadow state and is committed only after HALT, so malformed programs or non-finite
     transitions cannot partially mutate authoritative state.
     """
@@ -306,16 +306,18 @@ class OME6400SpatialKernel:
         self._state = committed
 
         axes, singularity = self.geometry(committed)
-        vertices = self._tetrahedron(committed, axes[2])
-        vertices = tuple(
-            self._rotate_and_scale(vertex, committed.rotation_angle, committed.pulse)
-            for vertex in vertices
+        base_vertices = self._tetrahedron(committed, axes[2])
+        vertices = (
+            self._rotate_and_scale(base_vertices[0], committed.rotation_angle, committed.pulse),
+            self._rotate_and_scale(base_vertices[1], committed.rotation_angle, committed.pulse),
+            self._rotate_and_scale(base_vertices[2], committed.rotation_angle, committed.pulse),
+            self._rotate_and_scale(base_vertices[3], committed.rotation_angle, committed.pulse),
         )
         return SpatialFrame(
             cycle=committed.cycle,
             axes=axes,
             singularity=singularity,
-            vertices=vertices,  # type: ignore[arg-type]
+            vertices=vertices,
             rotation_angle=committed.rotation_angle,
             pulse=committed.pulse,
             residual=committed.residual,
@@ -392,7 +394,7 @@ class OME6400SpatialKernel:
             working.state = self._seal(working.state)
         elif opcode is SpatialOpcode.HALT:
             working.halted = True
-        else:  # pragma: no cover
+        else:  # pragma: no cover - IntEnum validation makes this unreachable.
             raise RuntimeError(f"unhandled opcode {opcode!r}")
 
         self._validate_state(working.state)
@@ -426,9 +428,7 @@ class OME6400SpatialKernel:
         limit = self.config.projection_limit
         return min(limit, max(-limit, value))
 
-    def _tetrahedron(
-        self, state: SpatialState, recursion: float
-    ) -> Tuple[Vector3, Vector3, Vector3, Vector3]:
+    def _tetrahedron(self, state: SpatialState, recursion: float) -> Tuple[Vector3, Vector3, Vector3, Vector3]:
         return (
             (0.0, state.psi, 0.0),
             (self.config.phi, 0.0, 0.0),
@@ -438,6 +438,7 @@ class OME6400SpatialKernel:
 
     @staticmethod
     def _rotate_and_scale(vertex: Vector3, angle: float, scale: float) -> Vector3:
+        # Rodrigues rotation around normalized axis (1,1,1)/sqrt(3).
         x, y, z = vertex
         ux = uy = uz = 1.0 / math.sqrt(3.0)
         cosine = math.cos(angle)

--- a/src/jarvisx/dm_spatial_kernel.py
+++ b/src/jarvisx/dm_spatial_kernel.py
@@ -1,0 +1,472 @@
+"""Deterministic DM-vOmegaXi+ spatial-kernel reference.
+
+The module turns the symbolic three-axis Dr Moagi spatial equation into a bounded,
+auditable bytecode machine. It deliberately distinguishes a logical ROM capacity from
+the tiny physical program image used by the reference implementation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+from dataclasses import dataclass, replace
+from enum import IntEnum
+from typing import Iterable, Sequence, Tuple
+
+Vector3 = Tuple[float, float, float]
+
+
+class SpatialOpcode(IntEnum):
+    """Eight-byte micro-operations executed by :class:`OME6400SpatialKernel`."""
+
+    ENCODE = 0x10
+    EVOLVE = 0x20
+    PROJECT = 0x30
+    DECODE = 0x40
+    ROTATE = 0x50
+    PULSE = 0x60
+    SEAL = 0x70
+    HALT = 0xFF
+
+
+@dataclass(frozen=True)
+class SpatialInstruction:
+    """Fixed-width 64-bit instruction: opcode/flags/operand/immediate."""
+
+    opcode: SpatialOpcode
+    flags: int = 0
+    operand: int = 0
+    immediate: int = 0
+
+    WIDTH = 8
+    _STRUCT = struct.Struct(">BBHI")
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.flags <= 0xFF:
+            raise ValueError("flags must fit in 8 bits")
+        if not 0 <= self.operand <= 0xFFFF:
+            raise ValueError("operand must fit in 16 bits")
+        if not 0 <= self.immediate <= 0xFFFFFFFF:
+            raise ValueError("immediate must fit in 32 bits")
+
+    def to_bytes(self) -> bytes:
+        return self._STRUCT.pack(int(self.opcode), self.flags, self.operand, self.immediate)
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> "SpatialInstruction":
+        if len(payload) != cls.WIDTH:
+            raise ValueError("spatial instruction must be exactly 8 bytes")
+        opcode, flags, operand, immediate = cls._STRUCT.unpack(payload)
+        try:
+            decoded = SpatialOpcode(opcode)
+        except ValueError as exc:
+            raise ValueError(f"unsupported spatial opcode 0x{opcode:02X}") from exc
+        return cls(decoded, flags, operand, immediate)
+
+
+def default_program() -> Tuple[SpatialInstruction, ...]:
+    return tuple(
+        SpatialInstruction(opcode)
+        for opcode in (
+            SpatialOpcode.ENCODE,
+            SpatialOpcode.EVOLVE,
+            SpatialOpcode.PROJECT,
+            SpatialOpcode.DECODE,
+            SpatialOpcode.ROTATE,
+            SpatialOpcode.PULSE,
+            SpatialOpcode.SEAL,
+            SpatialOpcode.HALT,
+        )
+    )
+
+
+def assemble_program(program: Iterable[SpatialInstruction]) -> bytes:
+    instructions = tuple(program)
+    if not instructions:
+        raise ValueError("program cannot be empty")
+    return b"".join(instruction.to_bytes() for instruction in instructions)
+
+
+def decode_program(payload: bytes) -> Tuple[SpatialInstruction, ...]:
+    if not payload or len(payload) % SpatialInstruction.WIDTH:
+        raise ValueError("bytecode length must be a non-zero multiple of 8")
+    return tuple(
+        SpatialInstruction.from_bytes(payload[offset : offset + SpatialInstruction.WIDTH])
+        for offset in range(0, len(payload), SpatialInstruction.WIDTH)
+    )
+
+
+@dataclass(frozen=True)
+class SpatialKernelConfig:
+    """Numerical and execution bounds for the SK-3D reference machine."""
+
+    phi: float = 1.618033988749895
+    recursion_base: float = 2.0
+    projection_limit: float = 4.0
+    velocity: float = 0.75
+    dt: float = 1.0 / 60.0
+    kappa: float = 0.10
+    eta: float = 0.05
+    zeta: float = 0.05
+    omega_decay: float = 0.98
+    omega_gain: float = 0.05
+    pulse_base: float = 1.0
+    pulse_gain: float = 0.25
+    max_program_instructions: int = 64
+    max_cycles: int = 4096
+    virtual_rom_bytes: int = 6_400_000_000
+
+    def __post_init__(self) -> None:
+        for name in (
+            "phi",
+            "recursion_base",
+            "projection_limit",
+            "velocity",
+            "dt",
+            "kappa",
+            "eta",
+            "zeta",
+            "omega_decay",
+            "omega_gain",
+            "pulse_base",
+            "pulse_gain",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.phi <= 0.0:
+            raise ValueError("phi must be positive")
+        if self.recursion_base <= 0.0:
+            raise ValueError("recursion_base must be positive")
+        if self.projection_limit <= 0.0:
+            raise ValueError("projection_limit must be positive")
+        if self.dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if self.kappa < 0.0 or self.eta < 0.0 or self.zeta < 0.0:
+            raise ValueError("kappa, eta and zeta must be non-negative")
+        if not 0.0 <= self.omega_decay <= 1.0:
+            raise ValueError("omega_decay must be in [0, 1]")
+        if self.omega_gain < 0.0:
+            raise ValueError("omega_gain must be non-negative")
+        if self.pulse_base <= 0.0 or self.pulse_gain < 0.0:
+            raise ValueError("pulse_base must be positive and pulse_gain non-negative")
+
+        for name in ("max_program_instructions", "max_cycles", "virtual_rom_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+
+
+@dataclass(frozen=True)
+class SpatialInputs:
+    """External terms supplied to one bounded Dr Moagi recurrence."""
+
+    observation: float = 0.0
+    intent: float | None = None
+    prediction: float = 0.0
+    refinement: float = 0.0
+    grad_theta: float = 0.0
+    grad_h: float = 0.0
+
+    def validate(self) -> None:
+        for name in ("observation", "prediction", "refinement", "grad_theta", "grad_h"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if self.intent is not None:
+            if isinstance(self.intent, bool) or not isinstance(self.intent, (int, float)):
+                raise TypeError("intent must be numeric when supplied")
+            if not math.isfinite(float(self.intent)):
+                raise ValueError("intent must be finite")
+
+
+@dataclass(frozen=True)
+class SpatialState:
+    """Persistent state of the symbolic cognitive/recursive kernel."""
+
+    psi: float = 0.0
+    theta: float = 1.0
+    xi: float = 0.0
+    omega: float = 0.0
+    cycle: int = 0
+    rotation_angle: float = 0.0
+    pulse: float = 1.0
+    residual: float = 0.0
+    digest: str = ""
+
+
+@dataclass(frozen=True)
+class SpatialFrame:
+    """Decoded render-neutral manifold for a single committed cycle."""
+
+    cycle: int
+    axes: Vector3
+    singularity: float
+    vertices: Tuple[Vector3, Vector3, Vector3, Vector3]
+    rotation_angle: float
+    pulse: float
+    residual: float
+    digest: str
+
+
+@dataclass
+class _WorkingCycle:
+    state: SpatialState
+    encoded: float = 0.0
+    anticipation: float = 0.0
+    candidate_xi: float = 0.0
+    axes: Vector3 = (0.0, 0.0, 1.0)
+    singularity: float = 0.0
+    vertices: Tuple[Vector3, Vector3, Vector3, Vector3] = (
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+    )
+    halted: bool = False
+
+
+class OME6400SpatialKernel:
+    """Bounded bytecode executor for the DM-vOmegaXi+ SK-3D equation.
+
+    One bytecode program execution is one complete spatial cycle. All work occurs on a
+    shadow state and is committed only after HALT, so malformed programs or non-finite
+    transitions cannot partially mutate authoritative state.
+    """
+
+    def __init__(
+        self,
+        config: SpatialKernelConfig | None = None,
+        state: SpatialState | None = None,
+        program: Sequence[SpatialInstruction] | None = None,
+    ) -> None:
+        self.config = config or SpatialKernelConfig()
+        self._program = tuple(program or default_program())
+        self._validate_program(self._program)
+        initial = state or SpatialState(pulse=self.config.pulse_base)
+        self._validate_state(initial)
+        self._state = self._seal(initial)
+
+    @property
+    def state(self) -> SpatialState:
+        return self._state
+
+    @property
+    def program(self) -> Tuple[SpatialInstruction, ...]:
+        return self._program
+
+    @property
+    def rom_image(self) -> bytes:
+        return assemble_program(self._program)
+
+    @property
+    def physical_rom_bytes(self) -> int:
+        return len(self.rom_image)
+
+    @property
+    def virtual_rom_bytes(self) -> int:
+        return self.config.virtual_rom_bytes
+
+    def geometry(self, state: SpatialState | None = None) -> Tuple[Vector3, float]:
+        current = state or self._state
+        recursion = self.config.recursion_base ** current.omega
+        axes = (
+            self.config.phi * current.xi,
+            current.psi * current.theta,
+            recursion,
+        )
+        singularity = (current.psi * self.config.phi) / recursion
+        return axes, singularity
+
+    def execute_cycle(self, inputs: SpatialInputs | None = None) -> SpatialFrame:
+        if self._state.cycle >= self.config.max_cycles:
+            raise RuntimeError("maximum cycle budget reached")
+        supplied = inputs or SpatialInputs()
+        supplied.validate()
+        working = _WorkingCycle(state=self._state)
+
+        for instruction in self._program:
+            self._dispatch(instruction, supplied, working)
+            if working.halted:
+                break
+
+        if not working.halted:
+            raise RuntimeError("program terminated without HALT")
+        committed = replace(working.state, cycle=self._state.cycle + 1)
+        self._validate_state(committed)
+        committed = self._seal(committed)
+        self._state = committed
+
+        axes, singularity = self.geometry(committed)
+        vertices = self._tetrahedron(committed, axes[2])
+        vertices = tuple(
+            self._rotate_and_scale(vertex, committed.rotation_angle, committed.pulse)
+            for vertex in vertices
+        )
+        return SpatialFrame(
+            cycle=committed.cycle,
+            axes=axes,
+            singularity=singularity,
+            vertices=vertices,  # type: ignore[arg-type]
+            rotation_angle=committed.rotation_angle,
+            pulse=committed.pulse,
+            residual=committed.residual,
+            digest=committed.digest,
+        )
+
+    def run(self, cycles: int, inputs: SpatialInputs | None = None) -> SpatialFrame:
+        if isinstance(cycles, bool) or not isinstance(cycles, int):
+            raise TypeError("cycles must be an integer")
+        if cycles <= 0:
+            raise ValueError("cycles must be positive")
+        if self._state.cycle + cycles > self.config.max_cycles:
+            raise RuntimeError("requested cycles exceed maximum cycle budget")
+        frame: SpatialFrame | None = None
+        for _ in range(cycles):
+            frame = self.execute_cycle(inputs)
+        assert frame is not None
+        return frame
+
+    def _dispatch(
+        self,
+        instruction: SpatialInstruction,
+        inputs: SpatialInputs,
+        working: _WorkingCycle,
+    ) -> None:
+        opcode = instruction.opcode
+        if opcode is SpatialOpcode.ENCODE:
+            psi = working.state.psi if inputs.intent is None else self._project(float(inputs.intent))
+            encoded = math.tanh(psi * self.config.phi + float(inputs.observation))
+            anticipation = math.tanh(float(inputs.prediction) + encoded + 0.5 * working.state.xi)
+            working.state = replace(working.state, psi=psi)
+            working.encoded = encoded
+            working.anticipation = anticipation
+        elif opcode is SpatialOpcode.EVOLVE:
+            _, decoded = self.geometry(working.state)
+            residual = float(inputs.observation) - decoded
+            omega = self._project(
+                self.config.omega_decay * working.state.omega
+                + self.config.omega_gain * residual
+            )
+            theta = self._project(
+                working.state.theta - self.config.eta * float(inputs.grad_theta)
+            )
+            working.candidate_xi = (
+                working.state.xi
+                + working.anticipation
+                - residual
+                + omega
+                + self.config.kappa * float(inputs.refinement)
+                - self.config.eta * float(inputs.grad_theta)
+                - self.config.zeta * float(inputs.grad_h)
+            )
+            working.state = replace(
+                working.state,
+                theta=theta,
+                omega=omega,
+                residual=residual,
+            )
+        elif opcode is SpatialOpcode.PROJECT:
+            working.state = replace(working.state, xi=self._project(working.candidate_xi))
+        elif opcode is SpatialOpcode.DECODE:
+            working.axes, working.singularity = self.geometry(working.state)
+            working.vertices = self._tetrahedron(working.state, working.axes[2])
+        elif opcode is SpatialOpcode.ROTATE:
+            angular_velocity = self.config.velocity * (working.state.omega * working.state.xi)
+            angle = (working.state.rotation_angle + angular_velocity * self.config.dt) % (
+                2.0 * math.pi
+            )
+            working.state = replace(working.state, rotation_angle=angle)
+        elif opcode is SpatialOpcode.PULSE:
+            pulse = self.config.pulse_base + self.config.pulse_gain * abs(working.state.residual)
+            working.state = replace(working.state, pulse=pulse)
+        elif opcode is SpatialOpcode.SEAL:
+            working.state = self._seal(working.state)
+        elif opcode is SpatialOpcode.HALT:
+            working.halted = True
+        else:  # pragma: no cover
+            raise RuntimeError(f"unhandled opcode {opcode!r}")
+
+        self._validate_state(working.state)
+
+    def _validate_program(self, program: Sequence[SpatialInstruction]) -> None:
+        if not program:
+            raise ValueError("program cannot be empty")
+        if len(program) > self.config.max_program_instructions:
+            raise ValueError("program exceeds instruction budget")
+        if SpatialOpcode.HALT not in tuple(instruction.opcode for instruction in program):
+            raise ValueError("program must contain HALT")
+
+    def _validate_state(self, state: SpatialState) -> None:
+        if isinstance(state.cycle, bool) or not isinstance(state.cycle, int) or state.cycle < 0:
+            raise ValueError("cycle must be a non-negative integer")
+        for name in ("psi", "theta", "xi", "omega", "rotation_angle", "pulse", "residual"):
+            value = getattr(state, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"state {name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"state {name} must be finite")
+        for name in ("psi", "theta", "xi", "omega"):
+            if abs(float(getattr(state, name))) > self.config.projection_limit + 1.0e-12:
+                raise ValueError(f"state {name} lies outside the projection manifold")
+        if state.pulse <= 0.0:
+            raise ValueError("state pulse must be positive")
+
+    def _project(self, value: float) -> float:
+        if not math.isfinite(value):
+            raise ValueError("projection candidate must be finite")
+        limit = self.config.projection_limit
+        return min(limit, max(-limit, value))
+
+    def _tetrahedron(
+        self, state: SpatialState, recursion: float
+    ) -> Tuple[Vector3, Vector3, Vector3, Vector3]:
+        return (
+            (0.0, state.psi, 0.0),
+            (self.config.phi, 0.0, 0.0),
+            (0.0, 0.0, recursion),
+            (-state.omega, -state.theta, -state.xi),
+        )
+
+    @staticmethod
+    def _rotate_and_scale(vertex: Vector3, angle: float, scale: float) -> Vector3:
+        x, y, z = vertex
+        ux = uy = uz = 1.0 / math.sqrt(3.0)
+        cosine = math.cos(angle)
+        sine = math.sin(angle)
+        dot = ux * x + uy * y + uz * z
+        cross = (uy * z - uz * y, uz * x - ux * z, ux * y - uy * x)
+        rotated = (
+            x * cosine + cross[0] * sine + ux * dot * (1.0 - cosine),
+            y * cosine + cross[1] * sine + uy * dot * (1.0 - cosine),
+            z * cosine + cross[2] * sine + uz * dot * (1.0 - cosine),
+        )
+        return tuple(scale * component for component in rotated)  # type: ignore[return-value]
+
+    def _seal(self, state: SpatialState) -> SpatialState:
+        digest = hashlib.sha256()
+        digest.update(b"jarvisx-dm-vomegaxi-sk3d-v1\0")
+        digest.update(struct.pack(">Q", state.cycle))
+        for value in (
+            self.config.phi,
+            self.config.recursion_base,
+            self.config.projection_limit,
+            state.psi,
+            state.theta,
+            state.xi,
+            state.omega,
+            state.rotation_angle,
+            state.pulse,
+            state.residual,
+        ):
+            digest.update(struct.pack(">d", float(value)))
+        digest.update(self.rom_image)
+        return replace(state, digest=digest.hexdigest())

--- a/tests/test_dm_spatial_kernel.py
+++ b/tests/test_dm_spatial_kernel.py
@@ -1,0 +1,107 @@
+import math
+
+import pytest
+
+from jarvisx.dm_spatial_kernel import (
+    OME6400SpatialKernel,
+    SpatialInstruction,
+    SpatialInputs,
+    SpatialKernelConfig,
+    SpatialOpcode,
+    SpatialState,
+    assemble_program,
+    decode_program,
+    default_program,
+)
+
+
+def test_default_program_is_real_fixed_width_bytecode() -> None:
+    program = default_program()
+    payload = assemble_program(program)
+
+    assert len(program) == 8
+    assert len(payload) == 64
+    assert decode_program(payload) == program
+    assert program[-1].opcode is SpatialOpcode.HALT
+
+
+def test_geometry_matches_three_axis_equation() -> None:
+    state = SpatialState(psi=0.5, theta=0.25, xi=0.75, omega=1.0)
+    kernel = OME6400SpatialKernel(state=state)
+
+    axes, singularity = kernel.geometry()
+
+    assert axes[0] == pytest.approx(kernel.config.phi * state.xi)
+    assert axes[1] == pytest.approx(state.psi * state.theta)
+    assert axes[2] == pytest.approx(kernel.config.recursion_base**state.omega)
+    assert singularity == pytest.approx(state.psi * kernel.config.phi / axes[2])
+
+
+def test_cycle_is_deterministic_and_bounded() -> None:
+    inputs = SpatialInputs(
+        observation=0.75,
+        intent=0.4,
+        prediction=0.2,
+        refinement=0.1,
+        grad_theta=-0.05,
+        grad_h=0.025,
+    )
+    first = OME6400SpatialKernel()
+    second = OME6400SpatialKernel()
+
+    a = first.run(6, inputs)
+    b = second.run(6, inputs)
+
+    assert a == b
+    assert first.state == second.state
+    assert len(a.digest) == 64
+    for value in (first.state.psi, first.state.theta, first.state.xi, first.state.omega):
+        assert abs(value) <= first.config.projection_limit
+        assert math.isfinite(value)
+
+
+def test_virtual_rom_capacity_does_not_allocate_6_4_gb() -> None:
+    kernel = OME6400SpatialKernel()
+
+    assert kernel.virtual_rom_bytes == 6_400_000_000
+    assert kernel.physical_rom_bytes == 64
+
+
+def test_error_drives_pulse_telemetry() -> None:
+    low = OME6400SpatialKernel(state=SpatialState(psi=0.0, theta=1.0))
+    high = OME6400SpatialKernel(state=SpatialState(psi=0.0, theta=1.0))
+
+    low_frame = low.execute_cycle(SpatialInputs(observation=0.0))
+    high_frame = high.execute_cycle(SpatialInputs(observation=1.0))
+
+    assert high_frame.pulse > low_frame.pulse
+
+
+def test_invalid_inputs_are_rejected_without_mutation() -> None:
+    kernel = OME6400SpatialKernel()
+    before = kernel.state
+
+    with pytest.raises(ValueError, match="finite"):
+        kernel.execute_cycle(SpatialInputs(observation=float("nan")))
+
+    assert kernel.state == before
+
+
+def test_program_without_halt_is_rejected() -> None:
+    with pytest.raises(ValueError, match="HALT"):
+        OME6400SpatialKernel(program=(SpatialInstruction(SpatialOpcode.ENCODE),))
+
+
+def test_cycle_budget_is_enforced() -> None:
+    kernel = OME6400SpatialKernel(SpatialKernelConfig(max_cycles=2))
+    kernel.run(2)
+
+    with pytest.raises(RuntimeError, match="maximum cycle budget"):
+        kernel.execute_cycle()
+
+
+def test_bad_opcode_and_bad_bytecode_width_are_rejected() -> None:
+    with pytest.raises(ValueError, match="multiple of 8"):
+        decode_program(b"abc")
+    with pytest.raises(ValueError, match="unsupported spatial opcode"):
+        SpatialInstruction.from_bytes(bytes([0x01, 0, 0, 0, 0, 0, 0, 0]))


### PR DESCRIPTION
## What changed

- add `src/jarvisx/dm_spatial_kernel.py`, a deterministic bounded OME-6400 spatial-kernel reference
- implement a real fixed-width 64-bit microcode format and canonical eight-op cycle: `ENCODE -> EVOLVE -> PROJECT -> DECODE -> ROTATE -> PULSE -> SEAL -> HALT`
- map the submitted three-axis equation to executable coordinates `X = ΦΞ`, `Y = ΨΘ`, and `Z = Λ^Ω`
- implement the contraction scalar `s = ΨΦ / Λ^Ω`
- implement bounded Ξ recurrence terms, residual Ω memory, explicit projection, cycle and instruction budgets, and shadow-state-before-commit semantics
- decode every committed state into a renderer-neutral tetrahedral manifold with deterministic Rodrigues rotation and residual-driven pulse telemetry
- seal committed state with SHA-256 over canonical numeric state and the exact ROM program image
- add a runnable JSON receipt example and a full engineering specification
- add focused invariants for bytecode round-trip, exact geometry, determinism, projection bounds, logical-versus-physical ROM capacity, failure atomicity, and execution budgets

## Why

The submitted DM-vΩΞ⁺ spatial equation described a rotating tetrahedral entity and a nominal 6.4 GB auto-executing ROM, but the pseudocode used non-executable semantics such as floating-point XOR for exponentiation and literal infinite recursion. This PR converts the concept into a finite auditable software contract while preserving the intended geometry and recurrence vocabulary.

## Operational contract

```text
64-bit ROM instruction
    -> ENCODE
    -> EVOLVE
    -> Π projection
    -> DECODE X/Y/Z
    -> ROTATE manifold
    -> PULSE residual telemetry
    -> SHA-256 SEAL
    -> HALT / atomic commit
```

The reference exposes `virtual_rom_bytes = 6_400_000_000` as logical capacity while the canonical program physically occupies 64 bytes. No 6.4 GB dense allocation is required.

## Validation

Focused local reference validation:

```text
9 passed in 0.03s
```

Additional local checks:

- Python bytecode compilation: passed
- runnable JSON example: passed
- branch diff versus `main`: 4 new files, 760 additions, 0 deletions

Repository CI remains authoritative before this draft is marked ready.

## Capability boundary

This is an executable mathematical research reference. It does not implement literal infinite recursion, physical OME-6400 hardware, arbitrary native-code self-rewriting, consciousness, direct physical-world effects, learned multimodal neural encoders/decoders, GPU acceleration, or production performance guarantees. Those require separate implementation and empirical evidence.