### PR TITLE
Permeate orthogonal quantization precision gate across Jarvis-X

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,6 +105,7 @@ Responsibilities may include:
 - bounded geometric refinement;
 - rendering orchestration;
 - multimedia codec and archive adapters;
+- orthogonal transform precision verification;
 - inverse geometric inference;
 - rate-distortion measurement;
 - parameter candidate generation;
@@ -118,6 +119,8 @@ Adaptive systems must optimize constrained representations, not rewrite arbitrar
 For volumetric autoencoding systems, additive evolution terms must inhabit the same authoritative field space. Latent tensors are transformed through an explicit decoder before they participate in a field residual.
 
 The Moagi-Helmholtz functional is the canonical Layer 5 orchestration contract for multimodal-conditioned geometry generation, refinement, archival coding and reverse inference. It does not require the canonical VM to depend on a neural, renderer or codec backend.
+
+Orthogonal transform adapters additionally inherit ADR-005: normalization is verified before transpose-as-inverse reconstruction, quantization error receives its own deterministic envelope, and a transform defect cannot be hidden by widening a multimedia distortion threshold.
 
 ### Layer 6 — Interfaces and visualization
 
@@ -179,6 +182,9 @@ The research transform cannot make itself authoritative merely by computing a ca
 13. **No false inverse:** ordinary lossy rendering or video coding is not treated as globally invertible to original geometry.
 14. **Rate-distortion visibility:** codec optimization reports both distortion and coded representation size.
 15. **Convergence by evidence:** unique convergence is claimed only under sufficient mathematical assumptions or a validated restricted domain.
+16. **Transform precision separation:** orthogonal transform/quantization error is measured against its own deterministic bound and is not absorbed into render, cycle or perceptual tolerances.
+17. **Normalize before inversion:** a backend may use `D^T` as the inverse only when the declared transform has passed its orthonormality contract within tolerance.
+18. **Diagnose before widening:** a precision-gate failure triggers transform/payload/precision diagnosis before any quantization threshold is relaxed.
 
 ## 5. Data contracts
 
@@ -288,6 +294,46 @@ A -> Demux -> B -> Decode -> F_hat -> I_phi -> (z_hat,c_hat) -> D -> V_hat0 -> R
 
 The reverse path is inference unless sufficient side information establishes exact replay.
 
+### Orthogonal quantization candidate
+
+An adapter that claims the ADR-005 precision contract declares:
+
+```text
+input dimension M
+transform/basis identity and version
+orthogonality tolerance
+measured ||D^T D - I||_max
+coefficient step vector or uniform Delta
+rounding convention
+quantized integer coefficients
+transform-domain residual
+spatial reconstruction residual
+B_Q
+Lambda_Q
+verification tolerance
+precision-gate result
+```
+
+The canonical law is
+
+```text
+X       = D x
+A_k     = round_nearest(X_k / delta_k)
+Xhat_k  = delta_k A_k
+xhat    = D^T Xhat
+B_Q     = 0.5 * sqrt(sum_k delta_k^2)
+Lambda_Q= ||x-xhat||_2 / B_Q
+```
+
+with
+
+```text
+D^T D = I
+Lambda_Q <= 1.
+```
+
+For uniform `Delta`, `B_Q = Delta * sqrt(M) / 2`.
+
 ## 6. Integration rule
 
 A research subsystem may enter the canonical package only when it provides:
@@ -306,6 +352,8 @@ Large pull requests should be decomposed into infrastructure, kernel, integratio
 A field or latent runtime must additionally demonstrate sparse support confinement, candidate rollback, explicit timestep/resource limits, and honest information-capacity claims for its latent representation.
 
 A generative/archive runtime must additionally separate renderer, codec and container semantics; account for side information; expose cycle error and archive size; and reject candidates before publication when validation fails.
+
+An orthogonal transform backend must additionally prove its normalization/inverse pairing, document its rounding convention, reproduce the deterministic coefficient/spatial error envelope, and fail closed on malformed/non-finite inputs.
 
 ## 7. Decision records
 
@@ -326,6 +374,8 @@ ADR-003 extends ADR-002 by defining the same-space Dr Moagi field evolution cont
 
 ADR-004 extends ADR-003 by defining the Moagi-Helmholtz multimodal generative, geometric, rendering, archival and inverse-inference orchestration contract.
 
+ADR-005 extends ADR-004 by defining the orthogonal transform normalization, quantization error envelope and precision-gate semantics used by eligible latent/archive backends.
+
 ## 8. Security boundary
 
 The policy layer is an application-level guard, not a complete security sandbox. Untrusted bytecode, native plugins, model files and browser content require dedicated threat models. See [`SECURITY.md`](../SECURITY.md).
@@ -333,6 +383,8 @@ The policy layer is an application-level guard, not a complete security sandbox.
 Self-modification is never equivalent to unrestricted writes into authoritative code memory. Adaptive code, model, tile, or schedule changes are represented as candidate patches that require validation and commit; otherwise the prior authoritative state remains active.
 
 Decoded multimedia, model weights, geometry sidecars and archive metadata are also untrusted inputs. Backend adapters must validate sizes, formats, coordinate ranges and version bindings before allocating or publishing authoritative state.
+
+Transform metadata is untrusted as well. A payload may not assert orthogonality, a step vector, or a basis version without local validation against the implementation contract.
 
 ## 9. Dr Moagi Field Runtime v2 integration
 
@@ -432,3 +484,40 @@ browser/3D UI        -> visualization and telemetry unless separately promoted
 ```
 
 None of these backends may bypass the canonical evidence, resource, policy, provenance, or rollback boundaries.
+
+## 11. Orthogonal quantization system-wide permeation
+
+The transform precision layer sits inside any eligible latent or archive backend and before its enclosing transaction gate:
+
+```text
+state x
+  -> load declared basis D
+  -> verify D^T D ~= I
+  -> X = D x
+  -> A = Q_delta(X)
+  -> Xhat = Q_delta^-1(A)
+  -> xhat = D^T Xhat
+  -> E_Q = ||x-xhat||_2
+  -> B_Q = 0.5 * sqrt(sum delta_k^2)
+  -> Lambda_Q = E_Q / B_Q
+  -> precision PASS / FAIL
+  -> rate-distortion / cycle / policy checks
+  -> Pi_Lambda
+  -> COMMIT / ROLLBACK
+  -> provenance
+```
+
+The precision layer reports independently from broader multimedia metrics:
+
+```text
+E_Q       transform/quantization reconstruction error
+B_Q       deterministic transform precision bound
+Lambda_Q  bound utilization
+E_render  renderer/video distortion
+E_cycle   end-to-end geometry cycle error
+E_anchor  drift from immutable source anchor
+```
+
+A backend is not permitted to trade a failed `Lambda_Q` against a permissive `E_render` or `E_cycle`.  Numerical correctness at the transform boundary is a prerequisite for higher-level quality optimization.
+
+The reference implementation is `src/jarvisx/orthogonal_quantization.py`.  Optimized C++, CUDA, DMEB, FPGA, native SIMD or codec-specific implementations must reproduce the same declared transform, quantizer and receipt semantics before promotion.

--- a/docs/DR_MOAGI_MOAGI_HELMHOLTZ.md
+++ b/docs/DR_MOAGI_MOAGI_HELMHOLTZ.md
@@ -341,3 +341,57 @@ Virtual/logical scale is always reported separately from measured hardware perfo
 ## 17. Canonical interpretation
 
 The Moagi-Helmholtz system is a conditional 3D generative, refinement and multimedia archival architecture. Its canonical strength is not a claim of magical inversion; it is the explicit coupling of generation, geometry, codec economics, inverse inference, evidence and reversible adaptation inside one auditable Jarvis-X state machine.
+
+## 18. Orthogonal transform precision gate
+
+Transform-based latent or archive adapters that claim an orthonormal reconstruction boundary additionally inherit ADR-005.
+
+For
+
+```text
+X       = D x
+A_k     = round_nearest(X_k / delta_k)
+Xhat_k  = delta_k A_k
+xhat    = D^T Xhat
+D^T D   = I
+```
+
+the deterministic precision envelope is
+
+```text
+B_Q = 0.5 * sqrt(sum_k delta_k^2)
+||x - xhat||_2 <= B_Q.
+```
+
+For a uniform step `Delta`,
+
+```text
+B_Q = Delta * sqrt(M) / 2.
+```
+
+The transform gate is
+
+```text
+Lambda_Q = ||x - xhat||_2 / B_Q <= 1.
+```
+
+A precision-gate failure is diagnosed before the enclosing codec or geometry tolerance is changed.  In particular, the runtime must distinguish transform normalization/inverse defects from genuine quantization distortion.
+
+The canonical verification order is
+
+```text
+render / latent state
+-> declared transform
+-> verify D^T D ~= I
+-> quantize / dequantize
+-> reconstruct with D^T
+-> Lambda_Q
+-> rate/distortion accounting
+-> archive reconstruction / cycle metrics
+-> Pi_Lambda
+-> COMMIT or ROLLBACK.
+```
+
+The precision receipt reports its own transform error, quantization bound and gate ratio separately from render distortion and `E_cycle`.  This prevents one numerical layer from hiding defects inside a broader multimedia error budget.
+
+The reference implementation is `src/jarvisx/orthogonal_quantization.py`; the normative numerical contract is `DR_MOAGI_ORTHOGONAL_QUANTIZATION.md`.

--- a/docs/DR_MOAGI_ORTHOGONAL_QUANTIZATION.md
+++ b/docs/DR_MOAGI_ORTHOGONAL_QUANTIZATION.md
@@ -1,0 +1,277 @@
+# Dr Moagi Orthogonal Quantization Precision Boundary
+
+## Status
+
+Canonical numerical verification contract for orthogonal transform quantization inside Jarvis-X Layer 5 research runtimes and codec/archive adapters.
+
+This specification extends ADR-005 and the Moagi-Helmholtz archive contract.  It does not claim that a DCT is itself an MP4 codec, nor that every backend transform is orthogonal.
+
+## 1. State and transform
+
+Let
+
+```text
+x in R^M
+D in R^(M x M)
+D^T D = I
+```
+
+and let each transformed coefficient have a positive quantization step `delta_k`.
+
+The complete transform boundary is
+
+```text
+X       = D x
+A_k     = round_nearest(X_k / delta_k)
+Xhat_k  = delta_k A_k
+xhat    = D^T Xhat.
+```
+
+For a uniform precision step `Delta`, every `delta_k = Delta`.
+
+## 2. Canonical rounding
+
+The dependency-free reference uses nearest-neighbour quantization with exact half-step ties away from zero:
+
+```text
++0.5 -> +1
+-0.5 -> -1
+```
+
+A hardware or codec backend may use a different deterministic tie rule only when that rule is explicitly versioned and still reconstructs the nearest quantization level.
+
+## 3. Deterministic coefficient envelope
+
+For every coefficient,
+
+```text
+epsilon_k = X_k - Xhat_k
+|epsilon_k| <= delta_k / 2.
+```
+
+Therefore
+
+```text
+||epsilon||_2 <= 0.5 * sqrt(sum_k delta_k^2).
+```
+
+Because `D` is orthonormal,
+
+```text
+||x - xhat||_2 = ||D^T epsilon||_2 = ||epsilon||_2.
+```
+
+Hence
+
+```text
+B_Q = 0.5 * sqrt(sum_k delta_k^2)
+||x - xhat||_2 <= B_Q.
+```
+
+For uniform `Delta`,
+
+```text
+B_Q = Delta * sqrt(M) / 2.
+```
+
+No statistical cancellation assumption is required.
+
+## 4. Precision gate
+
+Define
+
+```text
+Lambda_Q = ||x - xhat||_2 / B_Q.
+```
+
+The quantized transform candidate is admissible when
+
+```text
+Lambda_Q <= 1.
+```
+
+The candidate then proceeds to the enclosing Jarvis-X validator.  A passing precision gate does not itself authorize a complete archive, model or geometry transaction.
+
+```text
+transform candidate
+-> verify D^T D ~= I
+-> quantize
+-> reconstruct
+-> compute Lambda_Q
+-> precision COMMIT candidate
+-> enclosing Pi_Lambda / policy / cycle checks
+-> authoritative COMMIT or ROLLBACK.
+```
+
+## 5. Canonical arithmetic fixture at Delta = 0.1
+
+Use
+
+```text
+x = [1.5, 1.9]^T
+M = 2
+Delta = 0.1
+```
+
+with the exact orthonormal two-point DCT-II basis
+
+```text
+D = (1/sqrt(2)) * [[1, 1], [1, -1]].
+```
+
+The forward coefficients are
+
+```text
+X = [
+   2.4041630560342613,
+  -0.2828427124746189
+].
+```
+
+Nearest-neighbour quantization gives
+
+```text
+A = [24, -3].
+```
+
+Dequantization gives
+
+```text
+Xhat = [2.4, -0.3].
+```
+
+The exact transpose inverse reconstructs
+
+```text
+xhat = [
+  1.48492424049175,
+  1.9091883092036785
+].
+```
+
+The spatial residual is
+
+```text
+e = x - xhat
+  = [
+      0.0150757595082500,
+     -0.0091883092036786
+    ].
+```
+
+Thus
+
+```text
+||e||_2 = 0.0176551281720920
+B_Q     = 0.1 * sqrt(2) / 2
+        = 0.0707106781186548
+Lambda_Q= 0.249681217064078.
+```
+
+Therefore
+
+```text
+Lambda_Q < 1
+PRECISION GATE: PASS.
+```
+
+## 6. Normalization-failure diagnosis
+
+The matrix
+
+```text
+D_bad = [[1/sqrt(2), 1/sqrt(2)], [0.5, -0.5]]
+```
+
+is not orthonormal:
+
+```text
+D_bad D_bad^T = diag(1, 0.5).
+```
+
+Using `D_bad^T` as though it were `D_bad^-1` introduces deterministic transform distortion before quantization.  A resulting error near `sqrt(0.1^2 + 0.1^2)` is therefore not evidence that the correct nearest-neighbour error envelope should be doubled.
+
+The runtime must fail closed on this basis unless it is explicitly handled as a non-orthogonal transform with a separately justified inverse-norm bound.
+
+## 7. Frequency-selective precision
+
+Low-frequency structural coefficients may use smaller steps than high-frequency coefficients:
+
+```text
+delta_0 <= delta_1 <= ...
+```
+
+The deterministic spatial bound remains
+
+```text
+B_Q = 0.5 * sqrt(sum_k delta_k^2).
+```
+
+All steps are part of the payload/version contract.  Side-information bytes used to describe them count toward the rate/information budget.
+
+## 8. Backend requirements
+
+Any backend advertising this orthogonal precision contract must expose:
+
+```text
+basis or basis version
+orthogonality error
+orthogonality tolerance
+input dimension M
+coefficient step vector or uniform Delta
+rounding convention
+quantized integer coefficients
+reconstruction residual norm
+B_Q
+Lambda_Q
+floating-point verification tolerance
+```
+
+Production implementations may replace explicit dense matrices with factorized DCT/FFT-like kernels, provided the implemented transform is equivalent to the declared orthonormal operator within the tested tolerance.
+
+## 9. Moagi-Helmholtz integration
+
+The orthogonal precision gate is inserted inside transform-based archive or latent adapters:
+
+```text
+Vstar / F / z
+-> declared orthogonal transform D
+-> X
+-> Q_delta
+-> integer payload A
+-> dequantize
+-> D^T
+-> reconstruction
+-> Lambda_Q
+-> rate/distortion + cycle verification
+-> Pi_Lambda
+-> COMMIT / ROLLBACK.
+```
+
+For an MP4/video backend, this contract applies only to the transform stage that the backend explicitly maps to it.  The MP4 container, temporal prediction, entropy coding and codec syntax remain separate concerns.
+
+## 10. Reference implementation
+
+`src/jarvisx/orthogonal_quantization.py` provides:
+
+```text
+dct2_orthonormal_basis(size)
+orthogonal_quantization_trace(values, transform, delta)
+uniform_error_bound(delta, dimension)
+OrthogonalQuantizationTrace
+```
+
+The implementation is dependency-free and correctness-oriented.  It is not intended to replace optimized numerical libraries or production codec kernels.
+
+## 11. System invariant
+
+The canonical invariant is
+
+```text
+||x - D^T [delta * round_nearest(Dx / delta)]||_2
+<= delta * sqrt(M) / 2
+```
+
+for a uniform scalar `delta` and an orthonormal `D`.
+
+A failed invariant triggers diagnosis and rollback; it does not automatically authorize a wider threshold.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -35,6 +35,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
 | Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
 | Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures, not production neural or MP4 implementations |
+| Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, `test_orthogonal_quantization.py`, ADR-005 | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production DCT/video codec kernel |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
@@ -58,7 +59,7 @@ The gate currently tests five falsifiable properties:
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
 
-The Field Runtime v2 and Moagi-Helmholtz orchestration runtime are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
+The Field Runtime v2, Moagi-Helmholtz orchestration runtime and orthogonal quantization precision gate are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -89,6 +90,8 @@ Jarvis-X does not currently claim:
 - lossless compression of arbitrary data into a smaller state without side information;
 - global invertibility of ordinary RGB/video rendering to the original 3D mesh;
 - that MP4 is itself a global 3D-DCT codec;
+- that every transform used by a production codec is orthogonal or governed by ADR-005;
+- that a failed orthogonal precision gate may be repaired by simply doubling the admissible quantization threshold;
 - unique convergence of arbitrary learned Moagi-Helmholtz pipelines without sufficient mathematical assumptions;
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
@@ -144,7 +147,8 @@ A capability moves to `main` only when all applicable items are satisfied:
 - rollback-complete state transitions;
 - codec/model version binding for adaptive field runtimes;
 - Moagi-Helmholtz conditioner/geometry/renderer/archive backend adapters with measured capability boundaries;
-- rate-distortion and cycle-reconstruction telemetry;
+- orthogonal transform receipts carrying basis/version, step vector, rounding rule, `B_Q` and `Lambda_Q`;
+- rate-distortion and cycle-reconstruction telemetry separated from transform precision telemetry;
 - anchor-drift and reconstruction telemetry in the consolidated empirical evidence artifact;
 - metric-hacking tests;
 - experiment manifests and replay.

--- a/docs/adr/0005-orthogonal-quantization-precision-boundary.md
+++ b/docs/adr/0005-orthogonal-quantization-precision-boundary.md
@@ -1,0 +1,173 @@
+# ADR-005: Adopt the orthogonal quantization precision boundary
+
+**Status:** Accepted  
+**Date:** 2026-08-12  
+**Extends:** ADR-004
+
+## Context
+
+The Moagi-Helmholtz archival path permits transform/quantization backends, but a recent two-coordinate verification exposed an important distinction between quantization error and transform-normalization error.  A matrix whose second DCT row was scaled as `[0.5, -0.5]` was described as orthonormal and then inverted with its transpose.  It is not orthonormal, so the resulting approximately `[-0.1,+0.1]` spatial residual was primarily a basis/inverse mismatch rather than evidence that the nearest-neighbour quantization bound should be doubled.
+
+Jarvis-X therefore needs one canonical precision contract for any backend that claims orthogonal transform quantization.
+
+## Decision
+
+For an input `x in R^M`, an orthonormal transform `D`, and positive coefficient steps `delta_k`, define
+
+```text
+X       = D x
+A_k     = round_nearest(X_k / delta_k)
+Xhat_k  = delta_k A_k
+xhat    = D^T Xhat
+```
+
+with the invariant
+
+```text
+D^T D = I.
+```
+
+The reference rounding rule is nearest neighbour with exact half-step ties away from zero.  Backends may use another declared deterministic tie rule, but they must preserve the nearest-level residual property.
+
+For every coefficient,
+
+```text
+|X_k - Xhat_k| <= delta_k / 2.
+```
+
+Therefore
+
+```text
+||x - xhat||_2
+= ||X - Xhat||_2
+<= 0.5 * sqrt(sum_k delta_k^2).
+```
+
+For a uniform step `Delta`, this reduces to
+
+```text
+||x - xhat||_2 <= Delta * sqrt(M) / 2.
+```
+
+This is a deterministic worst-case bound.  It does not rely on independent, zero-mean, uniformly distributed, or cancelling quantization errors.
+
+## Precision gate
+
+Define
+
+```text
+Lambda_Q = ||x - xhat||_2 / B_Q
+B_Q      = 0.5 * sqrt(sum_k delta_k^2).
+```
+
+The transform/quantization candidate is admissible only when
+
+```text
+Lambda_Q <= 1
+```
+
+within the declared floating-point verification tolerance.
+
+If the gate fails, the implementation must first diagnose:
+
+1. transform normalization;
+2. inverse pairing;
+3. rounding/quantizer convention;
+4. payload corruption;
+5. precision, overflow or non-finite values;
+6. coefficient-step/version mismatch;
+7. substitution of a non-orthogonal transform.
+
+The deterministic gate may not be silently widened merely because a malformed transform produced a larger error.
+
+## Canonical two-coordinate fixture
+
+For
+
+```text
+x       = [1.5, 1.9]^T
+Delta   = 0.1
+D       = (1/sqrt(2)) [[1,1],[1,-1]]
+```
+
+the verified reference trace is
+
+```text
+X       = [ 2.4041630560342613, -0.2828427124746189 ]
+A       = [ 24, -3 ]
+Xhat    = [ 2.4, -0.3 ]
+xhat    = [ 1.48492424049175, 1.9091883092036785 ]
+e       = [ 0.0150757595082500, -0.0091883092036786 ]
+||e||_2 = 0.0176551281720920
+B_Q     = 0.0707106781186548
+Lambda_Q= 0.249681217064078
+```
+
+The transition therefore commits with substantial deterministic margin.
+
+## Non-uniform precision
+
+For frequency-selective steps `delta_k`, the exact reference envelope is
+
+```text
+B_Q = 0.5 * sqrt(sum_k delta_k^2).
+```
+
+This permits lower-frequency coefficients to use smaller steps while high-frequency coefficients use larger steps, provided the complete step vector is versioned and included in the archive/receipt information budget.
+
+## Non-orthogonal transforms
+
+A non-orthogonal but invertible transform is a different contract.  If `T` is used, the safe induced bound requires the inverse operator norm, for example
+
+```text
+||x - xhat||_2 <= ||T^-1||_2 * 0.5 * sqrt(sum_k delta_k^2).
+```
+
+Such a backend may not claim the orthogonal bound unless it proves the required norm property.  ADR-005 does not make non-orthogonal transforms canonical; it merely prevents accidental transpose-as-inverse reasoning.
+
+## Transaction and provenance boundary
+
+Every orthogonal quantization receipt records at least:
+
+```text
+transform/version or basis identity
+orthogonality tolerance and measured error
+coefficient step(s)
+rounding convention
+quantized coefficient payload
+reconstruction residual norm
+B_Q
+Lambda_Q
+validator decision
+COMMIT / ROLLBACK outcome
+```
+
+When used inside Moagi-Helmholtz, this precision receipt is subordinate to the existing candidate-first transaction:
+
+```text
+render/latent state
+-> orthogonal transform
+-> quantize
+-> reconstruct
+-> precision gate
+-> archive/cycle validation
+-> COMMIT or ROLLBACK
+-> journal.
+```
+
+## Architectural effect
+
+The canonical 64-bit VM is unchanged.  ADR-005 adds a reusable Layer 5 numerical verification primitive for DCT/tensor/archive backends.  C++, CUDA, DMEB, FPGA, native SIMD and video-codec adapters may implement accelerated versions only if they preserve the same declared normalization, error-bound and transaction semantics.
+
+## Validation
+
+Acceptance requires executable tests for:
+
+- the exact two-coordinate DCT fixture;
+- rejection of the incorrectly normalized basis;
+- uniform and non-uniform bounds;
+- declared half-step rounding behavior;
+- malformed/non-finite inputs;
+- a second orthogonal basis demonstrating norm preservation.
+
+The reference implementation is `src/jarvisx/orthogonal_quantization.py`.

--- a/src/jarvisx/orthogonal_quantization.py
+++ b/src/jarvisx/orthogonal_quantization.py
@@ -1,0 +1,217 @@
+"""Deterministic orthogonal-transform quantization verification for Jarvis-X.
+
+The reference implements the canonical precision law
+
+    ||x - D^T Q^-1(Q(Dx))||_2 <= 0.5 * sqrt(sum(delta_k^2))
+
+when ``D`` is orthonormal and every coefficient is quantized to its nearest
+uniform reconstruction level.  It is a correctness/reference layer, not a
+production video codec or accelerator kernel.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+Vector = tuple[float, ...]
+Matrix = tuple[tuple[float, ...], ...]
+StepSpec = float | Sequence[float]
+
+
+@dataclass(frozen=True)
+class OrthogonalQuantizationTrace:
+    """Complete deterministic receipt for one transform/quantization cycle."""
+
+    input_values: Vector
+    transform: Matrix
+    coefficient_steps: Vector
+    transformed_values: Vector
+    quantized_values: tuple[int, ...]
+    dequantized_values: Vector
+    transform_residual: Vector
+    reconstructed_values: Vector
+    spatial_residual: Vector
+    residual_norm: float
+    deterministic_bound: float
+    gate_ratio: float
+    orthogonality_error: float
+    committed: bool
+
+
+def dct2_orthonormal_basis(size: int) -> Matrix:
+    """Return the orthonormal DCT-II basis for a positive dimension."""
+
+    if isinstance(size, bool) or not isinstance(size, int):
+        raise TypeError("size must be an integer")
+    if size <= 0:
+        raise ValueError("size must be positive")
+
+    rows: list[tuple[float, ...]] = []
+    for k in range(size):
+        alpha = math.sqrt(1.0 / size) if k == 0 else math.sqrt(2.0 / size)
+        rows.append(
+            tuple(
+                alpha * math.cos(math.pi * (n + 0.5) * k / size)
+                for n in range(size)
+            )
+        )
+    return tuple(rows)
+
+
+def orthogonal_quantization_trace(
+    values: Sequence[float],
+    transform: Sequence[Sequence[float]],
+    delta: StepSpec,
+    *,
+    orthogonality_tolerance: float = 1e-10,
+    verification_tolerance: float = 1e-12,
+) -> OrthogonalQuantizationTrace:
+    """Transform, quantize, reconstruct and verify the deterministic error bound.
+
+    Quantization uses nearest-neighbour rounding with exact half-step ties away
+    from zero.  A scalar ``delta`` applies uniformly to all coefficients; a
+    sequence enables non-uniform precision.  Non-orthonormal transforms fail
+    closed rather than silently widening the admissible error envelope.
+    """
+
+    x = _finite_vector(values, "values")
+    size = len(x)
+    basis = _square_matrix(transform, size)
+    steps = _normalise_steps(delta, size)
+
+    if not math.isfinite(orthogonality_tolerance) or orthogonality_tolerance < 0.0:
+        raise ValueError("orthogonality_tolerance must be finite and non-negative")
+    if not math.isfinite(verification_tolerance) or verification_tolerance < 0.0:
+        raise ValueError("verification_tolerance must be finite and non-negative")
+
+    orthogonality_error = _orthogonality_error(basis)
+    if orthogonality_error > orthogonality_tolerance:
+        raise ValueError(
+            "transform is not orthonormal within tolerance; "
+            "do not use transpose-as-inverse precision bounds"
+        )
+
+    transformed = _matvec(basis, x)
+    quantized = tuple(
+        _round_half_away_from_zero(value / step)
+        for value, step in zip(transformed, steps)
+    )
+    dequantized = tuple(float(index) * step for index, step in zip(quantized, steps))
+    transform_residual = tuple(
+        value - reconstructed
+        for value, reconstructed in zip(transformed, dequantized)
+    )
+
+    # Every nearest-neighbour coefficient residual must satisfy |e_k| <= delta_k/2.
+    for residual, step in zip(transform_residual, steps):
+        if abs(residual) > (0.5 * step + verification_tolerance):
+            raise RuntimeError("coefficient residual exceeds nearest-neighbour bound")
+
+    reconstructed = _matvec(_transpose(basis), dequantized)
+    spatial_residual = tuple(value - recovered for value, recovered in zip(x, reconstructed))
+    residual_norm = _norm2(spatial_residual)
+    deterministic_bound = 0.5 * math.sqrt(sum(step * step for step in steps))
+    gate_ratio = residual_norm / deterministic_bound
+    committed = residual_norm <= deterministic_bound + verification_tolerance
+
+    if not committed:
+        raise RuntimeError(
+            "orthogonal quantization residual exceeds deterministic bound; "
+            "diagnose transform, payload and precision before widening the gate"
+        )
+
+    return OrthogonalQuantizationTrace(
+        input_values=x,
+        transform=basis,
+        coefficient_steps=steps,
+        transformed_values=transformed,
+        quantized_values=quantized,
+        dequantized_values=dequantized,
+        transform_residual=transform_residual,
+        reconstructed_values=reconstructed,
+        spatial_residual=spatial_residual,
+        residual_norm=residual_norm,
+        deterministic_bound=deterministic_bound,
+        gate_ratio=gate_ratio,
+        orthogonality_error=orthogonality_error,
+        committed=True,
+    )
+
+
+def uniform_error_bound(delta: float, dimension: int) -> float:
+    """Return ``delta * sqrt(dimension) / 2`` after validating inputs."""
+
+    if isinstance(dimension, bool) or not isinstance(dimension, int):
+        raise TypeError("dimension must be an integer")
+    if dimension <= 0:
+        raise ValueError("dimension must be positive")
+    if isinstance(delta, bool) or not isinstance(delta, (int, float)):
+        raise TypeError("delta must be numeric")
+    delta_f = float(delta)
+    if not math.isfinite(delta_f) or delta_f <= 0.0:
+        raise ValueError("delta must be finite and positive")
+    return delta_f * math.sqrt(dimension) / 2.0
+
+
+def _finite_vector(values: Sequence[float], name: str) -> Vector:
+    result = tuple(float(value) for value in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if not all(math.isfinite(value) for value in result):
+        raise ValueError(f"{name} must contain only finite values")
+    return result
+
+
+def _square_matrix(transform: Sequence[Sequence[float]], size: int) -> Matrix:
+    rows = tuple(tuple(float(value) for value in row) for row in transform)
+    if len(rows) != size or any(len(row) != size for row in rows):
+        raise ValueError("transform must be square and match the input dimension")
+    if not all(math.isfinite(value) for row in rows for value in row):
+        raise ValueError("transform must contain only finite values")
+    return rows
+
+
+def _normalise_steps(delta: StepSpec, size: int) -> Vector:
+    if isinstance(delta, bool):
+        raise TypeError("delta must be numeric or a sequence of numeric steps")
+    if isinstance(delta, (int, float)):
+        steps = (float(delta),) * size
+    else:
+        steps = tuple(float(step) for step in delta)
+        if len(steps) != size:
+            raise ValueError("non-uniform delta must provide one step per coefficient")
+    if not all(math.isfinite(step) and step > 0.0 for step in steps):
+        raise ValueError("all quantization steps must be finite and positive")
+    return steps
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    if value >= 0.0:
+        return int(math.floor(value + 0.5))
+    return int(math.ceil(value - 0.5))
+
+
+def _matvec(matrix: Matrix, vector: Vector) -> Vector:
+    return tuple(sum(weight * value for weight, value in zip(row, vector)) for row in matrix)
+
+
+def _transpose(matrix: Matrix) -> Matrix:
+    return tuple(tuple(matrix[row][column] for row in range(len(matrix))) for column in range(len(matrix)))
+
+
+def _orthogonality_error(matrix: Matrix) -> float:
+    transpose = _transpose(matrix)
+    size = len(matrix)
+    maximum = 0.0
+    for row in range(size):
+        for column in range(size):
+            value = sum(transpose[row][k] * matrix[k][column] for k in range(size))
+            expected = 1.0 if row == column else 0.0
+            maximum = max(maximum, abs(value - expected))
+    return maximum
+
+
+def _norm2(values: Sequence[float]) -> float:
+    return math.sqrt(sum(float(value) * float(value) for value in values))

--- a/tests/test_orthogonal_quantization.py
+++ b/tests/test_orthogonal_quantization.py
@@ -1,0 +1,97 @@
+import math
+
+import pytest
+
+from jarvisx.orthogonal_quantization import (
+    dct2_orthonormal_basis,
+    orthogonal_quantization_trace,
+    uniform_error_bound,
+)
+
+
+def test_canonical_two_point_dct_trace() -> None:
+    basis = dct2_orthonormal_basis(2)
+    trace = orthogonal_quantization_trace((1.5, 1.9), basis, 0.1)
+
+    assert trace.quantized_values == (24, -3)
+    assert trace.transformed_values == pytest.approx(
+        (2.4041630560342613, -0.2828427124746189)
+    )
+    assert trace.dequantized_values == pytest.approx((2.4, -0.3))
+    assert trace.reconstructed_values == pytest.approx(
+        (1.4849242404917498, 1.9091883092036783)
+    )
+    assert trace.spatial_residual == pytest.approx(
+        (0.0150757595082502, -0.0091883092036784)
+    )
+    assert trace.residual_norm == pytest.approx(0.0176551277, rel=1e-8)
+    assert trace.deterministic_bound == pytest.approx(0.1 * math.sqrt(2.0) / 2.0)
+    assert trace.gate_ratio < 0.25
+    assert trace.committed is True
+
+
+def test_incorrectly_normalised_dct_fails_closed() -> None:
+    bad_basis = (
+        (1.0 / math.sqrt(2.0), 1.0 / math.sqrt(2.0)),
+        (0.5, -0.5),
+    )
+
+    with pytest.raises(ValueError, match="not orthonormal"):
+        orthogonal_quantization_trace((1.5, 1.9), bad_basis, 0.1)
+
+
+def test_nonuniform_steps_use_root_sum_square_bound() -> None:
+    basis = dct2_orthonormal_basis(2)
+    trace = orthogonal_quantization_trace((1.5, 1.9), basis, (0.05, 0.2))
+
+    expected = 0.5 * math.sqrt(0.05**2 + 0.2**2)
+    assert trace.deterministic_bound == pytest.approx(expected)
+    assert trace.residual_norm <= trace.deterministic_bound
+
+
+def test_half_step_ties_are_rounded_away_from_zero() -> None:
+    identity = ((1.0, 0.0), (0.0, 1.0))
+    trace = orthogonal_quantization_trace((0.05, -0.05), identity, 0.1)
+
+    assert trace.quantized_values == (1, -1)
+    assert trace.reconstructed_values == pytest.approx((0.1, -0.1))
+    assert trace.residual_norm == pytest.approx(math.sqrt(0.05**2 + 0.05**2))
+    assert trace.residual_norm == pytest.approx(trace.deterministic_bound)
+
+
+def test_uniform_bound_validation() -> None:
+    assert uniform_error_bound(0.1, 2) == pytest.approx(0.07071067811865477)
+
+    with pytest.raises(ValueError):
+        uniform_error_bound(0.0, 2)
+    with pytest.raises(ValueError):
+        uniform_error_bound(0.1, 0)
+
+
+def test_invalid_shapes_and_nonfinite_values_are_rejected() -> None:
+    basis = dct2_orthonormal_basis(2)
+
+    with pytest.raises(ValueError, match="square"):
+        orthogonal_quantization_trace((1.0, 2.0), ((1.0,),), 0.1)
+    with pytest.raises(ValueError, match="finite"):
+        orthogonal_quantization_trace((1.0, math.inf), basis, 0.1)
+    with pytest.raises(ValueError, match="positive"):
+        orthogonal_quantization_trace((1.0, 2.0), basis, -0.1)
+    with pytest.raises(ValueError, match="one step per coefficient"):
+        orthogonal_quantization_trace((1.0, 2.0), basis, (0.1,))
+
+
+def test_general_orthogonal_basis_preserves_quantization_norm() -> None:
+    # Normalized 4x4 Hadamard matrix.
+    scale = 0.5
+    basis = (
+        (scale, scale, scale, scale),
+        (scale, -scale, scale, -scale),
+        (scale, scale, -scale, -scale),
+        (scale, -scale, -scale, scale),
+    )
+    trace = orthogonal_quantization_trace((0.3, -0.7, 1.2, 0.4), basis, 0.1)
+
+    transform_norm = math.sqrt(sum(value * value for value in trace.transform_residual))
+    assert trace.residual_norm == pytest.approx(transform_norm, abs=1e-12)
+    assert trace.residual_norm <= trace.deterministic_bound

--- a/tests/test_orthogonal_quantization.py
+++ b/tests/test_orthogonal_quantization.py
@@ -22,11 +22,11 @@ def test_canonical_two_point_dct_trace() -> None:
         (1.4849242404917498, 1.9091883092036783)
     )
     assert trace.spatial_residual == pytest.approx(
-        (0.0150757595082502, -0.0091883092036784)
+        (0.0150757595082500, -0.0091883092036786)
     )
-    assert trace.residual_norm == pytest.approx(0.0176551277, rel=1e-8)
+    assert trace.residual_norm == pytest.approx(0.0176551281720920)
     assert trace.deterministic_bound == pytest.approx(0.1 * math.sqrt(2.0) / 2.0)
-    assert trace.gate_ratio < 0.25
+    assert trace.gate_ratio == pytest.approx(0.249681217064078)
     assert trace.committed is True
 
 


### PR DESCRIPTION
## What changed

This PR permeates the verified orthogonal transform quantization law through the Jarvis-X numerical, codec and Moagi-Helmholtz architecture.

- adds ADR-005 adopting the canonical orthogonal quantization precision boundary
- adds `src/jarvisx/orthogonal_quantization.py`, a dependency-free correctness reference
- adds exact orthonormal DCT-II basis generation, transform validation, deterministic nearest-neighbour quantization, reconstruction and precision-gate receipts
- supports both uniform and frequency-selective coefficient step sizes
- rejects non-orthonormal transpose-as-inverse usage instead of widening the error budget
- adds focused tests for the exact `[1.5, 1.9]`, `Delta=0.1` arithmetic trace, malformed normalization, non-uniform bounds, half-step rounding, malformed inputs and norm preservation
- adds the normative `DR_MOAGI_ORTHOGONAL_QUANTIZATION.md` specification
- permeates the precision layer into the Moagi-Helmholtz archive contract, canonical architecture and project-status capability matrix

## Canonical precision law

For orthonormal `D` and coefficient steps `delta_k`:

```text
X       = D x
A_k     = round_nearest(X_k / delta_k)
Xhat_k  = delta_k A_k
xhat    = D^T Xhat
B_Q     = 0.5 * sqrt(sum_k delta_k^2)
Lambda_Q= ||x-xhat||_2 / B_Q
```

Admission requires:

```text
D^T D ~= I
Lambda_Q <= 1
```

For a uniform step `Delta`:

```text
B_Q = Delta * sqrt(M) / 2.
```

## Canonical arithmetic fixture

For `x=[1.5,1.9]^T`, `M=2`, `Delta=0.1` and the exact orthonormal two-point DCT-II:

```text
X        = [ 2.4041630560342613, -0.2828427124746189 ]
A        = [ 24, -3 ]
xhat     = [ 1.48492424049175, 1.9091883092036785 ]
||e||_2  = 0.0176551281720920
B_Q      = 0.0707106781186548
Lambda_Q = 0.249681217064078
```

The original apparent ~0.1414 divergence is classified as a transform-normalization/inverse mismatch, not evidence that the nearest-neighbour bound should be doubled.

## Architectural impact

Transform precision is now a prerequisite layer inside eligible latent/archive backends:

```text
state
-> verify basis
-> transform
-> quantize/dequantize
-> reconstruct
-> precision gate
-> rate-distortion / cycle checks
-> Pi_Lambda
-> COMMIT / ROLLBACK
```

Transform/quantization error is reported separately from rendering distortion, cycle reconstruction error and anchor drift. A failed precision gate cannot be traded against a permissive higher-level multimedia tolerance.

## Capability boundary

This is a numerical correctness reference, not a production DCT implementation, GPU kernel, learned codec, H.26x/AV1 backend or MP4 container implementation. Accelerated backends must reproduce the declared normalization, rounding, error-bound and transaction semantics before promotion.

## Validation intent

Repository CI should validate the new reference across the supported Python matrix, package-wide type/quality checks, dependency audit, package build, empirical validation and CodeQL before promotion.