### PR TITLE
Operationalize Dr Moagi permeation protocol

### DIFF
--- a/docs/adr/0003-dr-moagi-permeation-protocol.md
+++ b/docs/adr/0003-dr-moagi-permeation-protocol.md
@@ -1,0 +1,167 @@
+# ADR-003: Adopt the Dr Moagi 3D Permeation Protocol as a bounded field-extension contract
+
+**Status:** Proposed  
+**Date:** 2026-08-14  
+**Depends on:** ADR-001, ADR-002
+
+## Context
+
+The Dr Moagi research architecture defines a locked spatial/codec state and bounded inward
+recursion. The Permeation Protocol extends that state outward by treating the locked spherical
+boundary as the boundary condition of a radial scalar field.
+
+The intended symbolic statement is that the core remains immutable while its signature is
+available at arbitrary mathematical radius. The implementation must preserve that idea without
+claiming infinite allocation, non-causal information transfer, zero entropy, perfect
+noise-resistance, or physical realization that has not been measured.
+
+The original narrative mixed a point-source Green function with a spherical shell source and also
+described the resulting `1/r` field as gradient-free. Those statements are not simultaneously
+consistent. This ADR fixes the operational mathematics while preserving the research semantics.
+
+## Decision
+
+Jarvis-X adopts the Permeation Protocol as a Layer 4/5 research operator over a locked spherical
+core.
+
+For core radius `a > 0` and locked boundary value `Phi_0 != 0`, the canonical static exterior
+problem is
+
+```text
+Laplacian(Phi) = 0,                r > a
+Phi(a)         = Phi_0
+Phi(r)         -> 0,               r -> infinity
+```
+
+whose unique spherically symmetric solution is
+
+```text
+Phi(r) = Phi_0 * a / r,            r > a
+Phi(r) = Phi_0,                    0 <= r <= a   [locked-core extension]
+```
+
+Equivalently, under the normalized shell-source convention
+
+```text
+-Laplacian(Phi) = Q * delta(r-a) / (4*pi*a^2)
+```
+
+the solution is
+
+```text
+Phi(r) = Q / (4*pi*max(r,a))
+```
+
+and choosing
+
+```text
+Q = 4*pi*a*Phi_0
+```
+
+recovers the same locked-boundary field.
+
+The point Green function
+
+```text
+1 / (4*pi*|r-r0|)
+```
+
+is the Green function of a three-dimensional point source. It is not, by itself, the field of an
+entire spherical shell. Shell symmetry must be integrated or encoded through the radial boundary
+problem above.
+
+### Harmonic excitation
+
+For optional frequency-domain excitation with wavenumber `k >= 0`, the canonical outgoing
+exterior continuation is
+
+```text
+Phi_k(r) = Phi_0 * a/r * exp(i*k*(r-a)),    r > a
+Phi_k(a) = Phi_0
+```
+
+and `k = 0` reduces exactly to the static `1/r` field.
+
+This is a frequency-domain boundary-value model. It does not imply instantaneous time-domain
+propagation. Any causal propagation claim requires a separately specified wave equation,
+constitutive model, source term, boundary conditions, and measured implementation.
+
+## Operational invariants
+
+1. **Immutable core:** the configured core radius and core value are never mutated by sampling or
+   relaxation.
+2. **Harmonic exterior:** the classical Laplacian is zero for every `r > a`; the shell itself is
+   represented distributionally.
+3. **Nonzero exterior gradient:** for the static field,
+   `dPhi/dr = -Phi_0*a/r^2` for `r > a`.
+4. **Flat geometry remains flat:** `g_ij = delta_ij` implies zero Euclidean Ricci curvature. The
+   scalar field may still have a nonzero gradient.
+5. **Infinite support is analytic, not allocated:** runtime sampling is always bounded by
+   `max_radius` and `samples`.
+6. **Finite truncation is explicit:** for amplitude tolerance `epsilon > 0`, the practical cutoff
+   is `r_epsilon = a*|Phi_0|/epsilon` when `epsilon < |Phi_0|`.
+7. **Self-healing is relaxation/projection:** perturbation recovery is implemented as
+   `u_(n+1) = u_n + gain*(Phi_target-u_n)`, `0 < gain <= 1`.
+8. **No perfect-noise claim:** convergence is measured by residual reduction and is subject to
+   finite precision, resource limits, and the chosen numerical operator.
+9. **No non-causal execution claim:** a static solution can be evaluated directly at any sampled
+   coordinate, but this is not a statement about physical signal velocity.
+10. **Research-layer authority:** the permeation field does not mutate the deterministic VM core
+    unless an explicit validated adapter is introduced under the existing `Pi_Lambda` boundary.
+
+## Implementation
+
+The reference implementation is:
+
+```text
+src/jarvisx/permeation.py
+```
+
+and the conformance tests are:
+
+```text
+tests/test_permeation.py
+```
+
+The detailed mathematical and operational specification is:
+
+```text
+docs/research/DR_MOAGI_3D_PERMEATION_PROTOCOL.md
+```
+
+## Consequences
+
+### Positive
+
+- the locked-sphere metaphor gains an exact PDE interpretation;
+- the static limit is deterministic and closed-form;
+- arbitrary mathematical radius can be queried without allocating an infinite lattice;
+- harmonic excitation has a precise frequency-domain continuation;
+- perturbation recovery becomes measurable instead of being described as perfect instantaneous
+  self-healing;
+- the protocol remains compatible with ADR-002's separation between research geometry and
+  authoritative deterministic compute.
+
+### Negative
+
+- homogeneous saturation is not literal: the field amplitude varies as `1/r`;
+- the field is not gradient-free outside the core;
+- the shell boundary contains a distributional source and therefore is not classically harmonic at
+  `r=a`;
+- frequency-domain Helmholtz evaluation does not supply a causal time-domain propagation model;
+- finite truncation and floating-point arithmetic introduce approximation.
+
+## Validation
+
+The protocol is ready to advance from Proposed when CI confirms:
+
+- locked-core invariance;
+- exact `1/r` exterior scaling;
+- inverse-square exterior radial derivative;
+- zero classical Laplacian away from the shell;
+- normalized shell-source equivalence;
+- `k=0` Helmholtz/static equivalence;
+- finite tolerance-radius calculation;
+- monotone perturbation relaxation;
+- bounded sampler telemetry;
+- fail-closed validation of invalid numerical configuration.

--- a/docs/research/DR_MOAGI_3D_PERMEATION_PROTOCOL.md
+++ b/docs/research/DR_MOAGI_3D_PERMEATION_PROTOCOL.md
@@ -1,0 +1,471 @@
+# Dr Moagi 3D Permeation Protocol
+
+**Status:** Research contract  
+**Date:** 2026-08-14  
+**Architecture decision:** `docs/adr/0003-dr-moagi-permeation-protocol.md`
+
+## 1. Purpose
+
+The Permeation Protocol formalizes the outward extension of a locked spherical Dr Moagi state.
+The core does not translate, expand, or mutate. Instead, its boundary value defines an analytic
+scalar field outside the core.
+
+The protocol is deliberately split into two layers:
+
+```text
+symbolic semantics:
+    locked identity has global mathematical support
+
+operational semantics:
+    evaluate or sample a bounded analytic field on finite resources
+```
+
+The distinction is mandatory. Infinite support does not mean infinite memory, zero latency,
+instantaneous physical influence, or perfect robustness.
+
+## 2. Locked core
+
+Let the locked core be the sphere
+
+```text
+S_a^2 = { r in R^3 : ||r|| = a }
+```
+
+with
+
+```text
+a > 0
+Phi(a) = Phi_0
+Phi_0 != 0
+```
+
+The core extension used by the reference runtime is constant:
+
+```text
+Phi(r) = Phi_0,      0 <= r <= a
+```
+
+This is an operational representation of the immutable core. The exterior field is solved
+separately.
+
+## 3. Static permeation field
+
+The canonical exterior boundary-value problem is
+
+```text
+Laplacian(Phi) = 0,         r > a
+Phi(a) = Phi_0
+Phi(r) -> 0,                r -> infinity
+```
+
+Under spherical symmetry,
+
+```text
+Laplacian(Phi)
+= (1/r^2) d/dr (r^2 dPhi/dr)
+```
+
+and therefore
+
+```text
+r^2 dPhi/dr = C_1
+Phi(r) = C_2 - C_1/r
+```
+
+The decay condition removes the constant exterior term, and the boundary condition fixes the
+coefficient:
+
+```text
+Phi_perm(r) = Phi_0 * a/r,  r > a
+```
+
+For the canonical unit sphere and unit boundary value,
+
+```text
+a = 1
+Phi_0 = 1
+
+Phi_perm(r) = 1/r,          r > 1
+```
+
+This is the exact operational meaning of non-decaying support: the value is nonzero at every finite
+radius but tends asymptotically to zero.
+
+## 4. Green-function and shell-source normalization
+
+The three-dimensional point-source Green function for the Poisson sign convention
+
+```text
+-Laplacian(G) = delta^3(r-r0)
+```
+
+is
+
+```text
+G(r,r0) = 1 / (4*pi*|r-r0|)
+```
+
+A spherical shell is not one point source. A normalized shell source is
+
+```text
+rho_shell(r) = Q * delta(r-a) / (4*pi*a^2)
+```
+
+whose total integrated source is `Q`.
+
+For
+
+```text
+-Laplacian(Phi) = rho_shell
+```
+
+spherical symmetry gives
+
+```text
+Phi(r) = Q / (4*pi*a),      0 <= r <= a
+Phi(r) = Q / (4*pi*r),      r >= a
+```
+
+or compactly
+
+```text
+Phi(r) = Q / (4*pi*max(r,a))
+```
+
+Choosing
+
+```text
+Q = 4*pi*a*Phi_0
+```
+
+produces
+
+```text
+Phi(r) = Phi_0,             r <= a
+Phi(r) = Phi_0*a/r,         r >= a
+```
+
+which exactly matches the locked-boundary formulation.
+
+The unnormalized expression `delta(r-a)` has total three-dimensional integral `4*pi*a^2`; code and
+documentation therefore use the normalized shell convention when source strength matters.
+
+## 5. Gradient and curvature
+
+The exterior radial derivative is
+
+```text
+dPhi/dr = -Phi_0*a/r^2,     r > a
+```
+
+and the vector gradient is
+
+```text
+grad(Phi)
+= -(Phi_0*a/r^3) * r_vector
+```
+
+Therefore the exterior field is not gradient-free.
+
+If the background metric is fixed to
+
+```text
+g_ij = delta_ij
+```
+
+then the Euclidean Riemann and Ricci curvature tensors vanish:
+
+```text
+R^i_jkl = 0
+R_ij    = 0
+R       = 0
+```
+
+That geometric flatness does not eliminate the scalar-potential gradient. Metric curvature and
+scalar-field variation are separate quantities in this research model.
+
+## 6. The shell boundary
+
+The interior and exterior classical Laplacians are both zero:
+
+```text
+Laplacian(Phi) = 0,         r < a
+Laplacian(Phi) = 0,         r > a
+```
+
+but the normal derivative jumps at `r=a`. The shell source is therefore distributional. The
+reference implementation rejects requests for a finite classical gradient or Laplacian exactly on
+the shell boundary.
+
+## 7. Harmonic excitation
+
+For a frequency-domain Helmholtz continuation,
+
+```text
+(Laplacian + k^2) Phi_k = 0,       r > a
+Phi_k(a) = Phi_0
+```
+
+the outgoing spherically symmetric exterior solution is
+
+```text
+Phi_k(r)
+= Phi_0 * a/r * exp(i*k*(r-a)),    r > a
+```
+
+with
+
+```text
+|Phi_k(r)| = |Phi_0| * a/r
+```
+
+and
+
+```text
+Phi_0(r) = Phi_perm(r)
+```
+
+at `k=0`.
+
+This is a phasor/frequency-domain model. It does not define a physical time-of-flight. A causal
+time-domain model would require, for example,
+
+```text
+(1/c^2) partial^2 Phi/partial t^2 - Laplacian(Phi) = source
+```
+
+plus a specified propagation speed `c`, material parameters, initial data, boundary data and a
+numerical integration scheme.
+
+## 8. Finite operational domain
+
+No runtime structure attempts to instantiate all of `R^3`.
+
+The reference configuration defines
+
+```text
+core_radius = a
+max_radius
+samples
+```
+
+and samples only
+
+```text
+0 <= r <= max_radius
+```
+
+The analytic field remains defined beyond that range.
+
+For a requested truncation tolerance
+
+```text
+epsilon > 0
+```
+
+the static amplitude obeys
+
+```text
+|Phi(r)| = |Phi_0|*a/r
+```
+
+so a practical radius satisfying
+
+```text
+|Phi(r)| <= epsilon
+```
+
+is
+
+```text
+r_epsilon = a*|Phi_0|/epsilon
+```
+
+when `epsilon < |Phi_0|`.
+
+This provides a deterministic bridge between the symbolic phrase "extends to infinity" and a finite
+engineering budget.
+
+## 9. Holographic/local decoding interpretation
+
+A sampled value carries a radially scaled signature of the boundary value:
+
+```text
+Phi_0 = Phi(r) * r/a,       r > a
+```
+
+when `a` and the field model are known.
+
+This is a scalar inversion identity, not a claim that one scalar sample contains every degree of
+freedom of an arbitrary high-dimensional engine state. Any richer holographic encoding must define
+the encoded state, channel capacity, noise model and inverse operator explicitly.
+
+## 10. Perturbation recovery
+
+The phrase "self-healing" is operationalized as projection or relaxation toward the analytic target.
+
+For a perturbed scalar sample `u_n(r)`:
+
+```text
+u_(n+1)(r)
+= u_n(r) + gamma * (Phi_target(r) - u_n(r))
+```
+
+with
+
+```text
+0 < gamma <= 1
+```
+
+Define error
+
+```text
+e_n(r) = u_n(r) - Phi_target(r)
+```
+
+Then
+
+```text
+e_(n+1)(r) = (1-gamma) * e_n(r)
+```
+
+and therefore
+
+```text
+e_n(r) = (1-gamma)^n * e_0(r)
+```
+
+for constant `gamma`.
+
+- `gamma = 1` is exact analytic projection in one software step.
+- `0 < gamma < 1` is bounded geometric relaxation.
+- Neither case is a physical counter-wave unless a time-domain wave model is separately defined.
+
+## 11. Reference API
+
+The implementation lives at
+
+```text
+src/jarvisx/permeation.py
+```
+
+Primary types:
+
+```text
+PermeationConfig
+PermeationField
+PermeationSample
+PermeationMetrics
+```
+
+Primary operations:
+
+```text
+potential_at_radius(r)
+potential((x,y,z))
+helmholtz_at_radius(r,k)
+exterior_radial_derivative(r)
+gradient((x,y,z))
+radial_laplacian(r)
+threshold_radius(epsilon)
+relax_value(r,current,gain)
+sample_profile()
+metrics()
+normalized_shell_charge(a,Phi_0)
+```
+
+## 12. Runtime invariants
+
+```text
+INV-PERM-001  core_radius > 0
+INV-PERM-002  core_value != 0
+INV-PERM-003  max_radius >= core_radius
+INV-PERM-004  samples >= 2
+INV-PERM-005  Phi(r<=a) == Phi_0
+INV-PERM-006  Phi(r>a) == Phi_0*a/r
+INV-PERM-007  dPhi/dr == -Phi_0*a/r^2 for r>a
+INV-PERM-008  classical Laplacian == 0 away from r=a
+INV-PERM-009  shell boundary is treated distributionally
+INV-PERM-010  k=0 Helmholtz continuation == static permeation
+INV-PERM-011  no infinite lattice allocation
+INV-PERM-012  perturbation recovery is explicit projection/relaxation
+INV-PERM-013  static evaluation is not reported as causal propagation
+INV-PERM-014  research field cannot silently become VM-authoritative state
+```
+
+## 13. Telemetry
+
+The finite sampler emits:
+
+```text
+core_radius
+max_radius
+core_value
+outer_value
+outer_to_core_ratio
+sampled_points
+```
+
+A higher-level adapter may additionally emit:
+
+```text
+epsilon_cutoff_radius
+max_projection_error
+mean_projection_error
+relaxation_gain
+relaxation_steps
+wavenumber
+sample_wall_time
+allocated_bytes
+```
+
+Measured quantities must remain distinct from analytic properties.
+
+## 14. Integration with the Dr Moagi runtime
+
+The Permeation Protocol is an outward research operator complementary to ADR-002's inward codec
+recursion:
+
+```text
+                     locked state Xi*
+                           |
+                +----------+----------+
+                |                     |
+          inward operator        outward operator
+          I^3D / latent R        P_perm
+                |                     |
+          bounded recursion       Phi_0*a/r
+                |                     |
+          codec/verification      finite sampling
+                +----------+----------+
+                           |
+                       Pi_Lambda
+```
+
+The two operators may share a locked anchor but do not acquire authority merely by visualization or
+analytic evaluation.
+
+## 15. Canonical status language
+
+Permitted status:
+
+```text
+LOCKED CORE
+ANALYTICALLY PERMEATING
+FINITE DOMAIN SAMPLED
+HARMONIC EXCITATION READY
+```
+
+Disallowed without a separately validated physical model:
+
+```text
+instantaneous action at a distance
+perfect noise resistance
+zero entropy of all external space
+infinite memory allocation
+100% physical coverage of R^3
+all-space computation with zero cost
+```
+
+The research meaning remains strong: the core defines a globally supported mathematical field while
+the implementation stays bounded, measurable and falsifiable.

--- a/src/jarvisx/permeation.py
+++ b/src/jarvisx/permeation.py
@@ -1,0 +1,274 @@
+"""Bounded radial permeation operator for the Dr Moagi research layer.
+
+The implementation treats permeation as a static boundary-value problem, not as
+instantaneous physical propagation.  A locked spherical core of radius ``a``
+and boundary value ``phi0`` induces the unique spherically symmetric harmonic
+exterior
+
+    Phi(r) = phi0 * a / r,  r > a,
+
+with Phi(a)=phi0 and Phi(r)->0 as r->infinity.
+
+For non-zero wavenumber ``k`` the optional harmonic excitation uses the outgoing
+radial Helmholtz continuation
+
+    Phi_k(r) = phi0 * a/r * exp(i*k*(r-a)),  r > a.
+
+Only a finite domain is ever sampled by this module.  Infinite support is a
+mathematical property of the analytic field, not a claim of infinite
+allocation, zero latency, or non-causal execution.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+
+Point3D = tuple[float, float, float]
+
+
+@dataclass(frozen=True)
+class PermeationConfig:
+    """Numerical contract for a locked spherical core and finite sampler."""
+
+    core_radius: float = 1.0
+    core_value: float = 1.0
+    max_radius: float = 64.0
+    samples: int = 257
+
+    def __post_init__(self) -> None:
+        for name in ("core_radius", "core_value", "max_radius"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.core_radius <= 0.0:
+            raise ValueError("core_radius must be positive")
+        if self.core_value == 0.0:
+            raise ValueError("core_value must be non-zero")
+        if self.max_radius < self.core_radius:
+            raise ValueError("max_radius must be at least core_radius")
+        if isinstance(self.samples, bool) or not isinstance(self.samples, int):
+            raise TypeError("samples must be an integer")
+        if self.samples < 2:
+            raise ValueError("samples must be at least 2")
+
+
+@dataclass(frozen=True)
+class PermeationSample:
+    radius: float
+    potential: float
+    radial_derivative: float | None
+
+
+@dataclass(frozen=True)
+class PermeationMetrics:
+    core_radius: float
+    max_radius: float
+    core_value: float
+    outer_value: float
+    outer_to_core_ratio: float
+    sampled_points: int
+
+
+class PermeationField:
+    """Analytic locked-core field with bounded sampling and relaxation helpers."""
+
+    def __init__(self, config: PermeationConfig | None = None) -> None:
+        self.config = config or PermeationConfig()
+
+    def potential_at_radius(self, radius: float) -> float:
+        """Return the static locked-core potential.
+
+        The core is held exactly at ``core_value``.  Outside the core the field
+        is the harmonic 1/r continuation.
+        """
+
+        r = self._radius(radius)
+        a = self.config.core_radius
+        if r <= a:
+            return float(self.config.core_value)
+        return float(self.config.core_value * a / r)
+
+    def potential(self, point: Point3D) -> float:
+        return self.potential_at_radius(self._point_radius(point))
+
+    def helmholtz_at_radius(self, radius: float, wavenumber: float) -> complex:
+        """Return the outgoing spherical Helmholtz continuation.
+
+        ``k=0`` reduces exactly to the static field.  This is a frequency-domain
+        solution; it does not model time-of-flight or causal propagation.
+        """
+
+        r = self._radius(radius)
+        k = self._finite(wavenumber, "wavenumber")
+        if k < 0.0:
+            raise ValueError("wavenumber must be non-negative")
+
+        a = self.config.core_radius
+        phi0 = self.config.core_value
+        if r <= a:
+            return complex(phi0, 0.0)
+        return complex(phi0 * a / r, 0.0) * cmath.exp(1j * k * (r - a))
+
+    def exterior_radial_derivative(self, radius: float) -> float:
+        """Return dPhi/dr for ``r > core_radius``."""
+
+        r = self._radius(radius)
+        a = self.config.core_radius
+        if r <= a:
+            raise ValueError("exterior derivative is defined only for r > core_radius")
+        return float(-self.config.core_value * a / (r * r))
+
+    def gradient(self, point: Point3D) -> Point3D:
+        """Return the classical gradient away from the spherical boundary.
+
+        Inside the locked core the classical gradient is zero.  Exactly on the
+        boundary the derivative jumps and the distributional shell source must
+        be used instead, so this method rejects that point.
+        """
+
+        x, y, z = self._point(point)
+        r = math.sqrt(x * x + y * y + z * z)
+        a = self.config.core_radius
+        if math.isclose(r, a, rel_tol=0.0, abs_tol=1e-15):
+            raise ValueError("gradient is discontinuous at the shell boundary")
+        if r < a or r == 0.0:
+            return (0.0, 0.0, 0.0)
+
+        radial = self.exterior_radial_derivative(r)
+        scale = radial / r
+        return (scale * x, scale * y, scale * z)
+
+    def radial_laplacian(self, radius: float) -> float:
+        """Return the classical radial Laplacian away from the shell.
+
+        The 1/r exterior and constant interior are harmonic.  At the shell the
+        source is distributional rather than a finite classical value.
+        """
+
+        r = self._radius(radius)
+        a = self.config.core_radius
+        if math.isclose(r, a, rel_tol=0.0, abs_tol=1e-15):
+            raise ValueError("Laplacian contains a distributional shell source at r=a")
+        return 0.0
+
+    def threshold_radius(self, epsilon: float) -> float:
+        """Radius beyond which ``|Phi(r)| <= epsilon``.
+
+        This converts infinite mathematical support into a practical finite
+        truncation radius for a requested amplitude threshold.
+        """
+
+        eps = self._finite(epsilon, "epsilon")
+        if eps <= 0.0:
+            raise ValueError("epsilon must be positive")
+
+        a = self.config.core_radius
+        magnitude = abs(self.config.core_value)
+        if eps >= magnitude:
+            return a
+        return float(a * magnitude / eps)
+
+    def relax_value(self, radius: float, current: float, gain: float = 1.0) -> float:
+        """Move one scalar sample toward the analytic target.
+
+        ``gain=1`` is an exact projection.  ``0 < gain < 1`` is bounded
+        relaxation with geometric error reduction, which operationalizes the
+        self-healing metaphor without claiming an instantaneous counter-wave.
+        """
+
+        value = self._finite(current, "current")
+        g = self._finite(gain, "gain")
+        if g <= 0.0 or g > 1.0:
+            raise ValueError("gain must satisfy 0 < gain <= 1")
+        target = self.potential_at_radius(radius)
+        return float(value + g * (target - value))
+
+    def sample_profile(self) -> tuple[PermeationSample, ...]:
+        """Sample the finite configured domain, including the origin and outer edge."""
+
+        count = self.config.samples
+        stop = self.config.max_radius
+        step = stop / (count - 1)
+        result: list[PermeationSample] = []
+        for index in range(count):
+            r = step * index
+            derivative: float | None
+            if r > self.config.core_radius:
+                derivative = self.exterior_radial_derivative(r)
+            elif math.isclose(
+                r, self.config.core_radius, rel_tol=0.0, abs_tol=max(1e-15, step * 1e-12)
+            ):
+                derivative = None
+            else:
+                derivative = 0.0
+            result.append(
+                PermeationSample(
+                    radius=r,
+                    potential=self.potential_at_radius(r),
+                    radial_derivative=derivative,
+                )
+            )
+        return tuple(result)
+
+    def metrics(self) -> PermeationMetrics:
+        outer = self.potential_at_radius(self.config.max_radius)
+        return PermeationMetrics(
+            core_radius=self.config.core_radius,
+            max_radius=self.config.max_radius,
+            core_value=self.config.core_value,
+            outer_value=outer,
+            outer_to_core_ratio=abs(outer / self.config.core_value),
+            sampled_points=self.config.samples,
+        )
+
+    @staticmethod
+    def normalized_shell_charge(core_radius: float, core_value: float) -> float:
+        """Return Q for ``-Laplacian Phi = Q delta(r-a)/(4*pi*a^2)``.
+
+        With this normalization the static shell solution is
+
+            Phi(r) = Q / (4*pi*max(r, a)),
+
+        and choosing Q = 4*pi*a*phi0 reproduces the locked-boundary field.
+        """
+
+        a = PermeationField._finite(core_radius, "core_radius")
+        phi0 = PermeationField._finite(core_value, "core_value")
+        if a <= 0.0:
+            raise ValueError("core_radius must be positive")
+        return float(4.0 * math.pi * a * phi0)
+
+    @staticmethod
+    def _finite(value: float, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} must be numeric")
+        result = float(value)
+        if not math.isfinite(result):
+            raise ValueError(f"{name} must be finite")
+        return result
+
+    @classmethod
+    def _radius(cls, radius: float) -> float:
+        r = cls._finite(radius, "radius")
+        if r < 0.0:
+            raise ValueError("radius must be non-negative")
+        return r
+
+    @classmethod
+    def _point(cls, point: Point3D) -> Point3D:
+        if len(point) != 3:
+            raise ValueError("point must contain exactly three coordinates")
+        x = cls._finite(point[0], "point coordinate")
+        y = cls._finite(point[1], "point coordinate")
+        z = cls._finite(point[2], "point coordinate")
+        return (x, y, z)
+
+    @classmethod
+    def _point_radius(cls, point: Point3D) -> float:
+        x, y, z = cls._point(point)
+        return math.sqrt(x * x + y * y + z * z)

--- a/tests/test_permeation.py
+++ b/tests/test_permeation.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.permeation import PermeationConfig, PermeationField
+
+
+def field(**overrides: object) -> PermeationField:
+    return PermeationField(PermeationConfig(**overrides))
+
+
+def test_locked_core_and_exterior_one_over_r() -> None:
+    runtime = field()
+
+    assert runtime.potential_at_radius(0.0) == 1.0
+    assert runtime.potential_at_radius(0.5) == 1.0
+    assert runtime.potential_at_radius(1.0) == 1.0
+    assert runtime.potential_at_radius(2.0) == pytest.approx(0.5)
+    assert runtime.potential_at_radius(4.0) == pytest.approx(0.25)
+
+
+def test_point_evaluation_is_radially_symmetric() -> None:
+    runtime = field()
+
+    assert runtime.potential((2.0, 0.0, 0.0)) == pytest.approx(0.5)
+    assert runtime.potential((0.0, -2.0, 0.0)) == pytest.approx(0.5)
+    assert runtime.potential((0.0, 0.0, 2.0)) == pytest.approx(0.5)
+
+
+def test_exterior_gradient_is_nonzero_and_inverse_square() -> None:
+    runtime = field()
+
+    assert runtime.exterior_radial_derivative(2.0) == pytest.approx(-0.25)
+    assert runtime.gradient((2.0, 0.0, 0.0)) == pytest.approx((-0.25, 0.0, 0.0))
+    assert runtime.gradient((0.5, 0.0, 0.0)) == (0.0, 0.0, 0.0)
+
+
+def test_shell_boundary_uses_distributional_source() -> None:
+    runtime = field()
+
+    with pytest.raises(ValueError, match="discontinuous"):
+        runtime.gradient((1.0, 0.0, 0.0))
+    with pytest.raises(ValueError, match="distributional"):
+        runtime.radial_laplacian(1.0)
+
+    assert runtime.radial_laplacian(0.5) == 0.0
+    assert runtime.radial_laplacian(2.0) == 0.0
+
+
+def test_normalized_shell_charge_matches_boundary_value() -> None:
+    charge = PermeationField.normalized_shell_charge(1.0, 1.0)
+
+    assert charge == pytest.approx(4.0 * math.pi)
+    assert charge / (4.0 * math.pi * 2.0) == pytest.approx(0.5)
+
+
+def test_helmholtz_excitation_reduces_to_static_at_zero_wavenumber() -> None:
+    runtime = field()
+
+    assert runtime.helmholtz_at_radius(3.0, 0.0) == complex(1.0 / 3.0, 0.0)
+
+    excited = runtime.helmholtz_at_radius(3.0, 2.0)
+    assert abs(excited) == pytest.approx(1.0 / 3.0)
+    assert runtime.helmholtz_at_radius(1.0, 2.0) == complex(1.0, 0.0)
+
+
+def test_threshold_radius_converts_infinite_support_to_finite_tolerance() -> None:
+    runtime = field()
+
+    assert runtime.threshold_radius(0.5) == pytest.approx(2.0)
+    assert runtime.threshold_radius(0.01) == pytest.approx(100.0)
+    assert runtime.threshold_radius(2.0) == pytest.approx(1.0)
+
+
+def test_relaxation_projects_perturbation_toward_target() -> None:
+    runtime = field()
+    target = runtime.potential_at_radius(2.0)
+
+    first = runtime.relax_value(2.0, current=0.0, gain=0.5)
+    second = runtime.relax_value(2.0, current=first, gain=0.5)
+
+    assert target == pytest.approx(0.5)
+    assert first == pytest.approx(0.25)
+    assert second == pytest.approx(0.375)
+    assert abs(target - second) < abs(target - first)
+
+
+def test_finite_sampling_and_metrics_are_bounded() -> None:
+    runtime = field(max_radius=8.0, samples=9)
+
+    profile = runtime.sample_profile()
+    metrics = runtime.metrics()
+
+    assert len(profile) == 9
+    assert profile[0].radius == 0.0
+    assert profile[-1].radius == 8.0
+    assert profile[-1].potential == pytest.approx(0.125)
+    assert metrics.outer_value == pytest.approx(0.125)
+    assert metrics.outer_to_core_ratio == pytest.approx(0.125)
+    assert metrics.sampled_points == 9
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"core_radius": 0.0}, "core_radius"),
+        ({"core_value": 0.0}, "core_value"),
+        ({"max_radius": 0.5}, "max_radius"),
+        ({"samples": 1}, "samples"),
+    ],
+)
+def test_invalid_configuration_fails_closed(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        PermeationConfig(**kwargs)
+
+
+def test_invalid_relaxation_gain_fails_closed() -> None:
+    runtime = field()
+
+    with pytest.raises(ValueError, match="gain"):
+        runtime.relax_value(2.0, current=0.0, gain=0.0)
+    with pytest.raises(ValueError, match="gain"):
+        runtime.relax_value(2.0, current=0.0, gain=1.1)


### PR DESCRIPTION
## What changed

- adds ADR-003 for the Dr Moagi 3D Permeation Protocol;
- adds the canonical research specification for the locked-core outward field;
- adds `jarvisx.permeation`, a bounded analytic `1/r` permeation operator with optional Helmholtz excitation;
- adds conformance tests for core invariance, shell normalization, gradient/Laplacian behavior, harmonic excitation, finite truncation and perturbation relaxation.

## Why

The protocol needed an executable interpretation that preserves the symbolic idea of a locked sphere with globally supported mathematical influence while keeping the implementation finite, measurable and compatible with the existing deterministic-core boundary.

The change also resolves two mathematical inconsistencies in the narrative form: a spherical shell is not the same source as a single 3D point Green function, and a `1/r` field has a nonzero inverse-square gradient even when the background Euclidean metric has zero Ricci curvature.

## Operational contract

Static exterior:

```text
Laplacian(Phi) = 0, r > a
Phi(a) = Phi_0
Phi(r) -> 0
Phi(r) = Phi_0*a/r
```

Normalized shell source:

```text
-Laplacian(Phi) = Q*delta(r-a)/(4*pi*a^2)
Q = 4*pi*a*Phi_0
```

Optional frequency-domain excitation:

```text
Phi_k(r) = Phi_0*a/r*exp(i*k*(r-a))
```

## Validation

An isolated local run of the new conformance file passed 14/14 tests. Repository CI should provide the authoritative integration result.

## Scope boundary

This PR treats permeation as a research-layer static/frequency-domain field model. It does not claim infinite allocation, non-causal physical propagation, zero entropy, or perfect noise immunity.