### PR TITLE
Permeate Moagi-Helmholtz across Jarvis-X

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,13 +93,20 @@ A large virtual extent never implies dense allocation. Every implementation must
 
 The Dr Moagi Field Runtime v2 is the canonical reference for a same-space sparse volumetric transition. Its default logical extent may be `1000^3`, while its physical state remains an explicitly bounded active support with deterministic background semantics.
 
-### Layer 5 — Adaptive research systems
+### Layer 5 — Adaptive and generative research systems
 
 Responsibilities may include:
 
 - residual correction memory;
 - autoencoder/decoder closure operators;
+- multimodal conditioning;
+- conditional geometry generation;
 - inward latent or field recurrence;
+- bounded geometric refinement;
+- rendering orchestration;
+- multimedia codec and archive adapters;
+- inverse geometric inference;
+- rate-distortion measurement;
 - parameter candidate generation;
 - shadow evaluation;
 - bounded schedule search;
@@ -109,6 +116,8 @@ Responsibilities may include:
 Adaptive systems must optimize constrained representations, not rewrite arbitrary native instructions. Fitness must exclude uncontrolled nondeterministic signals unless repeated statistical evaluation is explicitly part of the contract.
 
 For volumetric autoencoding systems, additive evolution terms must inhabit the same authoritative field space. Latent tensors are transformed through an explicit decoder before they participate in a field residual.
+
+The Moagi-Helmholtz functional is the canonical Layer 5 orchestration contract for multimodal-conditioned geometry generation, refinement, archival coding and reverse inference. It does not require the canonical VM to depend on a neural, renderer or codec backend.
 
 ### Layer 6 — Interfaces and visualization
 
@@ -166,6 +175,10 @@ The research transform cannot make itself authoritative merely by computing a ca
 9. **Same-space evolution:** terms combined in one authoritative state equation must share a defined state type and compatible units.
 10. **Candidate-first adaptation:** active model, schedule, topology, bytecode, or field state is not replaced until its candidate passes the declared admission gate.
 11. **Immutable drift reference:** self-referential research loops that measure generational preservation retain an immutable source anchor for the duration of a run.
+12. **Explicit generative boundaries:** conditioning, latent geometry, rendered frames, coded bitstreams and archive containers are distinct state types.
+13. **No false inverse:** ordinary lossy rendering or video coding is not treated as globally invertible to original geometry.
+14. **Rate-distortion visibility:** codec optimization reports both distortion and coded representation size.
+15. **Convergence by evidence:** unique convergence is claimed only under sufficient mathematical assumptions or a validated restricted domain.
 
 ## 5. Data contracts
 
@@ -240,6 +253,41 @@ With the canonical glyph stencil,
 G_moagi * Psi = -(1/6) Delta_6 Psi.
 ```
 
+### Moagi-Helmholtz orchestration candidate
+
+A unified generative candidate declares:
+
+```text
+multimodal observation/version
+conditioning representation/version
+latent representation/version
+source, generated and refined geometry
+renderer/camera/material contract
+coded bitstream and archive/container contract
+side-information budget
+inverse-inference model/version
+cycle-reconstruction metric
+anchor-drift metric
+rate/distortion telemetry
+resource ceilings
+validator decision
+commit/rollback outcome
+```
+
+The forward contract is
+
+```text
+M -> Phi -> c -> E -> z -> D -> V0 -> Refine -> V* -> Render -> F -> Codec -> B -> Mux -> A
+```
+
+and the reverse contract is
+
+```text
+A -> Demux -> B -> Decode -> F_hat -> I_phi -> (z_hat,c_hat) -> D -> V_hat0 -> Refine -> V_hat*.
+```
+
+The reverse path is inference unless sufficient side information establishes exact replay.
+
 ## 6. Integration rule
 
 A research subsystem may enter the canonical package only when it provides:
@@ -256,6 +304,8 @@ A research subsystem may enter the canonical package only when it provides:
 Large pull requests should be decomposed into infrastructure, kernel, integration and demonstration stages.
 
 A field or latent runtime must additionally demonstrate sparse support confinement, candidate rollback, explicit timestep/resource limits, and honest information-capacity claims for its latent representation.
+
+A generative/archive runtime must additionally separate renderer, codec and container semantics; account for side information; expose cycle error and archive size; and reject candidates before publication when validation fails.
 
 ## 7. Decision records
 
@@ -274,11 +324,15 @@ A newer accepted ADR may supersede an older one, but historical records should r
 
 ADR-003 extends ADR-002 by defining the same-space Dr Moagi field evolution contract and its executable sparse transaction semantics.
 
+ADR-004 extends ADR-003 by defining the Moagi-Helmholtz multimodal generative, geometric, rendering, archival and inverse-inference orchestration contract.
+
 ## 8. Security boundary
 
 The policy layer is an application-level guard, not a complete security sandbox. Untrusted bytecode, native plugins, model files and browser content require dedicated threat models. See [`SECURITY.md`](../SECURITY.md).
 
 Self-modification is never equivalent to unrestricted writes into authoritative code memory. Adaptive code, model, tile, or schedule changes are represented as candidate patches that require validation and commit; otherwise the prior authoritative state remains active.
+
+Decoded multimedia, model weights, geometry sidecars and archive metadata are also untrusted inputs. Backend adapters must validate sizes, formats, coordinate ranges and version bindings before allocating or publishing authoritative state.
 
 ## 9. Dr Moagi Field Runtime v2 integration
 
@@ -333,3 +387,48 @@ Psi_n
 ```
 
 This architecture is backend-neutral. Pure Python, C++, PyTorch/CUDA, distributed sparse workers, FPGA soft cores, and experimental tensor bytecodes may implement the transform, provided they preserve the same state, resource, and transaction semantics.
+
+## 10. Moagi-Helmholtz system-wide permeation
+
+The unified generative architecture composes the existing field and transaction principles into an end-to-end orchestration plane:
+
+```text
+OBSERVE multimodal M
+  -> CONDITION c = Phi(M)
+  -> ENCODE geometry z = E(G)
+  -> GENERATE V0 = D(z,c)
+  -> REFINE V* under E_MH and Pi_G
+  -> RENDER calibrated frames F
+  -> CODE bitstream B under rate-distortion control
+  -> ARCHIVE A = Mux(B, side_info)
+  -> DECODE / DEMUX
+  -> INFER (z_hat,c_hat) from decoded evidence + side info
+  -> REGENERATE V_hat*
+  -> MEASURE cycle error + anchor drift + rate + resources
+  -> PROPOSE model/codec/schedule adaptation
+  -> Pi_Lambda / shadow validation
+  -> COMMIT or ROLLBACK
+  -> JOURNAL
+  -> RE-ENTER
+```
+
+The Moagi-Helmholtz candidate operator is therefore subordinate to, and protected by, the same canonical transaction boundary as the Field Runtime v2:
+
+```text
+Xi_(t+1) = Pi_Lambda(M_MH(Xi_t)).
+```
+
+Backend lowering is explicit:
+
+```text
+Python reference     -> orchestration conformance
+C++                  -> geometric kernels / refinement
+PyTorch/CUDA         -> conditioning, latent and tensor acceleration
+renderer backend     -> calibrated image/depth production
+video codec backend  -> rate-distortion coding and container integration
+DMEB/tensor ISA      -> bounded accelerator lowering
+FPGA/native ISA      -> verified hardware implementation
+browser/3D UI        -> visualization and telemetry unless separately promoted
+```
+
+None of these backends may bypass the canonical evidence, resource, policy, provenance, or rollback boundaries.

--- a/docs/DR_MOAGI_MOAGI_HELMHOLTZ.md
+++ b/docs/DR_MOAGI_MOAGI_HELMHOLTZ.md
@@ -1,0 +1,343 @@
+# Dr Moagi Moagi-Helmholtz Unified Generative Functional
+
+## Status
+
+Canonical Layer 4/5 orchestration specification for multimodal-conditioned 3D generation, geometric refinement, rendering, archival coding, inverse inference, verification and transactional re-entry.
+
+This specification extends `DR_MOAGI_FIELD_RUNTIME_V2.md` and ADR-004. It does not replace the deterministic Jarvis-X VM or claim that the dependency-free reference implementation is a production neural or video-codec stack.
+
+## 1. State spaces
+
+Let
+
+```text
+M  : multimodal observation
+c  : conditioning state
+z  : latent state
+G  : mesh / geometric state
+F  : rendered frame sequence
+B  : coded multimedia bitstream
+A  : archive/container bytes
+Omega : persistent metrics/adaptation state
+```
+
+The authoritative orchestration state is
+
+```text
+Xi = (M, c, z, G, F, A, Theta, Omega, telemetry).
+```
+
+Every boundary is explicit. A renderer does not emit a latent; a container is not a codec; an inverse model does not become an exact inverse merely by naming.
+
+## 2. Forward functional
+
+```text
+c      = Phi(M)
+z      = E_thetae(G_source)
+V0     = D_thetad(z, c)
+Vstar  = Refine_E_MH(V0)
+F      = R(Vstar; camera, material, light)
+B      = C_q(F)
+A      = Mux(B, side_info)
+```
+
+The conditional geometric fixed-point objective is
+
+```text
+Vstar = argmin_{V in G_adm} [
+    E_MH(V)
+    + (xi/2) ||V - D(E(V), c)||_F^2
+].
+```
+
+## 3. Moagi-Helmholtz energy
+
+```text
+E_MH(V) =
+    (rho/2) tr(V^T L(V) V)
+  + (lambda/2) ||V - C(V)||_F^2
+  + (gamma/2) ||L(V)V||_F^2
+  + (mu/2) ((Area(V)-A_target)/A_target)^2
+  + nu B_geom(V,F).
+```
+
+`L(V)` is a cotangent Laplacian under an explicitly selected sign convention. `B_geom` is a bounded barrier/penalty used to reject or discourage degenerate or inadmissible geometry.
+
+Refinement is dissipative gradient flow:
+
+```text
+dV/dtau = - grad E_MH(V)
+```
+
+or a named numerical approximation such as a lagged-Laplacian update.
+
+A discrete candidate step is
+
+```text
+V_candidate = V_k - eta_k * g_E(V_k)
+V_(k+1)     = Pi_G(V_candidate).
+```
+
+## 4. Geometry projection
+
+`Pi_G` enforces at least:
+
+- finite coordinates;
+- vertex-count/resource limits;
+- valid triangle indices;
+- declared topology constraints;
+- bounded displacement where configured;
+- non-degenerate geometry where required.
+
+Invalid candidates fail closed.
+
+## 5. Rendering
+
+Rendering is a calibrated map
+
+```text
+F_t = R(Vstar, Faces, Camera_t, Materials_t, Lights_t).
+```
+
+Perspective or orthographic projection is backend-specific but camera calibration and depth conventions must be explicit whenever reverse geometric inference depends on them.
+
+Optional geometry-preserving channels include depth, normals, segmentation, camera transforms and topology descriptors.
+
+## 6. Multimedia archive
+
+The archival contract is
+
+```text
+B = VideoEncode_q(F)
+A = ContainerMux(B, side_info).
+```
+
+For an MP4 backend, MP4 is the container contract. The actual video codec, transform, prediction, quantization and entropy-coding tools are separate backend details.
+
+The rate-distortion objective is
+
+```text
+J_RD = D(F, F_hat) + lambda_R * Rate(B).
+```
+
+Both distortion and bit count must be reported for codec claims.
+
+## 7. Reverse inference
+
+```text
+(B_hat, side_info) = ContainerDemux(A)
+F_hat              = VideoDecode(B_hat)
+(z_hat, c_hat)     = I_phi(F_hat, side_info)
+V_hat0             = D_thetad(z_hat, c_hat)
+V_hatstar          = Refine_E_MH(V_hat0).
+```
+
+This is an inference/reconstruction path. A global inverse renderer is not assumed.
+
+Exact deterministic reconstruction may be claimed only when the archive contains sufficient information to establish it. Otherwise the result is an inferred compatible geometry.
+
+## 8. Side-information contract
+
+A geometry-aware archive may carry any explicitly versioned subset of:
+
+```text
+camera parameters
+frame timestamps
+latent code
+conditioning code
+mesh/topology descriptor
+depth
+normals
+segmentation/material IDs
+model versions
+codec parameters
+integrity digest
+transaction identifier
+```
+
+Side information is part of the information budget and may not be ignored when making compression claims.
+
+## 9. Cycle verification
+
+Let
+
+```text
+Vstar      = forward refined geometry
+V_hatstar  = reconstructed refined geometry.
+```
+
+The reference cycle metric is a topology-preserving RMS displacement when topology matches:
+
+```text
+E_cycle = rms(Vstar, V_hatstar).
+```
+
+Production implementations may additionally use Chamfer distance, normal consistency, topology metrics, perceptual render metrics and task-specific scores.
+
+The immutable source anchor provides drift telemetry:
+
+```text
+E_anchor = d_G(V_anchor, Vstar).
+```
+
+## 10. Grand training objective
+
+A compatible training objective is
+
+```text
+L_MH =
+    w_CD      L_chamfer
+  + w_normal  L_normal
+  + w_edge    L_edge
+  + w_KL      L_KL
+  + w_render  L_render
+  + w_rate    Rate
+  + w_station ||grad E_MH(Vstar)||^2
+  + w_cycle   L_cycle
+  + w_cond    L_condition.
+```
+
+Training and runtime coefficients are distinct configuration domains.
+
+## 11. Transactional permeation
+
+The full system cycle is
+
+```text
+OBSERVE
+-> CONDITION
+-> ENCODE
+-> GENERATE
+-> REFINE
+-> RENDER
+-> CODE
+-> ARCHIVE
+-> DECODE
+-> INFER
+-> REGENERATE
+-> MEASURE
+-> PROPOSE ADAPTATION
+-> VERIFY
+-> COMMIT / ROLLBACK
+-> JOURNAL
+-> RE-ENTER
+```
+
+No candidate model, tile schedule, geometry, codec policy or bytecode mutation becomes authoritative before validation.
+
+## 12. Master operator
+
+Let `M_MH` denote the composed generative/archive/reconstruction candidate operator. The bounded Jarvis-X transition is
+
+```text
+Xi_(t+1) = Pi_Lambda(M_MH(Xi_t)).
+```
+
+The broader inward recurrence remains
+
+```text
+Xi_(t+1) = Pi_Lambda_t[
+    Xi_t
+  + P_(1:M)^inward(Xi_t)
+  - E_t
+  + Omega_t
+  + kappa_t R_t^inward
+  - eta_t grad_Theta L_MH
+  - zeta_t grad_H C_t
+].
+```
+
+The Moagi-Helmholtz functional therefore supplies the concrete generative, geometric and archival semantics inside the broader Jarvis-X transactional loop.
+
+## 13. Fixed points
+
+A bounded orchestration fixed point satisfies
+
+```text
+Xi_star = Pi_Lambda(M_MH(Xi_star)).
+```
+
+A geometric stationary point satisfies
+
+```text
+grad_V [
+    E_MH(Vstar)
+    + (xi/2)||Vstar - D(E(Vstar),c)||_F^2
+] = 0.
+```
+
+Unique convergence is claimed only when a sufficient condition such as contractivity is demonstrated on the admissible state space.
+
+## 14. Reference implementation
+
+`src/jarvisx/moagi_helmholtz.py` provides protocol boundaries for:
+
+```text
+Conditioner
+GeometryEncoder
+GeometryDecoder
+GeometryRefiner
+Renderer
+ArchiveCodec
+InverseModel
+StateValidator
+```
+
+and `MoagiHelmholtzEngine.step()` implements candidate-first publication.
+
+The bundled conformance components intentionally use:
+
+- a deterministic identity-like mesh descriptor instead of a trained neural codec;
+- an identity geometric refiner instead of a cotangent-energy solver;
+- a logical frame serializer instead of a rasterizer;
+- deterministic JSON bytes instead of MP4;
+- archived latent/condition side information instead of learned inverse inference.
+
+This makes orchestration invariants executable without overstating backend capability.
+
+## 15. Backend permeation map
+
+The contract is intended to lower into the wider Jarvis-X ecosystem as follows:
+
+```text
+Python reference     -> orchestration and conformance
+C++ runtime          -> geometry/refinement kernels
+CUDA/GPU             -> tensor and rendering acceleration
+Neural backends      -> Phi, E, D, I_phi
+Video codec backend  -> C_q and container adapter
+DMEB / tensor ISA    -> bounded accelerator lowering
+FPGA/native ISA      -> verified hardware acceleration
+Browser/3D UI        -> visualization and telemetry only unless explicitly promoted
+```
+
+All backends inherit the same transaction, evidence and authority boundaries.
+
+## 16. Required telemetry
+
+A production run should expose at least:
+
+```text
+cycle
+source geometry size
+latent size
+conditioning version
+refinement iterations
+geometric energy
+stationarity norm
+render dimensions / frame count
+encoded bytes
+bitrate or rate estimate
+render distortion
+cycle reconstruction error
+anchor drift
+model/codec versions
+validator decision
+commit/rollback result
+measured latency and resident memory
+```
+
+Virtual/logical scale is always reported separately from measured hardware performance.
+
+## 17. Canonical interpretation
+
+The Moagi-Helmholtz system is a conditional 3D generative, refinement and multimedia archival architecture. Its canonical strength is not a claim of magical inversion; it is the explicit coupling of generation, geometry, codec economics, inverse inference, evidence and reversible adaptation inside one auditable Jarvis-X state machine.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -34,6 +34,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
 | Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
+| Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures, not production neural or MP4 implementations |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
@@ -57,7 +58,7 @@ The gate currently tests five falsifiable properties:
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
 
-The Field Runtime v2 is covered by focused unit tests in the normal CI suite. It is not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
+The Field Runtime v2 and Moagi-Helmholtz orchestration runtime are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -86,6 +87,9 @@ Jarvis-X does not currently claim:
 - unrestricted autonomous source-code mutation;
 - production-grade isolation of hostile bytecode;
 - lossless compression of arbitrary data into a smaller state without side information;
+- global invertibility of ordinary RGB/video rendering to the original 3D mesh;
+- that MP4 is itself a global 3D-DCT codec;
+- unique convergence of arbitrary learned Moagi-Helmholtz pipelines without sufficient mathematical assumptions;
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
 - safety certification from the presence of a policy or coherence gate;
@@ -139,6 +143,8 @@ A capability moves to `main` only when all applicable items are satisfied:
 - reproducible candidate generation;
 - rollback-complete state transitions;
 - codec/model version binding for adaptive field runtimes;
+- Moagi-Helmholtz conditioner/geometry/renderer/archive backend adapters with measured capability boundaries;
+- rate-distortion and cycle-reconstruction telemetry;
 - anchor-drift and reconstruction telemetry in the consolidated empirical evidence artifact;
 - metric-hacking tests;
 - experiment manifests and replay.

--- a/docs/adr/0004-moagi-helmholtz-unified-generative-functional.md
+++ b/docs/adr/0004-moagi-helmholtz-unified-generative-functional.md
@@ -1,0 +1,221 @@
+# ADR-004: Adopt the Moagi-Helmholtz unified generative functional
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Extends:** ADR-003
+
+## Context
+
+ADR-003 established a dimensionally consistent sparse volumetric field law for the Dr Moagi Layer 4/5 runtime. The wider Jarvis-X research architecture also requires one contract that connects multimodal conditioning, 3D geometry encoding, conditional generation, geometric refinement, rendering, multimedia archival, inverse inference, and transactional adaptation.
+
+Earlier descriptions mixed several distinct operations: gradient flow was called Hamiltonian flow, a global DCT was identified with MP4, RGB rendering was treated as globally invertible, and uniqueness was claimed without contractivity or convexity assumptions. Those shortcuts are not suitable as canonical operational semantics.
+
+The new functional must preserve the existing Jarvis-X authority boundary: the deterministic VM, policy, transaction and provenance layers remain canonical. Generative or codec subsystems may propose candidate states but cannot bypass validation or silently redefine execution semantics.
+
+## Decision
+
+Jarvis-X adopts the **Moagi-Helmholtz unified generative functional** as the canonical orchestration contract for conditional 3D generation and multimedia archival.
+
+The forward cycle is
+
+```text
+M
+-> c = Phi(M)
+-> z = E_thetae(G)
+-> V0 = D_thetad(z, c)
+-> V* = Refine_E(V0)
+-> F = Render(V*)
+-> B = VideoEncode_q(F)
+-> A = ContainerMux(B, side_info)
+```
+
+The reverse cycle is inference, not an assumed exact inverse:
+
+```text
+A
+-> (B, side_info) = ContainerDemux(A)
+-> F_hat = VideoDecode(B)
+-> (z_hat, c_hat) = I_phi(F_hat, side_info)
+-> V_hat0 = D_thetad(z_hat, c_hat)
+-> V_hat* = Refine_E(V_hat0)
+-> cycle verification
+```
+
+The complete candidate is then admitted through the existing projection and transaction boundary:
+
+```text
+candidate
+-> Pi_Lambda
+-> validator / shadow evaluation
+-> COMMIT or ROLLBACK
+-> journal
+```
+
+## Geometric objective
+
+The conditional geometry is defined variationally as
+
+```text
+V* = argmin_{V in G_adm} [
+       E_MH(V)
+       + (xi/2) ||V - D(E(V), c)||_F^2
+     ]
+```
+
+with
+
+```text
+E_MH = E_membrane
+     + E_local
+     + E_bend
+     + E_area
+     + E_barrier.
+```
+
+Refinement follows dissipative gradient flow:
+
+```text
+dV/dtau = - grad_V E_MH(V)
+```
+
+or an explicitly documented numerical approximation. A cotangent Laplacian that depends on geometry must not be differentiated as though it were constant unless the implementation declares a lagged-Laplacian approximation.
+
+## Rendering and codec boundary
+
+Rendering, codec transforms, compressed video bitstreams and file containers are separate contracts:
+
+```text
+geometry -> renderer -> frame sequence -> codec -> bitstream -> container
+```
+
+An implementation may use MP4 as a container, but MP4 is not defined as a global 3D DCT. Backend-specific codecs, transforms, prediction and rate-control tools remain adapter concerns.
+
+## Reconstruction boundary
+
+Ordinary RGB projection is many-to-one. Jarvis-X therefore does not define a global inverse renderer for arbitrary scenes. Reconstruction uses an inverse inference model and may consume explicit side information such as:
+
+- calibrated camera parameters;
+- depth or normal maps;
+- segmentation/material metadata;
+- latent codes;
+- conditioning embeddings;
+- geometry or topology sidecars;
+- model/version/integrity metadata.
+
+Exact deterministic replay is claimed only when the archive contains sufficient information for that claim. Otherwise reconstruction is an inferred geometry compatible with the decoded observations and declared priors.
+
+## Rate-distortion contract
+
+Archival quality is evaluated as a rate-distortion problem:
+
+```text
+J_RD = Distortion(F, F_hat) + lambda_R * Rate(B)
+```
+
+Video MSE alone is not a complete codec objective. The selected distortion metric, bit accounting method and operating point must be observable.
+
+## Unified training objective
+
+A compatible training objective may combine:
+
+```text
+L_MH =
+    w_CD      * L_chamfer
+  + w_normal  * L_normal
+  + w_edge    * L_edge
+  + w_KL      * L_KL
+  + w_render  * L_render
+  + w_rate    * Rate
+  + w_station * ||grad E_MH(V*)||^2
+  + w_cycle   * L_cycle
+  + w_cond    * L_condition.
+```
+
+Training losses do not automatically become runtime coefficients. Runtime and training contracts remain separately versioned.
+
+## Fixed-point and convergence semantics
+
+The orchestration state is
+
+```text
+Xi = (M, c, z, G, Theta, Omega, Archive, telemetry)
+```
+
+and the bounded transition is
+
+```text
+Xi_(t+1) = Pi_Lambda(M_MH(Xi_t)).
+```
+
+A fixed point satisfies
+
+```text
+Xi* = Pi_Lambda(M_MH(Xi*)).
+```
+
+Unique convergence is claimed only when the relevant map is proven contractive on the admissible domain or when another sufficient theorem applies. Otherwise the implementation reports measured convergence/stopping criteria without elevating them into a universal theorem.
+
+## Transactional adaptation
+
+Parameter, architecture, scheduler, codec, renderer, tile and bytecode adaptation is candidate-first:
+
+```text
+active
+-> candidate
+-> benchmark / verify
+-> Pi_Lambda
+-> COMMIT or ROLLBACK.
+```
+
+No research layer may rewrite authoritative code or state before validation.
+
+## Reference implementation
+
+`src/jarvisx/moagi_helmholtz.py` provides a dependency-free orchestration reference with typed protocol boundaries and deterministic conformance components. The conformance archive is JSON, not MP4, and the reference geometry codec is lossless, not a learned compressor. Their purpose is to test orchestration invariants rather than model quality or hardware throughput.
+
+## Required invariants
+
+1. Conditioning, latent, geometry, frame, bitstream and archive states have explicit boundaries.
+2. Geometric candidate states are finite and resource bounded.
+3. Refinement is gradient flow or a named approximation, not mislabeled Hamiltonian dynamics.
+4. Rendering and multimedia coding remain separate operators.
+5. Lossy RGB/video archival is not called globally invertible.
+6. Exact replay requires sufficient side information.
+7. Rate and distortion are both measurable for codec optimization.
+8. The original anchor may not be silently overwritten by self-reference.
+9. Candidate adaptation is transactional and reversible.
+10. Logical scale and measured physical throughput are reported separately.
+11. Unique convergence requires explicit sufficient assumptions.
+12. Backend adapters cannot redefine the canonical VM authority boundary.
+
+## Consequences
+
+### Positive
+
+- multimodal generation, geometry and codec research now share one end-to-end contract;
+- the reverse path becomes a measurable inference problem rather than a false inverse assumption;
+- archive side information and rate-distortion accounting become first-class;
+- C++/CUDA, neural, browser, DMEB, FPGA and native backends can share one orchestration state machine;
+- adaptation remains auditable and rollback-safe.
+
+### Negative
+
+- the unified system has more explicit interfaces and versioned state;
+- exact replay may require additional archive side information;
+- learned inverse reconstruction requires empirical evaluation;
+- convergence and performance claims remain backend-specific and evidence-gated.
+
+## Validation
+
+Canonical promotion requires:
+
+- end-to-end deterministic reference-cycle tests;
+- malformed geometry and resource-budget rejection;
+- immutable-anchor tests;
+- cycle-error telemetry;
+- validator rejection with atomic rollback;
+- archive-size bounds;
+- clear distinction between reference archive fixtures and production codecs;
+- CI across supported Python versions.
+
+The detailed operational specification is maintained in `docs/DR_MOAGI_MOAGI_HELMHOLTZ.md`.

--- a/src/jarvisx/moagi_helmholtz.py
+++ b/src/jarvisx/moagi_helmholtz.py
@@ -271,8 +271,13 @@ class ReferenceGeometryCodec:
     def decode(self, latent: Any, condition: Any) -> Mesh:
         del condition
         return Mesh(
-            vertices=tuple(tuple(float(v) for v in vertex) for vertex in latent["vertices"]),
-            faces=tuple(tuple(int(i) for i in face) for face in latent["faces"]),
+            vertices=tuple(
+                (float(vertex[0]), float(vertex[1]), float(vertex[2]))
+                for vertex in latent["vertices"]
+            ),
+            faces=tuple(
+                (int(face[0]), int(face[1]), int(face[2])) for face in latent["faces"]
+            ),
         )
 
 

--- a/src/jarvisx/moagi_helmholtz.py
+++ b/src/jarvisx/moagi_helmholtz.py
@@ -1,0 +1,315 @@
+"""Transactional orchestration contract for the Moagi-Helmholtz generative cycle.
+
+The module composes multimodal conditioning, geometry encoding/decoding,
+refinement, rendering, archival coding, inverse inference, verification and
+commit without making any backend-specific performance or invertibility claim.
+
+Production implementations may bind these protocols to neural, C++/CUDA,
+renderer, or video-codec backends. The included reference components are
+small deterministic conformance fixtures only.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+Vertex = tuple[float, float, float]
+Face = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class Mesh:
+    """Finite triangle mesh used at the orchestration boundary."""
+
+    vertices: tuple[Vertex, ...]
+    faces: tuple[Face, ...]
+
+    def __post_init__(self) -> None:
+        for vertex in self.vertices:
+            if len(vertex) != 3 or not all(math.isfinite(float(v)) for v in vertex):
+                raise ValueError("mesh vertices must contain three finite coordinates")
+        count = len(self.vertices)
+        for face in self.faces:
+            if len(face) != 3:
+                raise ValueError("faces must be triangles")
+            if any(isinstance(i, bool) or not isinstance(i, int) for i in face):
+                raise TypeError("face indices must be integers")
+            if any(i < 0 or i >= count for i in face):
+                raise ValueError("face index is outside the vertex buffer")
+            if len(set(face)) != 3:
+                raise ValueError("degenerate index triangle is not admissible")
+
+
+class Conditioner(Protocol):
+    def condition(self, multimodal: Mapping[str, Any]) -> Any:
+        ...
+
+
+class GeometryEncoder(Protocol):
+    def encode(self, mesh: Mesh) -> Any:
+        ...
+
+
+class GeometryDecoder(Protocol):
+    def decode(self, latent: Any, condition: Any) -> Mesh:
+        ...
+
+
+class GeometryRefiner(Protocol):
+    def refine(self, mesh: Mesh) -> Mesh:
+        ...
+
+
+class Renderer(Protocol):
+    def render(self, mesh: Mesh) -> Sequence[Any]:
+        ...
+
+
+class ArchiveCodec(Protocol):
+    def encode(self, frames: Sequence[Any], side_info: Mapping[str, Any]) -> bytes:
+        ...
+
+    def decode(self, archive: bytes) -> tuple[Sequence[Any], Mapping[str, Any]]:
+        ...
+
+
+class InverseModel(Protocol):
+    def infer(
+        self, frames: Sequence[Any], side_info: Mapping[str, Any]
+    ) -> tuple[Any, Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class MoagiHelmholtzMetrics:
+    cycle: int
+    source_vertices: int
+    archive_bytes: int
+    generation_rms: float
+    cycle_rms: float
+    anchor_rms: float
+
+
+@dataclass(frozen=True)
+class MoagiHelmholtzState:
+    cycle: int
+    condition: Any
+    latent: Any
+    generated_mesh: Mesh
+    refined_mesh: Mesh
+    archive: bytes
+    reconstructed_mesh: Mesh
+    metrics: MoagiHelmholtzMetrics
+
+
+StateValidator = Callable[[MoagiHelmholtzState], bool]
+
+
+@dataclass(frozen=True)
+class MoagiHelmholtzConfig:
+    max_vertices: int = 100_000
+    max_archive_bytes: int = 64 * 1024 * 1024
+    max_cycle_rms: float = math.inf
+
+    def __post_init__(self) -> None:
+        if isinstance(self.max_vertices, bool) or not isinstance(self.max_vertices, int):
+            raise TypeError("max_vertices must be an integer")
+        if self.max_vertices <= 0:
+            raise ValueError("max_vertices must be positive")
+        if isinstance(self.max_archive_bytes, bool) or not isinstance(self.max_archive_bytes, int):
+            raise TypeError("max_archive_bytes must be an integer")
+        if self.max_archive_bytes <= 0:
+            raise ValueError("max_archive_bytes must be positive")
+        if not isinstance(self.max_cycle_rms, (int, float)) or isinstance(
+            self.max_cycle_rms, bool
+        ):
+            raise TypeError("max_cycle_rms must be numeric")
+        if math.isnan(float(self.max_cycle_rms)) or self.max_cycle_rms < 0.0:
+            raise ValueError("max_cycle_rms must be non-negative")
+
+
+class MoagiHelmholtzEngine:
+    """Candidate-first transactional implementation of the unified cycle."""
+
+    def __init__(
+        self,
+        *,
+        conditioner: Conditioner,
+        encoder: GeometryEncoder,
+        decoder: GeometryDecoder,
+        refiner: GeometryRefiner,
+        renderer: Renderer,
+        archive_codec: ArchiveCodec,
+        inverse_model: InverseModel,
+        config: MoagiHelmholtzConfig | None = None,
+    ) -> None:
+        self.conditioner = conditioner
+        self.encoder = encoder
+        self.decoder = decoder
+        self.refiner = refiner
+        self.renderer = renderer
+        self.archive_codec = archive_codec
+        self.inverse_model = inverse_model
+        self.config = config or MoagiHelmholtzConfig()
+        self._state: MoagiHelmholtzState | None = None
+        self._anchor: Mesh | None = None
+
+    @property
+    def state(self) -> MoagiHelmholtzState | None:
+        return self._state
+
+    @property
+    def anchor(self) -> Mesh | None:
+        return self._anchor
+
+    def step(
+        self,
+        multimodal: Mapping[str, Any],
+        source_mesh: Mesh,
+        *,
+        validator: StateValidator | None = None,
+    ) -> MoagiHelmholtzState:
+        """Execute one full cycle and atomically publish only an admissible candidate."""
+
+        self._check_mesh_budget(source_mesh)
+        anchor = self._anchor or source_mesh
+
+        condition = self.conditioner.condition(multimodal)
+        latent = self.encoder.encode(source_mesh)
+        generated = self.decoder.decode(latent, condition)
+        self._check_mesh_budget(generated)
+
+        refined = self.refiner.refine(generated)
+        self._check_mesh_budget(refined)
+
+        frames = tuple(self.renderer.render(refined))
+        side_info = {"latent": latent, "condition": condition}
+        archive = bytes(self.archive_codec.encode(frames, side_info))
+        if len(archive) > self.config.max_archive_bytes:
+            raise RuntimeError("archive exceeds configured byte budget")
+
+        decoded_frames, decoded_side_info = self.archive_codec.decode(archive)
+        inferred_latent, inferred_condition = self.inverse_model.infer(
+            decoded_frames, decoded_side_info
+        )
+        reconstructed = self.decoder.decode(inferred_latent, inferred_condition)
+        reconstructed = self.refiner.refine(reconstructed)
+        self._check_mesh_budget(reconstructed)
+
+        next_cycle = 1 if self._state is None else self._state.cycle + 1
+        generation_rms = mesh_rms(source_mesh, generated)
+        cycle_rms = mesh_rms(refined, reconstructed)
+        anchor_rms = mesh_rms(anchor, refined)
+
+        metrics = MoagiHelmholtzMetrics(
+            cycle=next_cycle,
+            source_vertices=len(source_mesh.vertices),
+            archive_bytes=len(archive),
+            generation_rms=generation_rms,
+            cycle_rms=cycle_rms,
+            anchor_rms=anchor_rms,
+        )
+        candidate = MoagiHelmholtzState(
+            cycle=next_cycle,
+            condition=condition,
+            latent=latent,
+            generated_mesh=generated,
+            refined_mesh=refined,
+            archive=archive,
+            reconstructed_mesh=reconstructed,
+            metrics=metrics,
+        )
+
+        if cycle_rms > self.config.max_cycle_rms:
+            raise RuntimeError("cycle reconstruction exceeds configured tolerance")
+        if validator is not None and not bool(validator(candidate)):
+            raise RuntimeError("candidate rejected by Moagi-Helmholtz validator")
+
+        # Atomic publication boundary: no authoritative state changes occur before here.
+        if self._anchor is None:
+            self._anchor = source_mesh
+        self._state = candidate
+        return candidate
+
+    def _check_mesh_budget(self, mesh: Mesh) -> None:
+        if len(mesh.vertices) > self.config.max_vertices:
+            raise RuntimeError("mesh exceeds configured vertex budget")
+
+
+def mesh_rms(left: Mesh, right: Mesh) -> float:
+    """Topology-preserving RMS vertex displacement used for reference telemetry."""
+
+    if left.faces != right.faces or len(left.vertices) != len(right.vertices):
+        return math.inf
+    if not left.vertices:
+        return 0.0
+    squared = 0.0
+    for a, b in zip(left.vertices, right.vertices):
+        squared += sum((float(x) - float(y)) ** 2 for x, y in zip(a, b))
+    return math.sqrt(squared / (3 * len(left.vertices)))
+
+
+class ReferenceConditioner:
+    """Deterministic JSON-native conditioning fixture."""
+
+    def condition(self, multimodal: Mapping[str, Any]) -> Any:
+        return {key: multimodal[key] for key in sorted(multimodal)}
+
+
+class ReferenceGeometryCodec:
+    """Lossless mesh descriptor fixture; it is not a compression model."""
+
+    def encode(self, mesh: Mesh) -> Any:
+        return {
+            "vertices": [list(vertex) for vertex in mesh.vertices],
+            "faces": [list(face) for face in mesh.faces],
+        }
+
+    def decode(self, latent: Any, condition: Any) -> Mesh:
+        del condition
+        return Mesh(
+            vertices=tuple(tuple(float(v) for v in vertex) for vertex in latent["vertices"]),
+            faces=tuple(tuple(int(i) for i in face) for face in latent["faces"]),
+        )
+
+
+class IdentityGeometryRefiner:
+    def refine(self, mesh: Mesh) -> Mesh:
+        return mesh
+
+
+class ReferenceRenderer:
+    """Serializes geometry into one logical frame for conformance testing."""
+
+    def render(self, mesh: Mesh) -> Sequence[Any]:
+        return (
+            {
+                "vertices": [list(vertex) for vertex in mesh.vertices],
+                "faces": [list(face) for face in mesh.faces],
+            },
+        )
+
+
+class ReferenceArchiveCodec:
+    """Deterministic JSON archive fixture; not an MP4/video implementation."""
+
+    def encode(self, frames: Sequence[Any], side_info: Mapping[str, Any]) -> bytes:
+        payload = {"frames": list(frames), "side_info": dict(side_info)}
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    def decode(self, archive: bytes) -> tuple[Sequence[Any], Mapping[str, Any]]:
+        payload = json.loads(archive.decode("utf-8"))
+        return tuple(payload["frames"]), payload["side_info"]
+
+
+class SideInfoInverseModel:
+    """Exact conformance inverse using explicitly archived latent/condition side information."""
+
+    def infer(
+        self, frames: Sequence[Any], side_info: Mapping[str, Any]
+    ) -> tuple[Any, Any]:
+        del frames
+        return side_info["latent"], side_info["condition"]

--- a/tests/test_moagi_helmholtz.py
+++ b/tests/test_moagi_helmholtz.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.moagi_helmholtz import (
+    IdentityGeometryRefiner,
+    Mesh,
+    MoagiHelmholtzConfig,
+    MoagiHelmholtzEngine,
+    ReferenceArchiveCodec,
+    ReferenceConditioner,
+    ReferenceGeometryCodec,
+    ReferenceRenderer,
+    SideInfoInverseModel,
+    mesh_rms,
+)
+
+
+def triangle() -> Mesh:
+    return Mesh(
+        vertices=((0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (0.0, 1.0, 0.0)),
+        faces=((0, 1, 2),),
+    )
+
+
+def engine(**config_overrides: object) -> MoagiHelmholtzEngine:
+    config = MoagiHelmholtzConfig(**config_overrides)
+    codec = ReferenceGeometryCodec()
+    return MoagiHelmholtzEngine(
+        conditioner=ReferenceConditioner(),
+        encoder=codec,
+        decoder=codec,
+        refiner=IdentityGeometryRefiner(),
+        renderer=ReferenceRenderer(),
+        archive_codec=ReferenceArchiveCodec(),
+        inverse_model=SideInfoInverseModel(),
+        config=config,
+    )
+
+
+def test_reference_cycle_round_trips_geometry() -> None:
+    source = triangle()
+    runtime = engine()
+
+    state = runtime.step({"text": "triangle", "audio": [0.0, 1.0]}, source)
+
+    assert state.refined_mesh == source
+    assert state.reconstructed_mesh == source
+    assert state.metrics.generation_rms == 0.0
+    assert state.metrics.cycle_rms == 0.0
+    assert state.metrics.anchor_rms == 0.0
+    assert state.metrics.archive_bytes > 0
+    assert runtime.anchor == source
+    assert runtime.state == state
+
+
+def test_anchor_is_immutable_across_cycles() -> None:
+    first = triangle()
+    second = Mesh(
+        vertices=((0.1, 0.0, 0.0), (1.1, 0.0, 0.0), (0.1, 1.0, 0.0)),
+        faces=first.faces,
+    )
+    runtime = engine()
+
+    runtime.step({"text": "first"}, first)
+    state = runtime.step({"text": "second"}, second)
+
+    assert runtime.anchor == first
+    assert state.metrics.anchor_rms == pytest.approx(0.1 / (3**0.5))
+
+
+def test_validator_rejection_is_transactional() -> None:
+    runtime = engine()
+    accepted = runtime.step({"text": "accepted"}, triangle())
+
+    with pytest.raises(RuntimeError, match="validator"):
+        runtime.step(
+            {"text": "rejected"},
+            triangle(),
+            validator=lambda candidate: candidate.cycle < 2,
+        )
+
+    assert runtime.state == accepted
+    assert runtime.anchor == triangle()
+
+
+def test_archive_budget_rejects_before_commit() -> None:
+    runtime = engine(max_archive_bytes=1)
+
+    with pytest.raises(RuntimeError, match="archive exceeds"):
+        runtime.step({"text": "too large"}, triangle())
+
+    assert runtime.state is None
+    assert runtime.anchor is None
+
+
+def test_vertex_budget_is_enforced() -> None:
+    runtime = engine(max_vertices=2)
+
+    with pytest.raises(RuntimeError, match="vertex budget"):
+        runtime.step({}, triangle())
+
+
+def test_mesh_validation_rejects_bad_indices() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        Mesh(vertices=((0.0, 0.0, 0.0),), faces=((0, 1, 2),))
+
+
+def test_mesh_rms_requires_matching_topology() -> None:
+    source = triangle()
+    other = Mesh(
+        vertices=source.vertices,
+        faces=((0, 2, 1),),
+    )
+    assert mesh_rms(source, other) == float("inf")
+
+
+def test_cycle_tolerance_rejects_nonmatching_inverse() -> None:
+    class ShiftedDecoder(ReferenceGeometryCodec):
+        def decode(self, latent: object, condition: object) -> Mesh:
+            mesh = super().decode(latent, condition)
+            if condition == {"phase": "inverse"}:
+                return Mesh(
+                    vertices=tuple((x + 1.0, y, z) for x, y, z in mesh.vertices),
+                    faces=mesh.faces,
+                )
+            return mesh
+
+    class ShiftInverse(SideInfoInverseModel):
+        def infer(self, frames: object, side_info: object) -> tuple[object, object]:
+            latent, _condition = super().infer(frames, side_info)  # type: ignore[arg-type]
+            return latent, {"phase": "inverse"}
+
+    codec = ShiftedDecoder()
+    runtime = MoagiHelmholtzEngine(
+        conditioner=ReferenceConditioner(),
+        encoder=codec,
+        decoder=codec,
+        refiner=IdentityGeometryRefiner(),
+        renderer=ReferenceRenderer(),
+        archive_codec=ReferenceArchiveCodec(),
+        inverse_model=ShiftInverse(),
+        config=MoagiHelmholtzConfig(max_cycle_rms=0.1),
+    )
+
+    with pytest.raises(RuntimeError, match="cycle reconstruction"):
+        runtime.step({}, triangle())
+
+    assert runtime.state is None


### PR DESCRIPTION
## What changed

This PR permeates the perfected Moagi-Helmholtz functional through the Jarvis-X architecture while preserving the deterministic VM and transactional authority boundary.

- adds ADR-004 adopting the Moagi-Helmholtz unified generative functional
- adds the normative operational specification for conditioning -> geometry encode/decode -> refinement -> rendering -> archive coding -> inverse inference -> cycle verification
- adds `MoagiHelmholtzEngine`, a dependency-free transactional orchestration reference
- adds protocol boundaries for conditioner, geometry encoder/decoder, refiner, renderer, archive codec and inverse model
- adds immutable-anchor, cycle-error, archive-budget and candidate rollback semantics
- adds deterministic conformance components without presenting them as neural, rendering or MP4 production backends
- permeates the contract through `docs/ARCHITECTURE.md`
- classifies the runtime and tightens claims in `docs/PROJECT_STATUS.md`

## Canonical orchestration

```text
OBSERVE
-> CONDITION
-> ENCODE
-> GENERATE
-> REFINE
-> RENDER
-> CODE / ARCHIVE
-> DECODE
-> INFER
-> REGENERATE
-> MEASURE
-> VERIFY
-> COMMIT / ROLLBACK
-> JOURNAL
-> RE-ENTER
```

The bounded state transition is:

```text
Xi_(t+1) = Pi_Lambda(M_MH(Xi_t)).
```

## Capability boundary

The bundled reference archive is deterministic JSON, not MP4. The bundled geometry codec is a lossless conformance descriptor, not a trained compressor. Rendering is represented by a logical conformance frame. Production CLIP/ViT/audio encoders, cotangent refinement, CUDA rendering, MP4/video codecs, learned inverse models, DMEB and FPGA/native adapters remain backend implementations that must preserve the same evidence, resource and transaction semantics.

Ordinary lossy RGB/video is not treated as globally invertible. Exact replay requires sufficient archived side information; otherwise the reverse path is inverse inference.

## Validation intent

Focused tests cover end-to-end deterministic round trip, immutable anchors, vertex/archive resource ceilings, malformed geometry, cycle tolerance and validator rejection with atomic rollback.

Repository CI will validate the branch across the supported Python matrix, type/quality gates, package build, dependency audit, empirical validation and CodeQL before promotion.