### PR TITLE
Permeate DM-V3-PRIME executable codec baseline

### DIFF
--- a/docs/research/DM_V3_PRIME_BASELINE.md
+++ b/docs/research/DM_V3_PRIME_BASELINE.md
@@ -1,0 +1,313 @@
+# DM-V3-PRIME Baseline
+
+**Status:** Executable research baseline  
+**Repository:** `Lord-Xido/Jarvis-X`  
+**Parent specification:** `docs/research/DR_MOAGI_3D_CODEC_RUNTIME.md`  
+**Control plane:** `src/jarvisx/dm_v3_prime_control.py`  
+**Reference experiment:** `experiments/dm_v3_prime_torch.py`
+
+## 1. Purpose
+
+DM-V3-PRIME binds the Dr Moagi 3D adaptive codec-runtime specification to a
+concrete, measurable implementation without weakening the deterministic core
+boundary.
+
+The baseline implements four mechanisms that were previously only partially
+represented in the prototype:
+
+1. true 3D neighbourhood processing through `Conv3d` operators;
+2. recursive spectral latent refinement through an FFT-domain residual cell;
+3. explicit quantization plus a learned entropy-rate model and a real compressed
+   latent bitstream;
+4. fail-closed candidate verification with atomic commit-or-rollback semantics.
+
+The implementation deliberately separates *incremental acceptance* from the
+aspirational 1000x performance target.  A valid candidate may improve quality
+or efficiency while still reporting that the 1000x target has **not** been met.
+
+---
+
+## 2. PRIME state transition
+
+The executable baseline is summarized by
+
+```text
+X_t
+  -> E_theta^3D
+  -> Z_t^(0)
+  -> [R_omega^spectral]^ell
+  -> Z_t^*
+  -> Q_Delta
+  -> p_psi / entropy-rate model
+  -> B_t
+  -> Q_Delta^-1
+  -> D_phi^3D
+  -> X_hat_t
+  -> Pi_(H,Lambda)
+  -> COMMIT or ROLLBACK
+```
+
+For recursion depth `ell = 2`,
+
+```text
+Z^(k+1) = Z^(k) + alpha * R_omega^spectral(Z^(k)),  k in {0, 1}
+```
+
+where `R_omega^spectral` performs a real FFT over the latent axis, applies a
+learned bounded spectral gain, transforms back to latent space, and applies a
+learned residual MLP.
+
+---
+
+## 3. N^3 spatial encoder
+
+For a scalar voxel field
+
+```text
+X in R^(1 x 1 x 32 x 32 x 32)
+```
+
+the encoder performs
+
+```text
+32^3
+ -> Conv3d(1, 16, k=3, s=2)
+ -> 16^3
+ -> Conv3d(16, 32, k=3, s=2)
+ -> 8^3
+ -> Linear(32 * 8 * 8 * 8, L)
+ -> Z
+```
+
+The convolutional receptive field makes each encoded feature a function of its
+local 3D neighbourhood rather than an independent flattened voxel.
+
+This is a topology-aware data-plane implementation of the neighbourhood rule;
+it is **not** equivalent to physical hardware-placement optimisation.  The
+Section 15 placement objective remains a separate scheduler/runtime problem.
+
+---
+
+## 4. Recursive spectral upwelling
+
+The original stochastic perturbation
+
+```text
+Z' = Z + noise
+```
+
+is replaced by an actual spectral transform:
+
+```text
+U = FFT_r(LayerNorm(Z))
+U' = sigmoid(g_omega) * U
+R = MLP(IFFT_r(U'))
+Z_(k+1) = Z_k + alpha * R
+```
+
+This makes the term "spectral" operational rather than metaphorical.
+
+The residual step is bounded by an explicit step size and the training loop
+clips gradient norm before updating parameters.
+
+---
+
+## 5. Quantization and rate model
+
+Training uses straight-through scalar quantization:
+
+```text
+q = round(Z / Delta)
+Z_q = Z + stop_gradient(q * Delta - Z)
+```
+
+The entropy model is a learned factorized Laplace distribution.  For each
+quantization cell, the estimated discrete probability mass is
+
+```text
+p(q) = CDF((q + 1/2)Delta) - CDF((q - 1/2)Delta)
+```
+
+and the differentiable rate term is
+
+```text
+R_proxy = mean(-log2 p(q)).
+```
+
+The optimization objective used by the reference experiment is
+
+```text
+J = D_MSE(X, X_hat) + lambda_R * R_proxy.
+```
+
+For evaluation, quantized latent symbols are converted to signed 16-bit values,
+protected with a CRC32 checksum, and compressed with zlib.  The measured
+bitstream size is reported independently from the learned rate proxy.
+
+---
+
+## 6. Pi_(H,Lambda) verification gate
+
+The dependency-free control module defines a transactional gate:
+
+```text
+Pi_(H,Lambda)(candidate, incumbent)
+```
+
+A candidate is accepted only when all configured constraints pass, including:
+
+```text
+finite telemetry
+D_candidate <= D_max
+memory_candidate <= memory_max
+risk_candidate <= risk_max
+Safe(candidate) == true
+Stable(candidate) == true
+latency_candidate > 0
+T_incumbent / T_candidate >= min_speedup
+J_incumbent - J_candidate >= min_objective_improvement
+```
+
+The deployment rule is
+
+```text
+if admissible(candidate):
+    COMMIT candidate
+else:
+    ROLLBACK incumbent
+```
+
+The 1000x condition is separately recorded as
+
+```text
+speed_target_met = accepted and (T_incumbent / T_candidate >= 1000).
+```
+
+This prevents a convergence threshold or virtual recursion depth from being
+misreported as measured physical acceleration.
+
+---
+
+## 7. Correct timing semantics
+
+GPU kernels may execute asynchronously.  PRIME therefore synchronizes CUDA
+immediately before and after a timed call and uses `time.perf_counter()`.
+
+The experiment also constructs the 32^3 coordinate lattice once on the target
+device, outside the optimization loop, so codec latency is not contaminated by
+repeated mesh construction.
+
+Evaluation latency is the median of repeated measurements after warmup.
+
+---
+
+## 8. Candidate transaction
+
+The experiment treats training as candidate generation rather than immediate
+constitutional deployment:
+
+```text
+snapshot incumbent state
+        |
+        v
+train candidate
+        |
+        v
+validation workload
+  |       |       |
+quality  rate   latency
+  \       |      /
+   Pi_(H,Lambda)
+      /       \
+   COMMIT    ROLLBACK
+```
+
+The initial state dict is preserved.  After training, the candidate and
+incumbent are evaluated under the same validation workload.  The selected state
+is loaded only after the gate returns its decision.
+
+---
+
+## 9. Operational limits
+
+DM-V3-PRIME is an executable research baseline, not evidence of a demonstrated
+1000x self-optimising computer.
+
+In particular:
+
+- weight training normally changes representation quality, not FLOP count;
+- architecture-level acceleration requires kernel, graph, sparsity, placement,
+  precision, compilation, scheduling or hardware changes;
+- `1000x` is a benchmark target and must be measured against a declared
+  baseline under the same workload and accuracy envelope;
+- the learned entropy model is factorized rather than a full N^3 context model;
+- zlib is a reference entropy backend, not a production learned arithmetic or
+  range coder;
+- physical thermal and energy telemetry are not yet implemented by the PyTorch
+  experiment.
+
+These boundaries preserve the distinction between an executable prototype and
+an empirical hardware-performance claim.
+
+---
+
+## 10. Run contract
+
+Install the optional research dependencies and run from the repository root:
+
+```bash
+python -m pip install -e ".[dm-v3-prime]"
+python experiments/dm_v3_prime_torch.py --cycles 200
+```
+
+A minimal CPU smoke run is:
+
+```bash
+python experiments/dm_v3_prime_torch.py \
+  --device cpu \
+  --cycles 2 \
+  --latent-dim 16 \
+  --timing-repeats 1 \
+  --log-every 1
+```
+
+Expected terminal output includes:
+
+```text
+BASELINE
+training cycles
+CANDIDATE
+VERIFY Pi_(H,Lambda): COMMIT | ROLLBACK
+Measured speedup=<value>x
+1000x target=MET | NOT MET
+```
+
+---
+
+## 11. Canonical PRIME signature
+
+The baseline can be represented compactly as
+
+```text
+Sigma_DM-V3-PRIME =
+Pi_(H,Lambda)
+ o D_phi^3D
+ o Q_Delta^-1
+ o C^-1
+ o C
+ o Q_Delta
+ o [R_omega^spectral]^ell
+ o E_theta,N3^3D
+```
+
+with the explicit transactional invariant
+
+```text
+Reality of measurement > symbolic acceleration claim.
+```
+
+and the deployment invariant
+
+```text
+candidate mutation != active state until verification succeeds.
+```

--- a/experiments/dm_v3_prime_torch.py
+++ b/experiments/dm_v3_prime_torch.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Executable DM-V3-PRIME 3D auto-codec research baseline.
+
+The experiment binds the mathematical DM-V3-PRIME specification to a concrete
+PyTorch implementation while preserving the deterministic Jarvis-X core as a
+separate dependency-free control plane.
+
+Implemented mechanisms:
+
+* N^3 spatial context through 3D convolutions;
+* recursive latent refinement with a real FFT-domain spectral operator;
+* straight-through scalar quantization during training;
+* a learned factorized Laplace entropy model for rate optimisation;
+* a real zlib-compressed int16 latent bitstream for evaluation;
+* synchronized CUDA timing when applicable;
+* transactional Pi_{H,Lambda} verification with rollback;
+* an explicit, measured 1000x speed target that is never inferred from virtual
+  recursion depth.
+
+This remains a bounded research prototype.  Training weights does not by itself
+make the architecture execute 1000x faster; that target must be established by
+measurement against a declared baseline.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import math
+import struct
+import time
+import zlib
+from dataclasses import dataclass
+from statistics import median
+from typing import Callable, TypeVar
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from jarvisx.dm_v3_prime_control import DMV3Metrics, PiHLambdaGate, VerificationPolicy
+
+T = TypeVar("T")
+
+MAGIC = b"DMV3PRM\0"
+BITSTREAM_VERSION = 1
+HEADER = struct.Struct("<8sHIIfI")
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    metrics: DMV3Metrics
+    psnr_db: float
+    bits_per_voxel: float
+    bitstream_bytes: int
+
+
+class RecursiveSpectralRefiner(nn.Module):
+    """Bounded inward latent recursion with FFT-domain spectral gating."""
+
+    def __init__(self, latent_dim: int, depth: int = 2, step_size: float = 0.1) -> None:
+        super().__init__()
+        if depth < 1:
+            raise ValueError("depth must be at least one")
+        if step_size <= 0.0:
+            raise ValueError("step_size must be positive")
+
+        self.depth = depth
+        self.step_size = step_size
+        self.norm = nn.LayerNorm(latent_dim)
+        self.spectral_gain = nn.Parameter(torch.zeros(latent_dim // 2 + 1))
+        self.residual = nn.Sequential(
+            nn.Linear(latent_dim, latent_dim * 2),
+            nn.GELU(),
+            nn.Linear(latent_dim * 2, latent_dim),
+        )
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        for _ in range(self.depth):
+            normalized = self.norm(z)
+            spectrum = torch.fft.rfft(normalized, dim=-1)
+            gain = torch.sigmoid(self.spectral_gain)
+            upwelled = torch.fft.irfft(spectrum * gain, n=z.shape[-1], dim=-1)
+            z = z + self.step_size * self.residual(upwelled)
+        return z
+
+
+class FactorizedLaplaceEntropyModel(nn.Module):
+    """Learned factorized latent model used to estimate differentiable rate."""
+
+    def __init__(self, latent_dim: int) -> None:
+        super().__init__()
+        self.log_scale = nn.Parameter(torch.zeros(latent_dim))
+
+    @staticmethod
+    def _cdf(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+        negative = 0.5 * torch.exp(x / scale)
+        positive = 1.0 - 0.5 * torch.exp(-x / scale)
+        return torch.where(x < 0.0, negative, positive)
+
+    def bits(self, centers: torch.Tensor, delta: float) -> torch.Tensor:
+        scale = F.softplus(self.log_scale) + 1e-4
+        half_step = 0.5 * delta
+        upper = self._cdf(centers + half_step, scale)
+        lower = self._cdf(centers - half_step, scale)
+        probability = (upper - lower).clamp_min(1e-9)
+        return -torch.log2(probability)
+
+
+class DMV3PrimeEngine(nn.Module):
+    """32^3 convolutional auto-codec with recursive spectral latent refinement."""
+
+    def __init__(self, latent_dim: int = 64, recursion_depth: int = 2) -> None:
+        super().__init__()
+        self.latent_dim = latent_dim
+
+        self.encoder = nn.Sequential(
+            nn.Conv3d(1, 16, kernel_size=3, stride=2, padding=1),
+            nn.BatchNorm3d(16),
+            nn.ELU(),
+            nn.Conv3d(16, 32, kernel_size=3, stride=2, padding=1),
+            nn.BatchNorm3d(32),
+            nn.ELU(),
+            nn.Flatten(),
+            nn.Linear(32 * 8 * 8 * 8, latent_dim),
+        )
+
+        self.refiner = RecursiveSpectralRefiner(latent_dim, depth=recursion_depth)
+        self.entropy_model = FactorizedLaplaceEntropyModel(latent_dim)
+
+        self.decoder_linear = nn.Linear(latent_dim, 32 * 8 * 8 * 8)
+        self.decoder = nn.Sequential(
+            nn.ConvTranspose3d(32, 16, kernel_size=4, stride=2, padding=1),
+            nn.BatchNorm3d(16),
+            nn.ELU(),
+            nn.ConvTranspose3d(16, 1, kernel_size=4, stride=2, padding=1),
+            nn.Sigmoid(),
+        )
+
+    def encode_continuous(self, x: torch.Tensor) -> torch.Tensor:
+        return self.refiner(self.encoder(x))
+
+    def quantize_ste(self, z: torch.Tensor, delta: float) -> tuple[torch.Tensor, torch.Tensor]:
+        scaled = z / delta
+        q = torch.round(scaled)
+        dequantized = q * delta
+        z_ste = z + (dequantized - z).detach()
+        return z_ste, q
+
+    def decode_latent(self, z: torch.Tensor) -> torch.Tensor:
+        flat = self.decoder_linear(z)
+        return self.decoder(flat.view(-1, 32, 8, 8, 8))
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        delta: float,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        z = self.encode_continuous(x)
+        z_q, _ = self.quantize_ste(z, delta)
+        x_hat = self.decode_latent(z_q)
+        rate_bits = self.entropy_model.bits(z_q, delta)
+        return x_hat, z_q, rate_bits
+
+    @torch.no_grad()
+    def encode_bitstream(self, x: torch.Tensor, delta: float) -> bytes:
+        self.eval()
+        z = self.encode_continuous(x)
+        q = torch.round(z / delta).clamp(-32768, 32767).to(torch.int16)
+        q_np = q.detach().cpu().numpy().astype("<i2", copy=False)
+        raw = q_np.tobytes(order="C")
+        checksum = zlib.crc32(raw) & 0xFFFFFFFF
+        compressed = zlib.compress(raw, level=9)
+        header = HEADER.pack(
+            MAGIC,
+            BITSTREAM_VERSION,
+            q_np.shape[0],
+            q_np.shape[1],
+            float(delta),
+            checksum,
+        )
+        return header + compressed
+
+    @torch.no_grad()
+    def decode_bitstream(self, bitstream: bytes, device: torch.device) -> torch.Tensor:
+        if len(bitstream) < HEADER.size:
+            raise ValueError("bitstream is shorter than the DM-V3-PRIME header")
+
+        magic, version, batch, latent_dim, delta, checksum = HEADER.unpack(
+            bitstream[: HEADER.size]
+        )
+        if magic != MAGIC:
+            raise ValueError("invalid DM-V3-PRIME bitstream magic")
+        if version != BITSTREAM_VERSION:
+            raise ValueError(f"unsupported bitstream version: {version}")
+        if latent_dim != self.latent_dim:
+            raise ValueError("bitstream latent dimension does not match decoder")
+
+        raw = zlib.decompress(bitstream[HEADER.size :])
+        expected_bytes = batch * latent_dim * np.dtype("<i2").itemsize
+        if len(raw) != expected_bytes:
+            raise ValueError("bitstream payload length does not match its header")
+        if (zlib.crc32(raw) & 0xFFFFFFFF) != checksum:
+            raise ValueError("bitstream payload checksum mismatch")
+
+        q_np = np.frombuffer(raw, dtype="<i2").reshape(batch, latent_dim).copy()
+        q = torch.from_numpy(q_np).to(device=device, dtype=torch.float32)
+        return self.decode_latent(q * float(delta))
+
+
+def synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def timed_call(device: torch.device, fn: Callable[[], T]) -> tuple[T, float]:
+    synchronize(device)
+    started = time.perf_counter()
+    result = fn()
+    synchronize(device)
+    elapsed_ms = (time.perf_counter() - started) * 1000.0
+    return result, elapsed_ms
+
+
+def parameter_memory_bytes(model: nn.Module) -> int:
+    total = 0
+    for tensor in list(model.parameters()) + list(model.buffers()):
+        total += tensor.numel() * tensor.element_size()
+    return total
+
+
+def make_field(
+    grid_x: torch.Tensor,
+    grid_y: torch.Tensor,
+    grid_z: torch.Tensor,
+    phase: float,
+) -> torch.Tensor:
+    del grid_y  # reserved for future anisotropic field terms
+    field = 0.5 + 0.5 * torch.sin(3.0 * grid_x + phase) * torch.cos(
+        4.0 * grid_z - 0.5 * phase
+    )
+    return field.unsqueeze(0).unsqueeze(0)
+
+
+@torch.no_grad()
+def evaluate_engine(
+    engine: DMV3PrimeEngine,
+    x: torch.Tensor,
+    delta: float,
+    rate_weight: float,
+    timing_repeats: int,
+) -> Evaluation:
+    engine.eval()
+    device = x.device
+
+    for _ in range(2):
+        engine(x, delta)
+    synchronize(device)
+
+    latencies: list[float] = []
+    output: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None
+    for _ in range(timing_repeats):
+        output, elapsed_ms = timed_call(device, lambda: engine(x, delta))
+        latencies.append(elapsed_ms)
+
+    assert output is not None
+    x_hat, z_q, rate_bits = output
+    distortion = F.mse_loss(x_hat, x).item()
+    differentiable_rate = rate_bits.mean().item()
+    objective = distortion + rate_weight * differentiable_rate
+
+    bitstream = engine.encode_bitstream(x, delta)
+    decoded = engine.decode_bitstream(bitstream, device)
+    finite = bool(torch.isfinite(decoded).all().item() and torch.isfinite(z_q).all().item())
+    decoded_distortion = F.mse_loss(decoded, x).item()
+
+    psnr_db = float("inf") if distortion == 0.0 else 10.0 * math.log10(1.0 / distortion)
+    bits_per_voxel = len(bitstream) * 8.0 / x.numel()
+    memory_bytes = parameter_memory_bytes(engine) + x.numel() * x.element_size()
+
+    metrics = DMV3Metrics(
+        distortion=decoded_distortion,
+        latency_ms=median(latencies),
+        objective=objective,
+        memory_bytes=memory_bytes,
+        risk=0.0 if finite else 1.0,
+        stable=finite,
+        safe=finite,
+    )
+    return Evaluation(
+        metrics=metrics,
+        psnr_db=psnr_db,
+        bits_per_voxel=bits_per_voxel,
+        bitstream_bytes=len(bitstream),
+    )
+
+
+def execute_moagi_engine(args: argparse.Namespace) -> int:
+    torch.manual_seed(args.seed)
+    np.random.seed(args.seed)
+
+    if args.device == "auto":
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    else:
+        device = torch.device(args.device)
+
+    resolution = 32
+    coords = torch.linspace(-1.0, 1.0, resolution, device=device)
+    grid_x, grid_y, grid_z = torch.meshgrid(coords, coords, coords, indexing="ij")
+
+    engine = DMV3PrimeEngine(
+        latent_dim=args.latent_dim,
+        recursion_depth=args.recursion_depth,
+    ).to(device)
+    optimizer = torch.optim.AdamW(engine.parameters(), lr=args.lr, weight_decay=1e-5)
+
+    validation_x = make_field(grid_x, grid_y, grid_z, phase=0.37)
+    incumbent_state = copy.deepcopy(engine.state_dict())
+    incumbent = evaluate_engine(
+        engine,
+        validation_x,
+        args.delta,
+        args.rate_weight,
+        args.timing_repeats,
+    )
+
+    print("BOOT: DM-V3-PRIME Engine operational")
+    print(
+        f"Lattice: {resolution}^3 | Device: {device} | "
+        f"Latent: {args.latent_dim} | Recursion depth: {args.recursion_depth}"
+    )
+    print(
+        "BASELINE: "
+        f"J={incumbent.metrics.objective:.6f} | "
+        f"D={incumbent.metrics.distortion:.6f} | "
+        f"PSNR={incumbent.psnr_db:.2f}dB | "
+        f"Rate={incumbent.bits_per_voxel:.4f} b/voxel | "
+        f"Latency={incumbent.metrics.latency_ms:.3f}ms"
+    )
+
+    engine.train()
+    for cycle in range(args.cycles):
+        phase = cycle * 0.1
+        x = make_field(grid_x, grid_y, grid_z, phase=phase)
+
+        optimizer.zero_grad(set_to_none=True)
+        x_hat, _, rate_bits = engine(x, args.delta)
+        distortion = F.mse_loss(x_hat, x)
+        rate = rate_bits.mean()
+        objective = distortion + args.rate_weight * rate
+        objective.backward()
+        torch.nn.utils.clip_grad_norm_(engine.parameters(), max_norm=5.0)
+        optimizer.step()
+
+        if cycle % args.log_every == 0 or cycle == args.cycles - 1:
+            distortion_value = distortion.detach().item()
+            psnr = (
+                float("inf")
+                if distortion_value == 0.0
+                else 10.0 * math.log10(1.0 / distortion_value)
+            )
+            print(
+                f"[Cycle {cycle:04d}] J={objective.detach().item():.6f} | "
+                f"D={distortion_value:.6f} | PSNR={psnr:.2f}dB | "
+                f"RateProxy={rate.detach().item():.3f} bits/latent"
+            )
+
+    candidate_state = copy.deepcopy(engine.state_dict())
+    candidate = evaluate_engine(
+        engine,
+        validation_x,
+        args.delta,
+        args.rate_weight,
+        args.timing_repeats,
+    )
+
+    policy = VerificationPolicy(
+        max_distortion=args.max_distortion,
+        max_memory_bytes=args.max_memory_mb * 1024 * 1024,
+        max_risk=0.1,
+        min_speedup=args.min_speedup,
+        min_objective_improvement=args.min_objective_improvement,
+        target_speedup=1000.0,
+    )
+    gate: PiHLambdaGate[dict[str, torch.Tensor]] = PiHLambdaGate(policy)
+    selected_state, decision = gate.deploy(
+        incumbent_state,
+        candidate_state,
+        incumbent.metrics,
+        candidate.metrics,
+    )
+    engine.load_state_dict(selected_state)
+
+    print("\nCANDIDATE:")
+    print(
+        f"J={candidate.metrics.objective:.6f} | "
+        f"D={candidate.metrics.distortion:.6f} | "
+        f"PSNR={candidate.psnr_db:.2f}dB | "
+        f"Rate={candidate.bits_per_voxel:.4f} b/voxel | "
+        f"Bitstream={candidate.bitstream_bytes} bytes | "
+        f"Latency={candidate.metrics.latency_ms:.3f}ms"
+    )
+    print(
+        f"VERIFY Pi_(H,Lambda): {'COMMIT' if decision.accepted else 'ROLLBACK'} | "
+        f"Measured speedup={decision.speedup:.3f}x | "
+        f"1000x target={'MET' if decision.speed_target_met else 'NOT MET'}"
+    )
+    if decision.reasons:
+        for reason in decision.reasons:
+            print(f"  - {reason}")
+
+    print(f"Total parameter count: {sum(p.numel() for p in engine.parameters())}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the DM-V3-PRIME 3D auto-codec baseline")
+    parser.add_argument("--cycles", type=int, default=200)
+    parser.add_argument("--latent-dim", type=int, default=64)
+    parser.add_argument("--recursion-depth", type=int, default=2)
+    parser.add_argument("--delta", type=float, default=0.05)
+    parser.add_argument("--rate-weight", type=float, default=1e-3)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--device", choices=("auto", "cpu", "cuda"), default="auto")
+    parser.add_argument("--seed", type=int, default=7)
+    parser.add_argument("--log-every", type=int, default=20)
+    parser.add_argument("--timing-repeats", type=int, default=7)
+    parser.add_argument("--max-distortion", type=float, default=0.05)
+    parser.add_argument("--max-memory-mb", type=int, default=4096)
+    parser.add_argument("--min-speedup", type=float, default=1.0)
+    parser.add_argument("--min-objective-improvement", type=float, default=0.0)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    if args.cycles < 1:
+        raise SystemExit("--cycles must be at least one")
+    if args.delta <= 0.0:
+        raise SystemExit("--delta must be positive")
+    if args.timing_repeats < 1:
+        raise SystemExit("--timing-repeats must be at least one")
+    return execute_moagi_engine(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ test = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]
+dm-v3-prime = [
+    "numpy>=1.26",
+    "torch>=2.2",
+]
 
 [project.urls]
 Homepage = "https://github.com/Lord-Xido/Jarvis-X"

--- a/src/jarvisx/dm_v3_prime_control.py
+++ b/src/jarvisx/dm_v3_prime_control.py
@@ -1,0 +1,158 @@
+"""DM-V3-PRIME verification and transactional deployment primitives.
+
+This module implements the dependency-free control-plane portion of the
+DM-V3-PRIME research baseline.  The neural codec is intentionally kept out of
+this module so the deterministic Jarvis-X core does not acquire a mandatory
+PyTorch dependency.
+
+The governing rule is fail-closed: a candidate may replace the incumbent only
+when every configured admissibility condition is satisfied.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import isfinite
+from typing import Generic, TypeVar
+
+StateT = TypeVar("StateT")
+
+
+@dataclass(frozen=True)
+class DMV3Metrics:
+    """Measured state used by the DM-V3-PRIME verification plane."""
+
+    distortion: float
+    latency_ms: float
+    objective: float
+    memory_bytes: int = 0
+    risk: float = 0.0
+    stable: bool = True
+    safe: bool = True
+
+    def finite(self) -> bool:
+        """Return ``True`` when all scalar telemetry is numerically finite."""
+
+        return all(
+            isfinite(value)
+            for value in (
+                self.distortion,
+                self.latency_ms,
+                self.objective,
+                float(self.memory_bytes),
+                self.risk,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class VerificationPolicy:
+    """Admissible-set configuration for :math:`Pi_{H,Lambda}`."""
+
+    max_distortion: float
+    max_memory_bytes: int
+    max_risk: float
+    min_speedup: float = 1.0
+    min_objective_improvement: float = 0.0
+    target_speedup: float = 1000.0
+
+    def __post_init__(self) -> None:
+        if self.max_distortion < 0.0:
+            raise ValueError("max_distortion must be non-negative")
+        if self.max_memory_bytes < 0:
+            raise ValueError("max_memory_bytes must be non-negative")
+        if self.max_risk < 0.0:
+            raise ValueError("max_risk must be non-negative")
+        if self.min_speedup <= 0.0:
+            raise ValueError("min_speedup must be positive")
+        if self.target_speedup <= 0.0:
+            raise ValueError("target_speedup must be positive")
+        if self.min_objective_improvement < 0.0:
+            raise ValueError("min_objective_improvement must be non-negative")
+
+
+@dataclass(frozen=True)
+class VerificationDecision:
+    """Result of evaluating a candidate against the active state."""
+
+    accepted: bool
+    speedup: float
+    speed_target_met: bool
+    reasons: tuple[str, ...]
+
+
+class PiHLambdaGate(Generic[StateT]):
+    """Fail-closed DM-V3-PRIME verification and deployment gate.
+
+    ``PiHLambdaGate`` deliberately distinguishes *acceptance* from the
+    aspirational 1000x target.  A candidate can be a valid incremental
+    improvement without claiming that the 1000x benchmark has been reached.
+    """
+
+    def __init__(self, policy: VerificationPolicy) -> None:
+        self.policy = policy
+
+    @staticmethod
+    def speedup(incumbent: DMV3Metrics, candidate: DMV3Metrics) -> float:
+        """Return incumbent latency divided by candidate latency."""
+
+        if candidate.latency_ms <= 0.0:
+            return float("inf") if incumbent.latency_ms > 0.0 else 0.0
+        return incumbent.latency_ms / candidate.latency_ms
+
+    def evaluate(
+        self,
+        incumbent: DMV3Metrics,
+        candidate: DMV3Metrics,
+    ) -> VerificationDecision:
+        """Evaluate one candidate transaction against the admissible set."""
+
+        reasons: list[str] = []
+
+        if not incumbent.finite():
+            reasons.append("incumbent telemetry is non-finite")
+        if not candidate.finite():
+            reasons.append("candidate telemetry is non-finite")
+
+        measured_speedup = self.speedup(incumbent, candidate)
+
+        if candidate.distortion > self.policy.max_distortion:
+            reasons.append("distortion exceeds configured maximum")
+        if candidate.memory_bytes > self.policy.max_memory_bytes:
+            reasons.append("resident memory exceeds configured maximum")
+        if candidate.risk > self.policy.max_risk:
+            reasons.append("risk exceeds configured maximum")
+        if not candidate.safe:
+            reasons.append("candidate is not marked safe")
+        if not candidate.stable:
+            reasons.append("candidate is not marked stable")
+        if candidate.latency_ms <= 0.0:
+            reasons.append("candidate latency must be positive")
+        if measured_speedup < self.policy.min_speedup:
+            reasons.append("candidate does not satisfy minimum speedup")
+
+        objective_improvement = incumbent.objective - candidate.objective
+        if objective_improvement < self.policy.min_objective_improvement:
+            reasons.append("objective improvement is below the configured minimum")
+
+        accepted = not reasons
+        return VerificationDecision(
+            accepted=accepted,
+            speedup=measured_speedup,
+            speed_target_met=accepted and measured_speedup >= self.policy.target_speedup,
+            reasons=tuple(reasons),
+        )
+
+    def deploy(
+        self,
+        incumbent_state: StateT,
+        candidate_state: StateT,
+        incumbent_metrics: DMV3Metrics,
+        candidate_metrics: DMV3Metrics,
+    ) -> tuple[StateT, VerificationDecision]:
+        """Atomically select candidate or roll back to the incumbent state."""
+
+        decision = self.evaluate(incumbent_metrics, candidate_metrics)
+        if decision.accepted:
+            return candidate_state, decision
+        return incumbent_state, decision

--- a/tests/test_dm_v3_prime_control.py
+++ b/tests/test_dm_v3_prime_control.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.dm_v3_prime_control import DMV3Metrics, PiHLambdaGate, VerificationPolicy
+
+
+@pytest.fixture
+def gate() -> PiHLambdaGate[str]:
+    policy = VerificationPolicy(
+        max_distortion=0.02,
+        max_memory_bytes=512 * 1024 * 1024,
+        max_risk=0.1,
+        min_speedup=1.0,
+        min_objective_improvement=0.001,
+        target_speedup=1000.0,
+    )
+    return PiHLambdaGate(policy)
+
+
+def test_accepts_verified_incremental_improvement(gate: PiHLambdaGate[str]) -> None:
+    incumbent = DMV3Metrics(distortion=0.015, latency_ms=10.0, objective=0.10)
+    candidate = DMV3Metrics(distortion=0.010, latency_ms=5.0, objective=0.08)
+
+    selected, decision = gate.deploy("active", "candidate", incumbent, candidate)
+
+    assert selected == "candidate"
+    assert decision.accepted is True
+    assert decision.speedup == pytest.approx(2.0)
+    assert decision.speed_target_met is False
+    assert decision.reasons == ()
+
+
+def test_1000x_target_is_measured_separately_from_acceptance(gate: PiHLambdaGate[str]) -> None:
+    incumbent = DMV3Metrics(distortion=0.015, latency_ms=1000.0, objective=0.10)
+    candidate = DMV3Metrics(distortion=0.010, latency_ms=1.0, objective=0.08)
+
+    decision = gate.evaluate(incumbent, candidate)
+
+    assert decision.accepted is True
+    assert decision.speedup == pytest.approx(1000.0)
+    assert decision.speed_target_met is True
+
+
+def test_rejects_unsafe_candidate_and_rolls_back(gate: PiHLambdaGate[str]) -> None:
+    incumbent = DMV3Metrics(distortion=0.015, latency_ms=10.0, objective=0.10)
+    candidate = DMV3Metrics(
+        distortion=0.010,
+        latency_ms=5.0,
+        objective=0.08,
+        safe=False,
+    )
+
+    selected, decision = gate.deploy("active", "candidate", incumbent, candidate)
+
+    assert selected == "active"
+    assert decision.accepted is False
+    assert "candidate is not marked safe" in decision.reasons
+
+
+def test_rejects_non_finite_candidate(gate: PiHLambdaGate[str]) -> None:
+    incumbent = DMV3Metrics(distortion=0.015, latency_ms=10.0, objective=0.10)
+    candidate = DMV3Metrics(
+        distortion=math.nan,
+        latency_ms=5.0,
+        objective=0.08,
+    )
+
+    decision = gate.evaluate(incumbent, candidate)
+
+    assert decision.accepted is False
+    assert "candidate telemetry is non-finite" in decision.reasons
+
+
+def test_policy_rejects_invalid_bounds() -> None:
+    with pytest.raises(ValueError):
+        VerificationPolicy(
+            max_distortion=-1.0,
+            max_memory_bytes=1,
+            max_risk=0.1,
+        )


### PR DESCRIPTION
## What changed

This PR permeates the DM-V3-PRIME baseline into Jarvis-X as an executable research layer while preserving the deterministic core boundary.

- adds `src/jarvisx/dm_v3_prime_control.py` with a dependency-free fail-closed `Pi_(H,Lambda)` verification/deployment gate;
- adds tests for commit/rollback semantics, non-finite telemetry rejection, and explicit separation of incremental acceptance from the measured 1000x target;
- adds `experiments/dm_v3_prime_torch.py`, a 32^3 PyTorch 3D auto-codec with Conv3d N^3 context, recursive FFT-domain spectral refinement, straight-through quantization, learned Laplace rate modelling, a real zlib-compressed int16 latent bitstream, synchronized CUDA timing, and candidate rollback;
- adds `docs/research/DM_V3_PRIME_BASELINE.md` mapping the executable implementation back to the canonical Dr Moagi codec-runtime specification;
- adds an optional `dm-v3-prime` dependency extra for NumPy/PyTorch without making those dependencies mandatory for the core package.

## Why

The prior prototype used 3D convolutions but treated “spectral upwelling” as stochastic latent noise, treated convergence as verification, and did not measure the 1000x speed target. PRIME makes those distinctions operational and auditable.

## Invariants preserved

- candidate mutation is not active state until verification succeeds;
- unsafe, unstable, non-finite, over-risk, over-memory, or over-distortion candidates fail closed;
- entropy bitstream integrity is checked before decode;
- virtual recursion depth is never reported as measured hardware throughput;
- the 1000x target remains an empirical benchmark, not a symbolic claim.

## Validation

The branch is five commits ahead of `main` and touches only the PRIME control plane, reference experiment, tests, documentation, and optional dependency metadata. Local network access from the execution container was unavailable, so repository validation is delegated to the existing GitHub Actions PR workflows. The PyTorch reference experiment is intentionally outside the mandatory core import path.
