### PR TITLE
Engineer end-to-end transactional execution fabric

### DIFF
--- a/docs/adr/0007-transactional-execution-fabric.md
+++ b/docs/adr/0007-transactional-execution-fabric.md
@@ -1,0 +1,49 @@
+# ADR-007: Adopt the Jarvis-X transactional execution fabric
+
+**Status:** Accepted  
+**Date:** 2026-08-13
+
+## Context
+
+Jarvis-X now contains a deterministic VM, provenance/journaling, sparse spatial runtimes, Dr Moagi field dynamics, codec/quantization research components, Moagi-Helmholtz orchestration, and the M³-ACME data-facing adapter. The remaining systems-level gap is a single authority-preserving transaction boundary that composes those subsystems without allowing a research transform to mutate authoritative state directly.
+
+## Decision
+
+Jarvis-X adopts a universal transaction fabric:
+
+```text
+OBSERVE -> NORMALIZE -> PROVENANCE -> AUTHORIZE -> ENCODE -> TRANSFORM
+-> RECONSTRUCT -> MEASURE -> PROPOSE -> VERIFY -> PI_LAMBDA
+-> COMMIT / ROLLBACK -> OMEGA RECEIPT -> RE-ENTER
+```
+
+The executable reference is `src/jarvisx/transaction_fabric.py`.
+
+The authoritative transition is:
+
+```text
+Xi_(t+1) = Commit(Pi_Lambda(T_nu(Xi_t, I_t)))
+```
+
+where `T_nu` is a version-bound research transform.
+
+## Required invariants
+
+1. Input admission precedes research execution.
+2. Every optional transform is adapter-driven and version identified.
+3. Candidate state is isolated from authoritative state until validation succeeds.
+4. Pi_Lambda enforces resource, numerical and adapter-specific validation.
+5. Failed candidates roll back to the prior authoritative state.
+6. Input/output state receives deterministic canonical digests.
+7. Transactions emit explicit decisions and metrics.
+8. Omega receipts form an append-only hash chain with verification.
+9. Virtual scale is separated from measured throughput and resident allocation.
+10. The fabric is an orchestration boundary, not an OS security sandbox.
+
+## Consequences
+
+Jarvis-X gains one executable control plane that can host existing and future research adapters while retaining deterministic-core authority. Specialized adapters remain responsible for their own mathematical and domain-specific correctness; the fabric supplies composition, rollback, provenance and resource gating.
+
+## Validation
+
+Promotion requires focused tests for deterministic execution, adapter commit, adapter rollback, resource rejection, admission behavior, Omega-chain verification and stable receipt serialization. CI must pass before merge.

--- a/docs/research/JARVIS_X_TRANSACTION_FABRIC.md
+++ b/docs/research/JARVIS_X_TRANSACTION_FABRIC.md
@@ -1,0 +1,77 @@
+# Jarvis-X End-to-End Transaction Fabric
+
+## Status
+
+Executable integration specification governed by ADR-007. This document defines the control plane that composes M³-ACME and optional research adapters without weakening canonical authority boundaries.
+
+## Universal cycle
+
+```text
+OBSERVE
+-> validate input bounds
+-> M³-ACME compliance/provenance gate
+-> deterministic encode/abstract/decode/loss
+-> freeze authoritative snapshot
+-> for each adapter:
+     transform(snapshot) -> candidate
+     validate candidate
+     Pi_Lambda
+     COMMIT candidate or ROLLBACK
+-> compute output digest
+-> emit metrics
+-> append Omega receipt
+```
+
+## Transaction law
+
+```text
+candidate_i = T_i(Xi_i)
+failures_i  = Pi_Lambda(Xi_i, candidate_i, version_i)
+Xi_(i+1)    = candidate_i if failures_i == empty else Xi_i
+```
+
+## Pi_Lambda reference gate
+
+The reference fabric checks maximum input records, maximum adapter count, maximum canonical state bytes, finite numeric values, a configurable numeric magnitude ceiling, adapter-specific validation and fail-closed adapter exceptions.
+
+Future adapters may add transform normalization, anchor drift, distortion/rate, model integrity, geometry validity, schedule ceilings or hardware-specific checks without bypassing the common gate.
+
+## Omega receipt
+
+Each transaction emits a canonical transaction identifier, observation time, commit state, input/output digests, accepted/rejected record counts, adapter decisions, metrics and hash-chain linkage.
+
+SHA-256 provides tamper evidence; it does not provide encryption or certify that original observations were truthful.
+
+## Adapter contract
+
+An adapter exposes a name, version, `transform(state)` and `validate(before, candidate)` contract. Eligible implementations include sparse Dr Moagi field steps, orthogonal quantization checks, codec/rate-distortion passes, Moagi-Helmholtz generation/refinement, bounded architecture candidates and hardware-lowering receipts.
+
+The adapter surface is intentionally narrow so Python, C++, CUDA, FPGA, distributed, neural and browser implementations can participate behind the same authority contract.
+
+## Operational interpretation
+
+```text
+input evidence
+   |
+   v
+M³-ACME admission + codec baseline
+   |
+   v
+authoritative transaction snapshot
+   |
+   +--> field candidate
+   +--> codec/quantization candidate
+   +--> generative/refinement candidate
+   +--> adaptive candidate
+   |
+   v
+Pi_Lambda
+   |
+   +--> COMMIT
+   `--> ROLLBACK
+   |
+   v
+Omega provenance + telemetry
+```
+
+This transaction fabric is the integration boundary for subsequent Jarvis-X system engineering.

--- a/src/jarvisx/transaction_fabric.py
+++ b/src/jarvisx/transaction_fabric.py
@@ -7,7 +7,7 @@ OBSERVE -> NORMALIZE -> PROVENANCE -> AUTHORIZE -> ENCODE -> TRANSFORM
 -> COMMIT/ROLLBACK -> OMEGA RECEIPT.
 
 The fabric is deliberately adapter-driven. Research subsystems may propose state but
-cannot become authoritative without passing the transaction gate.
+cannot become authoritative without passing the gate.
 """
 
 from __future__ import annotations
@@ -17,9 +17,9 @@ import json
 import math
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Mapping, MutableMapping, Protocol, Sequence
+from typing import Any, Mapping, MutableMapping, Protocol, Sequence
 
-from .m3_acme import RuntimeReport, process_records
+from .m3_acme import M3ACMERuntime, RuntimeReport, webbit_from_mapping
 
 
 class FabricError(RuntimeError):
@@ -27,7 +27,7 @@ class FabricError(RuntimeError):
 
 
 class AdmissionRejected(FabricError):
-    """Raised when a candidate cannot cross Pi_Lambda."""
+    """Raised when transaction-level admission limits reject an input."""
 
 
 class TransactionAdapter(Protocol):
@@ -94,7 +94,7 @@ class OmegaChain:
     def verify(self) -> bool:
         previous_hash = "0" * 64
         for entry in self.entries:
-            payload = {k: v for k, v in entry.items() if k not in {"previous_hash", "hash"}}
+            payload = {key: value for key, value in entry.items() if key not in {"previous_hash", "hash"}}
             expected = hashlib.sha256(previous_hash.encode("ascii") + _canonical_bytes(payload)).hexdigest()
             if entry.get("previous_hash") != previous_hash or entry.get("hash") != expected:
                 return False
@@ -114,7 +114,7 @@ def _state_size(value: Any) -> int:
     return len(_canonical_bytes(value))
 
 
-def _validate_numeric_tree(value: Any, limits: FabricLimits, path: str = "$.") -> list[str]:
+def _validate_numeric_tree(value: Any, limits: FabricLimits, path: str = "$") -> list[str]:
     failures: list[str] = []
     if isinstance(value, bool) or value is None or isinstance(value, str):
         return failures
@@ -127,11 +127,11 @@ def _validate_numeric_tree(value: Any, limits: FabricLimits, path: str = "$.") -
         return failures
     if isinstance(value, Mapping):
         for key, item in value.items():
-            failures.extend(_validate_numeric_tree(item, limits, f"{path}{key}."))
+            failures.extend(_validate_numeric_tree(item, limits, f"{path}.{key}"))
         return failures
     if isinstance(value, (list, tuple)):
         for index, item in enumerate(value):
-            failures.extend(_validate_numeric_tree(item, limits, f"{path}{index}."))
+            failures.extend(_validate_numeric_tree(item, limits, f"{path}[{index}]"))
     return failures
 
 
@@ -184,13 +184,12 @@ def execute_transaction(
     """Execute one complete bounded Jarvis-X research transaction.
 
     M3-ACME performs the admission/encode/abstract/decode/loss boundary. Optional adapters
-    then receive isolated candidate state. Each adapter must pass Pi_Lambda before its state
-    can become authoritative. A rejected adapter is rolled back atomically to the previous
-    authoritative state and recorded in the receipt.
+    receive an isolated snapshot and propose candidate state. Each candidate must pass the
+    common gate and adapter validation before it can replace authoritative transaction state.
     """
 
     effective_limits = limits or FabricLimits()
-    chain = omega or OmegaChain()
+    chain = omega if omega is not None else OmegaChain()
     timestamp = now or datetime.now(timezone.utc)
     if timestamp.tzinfo is None or timestamp.utcoffset() is None:
         raise ValueError("now must be timezone-aware")
@@ -200,7 +199,8 @@ def execute_transaction(
         raise AdmissionRejected("adapter count exceeds configured max_adapters")
 
     input_digest = _digest(records)
-    report = process_records(records, now=timestamp)
+    bits = [webbit_from_mapping(record) for record in records]
+    report = M3ACMERuntime().process(bits, now=timestamp)
     authoritative: MutableMapping[str, Any] = _report_to_state(report)
     decisions: list[CandidateDecision] = []
 
@@ -210,7 +210,7 @@ def execute_transaction(
         try:
             candidate = dict(adapter.transform(before))
             failures = _pi_lambda(before, candidate, adapter, effective_limits)
-        except Exception as exc:  # fail closed at the adapter boundary
+        except Exception as exc:
             candidate = None
             failures = (f"adapter exception: {type(exc).__name__}: {exc}",)
 

--- a/src/jarvisx/transaction_fabric.py
+++ b/src/jarvisx/transaction_fabric.py
@@ -1,0 +1,282 @@
+"""End-to-end transactional orchestration fabric for Jarvis-X.
+
+This module composes the canonical authority boundary into one bounded pipeline:
+
+OBSERVE -> NORMALIZE -> PROVENANCE -> AUTHORIZE -> ENCODE -> TRANSFORM
+-> RECONSTRUCT -> MEASURE -> PROPOSE -> VERIFY -> PI_LAMBDA
+-> COMMIT/ROLLBACK -> OMEGA RECEIPT.
+
+The fabric is deliberately adapter-driven. Research subsystems may propose state but
+cannot become authoritative without passing the transaction gate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, MutableMapping, Protocol, Sequence
+
+from .m3_acme import RuntimeReport, process_records
+
+
+class FabricError(RuntimeError):
+    """Base error for transaction fabric failures."""
+
+
+class AdmissionRejected(FabricError):
+    """Raised when a candidate cannot cross Pi_Lambda."""
+
+
+class TransactionAdapter(Protocol):
+    """Adapter contract for optional bounded research transforms."""
+
+    name: str
+    version: str
+
+    def transform(self, state: Mapping[str, Any]) -> Mapping[str, Any]: ...
+
+    def validate(self, before: Mapping[str, Any], after: Mapping[str, Any]) -> Sequence[str]: ...
+
+
+@dataclass(frozen=True)
+class FabricLimits:
+    max_records: int = 1024
+    max_state_bytes: int = 8 * 1024 * 1024
+    max_adapters: int = 16
+    max_numeric_abs: float = 1e12
+    require_finite: bool = True
+
+
+@dataclass(frozen=True)
+class CandidateDecision:
+    adapter: str
+    version: str
+    accepted: bool
+    reasons: tuple[str, ...]
+    before_digest: str
+    after_digest: str | None
+
+
+@dataclass(frozen=True)
+class FabricReceipt:
+    transaction_id: str
+    observed_at: str
+    committed: bool
+    input_digest: str
+    output_digest: str
+    accepted_records: int
+    rejected_records: int
+    decisions: tuple[CandidateDecision, ...]
+    metrics: Mapping[str, float]
+    authoritative_state: Mapping[str, Any]
+    omega_entry: Mapping[str, Any]
+
+
+@dataclass
+class OmegaChain:
+    """Dependency-free append-only hash chain for fabric receipts."""
+
+    entries: list[dict[str, Any]] = field(default_factory=list)
+
+    def append(self, payload: Mapping[str, Any]) -> Mapping[str, Any]:
+        previous_hash = self.entries[-1]["hash"] if self.entries else "0" * 64
+        canonical_payload = _canonical_bytes(payload)
+        digest = hashlib.sha256(previous_hash.encode("ascii") + canonical_payload).hexdigest()
+        entry = dict(payload)
+        entry["previous_hash"] = previous_hash
+        entry["hash"] = digest
+        self.entries.append(entry)
+        return entry
+
+    def verify(self) -> bool:
+        previous_hash = "0" * 64
+        for entry in self.entries:
+            payload = {k: v for k, v in entry.items() if k not in {"previous_hash", "hash"}}
+            expected = hashlib.sha256(previous_hash.encode("ascii") + _canonical_bytes(payload)).hexdigest()
+            if entry.get("previous_hash") != previous_hash or entry.get("hash") != expected:
+                return False
+            previous_hash = expected
+        return True
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(_canonical_bytes(value)).hexdigest()
+
+
+def _state_size(value: Any) -> int:
+    return len(_canonical_bytes(value))
+
+
+def _validate_numeric_tree(value: Any, limits: FabricLimits, path: str = "$.") -> list[str]:
+    failures: list[str] = []
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return failures
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if limits.require_finite and not math.isfinite(numeric):
+            failures.append(f"{path}: non-finite numeric value")
+        elif abs(numeric) > limits.max_numeric_abs:
+            failures.append(f"{path}: numeric magnitude exceeds limit")
+        return failures
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            failures.extend(_validate_numeric_tree(item, limits, f"{path}{key}."))
+        return failures
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            failures.extend(_validate_numeric_tree(item, limits, f"{path}{index}."))
+    return failures
+
+
+def _pi_lambda(
+    before: Mapping[str, Any],
+    candidate: Mapping[str, Any],
+    adapter: TransactionAdapter,
+    limits: FabricLimits,
+) -> tuple[str, ...]:
+    failures: list[str] = []
+    size = _state_size(candidate)
+    if size > limits.max_state_bytes:
+        failures.append(f"candidate state exceeds max_state_bytes ({size} > {limits.max_state_bytes})")
+    failures.extend(_validate_numeric_tree(candidate, limits))
+    failures.extend(str(reason) for reason in adapter.validate(before, candidate))
+    return tuple(failures)
+
+
+def _report_to_state(report: RuntimeReport) -> dict[str, Any]:
+    accepted = [
+        {
+            "index": record.index,
+            "latent_digest": record.latent_digest,
+            "compressed_bytes": record.compressed_bytes,
+            "abstraction": asdict(record.abstraction),
+            "reconstructed": record.reconstructed,
+            "loss": asdict(record.loss),
+        }
+        for record in report.accepted
+    ]
+    rejected = [asdict(record) for record in report.rejected]
+    return {
+        "m3_acme": {
+            "accepted": accepted,
+            "rejected": rejected,
+            "accepted_count": report.accepted_count,
+            "rejected_count": report.rejected_count,
+        }
+    }
+
+
+def execute_transaction(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    adapters: Sequence[TransactionAdapter] = (),
+    limits: FabricLimits | None = None,
+    omega: OmegaChain | None = None,
+    now: datetime | None = None,
+) -> FabricReceipt:
+    """Execute one complete bounded Jarvis-X research transaction.
+
+    M3-ACME performs the admission/encode/abstract/decode/loss boundary. Optional adapters
+    then receive isolated candidate state. Each adapter must pass Pi_Lambda before its state
+    can become authoritative. A rejected adapter is rolled back atomically to the previous
+    authoritative state and recorded in the receipt.
+    """
+
+    effective_limits = limits or FabricLimits()
+    chain = omega or OmegaChain()
+    timestamp = now or datetime.now(timezone.utc)
+    if timestamp.tzinfo is None or timestamp.utcoffset() is None:
+        raise ValueError("now must be timezone-aware")
+    if len(records) > effective_limits.max_records:
+        raise AdmissionRejected("record count exceeds configured max_records")
+    if len(adapters) > effective_limits.max_adapters:
+        raise AdmissionRejected("adapter count exceeds configured max_adapters")
+
+    input_digest = _digest(records)
+    report = process_records(records, now=timestamp)
+    authoritative: MutableMapping[str, Any] = _report_to_state(report)
+    decisions: list[CandidateDecision] = []
+
+    for adapter in adapters:
+        before = json.loads(json.dumps(authoritative))
+        before_digest = _digest(before)
+        try:
+            candidate = dict(adapter.transform(before))
+            failures = _pi_lambda(before, candidate, adapter, effective_limits)
+        except Exception as exc:  # fail closed at the adapter boundary
+            candidate = None
+            failures = (f"adapter exception: {type(exc).__name__}: {exc}",)
+
+        if failures:
+            decisions.append(
+                CandidateDecision(
+                    adapter=adapter.name,
+                    version=adapter.version,
+                    accepted=False,
+                    reasons=tuple(failures),
+                    before_digest=before_digest,
+                    after_digest=None if candidate is None else _digest(candidate),
+                )
+            )
+            continue
+
+        authoritative = candidate
+        decisions.append(
+            CandidateDecision(
+                adapter=adapter.name,
+                version=adapter.version,
+                accepted=True,
+                reasons=(),
+                before_digest=before_digest,
+                after_digest=_digest(candidate),
+            )
+        )
+
+    output_digest = _digest(authoritative)
+    losses = [record.loss.total for record in report.accepted]
+    metrics = {
+        "accepted_records": float(report.accepted_count),
+        "rejected_records": float(report.rejected_count),
+        "adapter_commits": float(sum(1 for item in decisions if item.accepted)),
+        "adapter_rollbacks": float(sum(1 for item in decisions if not item.accepted)),
+        "mean_moagi_loss": float(sum(losses) / len(losses)) if losses else 0.0,
+        "authoritative_state_bytes": float(_state_size(authoritative)),
+    }
+
+    committed = report.rejected_count == 0
+    transaction_id = hashlib.sha256(
+        f"{input_digest}:{output_digest}:{timestamp.isoformat()}".encode("utf-8")
+    ).hexdigest()
+    omega_payload = {
+        "transaction_id": transaction_id,
+        "observed_at": timestamp.isoformat(),
+        "committed": committed,
+        "input_digest": input_digest,
+        "output_digest": output_digest,
+        "accepted_records": report.accepted_count,
+        "rejected_records": report.rejected_count,
+        "adapter_decisions": [asdict(item) for item in decisions],
+        "metrics": metrics,
+    }
+    omega_entry = chain.append(omega_payload)
+
+    return FabricReceipt(
+        transaction_id=transaction_id,
+        observed_at=timestamp.isoformat(),
+        committed=committed,
+        input_digest=input_digest,
+        output_digest=output_digest,
+        accepted_records=report.accepted_count,
+        rejected_records=report.rejected_count,
+        decisions=tuple(decisions),
+        metrics=metrics,
+        authoritative_state=dict(authoritative),
+        omega_entry=omega_entry,
+    )

--- a/tests/test_transaction_fabric.py
+++ b/tests/test_transaction_fabric.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timezone
+
+from jarvisx.transaction_fabric import OmegaChain, execute_transaction
+
+NOW = datetime(2026, 8, 13, 12, 0, tzinfo=timezone.utc)
+
+
+def sample_record():
+    return {
+        "structure": {"tag": "article"},
+        "semantics": {"entities": ["Jarvis-X"], "topics": ["runtime"]},
+        "provenance_url": "https://example.com/source",
+        "observed_at": "2026-08-13T11:59:00+00:00",
+        "trust": 0.9,
+        "payload": {"text": "bounded observation"},
+        "compliance": {
+            "authorized": True,
+            "robots_permitted": True,
+            "terms_permitted": True,
+            "restricted_data": False,
+            "permission_basis": "fixture",
+        },
+    }
+
+
+class ReferenceAdapter:
+    name = "reference-adapter"
+    version = "1"
+
+    def transform(self, state):
+        candidate = dict(state)
+        candidate["derived"] = {"stable": True, "score": 1.0}
+        return candidate
+
+    def validate(self, before, after):
+        return ()
+
+
+def test_end_to_end_commit_and_omega_chain():
+    omega = OmegaChain()
+    receipt = execute_transaction([sample_record()], adapters=[ReferenceAdapter()], omega=omega, now=NOW)
+    assert receipt.committed is True
+    assert receipt.accepted_records == 1
+    assert receipt.decisions[0].accepted is True
+    assert receipt.authoritative_state["derived"]["stable"] is True
+    assert omega.verify() is True


### PR DESCRIPTION
## What changed

- add `src/jarvisx/transaction_fabric.py` as the common authority-preserving orchestration layer
- compose M³-ACME admission/encode/abstract/decode/loss with optional versioned research adapters
- isolate candidate state until Pi-Lambda validation succeeds
- add bounded record, adapter, state-size and numeric gates
- add deterministic input/output digests, explicit adapter commit/rollback decisions, telemetry and an append-only Omega hash-chain receipt
- add ADR-007 and the system-wide transaction-fabric research specification
- add a focused end-to-end commit-path test with Omega-chain verification

## Why

The repository has multiple strong research subsystems, but they need one execution fabric that composes them without weakening the deterministic-core authority boundary. This PR establishes the constitutional loop:

`OBSERVE -> NORMALIZE -> PROVENANCE -> AUTHORIZE -> ENCODE -> TRANSFORM -> RECONSTRUCT -> MEASURE -> PROPOSE -> VERIFY -> PI_LAMBDA -> COMMIT/ROLLBACK -> OMEGA RECEIPT -> RE-ENTER`

## Integration boundary

This is intentionally a stacked PR on `agent/m3-acme-runtime`, because the transaction fabric consumes the M³-ACME API introduced by PR #95. Once #95 lands, this PR can be retargeted to `main` without duplicating the M³-ACME changes.

## Validation

The branch includes a focused integration test. GitHub CI is the authoritative validation for the stacked branch.