### PR TITLE
Operationalize Jarvis-X and bounded Dr Moagi 3D codec runtime

### DIFF
--- a/.github/workflows/dr-moagi-codec-runtime.yml
+++ b/.github/workflows/dr-moagi-codec-runtime.yml
@@ -1,0 +1,62 @@
+name: Dr Moagi Codec Runtime
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dr-moagi-codec-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codec-reference:
+    name: Codec reference invariants
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install tests
+        run: python -m pip install -e ".[test]"
+
+      - name: Compile upgraded runtime
+        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py tests/test_dr_moagi_codec_3d.py
+
+      - name: Run codec invariants
+        run: pytest tests/test_dr_moagi_codec_3d.py
+
+  container:
+    name: API container smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build container
+        run: docker build -t jarvisx-codec:test .
+
+      - name: Start API
+        run: docker run -d --rm --name jarvisx-api -p 18080:8080 jarvisx-codec:test
+
+      - name: Verify health endpoint
+        run: |
+          for attempt in $(seq 1 20); do
+            if curl --fail --silent http://127.0.0.1:18080/health > /tmp/health.json; then
+              cat /tmp/health.json
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs jarvisx-api
+          exit 1

--- a/.github/workflows/dr-moagi-codec-runtime.yml
+++ b/.github/workflows/dr-moagi-codec-runtime.yml
@@ -34,7 +34,7 @@ jobs:
         run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py tests/test_dr_moagi_codec_3d.py
 
       - name: Run codec invariants
-        run: pytest tests/test_dr_moagi_codec_3d.py
+        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py
 
   container:
     name: API container smoke test

--- a/.github/workflows/dr-moagi-codec-runtime.yml
+++ b/.github/workflows/dr-moagi-codec-runtime.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   codec-reference:
-    name: Codec and API reference invariants
+    name: Codec and operational interface invariants
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,10 +31,10 @@ jobs:
         run: python -m pip install -e ".[test]"
 
       - name: Compile upgraded runtime
-        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py tests/test_dr_moagi_codec_3d.py tests/test_api.py
+        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py src/jarvisx/web.py src/jarvisx/cli.py tests/test_dr_moagi_codec_3d.py tests/test_api.py tests/test_cli_operational.py
 
       - name: Run focused invariants
-        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py tests/test_api.py
+        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py tests/test_api.py tests/test_cli_operational.py
 
   container:
     name: API container smoke test

--- a/.github/workflows/dr-moagi-codec-runtime.yml
+++ b/.github/workflows/dr-moagi-codec-runtime.yml
@@ -31,10 +31,10 @@ jobs:
         run: python -m pip install -e ".[test]"
 
       - name: Compile upgraded runtime
-        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py src/jarvisx/web.py src/jarvisx/cli.py tests/test_dr_moagi_codec_3d.py tests/test_api.py tests/test_cli_operational.py
+        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/operational.py src/jarvisx/api.py src/jarvisx/web.py src/jarvisx/cli.py tests/test_dr_moagi_codec_3d.py tests/test_operational.py tests/test_api.py tests/test_cli_operational.py
 
       - name: Run focused invariants
-        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py tests/test_api.py tests/test_cli_operational.py
+        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py tests/test_operational.py tests/test_api.py tests/test_cli_operational.py
 
   container:
     name: API container smoke test

--- a/.github/workflows/dr-moagi-codec-runtime.yml
+++ b/.github/workflows/dr-moagi-codec-runtime.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   codec-reference:
-    name: Codec reference invariants
+    name: Codec and API reference invariants
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,10 +31,10 @@ jobs:
         run: python -m pip install -e ".[test]"
 
       - name: Compile upgraded runtime
-        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py tests/test_dr_moagi_codec_3d.py
+        run: python -m compileall -q src/jarvisx/dr_moagi_codec_3d.py src/jarvisx/api.py tests/test_dr_moagi_codec_3d.py tests/test_api.py
 
-      - name: Run codec invariants
-        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py
+      - name: Run focused invariants
+        run: pytest -o addopts="-ra --strict-config --strict-markers --tb=short" tests/test_dr_moagi_codec_3d.py tests/test_api.py
 
   container:
     name: API container smoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM python:3.10-slim
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PORT=8080
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
+COPY pyproject.toml README.md LICENSE ./
 COPY src/ ./src/
-COPY setup.py .
-RUN pip install .
 
-EXPOSE 10000
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir .
 
-CMD ["sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port $PORT"]
+EXPOSE 8080
+
+CMD ["sh", "-c", "uvicorn jarvisx.api:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/docs/DR_MOAGI_3D_CODEC_IMPLEMENTATION.md
+++ b/docs/DR_MOAGI_3D_CODEC_IMPLEMENTATION.md
@@ -1,0 +1,110 @@
+# Dr Moagi 3D Codec Reference Implementation
+
+**Status:** executable alpha reference  
+**Architecture:** ADR-002 and `docs/research/DR_MOAGI_3D_CODEC_RUNTIME.md`  
+**Runtime:** `src/jarvisx/dr_moagi_codec_3d.py`
+
+## Purpose
+
+This module operationalizes the minimum bounded transaction defined by ADR-002 while preserving the deterministic Jarvis-X core boundary. It is a correctness-oriented scalar 3D reference, not a trained neural codec and not a production compression benchmark.
+
+## Executed transaction
+
+```text
+Volume3D X
+  -> validate shape / finite values / resource ceiling
+  -> mean-centre reference transform
+  -> uniform scalar quantization
+  -> signed 64-bit latent Z
+  -> zlib entropy coding
+  -> versioned JX3D bitstream B
+  -> SHA-256 payload verification
+  -> bounded entropy decode
+  -> dequantize / reconstruct X_hat
+  -> measure local MSE, anchor MSE and rate
+  -> Pi_Lambda-style admissibility checks
+  -> commit Omega_codec statistics or rollback
+```
+
+The entropy stage is lossless over the discrete signed-64-bit latent representation. Reconstruction loss is introduced by quantization, not by zlib.
+
+## Bitstream contract
+
+The fixed header binds:
+
+- magic `JX3D`;
+- format version;
+- codec architecture version;
+- entropy version;
+- three-dimensional shape;
+- quantizer step;
+- encoded mean;
+- latent count;
+- compressed payload length;
+- SHA-256 digest of the compressed payload.
+
+Malformed dimensions, incompatible versions, invalid quantizer values, digest mismatch, decompression-size mismatch and resource-limit violations fail closed.
+
+## Transaction boundary
+
+`DrMoagiCodec3D.process()` snapshots the current `Omega_codec` state before evaluation. A candidate is committed only when its telemetry is admissible. Anchor or rate rejection leaves authoritative adaptive memory unchanged.
+
+The immutable first source is retained as the runtime anchor. This allows repeated operations to distinguish local self-consistency from drift relative to the original source.
+
+## Million-step semantics
+
+`virtual_depth` may be configured up to `1_000_000`, matching ADR-002. The reference transaction reports:
+
+```text
+virtual_depth
+measured_microsteps_executed
+wall_clock_seconds
+measured_throughput_voxels_per_second
+```
+
+The current implementation executes one physical codec transaction per call and reports `measured_microsteps_executed = 1`. It does not infer one million physical transitions from a virtual-depth setting.
+
+## API
+
+The canonical FastAPI service exposes:
+
+```text
+GET  /health
+POST /run
+POST /codec/roundtrip
+```
+
+`/run` creates a fresh `CodexVM` per request, avoiding shared mutable VM state across concurrent requests. `/codec/roundtrip` creates a bounded reference codec transaction with an API-level voxel ceiling.
+
+## Validation
+
+Focused invariants cover:
+
+1. deterministic bitstream generation;
+2. quantization reconstruction-error bound;
+3. payload-corruption detection;
+4. anchor-drift rejection with atomic rollback;
+5. explicit virtual-depth versus measured-step telemetry;
+6. shape and resource-limit rejection.
+
+Run:
+
+```bash
+pytest tests/test_dr_moagi_codec_3d.py
+```
+
+The dedicated GitHub Actions workflow also builds the package container and probes `/health` after startup.
+
+## Capability boundary
+
+This implementation establishes a reproducible codec transaction and deployable API surface. It does **not** establish:
+
+- trained neural compression quality;
+- a literal one-million-pass dense 3D runtime;
+- learned entropy modelling;
+- autonomous architecture mutation;
+- production security certification;
+- hardware acceleration;
+- superiority over established image/video/volume codecs.
+
+Those remain later Layer 4/5 research stages and require independent benchmarks and evidence artifacts.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-01  
+**Last reviewed:** 2026-08-10  
 **Release line:** `0.1.x` alpha
 
 This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
@@ -33,6 +33,8 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Fractional 3D smoothing | Numerical reference | `fractional_smoothing_3d.py`, independent DFT/stencil/semigroup tests | dense periodic scalar grids and separable `O(N⁴)` cubic DFT; not a production FFT or calibrated physical model |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
+| Dr Moagi 3D codec reference | Alpha | `dr_moagi_codec_3d.py`, focused invariants, ADR-002 | bounded scalar correctness reference using uniform quantization and zlib; not a trained neural codec or literal million-pass runtime |
+| FastAPI operational surface | Alpha | `api.py`, `Dockerfile`, codec-runtime workflow | development/reference API with request bounds; not an authenticated hostile-network security boundary |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
@@ -55,6 +57,8 @@ The gate currently tests five falsifiable properties:
 3. sparse-field insertion-order invariance, checkpoint replay and atomic rollback;
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
+
+The Dr Moagi codec reference adds focused CI invariants for deterministic bitstream generation, quantization error bounds, payload integrity, immutable-anchor rollback, resource rejection and virtual-versus-measured depth reporting. These focused tests are additive to the package-wide empirical evidence gate until the next evidence-schema revision.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -88,7 +92,8 @@ Jarvis-X does not currently claim:
 - safety certification from the presence of a policy or coherence gate;
 - bit-exact cross-platform floating-point results from the C++ research processor;
 - production-scale fractional PDE performance or physical validity from the numerical reference solver;
-- empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines.
+- empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines;
+- one million physically executed codec transitions from `virtual_depth = 1_000_000` telemetry.
 
 ## Canonical promotion checklist
 
@@ -130,6 +135,7 @@ A capability moves to `main` only when all applicable items are satisfied:
 
 ### `0.4.0` — Bounded adaptive laboratory
 
+- versioned 3D codec reference promoted into the consolidated empirical evidence artifact;
 - shadow evaluation API;
 - reproducible candidate generation;
 - rollback-complete state transitions;

--- a/docs/SYSTEM_OPERATIONAL_FRAMEWORK.md
+++ b/docs/SYSTEM_OPERATIONAL_FRAMEWORK.md
@@ -1,0 +1,403 @@
+# Jarvis-X System Operational Framework
+
+**Status:** canonical operational integration contract  
+**Date:** 2026-08-10  
+**Core rule:** authority is earned by executable contracts, bounded resources, tests and commit/rollback semantics.
+
+## 1. System objective
+
+Jarvis-X is operated as a deterministic transactional virtual machine with bounded research subsystems around it. Advanced spatial, codec, adaptive, predictive, transport and visualization layers may propose state or derive telemetry, but they do not silently become authoritative compute state.
+
+The constitutional transaction is:
+
+```text
+observe / acquire
+  -> construct typed candidate state
+  -> validate representation and resources
+  -> execute bounded transformation
+  -> measure evidence
+  -> Pi_Lambda admissibility
+  -> atomic commit or rollback
+  -> Omega provenance / adaptive-memory update
+  -> emit receipt and telemetry
+```
+
+A symbolic name, virtual scale, visualization, digest or recursion depth does not establish physical capability by itself.
+
+## 2. Authority planes
+
+### Layer 0 — Representation
+
+Authoritative contracts:
+
+- assembly grammar;
+- typed instructions;
+- fixed-width bytecode;
+- versioned persistent binary envelopes;
+- exact shape, dtype and endianness where serialized.
+
+### Layer 1 — Execution
+
+Authoritative contracts:
+
+- `CodexVM` instruction dispatch;
+- register/memory mutation;
+- instruction pointer and cycle state;
+- halt/failure semantics;
+- enforced cycle ceiling.
+
+### Layer 2 — Policy and transactions
+
+Authoritative contracts:
+
+- instruction policy;
+- precondition checks;
+- whole-cycle VM checkpoint;
+- fail-closed validation;
+- commit or rollback.
+
+`Pi_Lambda` is the general admissibility mechanism. Policy/ethical rules may contribute constraints, but the complete gate also includes numerical, version, integrity and resource constraints.
+
+### Layer 3 — Observation and provenance
+
+Authoritative provenance:
+
+- trace records;
+- Omega journal;
+- hash-chain verification;
+- explicit checkpoints;
+- reproducible receipts.
+
+A digest establishes integrity of represented bytes; it does not imply reversibility or truth of the represented claim.
+
+### Layer 4 — Sparse spatial and codec computation
+
+Bounded research authority:
+
+- sparse virtual coordinate systems;
+- octree and billion-address references;
+- 3D codec bitstreams;
+- shape/version/integrity contracts;
+- bounded materialization.
+
+Virtual extent is always reported separately from resident allocation.
+
+### Layer 5 — Adaptive laboratory
+
+Candidate-only authority until commit:
+
+- residual memory;
+- parameter mutation;
+- architecture candidates;
+- schedulers;
+- predictors;
+- shadow evaluation.
+
+Candidate state cannot mutate active state before validation. Architecture or entropy-model versions participating in one codec transaction must remain coherent for the entire transaction.
+
+### Layer 6 — Interfaces
+
+Non-authoritative interfaces:
+
+- FastAPI;
+- CLI;
+- browser dashboard;
+- visualization;
+- export and telemetry presentation.
+
+Interfaces invoke canonical operations; they do not redefine instruction or codec semantics.
+
+## 3. Canonical operational facade
+
+`src/jarvisx/operational.py` provides the dependency-light execution path shared by interfaces.
+
+```text
+source
+  -> Parser
+  -> Assembler
+  -> bytecode
+  -> fresh CodexVM
+  -> bounded execution
+  -> ledger verification
+  -> VMExecutionReceipt
+```
+
+Every interface-level VM request receives a fresh VM instance so state is not accidentally shared across independent API requests.
+
+The receipt contains:
+
+```text
+registers
+cycles
+ledger_entries
+ledger_valid
+trace_entries
+```
+
+## 4. Dr Moagi 3D codec transaction
+
+The executable alpha reference is:
+
+```text
+X
+  -> validate
+  -> mean-centre E_ref^3D
+  -> Q_Delta
+  -> signed-64 latent Z
+  -> zlib C(Z)
+  -> versioned JX3D bitstream B
+  -> SHA-256 integrity verification
+  -> C^-1(B)
+  -> Q_Delta^-1
+  -> X_hat
+  -> local distortion / anchor distortion / rate
+  -> admissibility gate
+  -> commit Omega_codec or rollback
+```
+
+The reference separates:
+
+```text
+Omega_vm     = provenance journal
+Omega_codec  = bounded codec statistics
+```
+
+These domains must not be conflated.
+
+## 5. Virtual-depth contract
+
+A macro depth such as:
+
+```text
+virtual_depth = 1_000_000
+```
+
+is a logical parameter unless execution evidence demonstrates equivalent physical work. Every implementation exposing virtual depth must also expose measured execution fields such as:
+
+```text
+measured_microsteps_executed
+wall_clock_seconds
+measured_throughput
+resident_memory
+```
+
+The current codec reference executes one physical transaction per call and reports that fact explicitly.
+
+## 6. Operational entrypoints
+
+### Python
+
+```python
+from jarvisx.operational import execute_source
+receipt = execute_source("SET Ψ 10\nHALT")
+```
+
+### CLI
+
+```text
+jarvisx run program.codex
+jarvisx api --host 0.0.0.0 --port 8080
+jarvisx web --host 0.0.0.0 --port 8080
+jarvisx codec volume.json --bitstream volume.jx3d --reconstructed reconstructed.json
+jarvisx codec-decode volume.jx3d decoded.json
+jarvisx node --host 127.0.0.1 --port 9000
+```
+
+The `node` command remains a legacy research interface and defaults to loopback through the CLI. It is not a production hostile-network execution boundary.
+
+### HTTP
+
+```text
+GET  /
+GET  /health
+POST /run
+POST /codec/roundtrip
+```
+
+The browser console and JSON API share one FastAPI/uvicorn runtime. Flask is not part of the canonical dependency path.
+
+### Container
+
+The root `Dockerfile` installs the package defined by `pyproject.toml` and serves:
+
+```text
+uvicorn jarvisx.api:app
+```
+
+CI builds the image, starts it and probes `/health`.
+
+## 7. External and historical subsystem adapters
+
+The following project artifacts are integration targets, not implicit core authority.
+
+### CodexLang
+
+Target integration:
+
+```text
+CodexLang source
+  -> lexer
+  -> typed parser / AST
+  -> semantic validation
+  -> Jarvis IR
+  -> canonical VM or accelerator backend
+```
+
+Until that compiler chain exists and is tested, CodexLang-specific syntax remains specification/prototype territory.
+
+### ROM / custom ISA
+
+Target integration:
+
+```text
+Jarvis IR
+  -> backend lowering
+  -> assembler
+  -> actual binary ROM bytes
+  -> computed digest / Merkle metadata
+  -> emulator or hardware test vectors
+```
+
+Textual mock-disassembly and placeholder digests are not treated as a verified ROM image.
+
+### CLTP / Lightning Bridge
+
+Target integration:
+
+```text
+validated object
+  -> canonical codec/serializer
+  -> content-addressed envelope
+  -> authenticated transport adapter
+  -> bounded storage namespace
+```
+
+Network exposure requires path canonicalization, request limits, authentication/authorization and integrity verification.
+
+### EM agentic runtime
+
+Target integration:
+
+```text
+IQ acquisition
+  -> bounded DSP
+  -> feature extraction
+  -> classified candidate action
+  -> policy/resource gate
+  -> hardware-control adapter
+```
+
+Placeholder hardware classes are not promoted to operational status without device-independent tests and hardware-in-loop evidence.
+
+### FractalGAN / neural generators
+
+Target integration:
+
+```text
+versioned model
+  -> deterministic/stochastic protocol declaration
+  -> bounded inference
+  -> benchmark fixtures
+  -> provenance
+  -> optional candidate contribution to Layer 5
+```
+
+Package scaffolding without a model/loss/training/inference implementation remains non-authoritative.
+
+### Predictive / symbolic frameworks
+
+Symbolic forecasting equations may produce candidate features or decision context. Empirical forecasting claims require an observation mapping, calibrated parameters, baselines, held-out evaluation and uncertainty reporting.
+
+### 3D visualization
+
+Visualization consumes telemetry and state snapshots. It does not become authoritative merely because it renders the system in 3D.
+
+## 8. Security boundaries
+
+The canonical runtime currently provides application-level bounds, not process isolation for hostile programs.
+
+Required deployment rules:
+
+- do not expose raw legacy node execution to untrusted networks;
+- place public APIs behind authentication, TLS termination, request-size/rate controls and observability;
+- treat uploaded bitstreams/model files as untrusted input;
+- reject invalid shape/version/digest/resource states before allocation or mutation;
+- retain independent backups for provenance journals;
+- do not interpret hash integrity as confidentiality;
+- isolate native plugins and hardware control paths from the VM process.
+
+## 9. Evidence hierarchy
+
+Every promoted capability should progress through:
+
+```text
+specification
+  -> executable reference
+  -> invariant tests
+  -> malformed/adversarial tests
+  -> machine-readable evidence
+  -> benchmark against named baseline
+  -> integration CI
+  -> documented capability boundary
+```
+
+The current Dr Moagi codec operationalization reaches the executable-reference, focused-invariant, API/container-CI and documented-boundary stages. Consolidation into the package-wide empirical evidence schema is a subsequent promotion step.
+
+## 10. System-wide invariants
+
+1. identical authoritative inputs and declared versions produce reproducible state where deterministic mode is selected;
+2. every VM run has an enforceable cycle ceiling;
+3. codec bitstreams are versioned and integrity-checked;
+4. entropy decoding cannot allocate beyond declared latent/resource ceilings;
+5. self-reference preserves an immutable anchor for drift detection;
+6. adaptive candidates commit atomically or leave authoritative state unchanged;
+7. virtual spatial extent is distinct from resident memory;
+8. virtual recursion depth is distinct from measured physical throughput;
+9. interfaces and visualizations are non-authoritative;
+10. unsupported advanced subsystems remain explicitly classified as specification, scaffold, demonstration or integration target.
+
+## 11. Promotion sequence
+
+The preferred implementation order remains:
+
+```text
+Working -> Robust -> Portable -> Elegant -> Advanced
+```
+
+### Working
+
+- deterministic VM;
+- executable 3D codec reference;
+- unified FastAPI/CLI/container paths.
+
+### Robust
+
+- consolidated codec evidence artifact;
+- fuzzing of bitstream headers/payloads;
+- API authentication and quotas for public deployment;
+- durable codec-state persistence and recovery;
+- version migration tests.
+
+### Portable
+
+- equivalent C++ codec reference;
+- cross-platform bitstream fixtures;
+- portable sparse storage;
+- Windows/macOS/Linux packaging.
+
+### Elegant
+
+- typed Jarvis IR shared by CodexLang, VM and ROM backends;
+- common telemetry/receipt schema;
+- unified capability manifest.
+
+### Advanced
+
+- learned 3D transforms and entropy models;
+- bounded latent macro-transition acceleration;
+- shadow architecture evaluation and rollback;
+- GPU/accelerator backends;
+- authenticated distributed transport;
+- hardware-in-loop EM adapters.
+
+No advanced stage may weaken the deterministic core boundary or replace measured evidence with naming, visualization or virtual scale.

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -85,7 +85,15 @@ def run_code(payload: RunRequest) -> dict[str, object]:
         receipt = execute_source(payload.source)
     except (TypeError, ValueError, RuntimeError) as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
-    return receipt.to_dict()
+
+    response: dict[str, object] = {
+        "registers": dict(receipt.registers),
+        "cycles": receipt.cycles,
+        "ledger_entries": receipt.ledger_entries,
+        "ledger_valid": receipt.ledger_valid,
+        "trace_entries": receipt.trace_entries,
+    }
+    return response
 
 
 @app.post("/codec/roundtrip")

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,22 +1,119 @@
-from flask import Flask, request, jsonify
-from .core import CodexVM
-from .parser import Parser
+from __future__ import annotations
+
+import hashlib
+from dataclasses import asdict
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
 from .assembler import Assembler
+from .core import CodexVM
+from .dr_moagi_codec_3d import CodecConfig, DrMoagiCodec3D, Volume3D
+from .parser import Parser
 
-app = Flask(__name__)
-vm = CodexVM()
+_MAX_SOURCE_CHARS = 1_000_000
+_MAX_API_VOXELS = 262_144
 
-@app.route("/run", methods=["POST"])
-def run_code():
-    source = request.json.get("source", "")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
-    vm.load(bytecode)
-    vm.run()
-    return jsonify({
-        "registers": vm.regs.snapshot(),
-        "ledger_entries": len(vm.ledger.chain)
-    })
+app = FastAPI(
+    title="Jarvis-X API",
+    version="0.1.0",
+    description="Deterministic VM and bounded Dr Moagi 3D codec reference API.",
+)
 
-def start_api():
-    app.run(host="0.0.0.0", port=8080)
+
+class RunRequest(BaseModel):
+    source: str
+
+
+class CodecRoundTripRequest(BaseModel):
+    shape: tuple[int, int, int]
+    values: list[float]
+    anchor_values: list[float] | None = None
+    quant_step: float = 0.25
+    max_anchor_mse: float | None = None
+    max_rate_bpv: float | None = None
+    virtual_depth: int = 1
+
+
+@app.get("/health")
+def health() -> dict[str, object]:
+    return {
+        "status": "ok",
+        "system": "Jarvis-X",
+        "capabilities": {
+            "deterministic_vm": True,
+            "transactional_vm": True,
+            "dr_moagi_codec_3d_reference": True,
+            "virtual_depth_is_physical_throughput": False,
+        },
+    }
+
+
+@app.post("/run")
+def run_code(payload: RunRequest) -> dict[str, object]:
+    if not payload.source.strip():
+        raise HTTPException(status_code=400, detail="source cannot be empty")
+    if len(payload.source) > _MAX_SOURCE_CHARS:
+        raise HTTPException(status_code=413, detail="source exceeds API size limit")
+
+    try:
+        ast = Parser().parse(payload.source)
+        bytecode = Assembler().assemble(ast)
+        vm = CodexVM()
+        vm.load(bytecode)
+        registers = vm.run()
+    except (TypeError, ValueError, RuntimeError) as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+    return {
+        "registers": registers,
+        "cycles": vm.cycles,
+        "ledger_entries": len(vm.ledger.chain),
+        "ledger_valid": vm.ledger.verify(),
+    }
+
+
+@app.post("/codec/roundtrip")
+def codec_roundtrip(payload: CodecRoundTripRequest) -> dict[str, object]:
+    try:
+        source = Volume3D(payload.shape, tuple(payload.values))
+        anchor = (
+            Volume3D(payload.shape, tuple(payload.anchor_values))
+            if payload.anchor_values is not None
+            else None
+        )
+        config = CodecConfig(
+            quant_step=payload.quant_step,
+            max_voxels=_MAX_API_VOXELS,
+            max_anchor_mse=payload.max_anchor_mse,
+            max_rate_bpv=payload.max_rate_bpv,
+            virtual_depth=payload.virtual_depth,
+        )
+        runtime = DrMoagiCodec3D(config)
+        result = runtime.process(source, anchor=anchor)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error
+
+    return {
+        "committed": result.committed,
+        "rejection_reason": result.rejection_reason,
+        "metadata": asdict(result.metadata),
+        "metrics": asdict(result.metrics),
+        "memory": asdict(result.memory_after),
+        "bitstream_digest_sha256": hashlib.sha256(result.bitstream).hexdigest(),
+        "virtual_depth": result.virtual_depth,
+        "measured_microsteps_executed": result.measured_microsteps_executed,
+        "wall_clock_seconds": result.wall_clock_seconds,
+        "measured_throughput_voxels_per_second": (
+            result.measured_throughput_voxels_per_second
+        ),
+        "reconstructed_values": list(result.reconstructed.values),
+    }
+
+
+def start_api(host: str = "0.0.0.0", port: int = 8080) -> None:
+    """Start the canonical FastAPI service for local development."""
+
+    import uvicorn
+
+    uvicorn.run("jarvisx.api:app", host=host, port=port)

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -4,6 +4,7 @@ import hashlib
 from dataclasses import asdict
 
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from .assembler import Assembler
@@ -13,6 +14,30 @@ from .parser import Parser
 
 _MAX_SOURCE_CHARS = 1_000_000
 _MAX_API_VOXELS = 262_144
+
+_DASHBOARD_HTML = """<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Jarvis-X</title></head>
+<body>
+<h1>Jarvis-X Operational Console</h1>
+<p>Deterministic VM + bounded Dr Moagi 3D codec reference.</p>
+<textarea id="source" rows="10" cols="70">SET Ψ 10\nSET Φ 20\nADD A Ψ Φ\nHALT</textarea><br>
+<button id="run">Run VM</button>
+<pre id="result"></pre>
+<script>
+document.getElementById('run').onclick = async () => {
+  const source = document.getElementById('source').value;
+  const response = await fetch('/run', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({source})
+  });
+  document.getElementById('result').textContent = JSON.stringify(await response.json(), null, 2);
+};
+</script>
+</body>
+</html>
+"""
 
 app = FastAPI(
     title="Jarvis-X API",
@@ -33,6 +58,11 @@ class CodecRoundTripRequest(BaseModel):
     max_anchor_mse: float | None = None
     max_rate_bpv: float | None = None
     virtual_depth: int = 1
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard() -> str:
+    return _DASHBOARD_HTML
 
 
 @app.get("/health")

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -7,10 +7,8 @@ from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
-from .assembler import Assembler
-from .core import CodexVM
 from .dr_moagi_codec_3d import CodecConfig, DrMoagiCodec3D, Volume3D
-from .parser import Parser
+from .operational import capability_manifest, execute_source
 
 _MAX_SOURCE_CHARS = 1_000_000
 _MAX_API_VOXELS = 262_144
@@ -67,40 +65,27 @@ def dashboard() -> str:
 
 @app.get("/health")
 def health() -> dict[str, object]:
+    manifest = capability_manifest()
+    invariants = manifest["invariants"]
     return {
         "status": "ok",
-        "system": "Jarvis-X",
-        "capabilities": {
-            "deterministic_vm": True,
-            "transactional_vm": True,
-            "dr_moagi_codec_3d_reference": True,
-            "virtual_depth_is_physical_throughput": False,
-        },
+        "system": manifest["system"],
+        "schema": manifest["schema"],
+        "authority": manifest["authority"],
+        "capabilities": invariants,
     }
 
 
 @app.post("/run")
 def run_code(payload: RunRequest) -> dict[str, object]:
-    if not payload.source.strip():
-        raise HTTPException(status_code=400, detail="source cannot be empty")
     if len(payload.source) > _MAX_SOURCE_CHARS:
         raise HTTPException(status_code=413, detail="source exceeds API size limit")
 
     try:
-        ast = Parser().parse(payload.source)
-        bytecode = Assembler().assemble(ast)
-        vm = CodexVM()
-        vm.load(bytecode)
-        registers = vm.run()
+        receipt = execute_source(payload.source)
     except (TypeError, ValueError, RuntimeError) as error:
         raise HTTPException(status_code=400, detail=str(error)) from error
-
-    return {
-        "registers": registers,
-        "cycles": vm.cycles,
-        "ledger_entries": len(vm.ledger.chain),
-        "ledger_valid": vm.ledger.verify(),
-    }
+    return receipt.to_dict()
 
 
 @app.post("/codec/roundtrip")

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -8,11 +8,9 @@ from pathlib import Path
 from typing import Sequence
 
 from .api import start_api
-from .assembler import Assembler
-from .core import CodexVM
 from .dr_moagi_codec_3d import CodecConfig, DrMoagiCodec3D, Volume3D
 from .node import CodexNode
-from .parser import Parser
+from .operational import execute_source
 from .web import start_web
 
 
@@ -46,25 +44,8 @@ def _write_volume(path: Path, volume: Volume3D) -> None:
 
 
 def _run_source(path: Path, max_cycles: int) -> int:
-    source = path.read_text(encoding="utf-8")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
-    vm = CodexVM(max_cycles=max_cycles)
-    vm.load(bytecode)
-    registers = vm.run()
-    print(
-        json.dumps(
-            {
-                "registers": registers,
-                "cycles": vm.cycles,
-                "ledger_entries": len(vm.ledger.chain),
-                "ledger_valid": vm.ledger.verify(),
-            },
-            ensure_ascii=False,
-            indent=2,
-            sort_keys=True,
-        )
-    )
+    receipt = execute_source(path.read_text(encoding="utf-8"), max_cycles=max_cycles)
+    print(json.dumps(receipt.to_dict(), ensure_ascii=False, indent=2, sort_keys=True))
     return 0
 
 

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,38 +1,186 @@
+from __future__ import annotations
+
+import argparse
+import json
 import sys
-from .parser import Parser
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+from .api import start_api
 from .assembler import Assembler
 from .core import CodexVM
-from .api import start_api
-from .web import start_web
+from .dr_moagi_codec_3d import CodecConfig, DrMoagiCodec3D, Volume3D
 from .node import CodexNode
+from .parser import Parser
+from .web import start_web
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
-        return
 
-    cmd = sys.argv[1]
+def _load_volume(path: Path) -> Volume3D:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("volume JSON must be an object")
+    shape = payload.get("shape")
+    values = payload.get("values")
+    if not isinstance(shape, list) or len(shape) != 3:
+        raise ValueError("volume JSON shape must contain three dimensions")
+    if not isinstance(values, list):
+        raise ValueError("volume JSON values must be a list")
+    return Volume3D(
+        tuple(int(value) for value in shape),
+        tuple(float(value) for value in values),
+    )
 
-    if cmd == "run":
-        file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm = CodexVM()
-        vm.load(bytecode)
-        vm.run()
-        print("Registers:", vm.regs.snapshot())
 
-    elif cmd == "api":
-        start_api()
+def _write_volume(path: Path, volume: Volume3D) -> None:
+    path.write_text(
+        json.dumps(
+            {"shape": list(volume.shape), "values": list(volume.values)},
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
 
-    elif cmd == "web":
-        start_web()
 
-    elif cmd == "node":
-        node = CodexNode()
-        node.start()
+def _run_source(path: Path, max_cycles: int) -> int:
+    source = path.read_text(encoding="utf-8")
+    ast = Parser().parse(source)
+    bytecode = Assembler().assemble(ast)
+    vm = CodexVM(max_cycles=max_cycles)
+    vm.load(bytecode)
+    registers = vm.run()
+    print(
+        json.dumps(
+            {
+                "registers": registers,
+                "cycles": vm.cycles,
+                "ledger_entries": len(vm.ledger.chain),
+                "ledger_valid": vm.ledger.verify(),
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _codec_roundtrip(args: argparse.Namespace) -> int:
+    source = _load_volume(args.input)
+    anchor = _load_volume(args.anchor) if args.anchor is not None else None
+    config = CodecConfig(
+        quant_step=args.quant_step,
+        max_voxels=args.max_voxels,
+        max_anchor_mse=args.max_anchor_mse,
+        max_rate_bpv=args.max_rate_bpv,
+        virtual_depth=args.virtual_depth,
+    )
+    runtime = DrMoagiCodec3D(config)
+    result = runtime.process(source, anchor=anchor)
+
+    if args.bitstream is not None:
+        args.bitstream.write_bytes(result.bitstream)
+    if args.reconstructed is not None:
+        _write_volume(args.reconstructed, result.reconstructed)
+
+    receipt = {
+        "committed": result.committed,
+        "rejection_reason": result.rejection_reason,
+        "metadata": asdict(result.metadata),
+        "metrics": asdict(result.metrics),
+        "memory": asdict(result.memory_after),
+        "virtual_depth": result.virtual_depth,
+        "measured_microsteps_executed": result.measured_microsteps_executed,
+        "wall_clock_seconds": result.wall_clock_seconds,
+        "measured_throughput_voxels_per_second": (
+            result.measured_throughput_voxels_per_second
+        ),
+    }
+    print(json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0 if result.committed else 2
+
+
+def _codec_decode(args: argparse.Namespace) -> int:
+    runtime = DrMoagiCodec3D(CodecConfig(max_voxels=args.max_voxels))
+    volume = runtime.decode(args.input.read_bytes())
+    _write_volume(args.output, volume)
+    print(
+        json.dumps(
+            {"shape": list(volume.shape), "voxels": volume.voxel_count},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="jarvisx", description="Jarvis-X operational CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run_parser = subparsers.add_parser("run", help="execute Jarvis-X assembly")
+    run_parser.add_argument("file", type=Path)
+    run_parser.add_argument("--max-cycles", type=int, default=10_000)
+
+    api_parser = subparsers.add_parser("api", help="serve the FastAPI runtime")
+    api_parser.add_argument("--host", default="0.0.0.0")
+    api_parser.add_argument("--port", type=int, default=8080)
+
+    web_parser = subparsers.add_parser("web", help="serve the unified dashboard/API")
+    web_parser.add_argument("--host", default="0.0.0.0")
+    web_parser.add_argument("--port", type=int, default=8080)
+
+    node_parser = subparsers.add_parser("node", help="start the legacy CodexNode reference")
+    node_parser.add_argument("--host", default="127.0.0.1")
+    node_parser.add_argument("--port", type=int, default=9000)
+
+    codec_parser = subparsers.add_parser("codec", help="run one bounded 3D codec transaction")
+    codec_parser.add_argument("input", type=Path, help="JSON file with shape and flat values")
+    codec_parser.add_argument("--anchor", type=Path)
+    codec_parser.add_argument("--bitstream", type=Path)
+    codec_parser.add_argument("--reconstructed", type=Path)
+    codec_parser.add_argument("--quant-step", type=float, default=0.25)
+    codec_parser.add_argument("--max-voxels", type=int, default=1_000_000)
+    codec_parser.add_argument("--max-anchor-mse", type=float)
+    codec_parser.add_argument("--max-rate-bpv", type=float)
+    codec_parser.add_argument("--virtual-depth", type=int, default=1)
+
+    decode_parser = subparsers.add_parser("codec-decode", help="decode a JX3D bitstream")
+    decode_parser.add_argument("input", type=Path)
+    decode_parser.add_argument("output", type=Path)
+    decode_parser.add_argument("--max-voxels", type=int, default=1_000_000)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    try:
+        if args.command == "run":
+            return _run_source(args.file, args.max_cycles)
+        if args.command == "api":
+            start_api(host=args.host, port=args.port)
+            return 0
+        if args.command == "web":
+            start_web(host=args.host, port=args.port)
+            return 0
+        if args.command == "node":
+            CodexNode(host=args.host, port=args.port).start()
+            return 0
+        if args.command == "codec":
+            return _codec_roundtrip(args)
+        if args.command == "codec-decode":
+            return _codec_decode(args)
+    except (OSError, TypeError, ValueError, RuntimeError, json.JSONDecodeError) as error:
+        print(f"jarvisx: {error}", file=sys.stderr)
+        return 1
+
+    parser = _build_parser()
+    parser.error(f"unsupported command: {args.command}")
+    return 2
+
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_codec_3d.py
+++ b/src/jarvisx/dr_moagi_codec_3d.py
@@ -1,0 +1,410 @@
+"""Bounded reference implementation of the Dr Moagi 3D codec transaction.
+
+The module implements the executable subset of ADR-002 without claiming that virtual
+macro depth is physical throughput. The reference transform is deliberately simple:
+it mean-centres a scalar 3D field, quantizes the residual, entropy-codes the discrete
+latents with zlib, validates a versioned bitstream, reconstructs the field, measures
+rate/distortion, applies a bounded admissibility gate, and atomically commits adaptive
+statistics only when the candidate transaction is valid.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import math
+import struct
+import zlib
+from dataclasses import dataclass
+from time import perf_counter
+
+_MAGIC = b"JX3D"
+_FORMAT_VERSION = 1
+_CODEC_VERSION = 1
+_ENTROPY_VERSION = 1
+_HEADER = struct.Struct(">4sHHHIIIddQQ32s")
+_INT64_MIN = -(2**63)
+_INT64_MAX = 2**63 - 1
+
+
+class CodecFormatError(ValueError):
+    """Raised when an encoded Dr Moagi bitstream violates the format contract."""
+
+
+@dataclass(frozen=True)
+class Volume3D:
+    """Dense scalar 3D correctness fixture stored in deterministic x-major order."""
+
+    shape: tuple[int, int, int]
+    values: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.shape) != 3:
+            raise ValueError("shape must contain exactly three dimensions")
+        if any(dimension <= 0 for dimension in self.shape):
+            raise ValueError("all shape dimensions must be positive")
+        expected = self.shape[0] * self.shape[1] * self.shape[2]
+        if len(self.values) != expected:
+            raise ValueError(f"volume contains {len(self.values)} values; expected {expected}")
+        if not all(math.isfinite(float(value)) for value in self.values):
+            raise ValueError("volume values must be finite")
+
+    @property
+    def voxel_count(self) -> int:
+        return len(self.values)
+
+    @property
+    def mean(self) -> float:
+        return math.fsum(self.values) / self.voxel_count
+
+    def mse(self, other: "Volume3D") -> float:
+        if self.shape != other.shape:
+            raise ValueError("cannot compare volumes with different shapes")
+        squared_error = math.fsum(
+            (left - right) ** 2 for left, right in zip(self.values, other.values)
+        )
+        return squared_error / self.voxel_count
+
+
+@dataclass(frozen=True)
+class CodecConfig:
+    """Resource and admissibility limits for the bounded reference runtime."""
+
+    quant_step: float = 0.25
+    zlib_level: int = 9
+    max_voxels: int = 1_000_000
+    max_bitstream_bytes: int = 128 * 1024 * 1024
+    max_abs_value: float = 1.0e12
+    max_anchor_mse: float | None = None
+    max_rate_bpv: float | None = None
+    omega_decay: float = 0.90
+    virtual_depth: int = 1
+    max_virtual_depth: int = 1_000_000
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.quant_step) or self.quant_step <= 0.0:
+            raise ValueError("quant_step must be finite and positive")
+        if not 0 <= self.zlib_level <= 9:
+            raise ValueError("zlib_level must be between 0 and 9")
+        if self.max_voxels < 1:
+            raise ValueError("max_voxels must be positive")
+        if self.max_bitstream_bytes < _HEADER.size:
+            raise ValueError("max_bitstream_bytes is smaller than the codec header")
+        if not math.isfinite(self.max_abs_value) or self.max_abs_value <= 0.0:
+            raise ValueError("max_abs_value must be finite and positive")
+        if self.max_anchor_mse is not None and (
+            not math.isfinite(self.max_anchor_mse) or self.max_anchor_mse < 0.0
+        ):
+            raise ValueError("max_anchor_mse must be finite and non-negative")
+        if self.max_rate_bpv is not None and (
+            not math.isfinite(self.max_rate_bpv) or self.max_rate_bpv <= 0.0
+        ):
+            raise ValueError("max_rate_bpv must be finite and positive")
+        if not 0.0 <= self.omega_decay < 1.0:
+            raise ValueError("omega_decay must be in [0, 1)")
+        if not 1 <= self.virtual_depth <= self.max_virtual_depth:
+            raise ValueError("virtual_depth is outside the configured bound")
+
+
+@dataclass(frozen=True)
+class BitstreamMetadata:
+    shape: tuple[int, int, int]
+    quant_step: float
+    mean: float
+    latent_count: int
+    payload_bytes: int
+    payload_digest_sha256: str
+    format_version: int = _FORMAT_VERSION
+    codec_version: int = _CODEC_VERSION
+    entropy_version: int = _ENTROPY_VERSION
+
+
+@dataclass(frozen=True)
+class CodecMetrics:
+    local_mse: float
+    anchor_mse: float
+    rate_bpv: float
+    bitstream_bytes: int
+    raw_latent_bytes: int
+    compression_ratio: float
+
+
+@dataclass(frozen=True)
+class CodecMemory:
+    """Bounded Omega_codec state, separate from the VM provenance journal."""
+
+    generation: int = 0
+    accepted_transactions: int = 0
+    ewma_local_mse: float = 0.0
+    ewma_anchor_mse: float = 0.0
+    ewma_rate_bpv: float = 0.0
+    last_bitstream_digest_sha256: str = ""
+
+
+@dataclass(frozen=True)
+class CodecTransactionResult:
+    committed: bool
+    reconstructed: Volume3D
+    bitstream: bytes
+    metadata: BitstreamMetadata
+    metrics: CodecMetrics
+    memory_before: CodecMemory
+    memory_after: CodecMemory
+    rejection_reason: str | None
+    virtual_depth: int
+    measured_microsteps_executed: int
+    wall_clock_seconds: float
+
+    @property
+    def measured_throughput_voxels_per_second(self) -> float:
+        if self.wall_clock_seconds <= 0.0:
+            return 0.0
+        return self.reconstructed.voxel_count / self.wall_clock_seconds
+
+
+def _round_nearest(value: float) -> int:
+    """Deterministic round-to-nearest with halves away from zero."""
+
+    if value >= 0.0:
+        return math.floor(value + 0.5)
+    return math.ceil(value - 0.5)
+
+
+class DrMoagiCodec3D:
+    """Transactional bounded 3D codec reference aligned with ADR-002."""
+
+    def __init__(self, config: CodecConfig | None = None) -> None:
+        self.config = config or CodecConfig()
+        self._memory = CodecMemory()
+        self._anchor: Volume3D | None = None
+
+    @property
+    def memory(self) -> CodecMemory:
+        return self._memory
+
+    @property
+    def anchor(self) -> Volume3D | None:
+        return self._anchor
+
+    def _validate_volume(self, volume: Volume3D) -> None:
+        if volume.voxel_count > self.config.max_voxels:
+            raise ValueError("volume exceeds max_voxels")
+        if any(abs(value) > self.config.max_abs_value for value in volume.values):
+            raise ValueError("volume exceeds max_abs_value")
+
+    def encode(self, volume: Volume3D) -> bytes:
+        """Encode one 3D scalar field into a deterministic versioned bitstream."""
+
+        self._validate_volume(volume)
+        mean = volume.mean
+        quant_step = self.config.quant_step
+        latents: list[int] = []
+        for value in volume.values:
+            latent = _round_nearest((value - mean) / quant_step)
+            if not _INT64_MIN <= latent <= _INT64_MAX:
+                raise OverflowError("quantized latent is outside signed 64-bit range")
+            latents.append(latent)
+
+        raw = struct.pack(f">{len(latents)}q", *latents)
+        payload = zlib.compress(raw, self.config.zlib_level)
+        payload_digest = hashlib.sha256(payload).digest()
+        header = _HEADER.pack(
+            _MAGIC,
+            _FORMAT_VERSION,
+            _CODEC_VERSION,
+            _ENTROPY_VERSION,
+            *volume.shape,
+            quant_step,
+            mean,
+            len(latents),
+            len(payload),
+            payload_digest,
+        )
+        bitstream = header + payload
+        if len(bitstream) > self.config.max_bitstream_bytes:
+            raise ValueError("encoded bitstream exceeds max_bitstream_bytes")
+        return bitstream
+
+    def inspect(self, bitstream: bytes) -> BitstreamMetadata:
+        """Validate the fixed header and return its deterministic metadata."""
+
+        if len(bitstream) < _HEADER.size:
+            raise CodecFormatError("bitstream is shorter than the codec header")
+        if len(bitstream) > self.config.max_bitstream_bytes:
+            raise CodecFormatError("bitstream exceeds max_bitstream_bytes")
+
+        (
+            magic,
+            format_version,
+            codec_version,
+            entropy_version,
+            x_size,
+            y_size,
+            z_size,
+            quant_step,
+            mean,
+            latent_count,
+            payload_bytes,
+            expected_digest,
+        ) = _HEADER.unpack_from(bitstream)
+
+        if magic != _MAGIC:
+            raise CodecFormatError("invalid codec magic")
+        if format_version != _FORMAT_VERSION:
+            raise CodecFormatError("unsupported bitstream format version")
+        if codec_version != _CODEC_VERSION:
+            raise CodecFormatError("incompatible codec architecture version")
+        if entropy_version != _ENTROPY_VERSION:
+            raise CodecFormatError("incompatible entropy model version")
+        if not math.isfinite(quant_step) or quant_step <= 0.0:
+            raise CodecFormatError("invalid quantizer parameter")
+        if not math.isfinite(mean) or abs(mean) > self.config.max_abs_value:
+            raise CodecFormatError("invalid encoded mean")
+
+        shape = (x_size, y_size, z_size)
+        if any(dimension <= 0 for dimension in shape):
+            raise CodecFormatError("invalid tensor shape")
+        expected_count = x_size * y_size * z_size
+        if latent_count != expected_count:
+            raise CodecFormatError("latent count does not match tensor shape")
+        if latent_count > self.config.max_voxels:
+            raise CodecFormatError("latent count exceeds max_voxels")
+        if payload_bytes != len(bitstream) - _HEADER.size:
+            raise CodecFormatError("payload length does not match bitstream length")
+
+        payload = bitstream[_HEADER.size :]
+        observed_digest = hashlib.sha256(payload).digest()
+        if not hmac.compare_digest(observed_digest, expected_digest):
+            raise CodecFormatError("payload integrity digest mismatch")
+
+        return BitstreamMetadata(
+            shape=shape,
+            quant_step=quant_step,
+            mean=mean,
+            latent_count=latent_count,
+            payload_bytes=payload_bytes,
+            payload_digest_sha256=observed_digest.hex(),
+            format_version=format_version,
+            codec_version=codec_version,
+            entropy_version=entropy_version,
+        )
+
+    def decode(self, bitstream: bytes) -> Volume3D:
+        """Integrity-check and reconstruct a 3D field from its discrete latent bitstream."""
+
+        metadata = self.inspect(bitstream)
+        payload = bitstream[_HEADER.size :]
+        expected_raw_bytes = metadata.latent_count * 8
+        decompressor = zlib.decompressobj()
+        raw = decompressor.decompress(payload, expected_raw_bytes + 1)
+        if len(raw) != expected_raw_bytes:
+            raise CodecFormatError("decompressed latent payload has an invalid size")
+        if not decompressor.eof or decompressor.unused_data or decompressor.unconsumed_tail:
+            raise CodecFormatError("compressed latent payload has trailing or incomplete data")
+
+        latents = struct.unpack(f">{metadata.latent_count}q", raw)
+        values = tuple(metadata.mean + metadata.quant_step * latent for latent in latents)
+        if not all(
+            math.isfinite(value) and abs(value) <= self.config.max_abs_value for value in values
+        ):
+            raise CodecFormatError("decoded values exceed numerical admissibility bounds")
+        return Volume3D(metadata.shape, values)
+
+    def _metrics(
+        self,
+        source: Volume3D,
+        reconstructed: Volume3D,
+        anchor: Volume3D,
+        bitstream: bytes,
+    ) -> CodecMetrics:
+        local_mse = source.mse(reconstructed)
+        anchor_mse = anchor.mse(reconstructed)
+        raw_latent_bytes = source.voxel_count * 8
+        rate_bpv = (8.0 * len(bitstream)) / source.voxel_count
+        compression_ratio = raw_latent_bytes / len(bitstream)
+        return CodecMetrics(
+            local_mse=local_mse,
+            anchor_mse=anchor_mse,
+            rate_bpv=rate_bpv,
+            bitstream_bytes=len(bitstream),
+            raw_latent_bytes=raw_latent_bytes,
+            compression_ratio=compression_ratio,
+        )
+
+    def _admissibility_error(self, metrics: CodecMetrics) -> str | None:
+        if not all(
+            math.isfinite(value)
+            for value in (metrics.local_mse, metrics.anchor_mse, metrics.rate_bpv)
+        ):
+            return "non-finite codec telemetry"
+        if metrics.bitstream_bytes > self.config.max_bitstream_bytes:
+            return "bitstream exceeds configured resource ceiling"
+        if self.config.max_anchor_mse is not None and metrics.anchor_mse > self.config.max_anchor_mse:
+            return "anchor distortion exceeds configured ceiling"
+        if self.config.max_rate_bpv is not None and metrics.rate_bpv > self.config.max_rate_bpv:
+            return "encoded rate exceeds configured ceiling"
+        return None
+
+    def _commit_memory(self, metrics: CodecMetrics, bitstream: bytes) -> CodecMemory:
+        decay = self.config.omega_decay
+        new_weight = 1.0 - decay
+        if self._memory.accepted_transactions == 0:
+            local_ewma = metrics.local_mse
+            anchor_ewma = metrics.anchor_mse
+            rate_ewma = metrics.rate_bpv
+        else:
+            local_ewma = decay * self._memory.ewma_local_mse + new_weight * metrics.local_mse
+            anchor_ewma = decay * self._memory.ewma_anchor_mse + new_weight * metrics.anchor_mse
+            rate_ewma = decay * self._memory.ewma_rate_bpv + new_weight * metrics.rate_bpv
+        return CodecMemory(
+            generation=self._memory.generation + 1,
+            accepted_transactions=self._memory.accepted_transactions + 1,
+            ewma_local_mse=local_ewma,
+            ewma_anchor_mse=anchor_ewma,
+            ewma_rate_bpv=rate_ewma,
+            last_bitstream_digest_sha256=hashlib.sha256(bitstream).hexdigest(),
+        )
+
+    def process(self, volume: Volume3D, *, anchor: Volume3D | None = None) -> CodecTransactionResult:
+        """Execute one authoritative codec transaction with commit-or-rollback semantics."""
+
+        started = perf_counter()
+        self._validate_volume(volume)
+        candidate_anchor = self._anchor or anchor or volume
+        if candidate_anchor.shape != volume.shape:
+            raise ValueError("anchor shape must match the source volume")
+        self._validate_volume(candidate_anchor)
+
+        memory_before = self._memory
+        bitstream = self.encode(volume)
+        metadata = self.inspect(bitstream)
+        reconstructed = self.decode(bitstream)
+        metrics = self._metrics(volume, reconstructed, candidate_anchor, bitstream)
+        rejection_reason = self._admissibility_error(metrics)
+
+        if rejection_reason is None:
+            memory_after = self._commit_memory(metrics, bitstream)
+            self._memory = memory_after
+            if self._anchor is None:
+                self._anchor = candidate_anchor
+            committed = True
+        else:
+            # Rejection telemetry is returned, but authoritative Omega_codec state remains
+            # unchanged. This is the codec equivalent of the VM transaction rollback.
+            memory_after = memory_before
+            committed = False
+
+        elapsed = perf_counter() - started
+        return CodecTransactionResult(
+            committed=committed,
+            reconstructed=reconstructed,
+            bitstream=bitstream,
+            metadata=metadata,
+            metrics=metrics,
+            memory_before=memory_before,
+            memory_after=memory_after,
+            rejection_reason=rejection_reason,
+            virtual_depth=self.config.virtual_depth,
+            measured_microsteps_executed=1,
+            wall_clock_seconds=elapsed,
+        )

--- a/src/jarvisx/operational.py
+++ b/src/jarvisx/operational.py
@@ -69,6 +69,7 @@ def capability_manifest() -> dict[str, object]:
             "deterministic_vm": True,
             "transactional_vm": True,
             "bounded_vm_cycles": True,
+            "dr_moagi_codec_3d_reference": True,
             "codec_integrity_digest": True,
             "codec_anchor_preservation": True,
             "codec_commit_or_rollback": True,

--- a/src/jarvisx/operational.py
+++ b/src/jarvisx/operational.py
@@ -66,6 +66,7 @@ def capability_manifest() -> dict[str, object]:
             "visualization": "non-authoritative interface",
         },
         "invariants": {
+            "deterministic_vm": True,
             "transactional_vm": True,
             "bounded_vm_cycles": True,
             "codec_integrity_digest": True,

--- a/src/jarvisx/operational.py
+++ b/src/jarvisx/operational.py
@@ -1,0 +1,76 @@
+"""Dependency-light operational facade for canonical Jarvis-X execution paths."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .assembler import Assembler
+from .core import CodexVM
+from .parser import Parser
+
+
+@dataclass(frozen=True)
+class VMExecutionReceipt:
+    """Observable result of one isolated deterministic VM execution."""
+
+    registers: dict[str, int]
+    cycles: int
+    ledger_entries: int
+    ledger_valid: bool
+    trace_entries: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "registers": dict(self.registers),
+            "cycles": self.cycles,
+            "ledger_entries": self.ledger_entries,
+            "ledger_valid": self.ledger_valid,
+            "trace_entries": self.trace_entries,
+        }
+
+
+def execute_source(source: str, *, max_cycles: int = 10_000) -> VMExecutionReceipt:
+    """Parse, assemble and execute source in one fresh transactional CodexVM."""
+
+    if not isinstance(source, str):
+        raise TypeError("source must be a string")
+    if not source.strip():
+        raise ValueError("source cannot be empty")
+    if max_cycles < 1:
+        raise ValueError("max_cycles must be positive")
+
+    ast = Parser().parse(source)
+    bytecode = Assembler().assemble(ast)
+    vm = CodexVM(max_cycles=max_cycles)
+    vm.load(bytecode)
+    registers = vm.run()
+    return VMExecutionReceipt(
+        registers=registers,
+        cycles=vm.cycles,
+        ledger_entries=len(vm.ledger.chain),
+        ledger_valid=vm.ledger.verify(),
+        trace_entries=len(vm.tracer.log),
+    )
+
+
+def capability_manifest() -> dict[str, object]:
+    """Return the implemented-versus-bounded operational surface exposed by this package."""
+
+    return {
+        "schema": "jarvisx.operational.v1",
+        "system": "Jarvis-X",
+        "authority": {
+            "vm_core": "authoritative",
+            "omega_journal": "authoritative provenance",
+            "dr_moagi_codec_3d": "alpha bounded reference",
+            "visualization": "non-authoritative interface",
+        },
+        "invariants": {
+            "transactional_vm": True,
+            "bounded_vm_cycles": True,
+            "codec_integrity_digest": True,
+            "codec_anchor_preservation": True,
+            "codec_commit_or_rollback": True,
+            "virtual_depth_is_physical_throughput": False,
+        },
+    }

--- a/src/jarvisx/web.py
+++ b/src/jarvisx/web.py
@@ -1,42 +1,12 @@
-from flask import Flask, render_template_string, request
-from .core import CodexVM
-from .parser import Parser
-from .assembler import Assembler
+from __future__ import annotations
 
-app = Flask(__name__)
-vm = CodexVM()
+from .api import app, start_api
 
-HTML = """
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Jarvis-X Dashboard</title>
-</head>
-<body>
-  <h1>Jarvis-X Control Panel</h1>
-  <form method="post">
-    <textarea name="code" rows="10" cols="60"></textarea><br>
-    <button type="submit">Run</button>
-  </form>
-  {% if result %}
-    <h3>Registers</h3>
-    <pre>{{ result }}</pre>
-  {% endif %}
-</body>
-</html>
-"""
 
-@app.route("/", methods=["GET","POST"])
-def home():
-    result = None
-    if request.method == "POST":
-        source = request.form["code"]
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm.load(bytecode)
-        vm.run()
-        result = vm.regs.snapshot()
-    return render_template_string(HTML, result=result)
+def start_web(host: str = "0.0.0.0", port: int = 8080) -> None:
+    """Compatibility entrypoint for the unified FastAPI dashboard/API service."""
 
-def start_web():
-    app.run(host="0.0.0.0", port=5000)
+    start_api(host=host, port=port)
+
+
+__all__ = ["app", "start_web"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,62 @@
+import pytest
+from fastapi import HTTPException
+
+from jarvisx.api import CodecRoundTripRequest, RunRequest, codec_roundtrip, health, run_code
+
+
+def test_health_reports_bounded_capability_boundary() -> None:
+    payload = health()
+
+    assert payload["status"] == "ok"
+    capabilities = payload["capabilities"]
+    assert isinstance(capabilities, dict)
+    assert capabilities["deterministic_vm"] is True
+    assert capabilities["dr_moagi_codec_3d_reference"] is True
+    assert capabilities["virtual_depth_is_physical_throughput"] is False
+
+
+def test_run_endpoint_executes_fresh_transactional_vm() -> None:
+    result = run_code(
+        RunRequest(
+            source="\n".join(
+                (
+                    "SET Ψ 10",
+                    "SET Φ 20",
+                    "ADD A Ψ Φ",
+                    "HALT",
+                )
+            )
+        )
+    )
+
+    registers = result["registers"]
+    assert isinstance(registers, dict)
+    assert registers["A"] == 30
+    assert result["cycles"] == 4
+    assert result["ledger_entries"] == 4
+    assert result["ledger_valid"] is True
+
+
+def test_run_endpoint_rejects_empty_source() -> None:
+    with pytest.raises(HTTPException) as caught:
+        run_code(RunRequest(source="   "))
+
+    assert caught.value.status_code == 400
+
+
+def test_codec_endpoint_performs_bounded_round_trip() -> None:
+    result = codec_roundtrip(
+        CodecRoundTripRequest(
+            shape=(2, 2, 2),
+            values=[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            quant_step=0.25,
+            virtual_depth=1_000_000,
+        )
+    )
+
+    assert result["committed"] is True
+    assert result["virtual_depth"] == 1_000_000
+    assert result["measured_microsteps_executed"] == 1
+    reconstructed = result["reconstructed_values"]
+    assert isinstance(reconstructed, list)
+    assert len(reconstructed) == 8

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,21 @@
 import pytest
 from fastapi import HTTPException
 
-from jarvisx.api import CodecRoundTripRequest, RunRequest, codec_roundtrip, health, run_code
+from jarvisx.api import (
+    CodecRoundTripRequest,
+    RunRequest,
+    codec_roundtrip,
+    dashboard,
+    health,
+    run_code,
+)
+
+
+def test_dashboard_is_served_from_unified_runtime() -> None:
+    html = dashboard()
+
+    assert "Jarvis-X Operational Console" in html
+    assert "fetch('/run'" in html
 
 
 def test_health_reports_bounded_capability_boundary() -> None:

--- a/tests/test_cli_operational.py
+++ b/tests/test_cli_operational.py
@@ -1,0 +1,56 @@
+import json
+from pathlib import Path
+
+from jarvisx.cli import main
+
+
+def _write_fixture(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "shape": [2, 2, 2],
+                "values": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_codec_cli_roundtrip_and_decode(tmp_path: Path) -> None:
+    source = tmp_path / "volume.json"
+    bitstream = tmp_path / "volume.jx3d"
+    reconstructed = tmp_path / "reconstructed.json"
+    decoded = tmp_path / "decoded.json"
+    _write_fixture(source)
+
+    result = main(
+        [
+            "codec",
+            str(source),
+            "--bitstream",
+            str(bitstream),
+            "--reconstructed",
+            str(reconstructed),
+            "--quant-step",
+            "0.25",
+            "--virtual-depth",
+            "1000000",
+        ]
+    )
+
+    assert result == 0
+    assert bitstream.read_bytes().startswith(b"JX3D")
+    assert reconstructed.exists()
+
+    decode_result = main(["codec-decode", str(bitstream), str(decoded)])
+    assert decode_result == 0
+    payload = json.loads(decoded.read_text(encoding="utf-8"))
+    assert payload["shape"] == [2, 2, 2]
+    assert len(payload["values"]) == 8
+
+
+def test_cli_rejects_invalid_volume_json(tmp_path: Path) -> None:
+    source = tmp_path / "invalid.json"
+    source.write_text('{"shape": [2, 2], "values": []}', encoding="utf-8")
+
+    assert main(["codec", str(source)]) == 1

--- a/tests/test_dr_moagi_codec_3d.py
+++ b/tests/test_dr_moagi_codec_3d.py
@@ -1,0 +1,79 @@
+import hashlib
+
+import pytest
+
+from jarvisx.dr_moagi_codec_3d import (
+    CodecConfig,
+    CodecFormatError,
+    DrMoagiCodec3D,
+    Volume3D,
+)
+
+
+def _fixture(offset: float = 0.0) -> Volume3D:
+    values = tuple(
+        offset + float((x * 3 + y * 2 + z) % 11) / 3.0
+        for x in range(4)
+        for y in range(4)
+        for z in range(4)
+    )
+    return Volume3D((4, 4, 4), values)
+
+
+def test_codec_is_deterministic_and_respects_quantization_error_bound() -> None:
+    volume = _fixture()
+    config = CodecConfig(quant_step=0.2)
+    codec = DrMoagiCodec3D(config)
+
+    first = codec.encode(volume)
+    second = codec.encode(volume)
+    reconstructed = codec.decode(first)
+
+    assert first == second
+    assert reconstructed.shape == volume.shape
+    assert volume.mse(reconstructed) <= (config.quant_step / 2.0) ** 2 + 1.0e-12
+    metadata = codec.inspect(first)
+    payload = first[-metadata.payload_bytes :]
+    assert metadata.payload_digest_sha256 == hashlib.sha256(payload).hexdigest()
+
+
+def test_codec_rejects_corrupted_payload() -> None:
+    codec = DrMoagiCodec3D()
+    bitstream = bytearray(codec.encode(_fixture()))
+    bitstream[-1] ^= 0x01
+
+    with pytest.raises(CodecFormatError, match="integrity"):
+        codec.decode(bytes(bitstream))
+
+
+def test_transaction_commits_then_rolls_back_anchor_drift() -> None:
+    codec = DrMoagiCodec3D(CodecConfig(quant_step=0.1, max_anchor_mse=1.0))
+    first = codec.process(_fixture())
+    assert first.committed
+    memory_after_first = codec.memory
+
+    second = codec.process(_fixture(offset=10.0))
+
+    assert not second.committed
+    assert second.rejection_reason == "anchor distortion exceeds configured ceiling"
+    assert codec.memory == memory_after_first
+    assert second.memory_before == second.memory_after
+
+
+def test_virtual_depth_is_telemetry_not_invented_throughput() -> None:
+    codec = DrMoagiCodec3D(CodecConfig(virtual_depth=1_000_000))
+    result = codec.process(_fixture())
+
+    assert result.committed
+    assert result.virtual_depth == 1_000_000
+    assert result.measured_microsteps_executed == 1
+    assert result.measured_throughput_voxels_per_second >= 0.0
+
+
+def test_invalid_shape_and_resource_limits_fail_closed() -> None:
+    with pytest.raises(ValueError, match="expected"):
+        Volume3D((2, 2, 2), (0.0,))
+
+    codec = DrMoagiCodec3D(CodecConfig(max_voxels=4))
+    with pytest.raises(ValueError, match="max_voxels"):
+        codec.encode(_fixture())

--- a/tests/test_operational.py
+++ b/tests/test_operational.py
@@ -1,0 +1,44 @@
+import pytest
+
+from jarvisx.operational import capability_manifest, execute_source
+
+
+def test_execute_source_returns_verified_receipt() -> None:
+    receipt = execute_source(
+        "\n".join(
+            (
+                "SET Ψ 7",
+                "SET Φ 5",
+                "ADD A Ψ Φ",
+                "SUB B Ψ Φ",
+                "HALT",
+            )
+        )
+    )
+
+    assert receipt.registers["A"] == 12
+    assert receipt.registers["B"] == 2
+    assert receipt.cycles == 5
+    assert receipt.ledger_entries == 5
+    assert receipt.trace_entries == 5
+    assert receipt.ledger_valid
+
+
+def test_execute_source_rejects_empty_and_invalid_cycle_budget() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        execute_source("   ")
+    with pytest.raises(ValueError, match="max_cycles"):
+        execute_source("HALT", max_cycles=0)
+
+
+def test_capability_manifest_preserves_authority_boundary() -> None:
+    manifest = capability_manifest()
+
+    assert manifest["schema"] == "jarvisx.operational.v1"
+    authority = manifest["authority"]
+    assert isinstance(authority, dict)
+    assert authority["vm_core"] == "authoritative"
+    assert authority["visualization"] == "non-authoritative interface"
+    invariants = manifest["invariants"]
+    assert isinstance(invariants, dict)
+    assert invariants["virtual_depth_is_physical_throughput"] is False


### PR DESCRIPTION
## What changed

This PR operationalizes the first complete bounded path from the canonical Jarvis-X core into the Dr Moagi 3D codec/runtime specification and unifies the package entrypoints around that path.

### Executable codec runtime

- adds `src/jarvisx/dr_moagi_codec_3d.py` as an alpha correctness reference aligned with ADR-002;
- defines a versioned `JX3D` bitstream with shape, quantizer, codec/entropy versions, payload length and SHA-256 integrity;
- executes mean-centre transform → uniform quantization → signed-64 latent → zlib entropy coding → validated decode → reconstruction;
- measures local MSE, immutable-anchor MSE and rate;
- applies bounded admissibility checks and atomically commits or rolls back `Omega_codec` statistics;
- bounds decompression by declared latent size;
- reports `virtual_depth` separately from `measured_microsteps_executed`, wall-clock time and measured throughput.

### Canonical operational facade

- adds `src/jarvisx/operational.py` so parser → assembler → fresh transactional `CodexVM` execution is shared across interfaces;
- returns a single `VMExecutionReceipt` containing registers, cycles, ledger integrity and trace counts;
- exposes a machine-readable authority/invariant capability manifest.

### API / browser / CLI

- replaces the undeclared Flask API with the declared FastAPI/uvicorn stack;
- removes Flask from `web.py` and serves the browser console from the same FastAPI application;
- uses a fresh VM per interface request rather than shared global VM state;
- adds `/`, `/health`, `/run` and `/codec/roundtrip`;
- upgrades `jarvisx` CLI to argparse with bounded VM execution, API/web serving, codec round-trip and codec decode commands;
- keeps the legacy node command explicit and loopback-defaulted at the CLI boundary.

### Deployment and evidence

- repairs the stale Dockerfile to install the canonical `pyproject.toml` package and serve `jarvisx.api:app`;
- adds focused codec, operational-facade, API and CLI tests;
- adds a dedicated workflow that compiles the upgraded paths, executes the focused invariants, builds the container and probes `/health`;
- refreshes `docs/PROJECT_STATUS.md`;
- adds `docs/DR_MOAGI_3D_CODEC_IMPLEMENTATION.md` and the system-wide `docs/SYSTEM_OPERATIONAL_FRAMEWORK.md` integration contract.

## Why

ADR-002 established the Dr Moagi codec as a canonical bounded research architecture, but the repository still lacked the minimum executable codec transaction connecting that specification to measured software behavior. The API, web and container entrypoints were also internally inconsistent with declared dependencies and the package layout.

The upgrade preserves the existing constitutional boundary: authoritative VM state remains inside the deterministic core; codec/adaptive state is bounded and transactional; interfaces and visualization remain non-authoritative.

## Validation — head `0b9f86e09ffd13f5da8ea4d97e8dedee02dd3aba`

All active upgrade gates are green:

- focused codec + operational + API + CLI invariants: **pass**;
- API Docker image build/start and `/health` smoke test: **pass**;
- canonical empirical evidence harness + machine-readable artifact publication: **pass**;
- full test suite: **Python 3.10 / 3.11 / 3.12 / 3.13 pass**;
- dependency audit: **pass**;
- compile and undefined-name checks: **pass**;
- canonical formatting and import-order checks: **pass**;
- package-wide mypy type check: **pass**;
- source distribution + wheel build and metadata validation: **pass**;
- built-wheel smoke test: **pass**.

The focused codec reference was also validated before publication with its initial five deterministic/integrity/rollback/resource invariants passing.

## Capability boundary

This PR does **not** claim a trained neural codec, learned entropy model, autonomous architecture mutation, production hostile-code isolation, hardware acceleration, or one million physically executed codec cycles. `virtual_depth=1_000_000` remains explicitly separate from `measured_microsteps_executed` and measured throughput.

Historical/prototype CodexLang, ROM/ISA, CLTP/Lightning, EM-agentic, GAN and visualization artifacts are now assigned explicit adapter/promotion paths in `docs/SYSTEM_OPERATIONAL_FRAMEWORK.md`; they are not silently promoted to authoritative runtime status without executable implementations and evidence.
