### PR TITLE
Evolve Dr Moagi field runtime architecture v2

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,15 +85,21 @@ Responsibilities:
 - sparse blocks, bricks, tiles or octrees;
 - exact logical-to-physical addressing;
 - bounded materialization;
-- topology and geometry validation.
+- topology and geometry validation;
+- explicitly signed discrete spatial operators and boundary conditions;
+- bounded support closure for local field updates.
 
 A large virtual extent never implies dense allocation. Every implementation must state its resident working-set bound.
+
+The Dr Moagi Field Runtime v2 is the canonical reference for a same-space sparse volumetric transition. Its default logical extent may be `1000^3`, while its physical state remains an explicitly bounded active support with deterministic background semantics.
 
 ### Layer 5 — Adaptive research systems
 
 Responsibilities may include:
 
 - residual correction memory;
+- autoencoder/decoder closure operators;
+- inward latent or field recurrence;
 - parameter candidate generation;
 - shadow evaluation;
 - bounded schedule search;
@@ -101,6 +107,8 @@ Responsibilities may include:
 - commit and rollback decisions.
 
 Adaptive systems must optimize constrained representations, not rewrite arbitrary native instructions. Fitness must exclude uncontrolled nondeterministic signals unless repeated statistical evaluation is explicitly part of the contract.
+
+For volumetric autoencoding systems, additive evolution terms must inhabit the same authoritative field space. Latent tensors are transformed through an explicit decoder before they participate in a field residual.
 
 ### Layer 6 — Interfaces and visualization
 
@@ -132,6 +140,19 @@ fetch
 
 Reflex correction is opt-in. It must never silently change normal assembly semantics.
 
+Research runtimes that operate outside the core instruction loop use the analogous candidate-first boundary:
+
+```text
+snapshot
+  → bounded research transform
+  → candidate state
+  → projection / policy / resource validation
+  → commit or rollback
+  → telemetry / provenance
+```
+
+The research transform cannot make itself authoritative merely by computing a candidate.
+
 ## 4. Core invariants
 
 1. **Determinism:** identical authoritative inputs produce identical VM state, excluding explicitly recorded environmental values such as production timestamps.
@@ -142,6 +163,9 @@ Reflex correction is opt-in. It must never silently change normal assembly seman
 6. **Separation of authority:** visual, predictive and adaptive layers cannot silently mutate the canonical VM state.
 7. **Honest scale:** virtual geometry is reported separately from resident memory and measured throughput.
 8. **No claim by naming:** terms such as intelligence, cognition, self-evolution or neural do not establish those capabilities without operational tests.
+9. **Same-space evolution:** terms combined in one authoritative state equation must share a defined state type and compatible units.
+10. **Candidate-first adaptation:** active model, schedule, topology, bytecode, or field state is not replaced until its candidate passes the declared admission gate.
+11. **Immutable drift reference:** self-referential research loops that measure generational preservation retain an immutable source anchor for the duration of a run.
 
 ## 5. Data contracts
 
@@ -155,6 +179,8 @@ Canonical bytecode words are unsigned 64-bit integers. Persistent binary formats
 - capacity rules;
 - integrity checks;
 - malformed-input behavior.
+
+Experimental tensor instruction formats such as 256-bit, 512-bit, DMEB-32, CUDA, FPGA or native-extension encodings are adapters/research targets until a separate accepted ADR promotes them. They may not silently redefine the canonical core bytecode format.
 
 ### Journal
 
@@ -184,6 +210,36 @@ Every spatial subsystem must define:
 - serialization order;
 - neighborhood topology.
 
+### Dr Moagi field candidate
+
+A Field Runtime v2 candidate must declare:
+
+- logical side length and active-support ceiling;
+- codec/version identity;
+- timestep and coefficients `alpha`, `lambda`, `eta`;
+- reconstruction residual definition;
+- Laplacian and glyph sign conventions;
+- boundary conditions;
+- projection limits;
+- immutable anchor identity;
+- commit/rejection outcome and telemetry.
+
+The canonical field law is
+
+```text
+R(Psi) = Psi - D(E(Psi))
+
+dPsi/dt = -alpha R(Psi)
+          + lambda Delta_6 R(Psi)
+          + eta (G_moagi * Psi).
+```
+
+With the canonical glyph stencil,
+
+```text
+G_moagi * Psi = -(1/6) Delta_6 Psi.
+```
+
 ## 6. Integration rule
 
 A research subsystem may enter the canonical package only when it provides:
@@ -198,6 +254,8 @@ A research subsystem may enter the canonical package only when it provides:
 - no unresolved conflict with existing authoritative state.
 
 Large pull requests should be decomposed into infrastructure, kernel, integration and demonstration stages.
+
+A field or latent runtime must additionally demonstrate sparse support confinement, candidate rollback, explicit timestep/resource limits, and honest information-capacity claims for its latent representation.
 
 ## 7. Decision records
 
@@ -214,6 +272,64 @@ Validation
 
 A newer accepted ADR may supersede an older one, but historical records should remain available.
 
+ADR-003 extends ADR-002 by defining the same-space Dr Moagi field evolution contract and its executable sparse transaction semantics.
+
 ## 8. Security boundary
 
 The policy layer is an application-level guard, not a complete security sandbox. Untrusted bytecode, native plugins, model files and browser content require dedicated threat models. See [`SECURITY.md`](../SECURITY.md).
+
+Self-modification is never equivalent to unrestricted writes into authoritative code memory. Adaptive code, model, tile, or schedule changes are represented as candidate patches that require validation and commit; otherwise the prior authoritative state remains active.
+
+## 9. Dr Moagi Field Runtime v2 integration
+
+The evolved system architecture is:
+
+```text
+Canonical authority
+  Layer 0  representation / 64-bit bytecode
+  Layer 1  deterministic execution
+  Layer 2  policy + transaction control
+  Layer 3  provenance + replay
+       |
+       v
+Research compute envelope
+  Layer 4  sparse 3D support
+           -> six-neighbour topology
+           -> Delta_6
+           -> G_moagi
+       |
+       v
+  Layer 5  encode -> decode -> residual
+           -> inward field recurrence
+           -> candidate adaptation
+           -> Pi_Lambda
+       |
+       v
+Admission boundary
+  verify -> COMMIT / ROLLBACK -> provenance
+       |
+       v
+  Layer 6  API / CLI / visualization / hardware adapters
+```
+
+The operational cycle for the Dr Moagi field subsystem is:
+
+```text
+Psi_n
+  -> freeze snapshot
+  -> bounded support closure
+  -> E_theta(Psi_n)
+  -> D_theta(z, support)
+  -> R_n = Psi_n - Psi_hat_n
+  -> H_n = Delta_6 R_n
+  -> P_n = G_moagi * Psi_n
+  -> rhs_n = -alpha R_n + lambda H_n + eta P_n
+  -> candidate = Psi_n + dt rhs_n
+  -> Pi_Lambda
+  -> shadow/validator checks
+  -> COMMIT or ROLLBACK
+  -> reconstruction + anchor + resource telemetry
+  -> next inward cycle
+```
+
+This architecture is backend-neutral. Pure Python, C++, PyTorch/CUDA, distributed sparse workers, FPGA soft cores, and experimental tensor bytecodes may implement the transform, provided they preserve the same state, resource, and transaction semantics.

--- a/docs/DR_MOAGI_FIELD_RUNTIME_V2.md
+++ b/docs/DR_MOAGI_FIELD_RUNTIME_V2.md
@@ -1,0 +1,341 @@
+# Dr Moagi Field Runtime v2
+
+## Status
+
+Canonical Layer 4/5 operational research specification adopted by ADR-003.
+
+This document turns the Dr Moagi 3D autoencoding/decoding equation into a bounded sparse state-transition contract. It does **not** replace the deterministic Jarvis-X VM. It defines how a volumetric research runtime proposes a candidate transition that may then be admitted through the existing policy/transaction boundary.
+
+---
+
+## 1. State spaces
+
+Let the logical lattice be
+
+```text
+Omega_h = {0, ..., side-1}^3
+```
+
+with the default conceptual side length `side = 1000`.
+
+The authoritative working field is
+
+```text
+Psi_n : Omega_h -> R
+```
+
+but the reference implementation stores only a bounded active support
+
+```text
+A_n = {x in Omega_h : Psi_n(x) is materialized}
+|A_n| <= max_active_cells.
+```
+
+Coordinates outside the materialized support are deterministic zero background. Coordinates outside `Omega_h` obey Dirichlet-zero boundary semantics in the reference implementation.
+
+The initial projected state is frozen as
+
+```text
+Psi_anchor = Psi_0.
+```
+
+---
+
+## 2. Autoencoder closure
+
+The encoder and decoder are typed separately:
+
+```text
+E_theta : sparse field -> latent
+D_theta : latent x requested_support -> sparse field
+```
+
+Define the same-space reconstruction operator
+
+```text
+A_theta = D_theta o E_theta
+Psi_hat = A_theta[Psi]
+```
+
+and reconstruction residual
+
+```text
+R_theta(Psi) = Psi - Psi_hat.
+```
+
+The evolution law never subtracts a latent tensor directly from a field tensor.
+
+A scalar latent may be used for deliberately lossy experiments or a restricted decoder family. It is not a general invertible representation of an arbitrary `1000^3` field.
+
+---
+
+## 3. Spatial operators
+
+### Six-neighbour Laplacian
+
+For an interior coordinate `(i,j,k)`:
+
+```text
+Delta_6 Psi[i,j,k]
+  = Psi[i+1,j,k] + Psi[i-1,j,k]
+  + Psi[i,j+1,k] + Psi[i,j-1,k]
+  + Psi[i,j,k+1] + Psi[i,j,k-1]
+  - 6 Psi[i,j,k].
+```
+
+The reference implementation uses the same expression with missing/out-of-domain values equal to zero.
+
+### Moagi glyph kernel
+
+The fixed permeation kernel is
+
+```text
+G(0,0,0)      =  1
+G(face-neighbour) = -1/6
+G(otherwise)  =  0.
+```
+
+Therefore
+
+```text
+(G * Psi)[i,j,k]
+  = Psi[i,j,k] - (1/6) sum(face_neighbours)
+  = -(1/6) Delta_6 Psi[i,j,k].
+```
+
+The equality is normative for this kernel/sign convention.
+
+---
+
+## 4. Canonical field equation
+
+The runtime master equation is
+
+```text
+dPsi/dt
+  = -alpha * R_theta(Psi)
+    + lambda * Delta_6(R_theta(Psi))
+    + eta * (G * Psi).
+```
+
+Interpretation:
+
+1. `-alpha R` closes the working field toward its decoded representation.
+2. `lambda Delta_6 R` propagates reconstruction mismatch through local spatial structure.
+3. `eta G*Psi` applies the fixed permeation drive.
+
+Under the chosen sign convention a positive `eta` is not ordinary diffusion; the fixed glyph is `-Delta_6/6`. Implementations must therefore keep explicit timestep and projection guards.
+
+---
+
+## 5. Discrete transaction
+
+For explicit Euler step size `dt`:
+
+```text
+snapshot    = Psi_n
+latent      = E_theta(snapshot)
+Psi_hat     = D_theta(latent, requested_support)
+R_n         = snapshot - Psi_hat
+H_n         = Delta_6 R_n
+P_n         = G * snapshot
+rhs_n       = -alpha R_n + lambda H_n + eta P_n
+candidate   = snapshot + dt * rhs_n
+projected   = Pi_Lambda(candidate)
+```
+
+Commit rule:
+
+```text
+if projected is finite
+and resource bounds hold
+and optional validator accepts:
+    Psi_(n+1) = projected
+    COMMIT
+else:
+    Psi_(n+1) = Psi_n
+    ROLLBACK
+```
+
+One transaction reads one frozen snapshot. No operator observes partial writes from another operator in the same step.
+
+---
+
+## 6. Sparse support closure
+
+When halo expansion is enabled, the requested support is
+
+```text
+S_n = A_n union face_neighbours(A_n).
+```
+
+This allows one step of local residual/permeation propagation without dense materialization.
+
+The closure is rejected before codec execution when
+
+```text
+|S_n| > max_active_cells.
+```
+
+A decoder may return values only inside the requested support. Returning coordinates outside that set is a contract violation and fails closed.
+
+---
+
+## 7. Lambda projection
+
+`Pi_Lambda` is the runtime admission operator. The reference projection:
+
+- rejects non-finite coordinates or values;
+- rejects coordinates outside the logical lattice;
+- clamps values to configured `[value_min, value_max]`;
+- optionally prunes values within `prune_epsilon` of zero;
+- enforces `max_active_cells`;
+- runs an optional caller-supplied candidate validator before commit.
+
+A production implementation may add model-version checks, rate/distortion ceilings, memory reservations, scheduler ownership, checksums, or policy masks.
+
+---
+
+## 8. Stability guard
+
+For a non-expansive codec, the reference configuration uses the conservative operator bounds
+
+```text
+||I - A_theta|| <= 2
+||Delta_6|| <= 12
+||G|| <= 2
+```
+
+and rejects a default explicit step when
+
+```text
+dt * (2 alpha + 24 lambda + 2 |eta|) > 1.
+```
+
+This is an engineering admission guard. It does not prove convergence for an arbitrary learned codec.
+
+Default reference coefficients:
+
+```text
+alpha  = 1.0
+lambda = 1.0
+eta    = 0.1
+dt     = 0.025
+```
+
+The training coefficients `beta` and `gamma` belong to the model-training objective and are not runtime field coefficients by default.
+
+---
+
+## 9. Training objective
+
+A compatible codec may be trained with
+
+```text
+L(Psi, Psi_hat)
+  = mean((Psi - Psi_hat)^2)
+    + beta * ||z||^2
+    + gamma * ||grad(Psi) - grad(Psi_hat)||^2.
+```
+
+When decoder weights are tied to encoder weights, the decoder uses the true convolution adjoint: spatial kernel reversal and channel-axis transpose where applicable.
+
+Training updates are not committed into an active runtime model without shadow evaluation and the same candidate-first transaction rule used for other adaptive changes.
+
+---
+
+## 10. Telemetry
+
+Every attempted step reports at least:
+
+```text
+cycle
+support_cells
+active_cells_before
+active_cells_after
+reconstruction_mse
+anchor_mse
+max_abs_residual
+max_abs_rhs
+committed
+rejection_reason
+```
+
+`anchor_mse` is measured against the immutable `Psi_anchor` so a self-referential codec cannot hide generational drift merely by becoming self-consistent with its latest reconstruction.
+
+---
+
+## 11. System integration
+
+The full Jarvis-X flow is
+
+```text
+input / sparse field
+    -> Layer 4 support closure
+    -> Layer 5 encode
+    -> Layer 5 decode
+    -> same-space residual
+    -> Delta_6 + glyph operators
+    -> candidate Euler step
+    -> Pi_Lambda
+    -> validator / shadow evaluation
+    -> canonical transaction boundary
+    -> commit + provenance
+    -> next inward cycle
+```
+
+The canonical 64-bit VM remains the authority substrate. Alternative 256-bit/512-bit tensor ISAs, DMEB-32, CUDA kernels, C++ implementations, FPGA soft cores, and hardware extensions are permitted implementation targets only when they preserve this state-transition and transaction contract.
+
+---
+
+## 12. Bytecode lowering contract
+
+A tensor-oriented backend may lower one field step into conceptual operations such as
+
+```text
+BEGIN_TX
+LOAD_SPARSE_FIELD
+ENCODE3D
+DECODE3D
+RESIDUAL
+LAPLACIAN6
+GLYPH6
+FUSED_AXPY
+CHECK_BOUNDS
+CHECK_POLICY
+VERIFY
+JOURNAL
+COMMIT
+```
+
+but those names do not redefine the canonical VM instruction format. Backend-specific instruction encodings remain adapters until an ADR promotes them.
+
+Self-optimization follows
+
+```text
+active program/model
+-> candidate patch
+-> deterministic/shadow test
+-> reconstruction + anchor + resource checks
+-> Pi_Lambda
+-> COMMIT or ROLLBACK.
+```
+
+Direct unjournaled mutation of authoritative code or model state is outside this contract.
+
+---
+
+## 13. Conformance conditions
+
+A runtime conforms to Field Runtime v2 when it demonstrates:
+
+1. same-space `Psi - D(E(Psi))` residuals;
+2. exact six-face-neighbour stencil semantics;
+3. bounded sparse support and explicit boundary conditions;
+4. deterministic replay for deterministic codecs;
+5. immutable run anchors;
+6. candidate-first commit/rollback;
+7. explicit timestep/resource bounds;
+8. honest latent information limits;
+9. measured throughput reported separately from virtual/logical depth;
+10. tests showing invalid decoder support, non-finite values, and rejected candidates fail closed.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-01  
+**Last reviewed:** 2026-08-12  
 **Release line:** `0.1.x` alpha
 
 This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
@@ -33,6 +33,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Fractional 3D smoothing | Numerical reference | `fractional_smoothing_3d.py`, independent DFT/stencil/semigroup tests | dense periodic scalar grids and separable `O(N⁴)` cubic DFT; not a production FFT or calibrated physical model |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
+| Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
@@ -55,6 +56,8 @@ The gate currently tests five falsifiable properties:
 3. sparse-field insertion-order invariance, checkpoint replay and atomic rollback;
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
+
+The Field Runtime v2 is covered by focused unit tests in the normal CI suite. It is not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -88,6 +91,7 @@ Jarvis-X does not currently claim:
 - safety certification from the presence of a policy or coherence gate;
 - bit-exact cross-platform floating-point results from the C++ research processor;
 - production-scale fractional PDE performance or physical validity from the numerical reference solver;
+- convergence of arbitrary learned Dr Moagi codecs from the reference explicit-step guard alone;
 - empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines.
 
 ## Canonical promotion checklist
@@ -126,6 +130,7 @@ A capability moves to `main` only when all applicable items are satisfied:
 - durable block storage;
 - deterministic serialization;
 - transactional concurrency;
+- same-space sparse field operators with explicit topology and boundary semantics;
 - benchmark corpus with named baselines and uncertainty reporting.
 
 ### `0.4.0` — Bounded adaptive laboratory
@@ -133,5 +138,7 @@ A capability moves to `main` only when all applicable items are satisfied:
 - shadow evaluation API;
 - reproducible candidate generation;
 - rollback-complete state transitions;
+- codec/model version binding for adaptive field runtimes;
+- anchor-drift and reconstruction telemetry in the consolidated empirical evidence artifact;
 - metric-hacking tests;
 - experiment manifests and replay.

--- a/docs/adr/0003-dr-moagi-field-runtime-v2.md
+++ b/docs/adr/0003-dr-moagi-field-runtime-v2.md
@@ -1,0 +1,212 @@
+# ADR-003: Adopt the same-space Dr Moagi field runtime v2
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Extends:** ADR-002
+
+## Context
+
+The Dr Moagi 3D autoencoding/decoding work now has enough detail to separate four concerns that were previously mixed together: codec compression, volumetric state evolution, spatial residual correction, and bounded adaptive execution.
+
+The previous symbolic form subtracted an encoder output from a decoded volume even though those values inhabit different spaces. The revised architecture requires every term in the field evolution law to inhabit the same volumetric state space. It also makes the fixed Moagi glyph kernel explicit as a six-face-neighbour operator and keeps scalar bottlenecks classified as deliberately lossy or restricted-family representations rather than general invertible encodings.
+
+The deterministic 64-bit Jarvis-X VM remains the canonical authority boundary. Research runtimes may propose state transitions, but they may not silently replace the core bytecode format or bypass transaction, policy, resource, and provenance controls.
+
+## Decision
+
+Jarvis-X adopts the following same-space field law as the canonical Layer 4/5 Dr Moagi volumetric evolution contract.
+
+Let
+
+```text
+A_theta = D_theta o E_theta
+R_theta(Psi) = (I - A_theta)[Psi] = Psi - A_theta[Psi]
+```
+
+Then
+
+```text
+dPsi/dt = -alpha R_theta(Psi)
+          + lambda * Delta_6 R_theta(Psi)
+          + eta * G_moagi * Psi
+```
+
+where `Delta_6` is the six-face-neighbour discrete Laplacian and the fixed glyph kernel is
+
+```text
+G_moagi(0,0,0) = 1
+G_moagi(+/-1,0,0) = -1/6
+G_moagi(0,+/-1,0) = -1/6
+G_moagi(0,0,+/-1) = -1/6
+G_moagi(otherwise) = 0
+```
+
+With the convention
+
+```text
+Delta_6 Psi = sum(face_neighbours) - 6 Psi
+```
+
+the glyph operator satisfies
+
+```text
+G_moagi * Psi = -(1/6) Delta_6 Psi.
+```
+
+The relationship is recorded explicitly so implementations do not accidentally treat the two operators as independent mathematical primitives.
+
+## Discrete operational form
+
+The executable reference step is
+
+```text
+R_n       = Psi_n - A_theta(Psi_n)
+H_n       = Delta_6 R_n
+P_n       = G_moagi * Psi_n
+candidate = Psi_n + dt * (-alpha R_n + lambda H_n + eta P_n)
+Psi_n+1   = Pi_Lambda(candidate)
+```
+
+`Pi_Lambda` is a concrete admissibility projection. It validates finite values, coordinate bounds, resident-support ceilings, configured value bounds, version compatibility, and any caller-supplied acceptance predicate before commit.
+
+## Sparse physical state
+
+A logical `1000 x 1000 x 1000` field is an address space, not a dense allocation requirement.
+
+The physical runtime operates on an active support
+
+```text
+A_n subseteq {0,...,side-1}^3
+|A_n| <= max_active_cells
+```
+
+with deterministic zero background and, when enabled, a bounded one-cell face-neighbour halo. All operators for one step read a frozen snapshot and write only to a candidate map.
+
+## Anchor and drift semantics
+
+Each run freezes its initial projected field as an immutable anchor:
+
+```text
+Psi_anchor = Psi_0
+```
+
+Telemetry reports both local reconstruction error and drift relative to the anchor. Self-reference must never erase or overwrite the anchor within a run.
+
+## Codec boundary
+
+The field runtime does not prescribe one neural architecture. A codec must provide
+
+```text
+latent = encode(active_field)
+reconstruction = decode(latent, requested_support)
+```
+
+and may only materialize the requested bounded support.
+
+A scalar latent `z in R` is permitted only when the implementation explicitly declares either:
+
+1. a restricted one-dimensional decoder family, or
+2. lossy compression.
+
+No implementation may claim `D o E = I` on arbitrary billion-voxel fields when the latent representation lacks sufficient information capacity.
+
+## Adjoint decoder semantics
+
+When decoder kernels are tied to encoder kernels, `K^T` means the true convolution adjoint: spatial reversal plus input/output channel transpose where channels exist. A plain matrix transpose is not an adequate definition for a 3D convolutional kernel.
+
+## Runtime versus training
+
+The runtime field law and the training objective are separate contracts.
+
+A compatible training objective may be
+
+```text
+L = reconstruction_MSE
+    + beta * ||z||^2
+    + gamma * ||grad(Psi) - grad(Psi_hat)||^2
+```
+
+but `beta` and `gamma` do not become runtime PDE coefficients unless a specific implementation defines and validates such a coupling.
+
+## Stability and resource guard
+
+The reference explicit-Euler runtime exposes `dt` and rejects configurations outside a conservative operator-norm budget by default. For a non-expansive codec, the reference guard uses
+
+```text
+dt * (2 alpha + 24 lambda + 2 |eta|) <= 1.
+```
+
+This is a sufficient engineering guard for the reference model, not a proof of convergence for arbitrary learned codecs. Implementations may replace it with a stronger measured or analytically justified stability test, but may not remove bounded-step validation silently.
+
+## Transaction boundary
+
+Adaptive or self-modifying behaviour is candidate-first:
+
+```text
+snapshot
+-> encode/decode
+-> residual operators
+-> candidate field
+-> Pi_Lambda
+-> optional validator / shadow evaluation
+-> COMMIT or ROLLBACK
+-> journal telemetry
+```
+
+Model, schedule, tile, or bytecode candidates must follow the same rule. Active authoritative code or state is never rewritten before validation.
+
+## Architectural placement
+
+The runtime is integrated as follows:
+
+```text
+Layer 0-3: canonical deterministic VM, policy, transactions, provenance
+Layer 4:   sparse 3D support and spatial operators
+Layer 5:   codec, residual dynamics, inward recurrence, bounded adaptation
+Layer 6:   interfaces and visualization
+```
+
+The canonical 64-bit VM format remains unchanged by this ADR. Experimental 256-bit, 512-bit, DMEB-32, GPU, FPGA, or native-extension instruction formats are adapters/research targets until separately accepted and tested.
+
+## Required invariants
+
+1. Every additive term in the field evolution equation has the same field type and units.
+2. The six-neighbour Laplacian and Moagi glyph stencil are defined with explicit sign conventions.
+3. Sparse logical scale is reported separately from resident physical memory.
+4. One step reads one frozen snapshot; partial writes are never authoritative.
+5. Candidate state is finite, bounded, resource-admissible, and validator-approved before commit.
+6. The run anchor is immutable.
+7. Codec reconstruction is limited to requested support.
+8. Latent information limits are stated honestly.
+9. Virtual iteration depth is distinguished from measured physical throughput.
+10. Visualization and speculative hardware descriptions cannot silently redefine canonical compute state.
+
+## Consequences
+
+### Positive
+
+- the Dr Moagi equation becomes dimensionally consistent;
+- the autoencoder is integrated as a same-space closure operator rather than an incompatible additive latent term;
+- the glyph kernel receives exact discrete semantics;
+- sparse execution, stability, anchor preservation, and rollback are first-class runtime requirements;
+- neural, bytecode, C++, GPU, FPGA, and visualization implementations can share one operational contract.
+
+### Negative
+
+- a single scalar latent can no longer be presented as a general lossless billion-voxel representation;
+- positive permeation gain may be anti-diffusive under the chosen Laplacian sign convention, so projection and timestep guards remain necessary;
+- learned codecs still require empirical stability and reconstruction validation beyond the reference numerical guard.
+
+## Validation
+
+Acceptance requires an executable reference implementation with tests for:
+
+- configuration and timestep rejection;
+- same-space reconstruction residuals;
+- exact six-face-neighbour glyph behaviour;
+- sparse support confinement;
+- immutable anchors;
+- candidate rollback;
+- deterministic state transitions for deterministic codecs.
+
+The normative operational specification is maintained in `docs/DR_MOAGI_FIELD_RUNTIME_V2.md`.

--- a/src/jarvisx/dr_moagi_field_runtime.py
+++ b/src/jarvisx/dr_moagi_field_runtime.py
@@ -1,0 +1,401 @@
+"""Bounded sparse runtime for the Dr Moagi 3D field equation.
+
+This module operationalizes the same-space field law
+
+    dPsi/dt =
+        -alpha (I - D o E)[Psi]
+        + lambda * Laplacian((I - D o E)[Psi])
+        + eta * G_moagi * Psi
+
+on a sparse logical 3D lattice. It is intentionally independent of the
+canonical 64-bit VM: candidate field transitions are computed in a research
+layer and become authoritative only after projection and optional validation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+Coordinate = tuple[int, int, int]
+SparseField = dict[Coordinate, float]
+Validator = Callable[[Mapping[Coordinate, float], "FieldStepMetrics"], bool]
+
+
+class FieldCodec(Protocol):
+    """Codec boundary used by the field runtime.
+
+    ``decode`` receives the exact support that must be reconstructed. This
+    makes sparse materialization explicit and prevents a codec from silently
+    allocating the full logical lattice.
+    """
+
+    def encode(self, field: Mapping[Coordinate, float]) -> Any:
+        ...
+
+    def decode(
+        self, latent: Any, support: Sequence[Coordinate]
+    ) -> Mapping[Coordinate, float]:
+        ...
+
+
+class IdentityFieldCodec:
+    """Deterministic reference codec used for conformance tests."""
+
+    def encode(self, field: Mapping[Coordinate, float]) -> dict[Coordinate, float]:
+        return dict(field)
+
+    def decode(
+        self,
+        latent: Mapping[Coordinate, float],
+        support: Sequence[Coordinate],
+    ) -> Mapping[Coordinate, float]:
+        return {coordinate: float(latent.get(coordinate, 0.0)) for coordinate in support}
+
+
+@dataclass(frozen=True)
+class DrMoagiFieldConfig:
+    """Numerical and resource contract for one field-runtime run."""
+
+    side: int = 1000
+    alpha: float = 1.0
+    lambda_residual: float = 1.0
+    eta: float = 0.1
+    dt: float = 0.025
+    value_min: float = -1.0
+    value_max: float = 1.0
+    max_active_cells: int = 100_000
+    expand_halo: bool = True
+    prune_epsilon: float = 0.0
+    enforce_conservative_step_bound: bool = True
+
+    def __post_init__(self) -> None:
+        if isinstance(self.side, bool) or not isinstance(self.side, int) or self.side <= 0:
+            raise ValueError("side must be a positive integer")
+        if (
+            isinstance(self.max_active_cells, bool)
+            or not isinstance(self.max_active_cells, int)
+            or self.max_active_cells <= 0
+        ):
+            raise ValueError("max_active_cells must be a positive integer")
+
+        for name in (
+            "alpha",
+            "lambda_residual",
+            "eta",
+            "dt",
+            "value_min",
+            "value_max",
+            "prune_epsilon",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.alpha < 0.0:
+            raise ValueError("alpha must be non-negative")
+        if self.lambda_residual < 0.0:
+            raise ValueError("lambda_residual must be non-negative")
+        if self.dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+        if self.prune_epsilon < 0.0:
+            raise ValueError("prune_epsilon must be non-negative")
+
+        # For a non-expansive codec, ||I-A|| <= 2, ||Delta_6|| <= 12 and
+        # ||G_moagi|| <= 2. This is a conservative explicit-Euler budget,
+        # not a proof of stability for arbitrary learned codecs.
+        if self.enforce_conservative_step_bound and self.stability_load > 1.0:
+            raise ValueError(
+                "dt exceeds the conservative explicit-step budget; "
+                "reduce dt or disable the guard explicitly"
+            )
+
+    @property
+    def stability_load(self) -> float:
+        return self.dt * (
+            2.0 * self.alpha
+            + 24.0 * self.lambda_residual
+            + 2.0 * abs(self.eta)
+        )
+
+
+@dataclass(frozen=True)
+class FieldStepMetrics:
+    """Deterministic telemetry for one attempted transaction."""
+
+    cycle: int
+    support_cells: int
+    active_cells_before: int
+    active_cells_after: int
+    reconstruction_mse: float
+    anchor_mse: float
+    max_abs_residual: float
+    max_abs_rhs: float
+    committed: bool
+    rejection_reason: str | None = None
+
+
+class DrMoagiFieldRuntime:
+    """Sparse, transactional reference implementation of the field equation."""
+
+    _NEIGHBOURS: tuple[Coordinate, ...] = (
+        (-1, 0, 0),
+        (1, 0, 0),
+        (0, -1, 0),
+        (0, 1, 0),
+        (0, 0, -1),
+        (0, 0, 1),
+    )
+
+    def __init__(
+        self,
+        codec: FieldCodec,
+        config: DrMoagiFieldConfig | None = None,
+    ) -> None:
+        self.codec = codec
+        self.config = config or DrMoagiFieldConfig()
+        self._state: SparseField = {}
+        self._anchor: SparseField = {}
+        self._cycle = 0
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    @property
+    def virtual_cell_count(self) -> int:
+        return self.config.side**3
+
+    @property
+    def active_cell_count(self) -> int:
+        return len(self._state)
+
+    def snapshot(self) -> SparseField:
+        return dict(self._state)
+
+    def anchor_snapshot(self) -> SparseField:
+        return dict(self._anchor)
+
+    def load(self, field: Mapping[Coordinate, float]) -> None:
+        """Start a new run and freeze its immutable drift-detection anchor."""
+
+        projected = self._project(dict(field))
+        if len(projected) > self.config.max_active_cells:
+            raise RuntimeError("active-cell budget exceeded")
+        self._state = projected
+        self._anchor = dict(projected)
+        self._cycle = 0
+
+    def step(self, validator: Validator | None = None) -> FieldStepMetrics:
+        """Attempt one atomic field transition.
+
+        All terms are evaluated from one frozen snapshot. Candidate state is
+        projected first and becomes authoritative only if the optional
+        validator accepts it.
+        """
+
+        snapshot = dict(self._state)
+        support = self._support(snapshot)
+        active_before = len(snapshot)
+        cycle = self._cycle + 1
+
+        latent = self.codec.encode(snapshot)
+        reconstruction_raw = self.codec.decode(latent, support)
+        reconstruction = self._validated_reconstruction(reconstruction_raw, support)
+
+        residual = {
+            coordinate: self._value(snapshot, coordinate)
+            - self._value(reconstruction, coordinate)
+            for coordinate in support
+        }
+        rhs: SparseField = {}
+        for coordinate in support:
+            closure = -self.config.alpha * residual[coordinate]
+            holographic = self.config.lambda_residual * self._laplacian(
+                residual, coordinate
+            )
+            permeation = self.config.eta * self._glyph(snapshot, coordinate)
+            rhs[coordinate] = closure + holographic + permeation
+
+        candidate = self._project(
+            {
+                coordinate: self._value(snapshot, coordinate)
+                + self.config.dt * rhs[coordinate]
+                for coordinate in support
+            }
+        )
+
+        if len(candidate) > self.config.max_active_cells:
+            self._cycle = cycle
+            return self._metrics(
+                cycle,
+                support,
+                snapshot,
+                candidate,
+                reconstruction,
+                residual,
+                rhs,
+                committed=False,
+                rejection_reason="active-cell budget exceeded",
+            )
+
+        provisional = self._metrics(
+            cycle,
+            support,
+            snapshot,
+            candidate,
+            reconstruction,
+            residual,
+            rhs,
+            committed=False,
+        )
+        if validator is not None and not bool(validator(candidate, provisional)):
+            self._cycle = cycle
+            return replace(provisional, rejection_reason="validator rejected candidate")
+
+        self._state = candidate
+        self._cycle = cycle
+        return self._metrics(
+            cycle,
+            support,
+            snapshot,
+            candidate,
+            reconstruction,
+            residual,
+            rhs,
+            committed=True,
+        )
+
+    def _support(self, field: Mapping[Coordinate, float]) -> tuple[Coordinate, ...]:
+        support = set(field)
+        if self.config.expand_halo:
+            for coordinate in tuple(support):
+                for neighbour in self._iter_neighbours(coordinate):
+                    support.add(neighbour)
+        if len(support) > self.config.max_active_cells:
+            raise RuntimeError("support-closure budget exceeded")
+        return tuple(sorted(support, key=self._linear_address))
+
+    def _validated_reconstruction(
+        self,
+        reconstruction: Mapping[Coordinate, float],
+        support: Sequence[Coordinate],
+    ) -> SparseField:
+        allowed = set(support)
+        result: SparseField = {}
+        for coordinate, value in reconstruction.items():
+            coordinate = self._validate_coordinate(coordinate)
+            if coordinate not in allowed:
+                raise ValueError("decoder returned a coordinate outside requested support")
+            result[coordinate] = self._finite(value, "decoder value")
+        return result
+
+    def _project(self, field: Mapping[Coordinate, float]) -> SparseField:
+        projected: SparseField = {}
+        for coordinate, raw_value in field.items():
+            coordinate = self._validate_coordinate(coordinate)
+            value = self._finite(raw_value, "field value")
+            value = min(self.config.value_max, max(self.config.value_min, value))
+            if abs(value) <= self.config.prune_epsilon:
+                continue
+            projected[coordinate] = value
+        return projected
+
+    def _laplacian(
+        self, field: Mapping[Coordinate, float], coordinate: Coordinate
+    ) -> float:
+        center = self._value(field, coordinate)
+        neighbour_sum = sum(self._value(field, n) for n in self._iter_neighbours(coordinate))
+        return neighbour_sum - 6.0 * center
+
+    def _glyph(self, field: Mapping[Coordinate, float], coordinate: Coordinate) -> float:
+        # Canonical glyph kernel: +1 at the centre and -1/6 on the six face neighbours.
+        center = self._value(field, coordinate)
+        neighbour_sum = sum(self._value(field, n) for n in self._iter_neighbours(coordinate))
+        return center - neighbour_sum / 6.0
+
+    def _iter_neighbours(self, coordinate: Coordinate) -> tuple[Coordinate, ...]:
+        x, y, z = coordinate
+        neighbours: list[Coordinate] = []
+        for dx, dy, dz in self._NEIGHBOURS:
+            candidate = x + dx, y + dy, z + dz
+            if self._inside(candidate):
+                neighbours.append(candidate)
+        return tuple(neighbours)
+
+    def _value(self, field: Mapping[Coordinate, float], coordinate: Coordinate) -> float:
+        if not self._inside(coordinate):
+            return 0.0
+        return float(field.get(coordinate, 0.0))
+
+    def _inside(self, coordinate: Coordinate) -> bool:
+        x, y, z = coordinate
+        side = self.config.side
+        return 0 <= x < side and 0 <= y < side and 0 <= z < side
+
+    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
+        if (
+            not isinstance(coordinate, tuple)
+            or len(coordinate) != 3
+            or any(isinstance(v, bool) or not isinstance(v, int) for v in coordinate)
+        ):
+            raise TypeError("coordinates must be integer (x, y, z) tuples")
+        if not self._inside(coordinate):
+            raise ValueError("coordinate is outside the logical lattice")
+        return coordinate
+
+    def _linear_address(self, coordinate: Coordinate) -> int:
+        x, y, z = coordinate
+        side = self.config.side
+        return x + side * (y + side * z)
+
+    @staticmethod
+    def _finite(value: float, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} must be numeric")
+        value = float(value)
+        if not math.isfinite(value):
+            raise ValueError(f"{name} must be finite")
+        return value
+
+    @staticmethod
+    def _mse(a: Mapping[Coordinate, float], b: Mapping[Coordinate, float]) -> float:
+        support = set(a) | set(b)
+        if not support:
+            return 0.0
+        squared_error = sum(
+            (float(a.get(c, 0.0)) - float(b.get(c, 0.0))) ** 2 for c in support
+        )
+        return squared_error / len(support)
+
+    def _metrics(
+        self,
+        cycle: int,
+        support: Sequence[Coordinate],
+        snapshot: Mapping[Coordinate, float],
+        candidate: Mapping[Coordinate, float],
+        reconstruction: Mapping[Coordinate, float],
+        residual: Mapping[Coordinate, float],
+        rhs: Mapping[Coordinate, float],
+        *,
+        committed: bool,
+        rejection_reason: str | None = None,
+    ) -> FieldStepMetrics:
+        committed_state = candidate if committed else snapshot
+        return FieldStepMetrics(
+            cycle=cycle,
+            support_cells=len(support),
+            active_cells_before=len(snapshot),
+            active_cells_after=len(committed_state),
+            reconstruction_mse=self._mse(snapshot, reconstruction),
+            anchor_mse=self._mse(self._anchor, committed_state),
+            max_abs_residual=max((abs(value) for value in residual.values()), default=0.0),
+            max_abs_rhs=max((abs(value) for value in rhs.values()), default=0.0),
+            committed=committed,
+            rejection_reason=rejection_reason,
+        )

--- a/tests/test_dr_moagi_field_runtime.py
+++ b/tests/test_dr_moagi_field_runtime.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dr_moagi_field_runtime import (
+    DrMoagiFieldConfig,
+    DrMoagiFieldRuntime,
+    IdentityFieldCodec,
+)
+
+
+class ZeroCodec:
+    def encode(self, field):
+        return None
+
+    def decode(self, latent, support):
+        return {coordinate: 0.0 for coordinate in support}
+
+
+def test_conservative_step_guard_rejects_large_dt():
+    with pytest.raises(ValueError, match="conservative"):
+        DrMoagiFieldConfig(dt=1.0)
+
+
+def test_identity_codec_has_zero_reconstruction_residual():
+    runtime = DrMoagiFieldRuntime(
+        IdentityFieldCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    runtime.load({(2, 2, 2): 0.5})
+
+    metrics = runtime.step()
+
+    assert metrics.committed
+    assert metrics.reconstruction_mse == pytest.approx(0.0)
+    assert metrics.max_abs_residual == pytest.approx(0.0)
+    assert runtime.snapshot()[(2, 2, 2)] == pytest.approx(0.5)
+
+
+def test_autoencoder_closure_pulls_state_toward_reconstruction():
+    runtime = DrMoagiFieldRuntime(
+        ZeroCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    runtime.load({(2, 2, 2): 1.0})
+
+    metrics = runtime.step()
+
+    assert metrics.committed
+    assert runtime.snapshot()[(2, 2, 2)] == pytest.approx(0.9)
+
+
+def test_moagi_glyph_uses_six_face_neighbours():
+    runtime = DrMoagiFieldRuntime(
+        IdentityFieldCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=0.0,
+            lambda_residual=0.0,
+            eta=0.1,
+            dt=0.1,
+            expand_halo=True,
+        ),
+    )
+    runtime.load({(2, 2, 2): 1.0})
+
+    metrics = runtime.step()
+    state = runtime.snapshot()
+
+    assert metrics.committed
+    assert state[(2, 2, 2)] == pytest.approx(1.0)
+    expected_neighbour = -1.0 / 600.0
+    assert state[(1, 2, 2)] == pytest.approx(expected_neighbour)
+    assert state[(3, 2, 2)] == pytest.approx(expected_neighbour)
+    assert state[(2, 1, 2)] == pytest.approx(expected_neighbour)
+    assert state[(2, 3, 2)] == pytest.approx(expected_neighbour)
+    assert state[(2, 2, 1)] == pytest.approx(expected_neighbour)
+    assert state[(2, 2, 3)] == pytest.approx(expected_neighbour)
+
+
+def test_validator_rolls_back_candidate_and_preserves_anchor():
+    runtime = DrMoagiFieldRuntime(
+        ZeroCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    initial = {(2, 2, 2): 0.75}
+    runtime.load(initial)
+
+    metrics = runtime.step(validator=lambda candidate, telemetry: False)
+
+    assert not metrics.committed
+    assert metrics.rejection_reason == "validator rejected candidate"
+    assert runtime.snapshot() == initial
+    assert runtime.anchor_snapshot() == initial
+    assert runtime.cycle == 1
+
+
+def test_decoder_cannot_escape_requested_sparse_support():
+    class EscapingCodec:
+        def encode(self, field):
+            return None
+
+        def decode(self, latent, support):
+            return {(0, 0, 0): 1.0}
+
+    runtime = DrMoagiFieldRuntime(
+        EscapingCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=0.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    runtime.load({(2, 2, 2): 0.5})
+
+    with pytest.raises(ValueError, match="outside requested support"):
+        runtime.step()
+
+    assert runtime.snapshot() == {(2, 2, 2): 0.5}
+
+
+def test_support_closure_fails_before_dense_materialization():
+    runtime = DrMoagiFieldRuntime(
+        IdentityFieldCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=0.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=True,
+            max_active_cells=1,
+        ),
+    )
+    runtime.load({(2, 2, 2): 0.5})
+
+    with pytest.raises(RuntimeError, match="support-closure budget"):
+        runtime.step()


### PR DESCRIPTION
## What changed

This PR evolves the Dr Moagi research architecture into a dimensionally consistent, bounded, executable sparse-field runtime while preserving the canonical deterministic VM boundary.

- adds ADR-003 adopting the same-space field law
- adds the normative Field Runtime v2 operational specification
- adds `DrMoagiFieldRuntime`, a pure-Python sparse reference runtime
- adds exact six-face-neighbour Laplacian and Moagi glyph semantics
- adds immutable source-anchor telemetry, sparse support closure, conservative timestep/resource guards, and candidate-first commit/rollback
- adds focused tests for residual closure, glyph behaviour, support confinement, rollback, and timestep rejection
- integrates the runtime into `docs/ARCHITECTURE.md`
- updates `docs/PROJECT_STATUS.md` and release-readiness targets

## Canonical equation

```text
R(Psi) = Psi - D(E(Psi))

dPsi/dt = -alpha R(Psi)
          + lambda Delta_6 R(Psi)
          + eta (G_moagi * Psi)
```

With the locked glyph stencil:

```text
G_moagi * Psi = -(1/6) Delta_6 Psi
```

## Architectural impact

The existing 64-bit Jarvis-X VM remains the authoritative core. The new runtime lives in Layers 4/5 and proposes bounded candidate field transitions that must pass projection/validation before commit. Experimental 256-bit, 512-bit, DMEB-32, CUDA, FPGA, and native-extension formats remain backend adapters/research targets until separately promoted.

This avoids three prior ambiguities:

1. latent encoder outputs are no longer subtracted directly from volumetric fields;
2. six-neighbour glyph and Laplacian sign conventions are explicit;
3. scalar bottlenecks are treated as lossy/restricted-family representations rather than general invertible billion-voxel encodings.

## Validation

Focused unit tests were added under `tests/test_dr_moagi_field_runtime.py`. Local clone-based validation was unavailable in the current execution environment because outbound DNS to GitHub is blocked; repository CI should therefore be treated as the authoritative branch validation for this PR.

## Follow-up

After this integration is green, the next coherent steps are to add Field Runtime v2 to the consolidated empirical-validation artifact and then build backend adapters for the C++/CUDA and experimental tensor-bytecode paths without changing the canonical transaction semantics.