### PR TITLE
Add Omega3 electronic logic reference core

### DIFF
--- a/docs/research/OMEGA3_ELECTRONIC_LOGIC_CORE.md
+++ b/docs/research/OMEGA3_ELECTRONIC_LOGIC_CORE.md
@@ -1,0 +1,245 @@
+# Omega3 Dr Moagi Electronic Logic Core
+
+**Status:** Research reference implementation  
+**Scope:** Digital synchronous logic only  
+**Parent:** `docs/research/DR_MOAGI_3D_ELECTROMAGNETIC_OPERATION.md`
+
+## 1. Purpose
+
+This document closes the gap between the bitwise Omega3 formulation and an ordinary electronic digital implementation.
+
+The electronic hierarchy is:
+
+```text
+logical Omega3 operator
+-> fixed-width bits
+-> Boolean gates and arithmetic circuits
+-> combinational candidate path
+-> Pi_Lambda approval mask
+-> clocked state registers
+-> committed next state
+```
+
+This is a synthesizable/reference digital model, not a claim that a physical chip has been fabricated or benchmarked.
+
+## 2. Electrical bit representation
+
+A CMOS implementation represents logical bits using bounded node voltages:
+
+```text
+0 := V <= V_IL
+1 := V >= V_IH
+```
+
+with an invalid/noise-margin region between thresholds defined by the selected technology library. Logical AND, OR, XOR, NOT, addition and comparison are implemented by transistor networks whose node capacitances charge and discharge under the supply rails.
+
+At the architectural boundary, those analog transistor dynamics are abstracted as Boolean values sampled by synchronous registers.
+
+## 3. Clocked Omega3 state
+
+The reference core contains two authoritative registers:
+
+```text
+state_word : 64 bits
+omega_q15  : signed 16-bit Q1.15
+```
+
+and a 64-bit cycle counter.
+
+One electronic cycle is:
+
+```text
+current registers
+-> candidate combinational logic
+-> governance combinational logic
+-> commit multiplexer
+-> active clock edge
+-> next authoritative registers
+```
+
+## 4. Pi_Lambda gate
+
+The governance contract is represented by eight Boolean conditions:
+
+```text
+bit 0 numerical validity
+bit 1 semantic validity
+bit 2 anchor validity
+bit 3 memory validity
+bit 4 resource validity
+bit 5 security validity
+bit 6 rollback readiness
+bit 7 policy validity
+```
+
+The default required mask is:
+
+```text
+Lambda_required = 11111111b = 0xFF
+```
+
+Approval is:
+
+```text
+approved = (Lambda & Lambda_required) == Lambda_required
+```
+
+This maps directly to AND gates plus an equality comparator.
+
+## 5. Electronic commit/rollback multiplexer
+
+Let `Q_t` be the current 64-bit state register and `D_candidate` the candidate bus.
+
+Create the replicated approval mask:
+
+```text
+M = {64{approved}}
+```
+
+Then:
+
+```text
+D_next = (D_candidate AND M) OR (Q_t AND NOT M)
+```
+
+Therefore:
+
+```text
+approved = 1 -> D_next = D_candidate
+approved = 0 -> D_next = Q_t
+```
+
+On the active clock edge:
+
+```text
+Q_(t+1) <- D_next
+```
+
+This is the literal electronic implementation of bounded `Pi_Lambda` commit/rollback.
+
+## 6. Inward convergence circuit
+
+The bitwise difference field is:
+
+```text
+Delta = Q_t XOR D_candidate
+```
+
+A population-count tree computes:
+
+```text
+h = popcount(Delta)
+```
+
+and a comparator evaluates:
+
+```text
+converged = h <= tau
+```
+
+Strict digital fixed point is the special case:
+
+```text
+tau = 0
+Q_t XOR D_candidate = 0
+Q_t = D_candidate
+```
+
+Thus an inward recursive loop may stop when its proposed next state is bit-identical, or sufficiently close under a declared Hamming threshold.
+
+## 7. 1000^3 coordinate electronics
+
+Each axis requires ten bits because:
+
+```text
+2^9 < 1000 <= 2^10
+```
+
+A logical coordinate is packed as:
+
+```text
+[29:20] X
+[19:10] Y
+[ 9: 0] Z
+```
+
+with validity checks requiring every component to be less than 1000.
+
+The canonical linear address remains:
+
+```text
+a = x + 1000 * (y + 1000 * z)
+```
+
+The logical cube is virtual; this addressing contract does not imply one billion simultaneously resident electronic memory cells in the reference runtime.
+
+## 8. Omega memory circuit
+
+Adaptive memory is represented as signed Q1.15 fixed point:
+
+```text
+Omega_candidate = sat16(
+    (rho_q15 * Omega_t  >>> 15)
+  + (gain_q15 * error   >>> 15)
+)
+```
+
+Two signed multipliers, arithmetic shifters, an adder and saturating limiter implement this path.
+
+Omega is committed only when the same `Pi_Lambda` approval signal is asserted. Rejection retains the previous Omega register exactly.
+
+## 9. RTL reference
+
+`rtl/omega3_electronic_core.sv` implements:
+
+- 64-bit authoritative state register;
+- signed 16-bit Omega register;
+- eight-bit Lambda approval mask;
+- AND/OR candidate-current selection;
+- XOR + population-count Hamming distance;
+- convergence comparator;
+- Q1.15 Omega update;
+- synchronous commit/rollback;
+- cycle counter.
+
+`src/jarvisx/omega3_electronic_logic.py` is the deterministic software conformance model for the same contract.
+
+## 10. Operational electronic recurrence
+
+The electronic state transition is:
+
+```text
+C_t = CandidateLogic(Q_t, Omega_t, inputs_t)
+A_t = LambdaGate(validity_t)
+M_t = replicate64(A_t)
+Q_(t+1) = (C_t & M_t) | (Q_t & ~M_t)
+Omega_(t+1) = A_t ? Omega_candidate : Omega_t
+```
+
+or compactly:
+
+```text
+[Q_(t+1), Omega_(t+1)]
+=
+ElectronicPiLambda(
+    [Q_t, Omega_t],
+    CandidateLogic([Q_t, Omega_t], inputs_t)
+)
+```
+
+## 11. Physical boundary
+
+The SystemVerilog module is an RTL description. A physical electronic realization would still require:
+
+1. synthesis against a named cell library;
+2. timing constraints and static timing analysis;
+3. clock/reset design;
+4. CDC analysis where multiple clocks exist;
+5. place and route;
+6. power, IR-drop and thermal analysis;
+7. signal-integrity checks;
+8. gate-level simulation/formal equivalence;
+9. FPGA programming or ASIC fabrication;
+10. bench measurement.
+
+Accordingly, the repository may claim a digital electronic reference architecture and RTL model, but not fabricated hardware, clock frequency, energy efficiency or silicon performance without those downstream artifacts and measurements.

--- a/rtl/omega3_electronic_core.sv
+++ b/rtl/omega3_electronic_core.sv
@@ -1,0 +1,81 @@
+module omega3_electronic_core #(
+    parameter logic [7:0] REQUIRED_LAMBDA_MASK = 8'hFF
+) (
+    input  logic               clk,
+    input  logic               reset_n,
+    input  logic [63:0]        candidate_word,
+    input  logic [7:0]         lambda_mask,
+    input  logic signed [15:0] error_q15,
+    input  logic signed [15:0] rho_q15,
+    input  logic signed [15:0] gain_q15,
+    input  logic [6:0]         convergence_threshold,
+    output logic [63:0]        state_word,
+    output logic signed [15:0] omega_q15,
+    output logic [63:0]        selected_word,
+    output logic               lambda_approved,
+    output logic [6:0]         hamming_delta,
+    output logic               converged,
+    output logic [63:0]        cycle
+);
+
+    logic [63:0] commit_mask;
+    logic signed [31:0] omega_product;
+    logic signed [31:0] error_product;
+    logic signed [31:0] omega_sum;
+    logic signed [15:0] omega_candidate;
+
+    function automatic [6:0] popcount64(input logic [63:0] value);
+        integer i;
+        begin
+            popcount64 = 7'd0;
+            for (i = 0; i < 64; i = i + 1)
+                popcount64 = popcount64 + value[i];
+        end
+    endfunction
+
+    function automatic logic signed [15:0] saturate_q15(
+        input logic signed [31:0] value
+    );
+        begin
+            if (value > 32'sd32767)
+                saturate_q15 = 16'sh7FFF;
+            else if (value < -32'sd32768)
+                saturate_q15 = -16'sd32768;
+            else
+                saturate_q15 = value[15:0];
+        end
+    endfunction
+
+    always_comb begin
+        lambda_approved =
+            (lambda_mask & REQUIRED_LAMBDA_MASK) == REQUIRED_LAMBDA_MASK;
+
+        commit_mask = {64{lambda_approved}};
+        selected_word =
+            (candidate_word & commit_mask) |
+            (state_word & ~commit_mask);
+
+        hamming_delta = popcount64(state_word ^ candidate_word);
+        converged = hamming_delta <= convergence_threshold;
+
+        omega_product = $signed(rho_q15) * $signed(omega_q15);
+        error_product = $signed(gain_q15) * $signed(error_q15);
+        omega_sum = (omega_product >>> 15) + (error_product >>> 15);
+        omega_candidate = saturate_q15(omega_sum);
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            state_word <= 64'd0;
+            omega_q15 <= 16'sd0;
+            cycle <= 64'd0;
+        end else begin
+            cycle <= cycle + 64'd1;
+            if (lambda_approved) begin
+                state_word <= selected_word;
+                omega_q15 <= omega_candidate;
+            end
+        end
+    end
+
+endmodule

--- a/src/jarvisx/omega3_electronic_logic.py
+++ b/src/jarvisx/omega3_electronic_logic.py
@@ -1,0 +1,232 @@
+"""Deterministic bit-level reference for the Omega3 electronic commit core.
+
+This module maps a small, explicitly bounded part of the Omega3/Dr Moagi
+research architecture onto ordinary synchronous digital-logic semantics:
+fixed-width words, bit masks, signed Q1.15 adaptive memory, Hamming-distance
+convergence and a fail-closed commit/rollback gate.
+
+It is a software reference for RTL conformance. It does not claim a fabricated
+chip, measured transistor performance, or autonomous source-code mutation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+WORD_BITS = 64
+WORD_MASK = (1 << WORD_BITS) - 1
+XYZ_BITS = 10
+XYZ_MASK = (1 << XYZ_BITS) - 1
+XYZ_SIDE = 1000
+REQUIRED_LAMBDA_MASK = 0xFF
+Q15_SHIFT = 15
+Q15_MIN = -(1 << 15)
+Q15_MAX = (1 << 15) - 1
+
+
+def _require_int(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    return value
+
+
+def _require_word(value: int, name: str) -> int:
+    value = _require_int(value, name)
+    if value < 0 or value > WORD_MASK:
+        raise ValueError(f"{name} must fit in {WORD_BITS} bits")
+    return value
+
+
+def _require_u8(value: int, name: str) -> int:
+    value = _require_int(value, name)
+    if value < 0 or value > 0xFF:
+        raise ValueError(f"{name} must fit in 8 bits")
+    return value
+
+
+def _saturate_q15(value: int) -> int:
+    return max(Q15_MIN, min(Q15_MAX, int(value)))
+
+
+def pack_xyz(x: int, y: int, z: int) -> int:
+    """Pack a logical 1000^3 coordinate into a 30-bit integer."""
+
+    checked = []
+    for name, component in (("x", x), ("y", y), ("z", z)):
+        component = _require_int(component, name)
+        if component < 0 or component >= XYZ_SIDE:
+            raise ValueError(f"{name} must be in [0, {XYZ_SIDE - 1}]")
+        checked.append(component)
+    x, y, z = checked
+    return (x << 20) | (y << 10) | z
+
+
+def unpack_xyz(packed: int) -> tuple[int, int, int]:
+    """Unpack a 30-bit coordinate and reject codes outside the 1000^3 domain."""
+
+    packed = _require_int(packed, "packed")
+    if packed < 0 or packed >= (1 << 30):
+        raise ValueError("packed coordinate must fit in 30 bits")
+    x = (packed >> 20) & XYZ_MASK
+    y = (packed >> 10) & XYZ_MASK
+    z = packed & XYZ_MASK
+    if x >= XYZ_SIDE or y >= XYZ_SIDE or z >= XYZ_SIDE:
+        raise ValueError("packed coordinate is outside the logical 1000^3 lattice")
+    return x, y, z
+
+
+def linear_address(x: int, y: int, z: int) -> int:
+    """Map a coordinate to the canonical x + N(y + Nz) linear address."""
+
+    x, y, z = unpack_xyz(pack_xyz(x, y, z))
+    return x + XYZ_SIDE * (y + XYZ_SIDE * z)
+
+
+def approve_lambda(lambda_mask: int, required_mask: int = REQUIRED_LAMBDA_MASK) -> bool:
+    """Return True only when every required governance bit is asserted."""
+
+    lambda_mask = _require_u8(lambda_mask, "lambda_mask")
+    required_mask = _require_u8(required_mask, "required_mask")
+    return (lambda_mask & required_mask) == required_mask
+
+
+def hamming_distance(left: int, right: int) -> int:
+    """Return the number of differing bits between two 64-bit states."""
+
+    left = _require_word(left, "left")
+    right = _require_word(right, "right")
+    return (left ^ right).bit_count()
+
+
+def select_word(
+    current: int,
+    candidate: int,
+    lambda_mask: int,
+    required_mask: int = REQUIRED_LAMBDA_MASK,
+) -> int:
+    """Select candidate on full approval, otherwise retain current state.
+
+    The expression mirrors a hardware AND/OR multiplexer:
+
+        next = (candidate & mask) | (current & ~mask)
+
+    where mask is all ones on approval and all zeros on rejection.
+    """
+
+    current = _require_word(current, "current")
+    candidate = _require_word(candidate, "candidate")
+    approved = approve_lambda(lambda_mask, required_mask)
+    mask = WORD_MASK if approved else 0
+    return ((candidate & mask) | (current & (~mask & WORD_MASK))) & WORD_MASK
+
+
+def omega_candidate_q15(omega_q15: int, error_q15: int, rho_q15: int, gain_q15: int) -> int:
+    """Compute one saturated signed-Q1.15 adaptive-memory candidate."""
+
+    for name, value in (
+        ("omega_q15", omega_q15),
+        ("error_q15", error_q15),
+        ("rho_q15", rho_q15),
+        ("gain_q15", gain_q15),
+    ):
+        _require_int(value, name)
+    if not Q15_MIN <= omega_q15 <= Q15_MAX:
+        raise ValueError("omega_q15 must fit signed Q1.15")
+    if not Q15_MIN <= error_q15 <= Q15_MAX:
+        raise ValueError("error_q15 must fit signed Q1.15")
+    if not 0 <= rho_q15 <= Q15_MAX:
+        raise ValueError("rho_q15 must be a non-negative Q1.15 coefficient")
+    if not 0 <= gain_q15 <= Q15_MAX:
+        raise ValueError("gain_q15 must be a non-negative Q1.15 coefficient")
+
+    retained = (rho_q15 * omega_q15) >> Q15_SHIFT
+    correction = (gain_q15 * error_q15) >> Q15_SHIFT
+    return _saturate_q15(retained + correction)
+
+
+@dataclass(frozen=True)
+class ElectronicStepReport:
+    cycle: int
+    current_word: int
+    candidate_word: int
+    next_word: int
+    lambda_mask: int
+    committed: bool
+    hamming_delta: int
+    converged: bool
+    omega_before_q15: int
+    omega_candidate_q15: int
+    omega_after_q15: int
+
+
+class Omega3ElectronicCore:
+    """Clock-step reference for the bounded electronic Omega3 state register."""
+
+    def __init__(self, initial_word: int = 0, omega_q15: int = 0) -> None:
+        self._word = _require_word(initial_word, "initial_word")
+        if not Q15_MIN <= _require_int(omega_q15, "omega_q15") <= Q15_MAX:
+            raise ValueError("omega_q15 must fit signed Q1.15")
+        self._omega_q15 = omega_q15
+        self._cycle = 0
+
+    @property
+    def word(self) -> int:
+        return self._word
+
+    @property
+    def omega_q15(self) -> int:
+        return self._omega_q15
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    def step(
+        self,
+        *,
+        candidate_word: int,
+        lambda_mask: int,
+        error_q15: int = 0,
+        rho_q15: int = Q15_MAX,
+        gain_q15: int = 0,
+        convergence_threshold: int = 0,
+    ) -> ElectronicStepReport:
+        """Execute one clock-equivalent transaction.
+
+        Candidate word and candidate Omega are computed first. The governance
+        mask then controls both authoritative state registers. Rejection retains
+        the previous word and previous Omega exactly.
+        """
+
+        candidate_word = _require_word(candidate_word, "candidate_word")
+        convergence_threshold = _require_int(convergence_threshold, "convergence_threshold")
+        if convergence_threshold < 0 or convergence_threshold > WORD_BITS:
+            raise ValueError("convergence_threshold must be in [0, 64]")
+
+        current = self._word
+        omega_before = self._omega_q15
+        omega_candidate = omega_candidate_q15(
+            omega_before, error_q15, rho_q15, gain_q15
+        )
+        committed = approve_lambda(lambda_mask)
+        next_word = select_word(current, candidate_word, lambda_mask)
+        delta = hamming_distance(current, candidate_word)
+
+        self._cycle += 1
+        if committed:
+            self._word = next_word
+            self._omega_q15 = omega_candidate
+
+        return ElectronicStepReport(
+            cycle=self._cycle,
+            current_word=current,
+            candidate_word=candidate_word,
+            next_word=self._word,
+            lambda_mask=lambda_mask,
+            committed=committed,
+            hamming_delta=delta,
+            converged=delta <= convergence_threshold,
+            omega_before_q15=omega_before,
+            omega_candidate_q15=omega_candidate,
+            omega_after_q15=self._omega_q15,
+        )

--- a/tests/test_omega3_electronic_logic.py
+++ b/tests/test_omega3_electronic_logic.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.omega3_electronic_logic import (
+    Q15_MAX,
+    Omega3ElectronicCore,
+    approve_lambda,
+    hamming_distance,
+    linear_address,
+    pack_xyz,
+    select_word,
+    unpack_xyz,
+)
+
+
+def test_xyz_round_trip_and_linear_address():
+    packed = pack_xyz(999, 500, 1)
+    assert unpack_xyz(packed) == (999, 500, 1)
+    assert linear_address(999, 500, 1) == 999 + 1000 * (500 + 1000)
+
+
+def test_out_of_domain_coordinate_is_rejected():
+    with pytest.raises(ValueError):
+        pack_xyz(1000, 0, 0)
+
+
+def test_lambda_gate_is_fail_closed():
+    assert approve_lambda(0xFF)
+    assert not approve_lambda(0xFE)
+    assert select_word(0xAA, 0x55, 0xFE) == 0xAA
+    assert select_word(0xAA, 0x55, 0xFF) == 0x55
+
+
+def test_hamming_distance_uses_xor_population_count():
+    assert hamming_distance(0b1010, 0b0011) == 2
+    assert hamming_distance(0xFFFFFFFFFFFFFFFF, 0) == 64
+
+
+def test_rejected_candidate_rolls_back_word_and_omega():
+    core = Omega3ElectronicCore(initial_word=0x10, omega_q15=1024)
+    report = core.step(
+        candidate_word=0x20,
+        lambda_mask=0x7F,
+        error_q15=4096,
+        rho_q15=Q15_MAX,
+        gain_q15=8192,
+    )
+
+    assert not report.committed
+    assert core.word == 0x10
+    assert core.omega_q15 == 1024
+    assert core.cycle == 1
+
+
+def test_approved_candidate_commits_word_and_omega():
+    core = Omega3ElectronicCore(initial_word=0, omega_q15=0)
+    report = core.step(
+        candidate_word=0xF0,
+        lambda_mask=0xFF,
+        error_q15=8192,
+        rho_q15=Q15_MAX,
+        gain_q15=16384,
+    )
+
+    assert report.committed
+    assert core.word == 0xF0
+    assert core.omega_q15 > 0
+
+
+def test_bit_identical_candidate_is_converged_at_zero_threshold():
+    core = Omega3ElectronicCore(initial_word=0x1234)
+    report = core.step(
+        candidate_word=0x1234,
+        lambda_mask=0xFF,
+        convergence_threshold=0,
+    )
+
+    assert report.hamming_delta == 0
+    assert report.converged


### PR DESCRIPTION
## What changed

Adds the missing digital-electronic layer beneath the bitwise Omega3 / Dr Moagi formulation.

- `rtl/omega3_electronic_core.sv`: synchronous RTL reference core with a 64-bit state register, signed Q1.15 Omega memory, eight-bit Lambda governance gate, branchless candidate/current selection, XOR/popcount convergence detection, and clocked commit/rollback.
- `src/jarvisx/omega3_electronic_logic.py`: deterministic software conformance model for the same fixed-width semantics.
- `tests/test_omega3_electronic_logic.py`: tests XYZ packing, fail-closed governance, Hamming distance, commit/rollback, and Omega persistence.
- `docs/research/OMEGA3_ELECTRONIC_LOGIC_CORE.md`: electrical-to-digital mapping and physical implementation boundary.

## Operational equation

The electronic commit path is:

```text
approved = (Lambda & Required) == Required
mask = replicate64(approved)
Q_next = (candidate & mask) | (Q_current & ~mask)
Omega_next = approved ? Omega_candidate : Omega_current
```

with inward convergence measured by:

```text
h = popcount(Q_current XOR candidate)
converged = h <= threshold
```

## Boundary

This PR establishes a digital electronic reference architecture and RTL model. It does not claim FPGA synthesis, ASIC fabrication, measured clock frequency, power, thermal performance, or silicon speedup. Those require downstream synthesis, timing, place-and-route and bench evidence.

## Review focus

- fixed-width/Q1.15 semantics
- fail-closed Lambda gating
- RTL/Python conformance
- whether RTL compilation should become a dedicated CI job
