### PR TITLE
Permeate bounded kinetic system loop across Jarvis-X

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-kinetic-loop
+    src/kinetic_system_main.cpp
+)
+jarvisx_include_runtime(jarvisx-kinetic-loop)
+jarvisx_harden(jarvisx-kinetic-loop)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -109,6 +115,15 @@ add_test(
 )
 set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME kinetic-runtime-smoke
+    COMMAND jarvisx-kinetic-loop
+        --cycles 4
+        --nodes 16
+        --quiet
+)
+set_tests_properties(kinetic-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -135,3 +150,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-kinetic-system-tests
+    tests/kinetic_system_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-kinetic-system-tests)
+jarvisx_harden(jarvisx-kinetic-system-tests)
+
+add_test(NAME kinetic-system-regressions COMMAND jarvisx-kinetic-system-tests)
+set_tests_properties(kinetic-system-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/kinetic_system.hpp
+++ b/cpp_runtime/include/jarvisx/kinetic_system.hpp
@@ -1,0 +1,572 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+struct KineticVec3 {
+    float x{};
+    float y{};
+    float z{};
+
+    KineticVec3 operator+(const KineticVec3& other) const noexcept {
+        return {x + other.x, y + other.y, z + other.z};
+    }
+    KineticVec3 operator-(const KineticVec3& other) const noexcept {
+        return {x - other.x, y - other.y, z - other.z};
+    }
+    KineticVec3 operator*(float scalar) const noexcept {
+        return {x * scalar, y * scalar, z * scalar};
+    }
+    KineticVec3& operator+=(const KineticVec3& other) noexcept {
+        x += other.x;
+        y += other.y;
+        z += other.z;
+        return *this;
+    }
+    float norm_sq() const noexcept { return x * x + y * y + z * z; }
+    float norm() const noexcept { return std::sqrt(norm_sq()); }
+    KineticVec3 normalized() const noexcept {
+        const float n = norm();
+        return n > 1.0e-8F ? (*this) * (1.0F / n) : KineticVec3{};
+    }
+};
+
+using KineticNodeId = std::uint64_t;
+
+enum class KineticOperationType : std::uint8_t {
+    Encode,
+    Decode,
+    Physics,
+    AI,
+    Echo,
+    Learn,
+    Swarm,
+    Optimize,
+    Spawn,
+    Prune
+};
+
+enum class KineticScope : std::uint8_t {
+    Direct,
+    Global
+};
+
+struct KineticOperation {
+    KineticOperationType type{KineticOperationType::Encode};
+    KineticScope scope{KineticScope::Global};
+    KineticNodeId target{};
+    float strength{1.0F};
+    std::uint16_t ttl{8U};
+};
+
+struct KineticSynapse {
+    KineticNodeId target{};
+    float weight{0.5F};
+    float rest_length{1.0F};
+    float plasticity{0.1F};
+};
+
+struct KineticNode {
+    KineticNodeId id{};
+    KineticVec3 anchor_position{};
+    KineticVec3 position{};
+    KineticVec3 velocity{};
+    KineticVec3 normal{0.0F, 0.0F, 1.0F};
+    float curvature{0.1F};
+    float spectral_weight{1.0F};
+    float activation{0.0F};
+    float potential{0.0F};
+    float threshold{0.5F};
+    float decay{0.99F};
+    float residual_error{0.0F};
+    float fitness{0.5F};
+    float energy{1.0F};
+    std::vector<KineticSynapse> synapses;
+};
+
+struct KineticConfig {
+    float dt{0.016F};
+    float gravity{-9.8F};
+    float velocity_damping{0.98F};
+    float echo_damping{0.5F};
+    float echo_epsilon{1.0e-4F};
+    float learning_rate{0.01F};
+    float max_speed{50.0F};
+    float max_displacement{1.0F};
+    float max_abs_position{1.0e4F};
+    std::size_t max_nodes{200000U};
+    std::size_t max_events_per_step{100000U};
+
+    void validate() const {
+        if (!std::isfinite(dt) || dt <= 0.0F || dt > 1.0F) {
+            throw std::invalid_argument("kinetic dt must be in (0, 1]");
+        }
+        if (!std::isfinite(velocity_damping) || velocity_damping < 0.0F ||
+            velocity_damping > 1.0F) {
+            throw std::invalid_argument("velocity damping must be in [0, 1]");
+        }
+        if (!std::isfinite(echo_damping) || echo_damping < 0.0F ||
+            echo_damping > 1.0F) {
+            throw std::invalid_argument("echo damping must be in [0, 1]");
+        }
+        if (!std::isfinite(max_speed) || max_speed <= 0.0F ||
+            !std::isfinite(max_displacement) || max_displacement <= 0.0F ||
+            !std::isfinite(max_abs_position) || max_abs_position <= 0.0F) {
+            throw std::invalid_argument("kinetic bounds must be finite and positive");
+        }
+        if (max_nodes == 0U || max_events_per_step == 0U) {
+            throw std::invalid_argument("kinetic resource bounds must be non-zero");
+        }
+    }
+};
+
+struct KineticTelemetry {
+    std::uint64_t cycle{};
+    std::size_t nodes_before{};
+    std::size_t nodes_after{};
+    std::size_t operations_consumed{};
+    std::size_t propagated_events{};
+    std::size_t spawned_nodes{};
+    std::size_t pruned_synapses{};
+    float mean_activation{};
+    float mean_residual{};
+    float max_speed{};
+    float max_displacement{};
+    bool committed{};
+    const char* rejection_reason{""};
+};
+
+class KineticSystemLoop {
+public:
+    explicit KineticSystemLoop(KineticConfig config = {}) : config_(config) {
+        config_.validate();
+    }
+
+    KineticNodeId add_node(KineticNode node) {
+        if (nodes_.size() >= config_.max_nodes) {
+            throw std::runtime_error("kinetic node budget exceeded");
+        }
+        node.id = next_id_++;
+        node.anchor_position = node.position;
+        sanitize_node(node);
+        if (std::fabs(node.position.x) > config_.max_abs_position ||
+            std::fabs(node.position.y) > config_.max_abs_position ||
+            std::fabs(node.position.z) > config_.max_abs_position) {
+            throw std::invalid_argument("kinetic node outside position bounds");
+        }
+        nodes_.push_back(std::move(node));
+        rebuild_index();
+        return nodes_.back().id;
+    }
+
+    void connect(KineticNodeId source, KineticNodeId target, float weight,
+                 float rest_length = 1.0F, float plasticity = 0.1F) {
+        auto& node = nodes_.at(index_of(source));
+        (void)index_of(target);
+        if (!std::isfinite(weight) || !std::isfinite(rest_length) ||
+            rest_length < 0.0F || !std::isfinite(plasticity) || plasticity < 0.0F) {
+            throw std::invalid_argument("invalid kinetic synapse");
+        }
+        node.synapses.push_back({target, clamp(weight, -1.0F, 1.0F),
+                                 rest_length, clamp(plasticity, 0.0F, 1.0F)});
+    }
+
+    void enqueue(KineticOperation operation) {
+        if (!std::isfinite(operation.strength)) {
+            throw std::invalid_argument("operation strength must be finite");
+        }
+        if (operation.type == KineticOperationType::Spawn &&
+            operation.scope != KineticScope::Direct) {
+            throw std::invalid_argument("spawn requires direct scope");
+        }
+        if (operation.scope == KineticScope::Direct) {
+            (void)index_of(operation.target);
+        }
+        pending_.push_back(operation);
+    }
+
+    const std::vector<KineticNode>& nodes() const noexcept { return nodes_; }
+    const KineticTelemetry& telemetry() const noexcept { return telemetry_; }
+
+    const KineticNode& node(KineticNodeId id) const { return nodes_.at(index_of(id)); }
+
+    bool step() {
+        telemetry_ = {};
+        telemetry_.cycle = ++cycle_;
+        telemetry_.nodes_before = nodes_.size();
+
+        const std::vector<KineticNode> snapshot = nodes_;
+        const auto snapshot_index = make_index(snapshot);
+        std::vector<KineticNode> candidate = snapshot;
+        std::vector<KineticVec3> forces(candidate.size());
+        std::vector<SpawnRequest> spawn_requests;
+        KineticNodeId next_id_candidate = next_id_;
+
+        std::deque<KineticOperation> work;
+        work.swap(pending_);
+
+        while (!work.empty()) {
+            if (telemetry_.operations_consumed >= config_.max_events_per_step) {
+                return reject("event budget exceeded");
+            }
+            const KineticOperation operation = work.front();
+            work.pop_front();
+            ++telemetry_.operations_consumed;
+
+            if (operation.scope == KineticScope::Global) {
+                for (std::size_t i = 0; i < snapshot.size(); ++i) {
+                    apply_operation(operation, i, snapshot, snapshot_index,
+                                    candidate, forces, work, spawn_requests);
+                    if (telemetry_.operations_consumed + work.size() >
+                        config_.max_events_per_step) {
+                        return reject("propagation budget exceeded");
+                    }
+                }
+            } else {
+                const auto found = snapshot_index.find(operation.target);
+                if (found == snapshot_index.end()) {
+                    return reject("direct target missing from snapshot");
+                }
+                apply_operation(operation, found->second, snapshot, snapshot_index,
+                                candidate, forces, work, spawn_requests);
+            }
+        }
+
+        integrate(snapshot, candidate, forces);
+        if (!validate_candidate(candidate)) {
+            return reject("candidate projection failed");
+        }
+
+        for (const SpawnRequest& request : spawn_requests) {
+            if (candidate.size() >= config_.max_nodes) {
+                return reject("spawn would exceed node budget");
+            }
+            const auto candidate_index = make_index(candidate);
+            const auto found = candidate_index.find(request.parent);
+            if (found == candidate_index.end()) {
+                return reject("spawn parent missing");
+            }
+            const KineticNode parent = candidate[found->second];
+            for (std::size_t ordinal = 0; ordinal < request.count; ++ordinal) {
+                if (candidate.size() >= config_.max_nodes) {
+                    return reject("spawn would exceed node budget");
+                }
+                KineticNode child = parent;
+                child.id = next_id_candidate++;
+                const float sign = (ordinal % 2U == 0U) ? 1.0F : -1.0F;
+                const float scale = 0.05F * static_cast<float>(1U + ordinal);
+                child.position += child.normal.normalized() * (sign * scale);
+                child.anchor_position = child.position;
+                child.velocity = {};
+                child.activation = 0.5F;
+                child.potential = 0.0F;
+                child.synapses.clear();
+                candidate.push_back(std::move(child));
+                ++telemetry_.spawned_nodes;
+            }
+        }
+
+        if (!validate_candidate(candidate)) {
+            return reject("post-topology projection failed");
+        }
+
+        nodes_ = std::move(candidate);
+        next_id_ = next_id_candidate;
+        rebuild_index();
+        telemetry_.nodes_after = nodes_.size();
+        finalize_telemetry();
+        telemetry_.committed = true;
+        telemetry_.rejection_reason = "";
+        return true;
+    }
+
+private:
+    struct SpawnRequest {
+        KineticNodeId parent{};
+        std::size_t count{};
+    };
+
+    KineticConfig config_;
+    std::vector<KineticNode> nodes_;
+    std::unordered_map<KineticNodeId, std::size_t> index_;
+    std::deque<KineticOperation> pending_;
+    KineticNodeId next_id_{1U};
+    std::uint64_t cycle_{};
+    KineticTelemetry telemetry_{};
+
+    static float clamp(float value, float low, float high) noexcept {
+        return std::max(low, std::min(value, high));
+    }
+
+    static float sigmoid(float x) noexcept {
+        if (x >= 0.0F) {
+            const float e = std::exp(-x);
+            return 1.0F / (1.0F + e);
+        }
+        const float e = std::exp(x);
+        return e / (1.0F + e);
+    }
+
+    static bool finite_vec(const KineticVec3& v) noexcept {
+        return std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z);
+    }
+
+    static std::unordered_map<KineticNodeId, std::size_t>
+    make_index(const std::vector<KineticNode>& nodes) {
+        std::unordered_map<KineticNodeId, std::size_t> result;
+        result.reserve(nodes.size());
+        for (std::size_t i = 0; i < nodes.size(); ++i) {
+            result.emplace(nodes[i].id, i);
+        }
+        return result;
+    }
+
+    void rebuild_index() { index_ = make_index(nodes_); }
+
+    std::size_t index_of(KineticNodeId id) const {
+        const auto found = index_.find(id);
+        if (found == index_.end()) throw std::out_of_range("unknown kinetic node id");
+        return found->second;
+    }
+
+    static void sanitize_node(KineticNode& node) {
+        if (!finite_vec(node.position) || !finite_vec(node.velocity) ||
+            !finite_vec(node.normal)) {
+            throw std::invalid_argument("non-finite kinetic vector state");
+        }
+        node.normal = node.normal.normalized();
+        if (node.normal.norm_sq() < 1.0e-8F) node.normal = {0.0F, 0.0F, 1.0F};
+        node.curvature = clamp(node.curvature, 0.0F, 10.0F);
+        node.spectral_weight = clamp(node.spectral_weight, 0.01F, 10.0F);
+        node.activation = clamp(node.activation, 0.0F, 1.0F);
+        node.threshold = clamp(node.threshold, 0.01F, 0.99F);
+        node.decay = clamp(node.decay, 0.0F, 1.0F);
+        node.fitness = clamp(node.fitness, 0.0F, 1.0F);
+        node.energy = clamp(node.energy, 0.0F, 1000.0F);
+    }
+
+    void apply_operation(
+        const KineticOperation& operation,
+        std::size_t i,
+        const std::vector<KineticNode>& snapshot,
+        const std::unordered_map<KineticNodeId, std::size_t>& snapshot_index,
+        std::vector<KineticNode>& candidate,
+        std::vector<KineticVec3>& forces,
+        std::deque<KineticOperation>& work,
+        std::vector<SpawnRequest>& spawn_requests) {
+
+        const KineticNode& source = snapshot[i];
+        KineticNode& target = candidate[i];
+        const float strength = operation.strength;
+
+        switch (operation.type) {
+            case KineticOperationType::Encode: {
+                const float latent = std::tanh(
+                    0.50F * source.activation + 0.25F * source.potential +
+                    0.15F * source.curvature + 0.10F * source.spectral_weight);
+                const float decoded = sigmoid(
+                    source.spectral_weight * latent - source.threshold);
+                target.residual_error = source.activation - decoded;
+                target.potential -= strength * target.residual_error * 0.05F;
+                break;
+            }
+            case KineticOperationType::Decode: {
+                forces[i] += source.normal.normalized() *
+                    (strength * source.activation * source.spectral_weight);
+                break;
+            }
+            case KineticOperationType::Physics: {
+                forces[i].y += config_.gravity * strength;
+                for (const KineticSynapse& synapse : source.synapses) {
+                    const auto found = snapshot_index.find(synapse.target);
+                    if (found == snapshot_index.end()) continue;
+                    const KineticVec3 diff = snapshot[found->second].position - source.position;
+                    const float distance = diff.norm();
+                    if (distance <= 1.0e-8F) continue;
+                    const float extension = distance - synapse.rest_length;
+                    forces[i] += diff * ((0.1F * synapse.weight * extension) / distance);
+                }
+                break;
+            }
+            case KineticOperationType::AI: {
+                float prediction = 0.0F;
+                float normalizer = 0.0F;
+                for (const KineticSynapse& synapse : source.synapses) {
+                    const auto found = snapshot_index.find(synapse.target);
+                    if (found == snapshot_index.end()) continue;
+                    prediction += synapse.weight * snapshot[found->second].activation;
+                    normalizer += std::fabs(synapse.weight);
+                }
+                if (normalizer > 1.0e-8F) prediction /= normalizer;
+                const float error = source.activation - prediction;
+                target.potential -= strength * error * 0.05F;
+                target.residual_error = 0.5F * target.residual_error + 0.5F * error;
+                break;
+            }
+            case KineticOperationType::Echo: {
+                target.potential += strength * 0.1F;
+                if (operation.ttl > 0U && std::fabs(strength) >= config_.echo_epsilon) {
+                    for (const KineticSynapse& synapse : source.synapses) {
+                        const float next_strength = strength * synapse.weight *
+                                                    config_.echo_damping;
+                        if (std::fabs(next_strength) < config_.echo_epsilon) continue;
+                        work.push_back({KineticOperationType::Echo,
+                                        KineticScope::Direct,
+                                        synapse.target,
+                                        next_strength,
+                                        static_cast<std::uint16_t>(operation.ttl - 1U)});
+                        ++telemetry_.propagated_events;
+                    }
+                }
+                break;
+            }
+            case KineticOperationType::Learn: {
+                for (KineticSynapse& synapse : target.synapses) {
+                    const auto found = snapshot_index.find(synapse.target);
+                    if (found == snapshot_index.end()) continue;
+                    const float target_activation = snapshot[found->second].activation;
+                    const float dw = config_.learning_rate * strength *
+                        (source.activation * target_activation - 0.01F * synapse.weight);
+                    synapse.weight = clamp(synapse.weight + dw, -1.0F, 1.0F);
+                }
+                break;
+            }
+            case KineticOperationType::Swarm: {
+                KineticVec3 center{};
+                std::size_t count = 0U;
+                for (const KineticSynapse& synapse : source.synapses) {
+                    const auto found = snapshot_index.find(synapse.target);
+                    if (found == snapshot_index.end()) continue;
+                    center += snapshot[found->second].position;
+                    ++count;
+                }
+                if (count > 0U) {
+                    center = center * (1.0F / static_cast<float>(count));
+                    forces[i] += (center - source.position) * (0.05F * strength);
+                }
+                break;
+            }
+            case KineticOperationType::Optimize: {
+                target.threshold = clamp(
+                    source.threshold - config_.learning_rate * strength *
+                    source.residual_error,
+                    0.01F, 0.99F);
+                target.spectral_weight = clamp(
+                    source.spectral_weight - 0.1F * config_.learning_rate * strength *
+                    source.residual_error,
+                    0.01F, 10.0F);
+                break;
+            }
+            case KineticOperationType::Spawn: {
+                if (operation.scope != KineticScope::Direct) {
+                    throw std::invalid_argument("spawn requires direct scope");
+                }
+                const float requested = std::max(0.0F, strength);
+                const std::size_t count = static_cast<std::size_t>(std::floor(requested));
+                if (count > 0U) spawn_requests.push_back({source.id, count});
+                break;
+            }
+            case KineticOperationType::Prune: {
+                const float threshold = std::fabs(strength);
+                const auto before = target.synapses.size();
+                target.synapses.erase(
+                    std::remove_if(target.synapses.begin(), target.synapses.end(),
+                        [threshold](const KineticSynapse& synapse) {
+                            return std::fabs(synapse.weight) < threshold;
+                        }),
+                    target.synapses.end());
+                telemetry_.pruned_synapses += before - target.synapses.size();
+                break;
+            }
+        }
+    }
+
+    void integrate(const std::vector<KineticNode>& snapshot,
+                   std::vector<KineticNode>& candidate,
+                   const std::vector<KineticVec3>& forces) {
+        for (std::size_t i = 0; i < candidate.size(); ++i) {
+            KineticNode& node = candidate[i];
+            const KineticNode& old = snapshot[i];
+            node.potential *= old.decay;
+            node.activation = sigmoid((node.potential - node.threshold) * 2.0F);
+
+            KineticVec3 velocity = (old.velocity + forces[i] * config_.dt) *
+                                   config_.velocity_damping;
+            const float speed = velocity.norm();
+            if (speed > config_.max_speed) {
+                velocity = velocity * (config_.max_speed / speed);
+            }
+            KineticVec3 displacement = velocity * config_.dt;
+            const float displacement_norm = displacement.norm();
+            if (displacement_norm > config_.max_displacement) {
+                displacement = displacement *
+                    (config_.max_displacement / displacement_norm);
+            }
+            node.velocity = velocity;
+            node.position = old.position + displacement;
+            telemetry_.max_speed = std::max(telemetry_.max_speed, velocity.norm());
+            telemetry_.max_displacement = std::max(
+                telemetry_.max_displacement, displacement.norm());
+        }
+    }
+
+    bool validate_candidate(const std::vector<KineticNode>& candidate) const {
+        if (candidate.size() > config_.max_nodes) return false;
+        std::unordered_map<KineticNodeId, bool> ids;
+        ids.reserve(candidate.size());
+        for (const KineticNode& node : candidate) {
+            if (node.id == 0U || !ids.emplace(node.id, true).second) return false;
+        }
+        for (const KineticNode& node : candidate) {
+            if (!finite_vec(node.position) || !finite_vec(node.velocity) ||
+                !finite_vec(node.normal)) return false;
+            if (!std::isfinite(node.activation) || !std::isfinite(node.potential) ||
+                !std::isfinite(node.threshold) || !std::isfinite(node.residual_error) ||
+                !std::isfinite(node.spectral_weight)) return false;
+            if (std::fabs(node.position.x) > config_.max_abs_position ||
+                std::fabs(node.position.y) > config_.max_abs_position ||
+                std::fabs(node.position.z) > config_.max_abs_position) return false;
+            if (node.velocity.norm() > config_.max_speed + 1.0e-4F) return false;
+            for (const KineticSynapse& synapse : node.synapses) {
+                if (!std::isfinite(synapse.weight) || synapse.weight < -1.0F ||
+                    synapse.weight > 1.0F || ids.find(synapse.target) == ids.end()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    bool reject(const char* reason) {
+        telemetry_.nodes_after = nodes_.size();
+        telemetry_.committed = false;
+        telemetry_.rejection_reason = reason;
+        return false;
+    }
+
+    void finalize_telemetry() {
+        if (nodes_.empty()) return;
+        double activation = 0.0;
+        double residual = 0.0;
+        for (const KineticNode& node : nodes_) {
+            activation += node.activation;
+            residual += std::fabs(node.residual_error);
+        }
+        telemetry_.mean_activation = static_cast<float>(
+            activation / static_cast<double>(nodes_.size()));
+        telemetry_.mean_residual = static_cast<float>(
+            residual / static_cast<double>(nodes_.size()));
+    }
+};
+
+}  // namespace jarvisx

--- a/cpp_runtime/src/kinetic_system_main.cpp
+++ b/cpp_runtime/src/kinetic_system_main.cpp
@@ -1,0 +1,113 @@
+#include "jarvisx/kinetic_system.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using namespace jarvisx;
+
+namespace {
+
+std::size_t parse_size(const char* value, const char* name) {
+    try {
+        const auto parsed = std::stoull(value);
+        if (parsed == 0U) throw std::invalid_argument("zero");
+        return static_cast<std::size_t>(parsed);
+    } catch (...) {
+        throw std::invalid_argument(std::string("invalid ") + name);
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    std::size_t cycles = 120U;
+    std::size_t node_count = 64U;
+    bool quiet = false;
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--cycles" && i + 1 < argc) {
+            cycles = parse_size(argv[++i], "cycle count");
+        } else if (arg == "--nodes" && i + 1 < argc) {
+            node_count = parse_size(argv[++i], "node count");
+        } else if (arg == "--quiet") {
+            quiet = true;
+        } else if (arg == "--help") {
+            std::cout << "usage: jarvisx-kinetic-loop [--cycles N] [--nodes N] [--quiet]\n";
+            return 0;
+        } else {
+            std::cerr << "unknown argument: " << arg << "\n";
+            return 2;
+        }
+    }
+
+    KineticConfig config;
+    config.max_nodes = std::max<std::size_t>(node_count * 4U, 128U);
+    KineticSystemLoop runtime(config);
+    std::vector<KineticNodeId> ids;
+    ids.reserve(node_count);
+
+    constexpr float kPi = 3.14159265358979323846F;
+    for (std::size_t i = 0; i < node_count; ++i) {
+        const float phase = 2.0F * kPi * static_cast<float>(i) /
+                            static_cast<float>(node_count);
+        KineticNode node;
+        node.position = {10.0F * std::cos(phase),
+                         2.0F * std::sin(phase * 3.0F),
+                         10.0F * std::sin(phase)};
+        node.normal = node.position.normalized();
+        node.activation = 0.45F + 0.35F * std::sin(phase);
+        node.potential = node.activation;
+        node.threshold = 0.45F;
+        node.curvature = 0.1F + 0.1F * std::fabs(std::cos(phase));
+        ids.push_back(runtime.add_node(node));
+    }
+
+    for (std::size_t i = 0; i < ids.size(); ++i) {
+        const std::size_t next = (i + 1U) % ids.size();
+        const std::size_t prev = (i + ids.size() - 1U) % ids.size();
+        runtime.connect(ids[i], ids[next], 0.55F, 1.0F, 0.1F);
+        runtime.connect(ids[i], ids[prev], 0.55F, 1.0F, 0.1F);
+    }
+
+    for (std::size_t cycle = 0; cycle < cycles; ++cycle) {
+        runtime.enqueue({KineticOperationType::Encode, KineticScope::Global, 0U, 1.0F, 0U});
+        runtime.enqueue({KineticOperationType::AI, KineticScope::Global, 0U, 0.5F, 0U});
+        runtime.enqueue({KineticOperationType::Physics, KineticScope::Global, 0U, 0.02F, 0U});
+        runtime.enqueue({KineticOperationType::Swarm, KineticScope::Global, 0U, 0.2F, 0U});
+        runtime.enqueue({KineticOperationType::Decode, KineticScope::Global, 0U, 0.1F, 0U});
+        runtime.enqueue({KineticOperationType::Learn, KineticScope::Global, 0U, 0.25F, 0U});
+        runtime.enqueue({KineticOperationType::Optimize, KineticScope::Global, 0U, 0.1F, 0U});
+        if (cycle % 20U == 0U) {
+            runtime.enqueue({KineticOperationType::Echo, KineticScope::Direct,
+                             ids.front(), 1.0F, 6U});
+        }
+
+        if (!runtime.step()) {
+            std::cerr << "kinetic transaction rejected at cycle " << cycle
+                      << ": " << runtime.telemetry().rejection_reason << "\n";
+            return 1;
+        }
+
+        if (!quiet && (cycle % 10U == 0U || cycle + 1U == cycles)) {
+            const auto& t = runtime.telemetry();
+            std::cout << "cycle=" << std::setw(4) << t.cycle
+                      << " nodes=" << std::setw(4) << t.nodes_after
+                      << " ops=" << std::setw(5) << t.operations_consumed
+                      << " echo=" << std::setw(4) << t.propagated_events
+                      << " act=" << std::fixed << std::setprecision(4)
+                      << t.mean_activation
+                      << " residual=" << t.mean_residual
+                      << " vmax=" << t.max_speed
+                      << " dxmax=" << t.max_displacement << "\n";
+        }
+    }
+
+    return 0;
+}

--- a/cpp_runtime/tests/kinetic_system_tests.cpp
+++ b/cpp_runtime/tests/kinetic_system_tests.cpp
@@ -1,0 +1,107 @@
+#include "jarvisx/kinetic_system.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <set>
+
+using namespace jarvisx;
+
+static KineticNode make_node(float x, float activation) {
+    KineticNode node;
+    node.position = {x, 0.0F, 0.0F};
+    node.normal = {1.0F, 0.0F, 0.0F};
+    node.activation = activation;
+    node.potential = activation;
+    node.threshold = 0.4F;
+    return node;
+}
+
+int main() {
+    {
+        KineticSystemLoop runtime;
+        const auto a = runtime.add_node(make_node(0.0F, 0.8F));
+        const auto b = runtime.add_node(make_node(2.0F, 0.2F));
+        runtime.connect(a, b, 0.5F, 1.0F);
+        runtime.connect(b, a, 0.5F, 1.0F);
+        runtime.enqueue({KineticOperationType::Physics, KineticScope::Global, 0U, 0.1F, 0U});
+        runtime.enqueue({KineticOperationType::Swarm, KineticScope::Global, 0U, 1.0F, 0U});
+        assert(runtime.step());
+        assert(runtime.telemetry().committed);
+        assert(runtime.nodes().size() == 2U);
+        assert(runtime.node(a).position.x > 0.0F);
+        assert(runtime.node(b).position.x < 2.0F);
+    }
+
+    {
+        KineticConfig config;
+        config.echo_damping = 0.5F;
+        config.echo_epsilon = 1.0e-3F;
+        config.max_events_per_step = 100U;
+        KineticSystemLoop runtime(config);
+        const auto a = runtime.add_node(make_node(0.0F, 0.5F));
+        const auto b = runtime.add_node(make_node(1.0F, 0.5F));
+        runtime.connect(a, b, 0.5F);
+        runtime.connect(b, a, 0.5F);
+        runtime.enqueue({KineticOperationType::Echo, KineticScope::Direct, a, 1.0F, 6U});
+        assert(runtime.step());
+        assert(runtime.telemetry().propagated_events > 0U);
+        assert(runtime.telemetry().operations_consumed <= config.max_events_per_step);
+    }
+
+    {
+        KineticSystemLoop runtime;
+        const auto parent = runtime.add_node(make_node(0.0F, 0.5F));
+        runtime.enqueue({KineticOperationType::Spawn, KineticScope::Direct, parent, 3.0F, 0U});
+        assert(runtime.step());
+        assert(runtime.nodes().size() == 4U);
+        assert(runtime.telemetry().spawned_nodes == 3U);
+        std::set<KineticNodeId> ids;
+        for (const auto& node : runtime.nodes()) ids.insert(node.id);
+        assert(ids.size() == runtime.nodes().size());
+    }
+
+    {
+        KineticSystemLoop runtime;
+        const auto a = runtime.add_node(make_node(0.0F, 0.5F));
+        const auto b = runtime.add_node(make_node(1.0F, 0.5F));
+        runtime.connect(a, b, 0.01F);
+        runtime.connect(a, b, 0.5F);
+        runtime.enqueue({KineticOperationType::Prune, KineticScope::Direct, a, 0.05F, 0U});
+        assert(runtime.step());
+        assert(runtime.node(a).synapses.size() == 1U);
+        assert(runtime.telemetry().pruned_synapses == 1U);
+    }
+
+    {
+        KineticConfig config;
+        config.max_abs_position = 0.5F;
+        KineticSystemLoop runtime(config);
+        auto node = make_node(0.49F, 1.0F);
+        node.spectral_weight = 10.0F;
+        const auto id = runtime.add_node(node);
+        const auto before = runtime.node(id).position.x;
+        runtime.enqueue({KineticOperationType::Decode, KineticScope::Global, 0U, 100.0F, 0U});
+        assert(!runtime.step());
+        assert(!runtime.telemetry().committed);
+        assert(runtime.node(id).position.x == before);
+    }
+
+    {
+        KineticSystemLoop runtime;
+        const auto a = runtime.add_node(make_node(0.0F, 0.8F));
+        const auto b = runtime.add_node(make_node(1.0F, 0.2F));
+        runtime.connect(a, b, 0.7F);
+        const float old_weight = runtime.node(a).synapses.front().weight;
+        runtime.enqueue({KineticOperationType::Encode, KineticScope::Global, 0U, 1.0F, 0U});
+        runtime.enqueue({KineticOperationType::AI, KineticScope::Global, 0U, 1.0F, 0U});
+        runtime.enqueue({KineticOperationType::Learn, KineticScope::Global, 0U, 1.0F, 0U});
+        runtime.enqueue({KineticOperationType::Optimize, KineticScope::Global, 0U, 1.0F, 0U});
+        assert(runtime.step());
+        assert(std::isfinite(runtime.telemetry().mean_residual));
+        assert(runtime.node(a).synapses.front().weight != old_weight);
+    }
+
+    std::cout << "kinetic system regressions passed\n";
+    return 0;
+}

--- a/docs/DR_MOAGI_KINETIC_SYSTEM_LOOP.md
+++ b/docs/DR_MOAGI_KINETIC_SYSTEM_LOOP.md
@@ -1,0 +1,571 @@
+# Dr Moagi Kinetic System Loop
+
+## Status
+
+Canonical bounded kinetic extension for the Jarvis-X Layer 4/5 research runtime, adopted by ADR-006.
+
+This specification turns the unified ANN/swarm/physics/codec loop into a transactional state-transition system. It preserves the authority, sparse-state, anchor, codec, precision and rollback boundaries established by ADR-002 through ADR-005.
+
+---
+
+## 1. Three coupled kinetics
+
+Let the complete runtime be
+
+\[
+\mathcal K_t=(\Xi_t,\Theta_t,G_t,Q_t,\Omega_t),
+\]
+
+where:
+
+- \(\Xi_t\): committed geometric, neural, physical and latent state;
+- \(\Theta_t\): learnable/runtime parameters;
+- \(G_t=(V_t,E_t)\): stable-ID graph topology;
+- \(Q_t\): admitted operation/event stream;
+- \(\Omega_t\): telemetry, anchors, journals and persistent optimization memory.
+
+The conceptual continuous laws are
+
+\[
+\boxed{
+\frac{d\Xi}{dt}
+=
+\mathcal F_{ext}
++\mathcal F_{neural}
++\mathcal F_{physical}
++\mathcal F_{swarm}
++\mathcal F_{decode}
+-\nabla_{\Xi}\mathcal L
+}
+\]
+
+\[
+\boxed{
+\frac{d\Theta}{dt}
+=-\eta\nabla_{\Theta}\mathcal L+\mathcal M_{\Theta}
+}
+\]
+
+and
+
+\[
+\boxed{
+\frac{dG}{dt}
+=\mathcal T_{spawn}-\mathcal T_{prune}
++\mathcal T_{rewire}+\mathcal T_{merge}.
+}
+\]
+
+The runtime never integrates these expressions by mutating committed state in place. They define candidate deltas inside a transaction.
+
+---
+
+## 2. Per-node state
+
+For stable node ID \(i\):
+
+\[
+\xi_i=
+(x_i,v_i,n_i,c_i,s_i,a_i,p_i,\tau_i,e_i,f_i,\varepsilon_i,W_i),
+\]
+
+where:
+
+```text
+x_i           3D position
+v_i           velocity
+n_i           normalized local direction
+c_i           curvature descriptor
+s_i           spectral weight
+a_i           activation
+p_i           potential
+tau_i         activation threshold
+e_i           energy / resource state
+f_i           fitness or utility descriptor
+epsilon_i     reconstruction / prediction residual
+W_i           outgoing stable-ID synapses
+```
+
+Storage position is not identity. `i` remains stable when the physical container is relocated or compacted.
+
+---
+
+## 3. Operational cycle
+
+One cycle is:
+
+```text
+1  acquire admitted operations Q_t
+2  freeze snapshot S_t = (Xi_t, Theta_t, G_t)
+3  resolve DIRECT/GLOBAL targets against stable IDs
+4  compute operation-local forces and parameter deltas
+5  propagate GRAPH events with TTL/amplitude/event-budget bounds
+6  integrate node candidate state from S_t + deltas
+7  stage topology proposals
+8  run Pi_Lambda over state + topology + resource budgets
+9  COMMIT candidate atomically, including ID allocator state
+10 emit telemetry / receipt / rejection reason
+11 repeat from the new committed snapshot
+```
+
+The essential invariant is
+
+\[
+\boxed{
+S_t\;\text{is read-only during steps 3--7.}
+}
+\]
+
+---
+
+## 4. Routing semantics
+
+Operations carry an explicit scope.
+
+### Direct
+
+\[
+R_{direct}(o)=\{\operatorname{id}(o)\}.
+\]
+
+Failure to resolve the stable ID rejects the operation/candidate according to policy.
+
+### Global
+
+\[
+R_{global}(o)=V(S_t).
+\]
+
+A global `PHYSICS`, `AI`, `LEARN` or `RENDER` request is therefore not silently reduced to one best-scoring node.
+
+### Graph
+
+For a propagated event from node \(i\):
+
+\[
+R_{graph}(i)=\{j:(i,j)\in E_t\}.
+\]
+
+The synapse target is authoritative for that hop.
+
+---
+
+## 5. Mechanical kinetics
+
+For unit mass in the reference model,
+
+\[
+F_i
+=F_i^{physical}
++F_i^{spring}
++F_i^{swarm}
++F_i^{decode}
++F_i^{corrective}.
+\]
+
+Velocity and position are integrated as
+
+\[
+\tilde v_{i,t+1}
+=\gamma_v\left(v_{i,t}+\Delta t F_{i,t}\right),
+\]
+
+\[
+v_{i,t+1}=\Pi_{v_{max}}(\tilde v_{i,t+1}),
+\]
+
+\[
+\Delta x_i
+=\Pi_{\Delta x_{max}}(\Delta t\,v_{i,t+1}),
+\]
+
+\[
+x_{i,t+1}=x_{i,t}+\Delta x_i.
+\]
+
+The projection prevents one unstable force from producing an unbounded frame displacement.
+
+A spring edge may use
+
+\[
+F_{ij}^{spring}
+=k_{ij}(\|x_j-x_i\|-L_{ij})\hat r_{ij}.
+\]
+
+A bounded swarm cohesion term is
+
+\[
+F_i^{cohesion}=k_c(\bar x_{\mathcal N(i)}-x_i).
+\]
+
+Production variants may add alignment and separation so long as each contribution remains bounded and transactionally verified.
+
+---
+
+## 6. Neural kinetics
+
+Potential evolves as
+
+\[
+p_{i,t+1}
+=d_i p_{i,t}+I_{i,t}
+\]
+
+and activation as
+
+\[
+a_{i,t+1}
+=\sigma\left(k(p_{i,t+1}-\tau_i)\right).
+\]
+
+A graph inference predictor may be
+
+\[
+\hat a_i
+=\frac{\sum_j w_{ij}a_j}
+{\sum_j|w_{ij}|+\epsilon},
+\]
+
+with prediction residual
+
+\[
+r_i=a_i-\hat a_i.
+\]
+
+The residual may contribute a candidate potential correction and telemetry. It is not permitted to overwrite the immutable run anchor used by the codec/field runtime.
+
+---
+
+## 7. Encode/decode closure
+
+The production volumetric codec relationship remains ADR-003:
+
+\[
+A_\theta=D_\theta\circ E_\theta,
+\qquad
+R_\theta(\Psi)=\Psi-A_\theta(\Psi).
+\]
+
+Kinetic correction may use the same-space residual as a force or parameter signal:
+
+\[
+F^{corrective}
+=K_R\,\mathcal L_{lift}(R_\theta(\Psi)),
+\]
+
+where `L_lift` is an explicitly typed mapping from the field residual into the local kinetic state. No latent tensor may be subtracted directly from incompatible geometry.
+
+The C++ reference `ENCODE` operator implements only a bounded local surrogate so that routing, residual, learning and rollback mechanics can be tested without introducing a second codec implementation. It must not be reported as the canonical 3D encoder.
+
+---
+
+## 8. Echo as bounded wave propagation
+
+For hop \(h\):
+
+\[
+e_j^{h+1}=\gamma_e w_{ij}e_i^h.
+\]
+
+The linearized field is
+
+\[
+\mathbf e_{h+1}=\gamma_e W\mathbf e_h.
+\]
+
+A desirable stability condition is
+
+\[
+\rho(\gamma_eW)<1.
+\]
+
+Runtime safety does not rely on that condition alone. Every event also carries:
+
+```text
+stable target ID
+amplitude
+TTL
+```
+
+and propagation terminates on
+
+```text
+TTL == 0
+or abs(amplitude) < echo_epsilon
+or events_this_step >= max_events_per_step.
+```
+
+Exceeding the hard event budget rejects the candidate rather than allowing queue explosion.
+
+---
+
+## 9. Learning kinetics
+
+A bounded Hebbian candidate update may be
+
+\[
+\Delta w_{ij}
+=\eta a_i a_j-\eta\lambda_w w_{ij}.
+\]
+
+The updated weight is projected into its admissible interval before commit.
+
+True STDP requires explicit spike times:
+
+\[
+\Delta w=
+\begin{cases}
+A_+e^{-\Delta t/\tau_+},&\Delta t>0,\\
+-A_-e^{\Delta t/\tau_-},&\Delta t<0.
+\end{cases}
+\]
+
+An implementation may not label a purely activation-correlated rule as STDP unless relative spike timing is actually represented.
+
+---
+
+## 10. Optimization kinetics
+
+Let the measurable objective be
+
+\[
+\mathcal L_t
+=w_R D_{recon}
++w_A D_{anchor}
++w_L L
++w_M M
++w_E E_{compute}
+-w_U U_{verified}.
+\]
+
+Parameter updates are candidate transformations:
+
+\[
+\Theta'=
+\Pi_{\Theta}
+\left(\Theta-\eta\nabla_{\Theta}\mathcal L\right).
+\]
+
+A heuristic adaptation that does not evaluate a gradient must be reported as such rather than described as gradient descent.
+
+Mechanics-level candidate optimization continues to inherit the shadow/canary/rollback contract of the inward self-optimizing runtime.
+
+---
+
+## 11. Topology kinetics
+
+Topology changes are staged after node-state computation.
+
+### Spawn
+
+```text
+SPAWN(parent_id, count)
+```
+
+means exactly `count` candidate children, subject to `max_nodes`.
+
+For child \(k\):
+
+\[
+x_k=x_{parent}+\delta x_k,
+\qquad
+v_k=0.
+\]
+
+The stable-ID allocator belongs to candidate state. If the transaction fails, the allocator is restored and IDs are not consumed invisibly.
+
+### Prune
+
+A reference threshold operator may remove
+
+\[
+|w_{ij}|<\epsilon_w.
+\]
+
+A production system should prefer measured synaptic flux or utility when available:
+
+\[
+\Phi_{ij}=\operatorname{EMA}(|w_{ij}a_i|).
+\]
+
+### Merge and rewire
+
+Merge/rewire operators must emit explicit topology proposals and stable-ID remapping receipts. They may not compact storage first and repair edges later.
+
+---
+
+## 12. Pi_Lambda kinetic projection
+
+Before commit, the candidate must satisfy at least:
+
+```text
+all scalar/vector values finite
+unique non-zero stable IDs
+all synapse targets resolve
+abs(position_axis) <= max_abs_position
+speed <= max_speed
+displacement_per_step <= max_displacement
+node_count <= max_nodes
+events_processed <= max_events_per_step
+weights inside declared bounds
+codec/model versions coherent where codec operations participate
+policy/authority checks pass
+```
+
+The transaction is
+
+\[
+\Xi_t
+\xrightarrow{propose}
+\widetilde\Xi_{t+1}
+\xrightarrow{\Pi_\Lambda}
+\begin{cases}
+\Xi_{t+1}=\widetilde\Xi_{t+1},&accept,\\
+\Xi_{t+1}=\Xi_t,&reject.
+\end{cases}
+\]
+
+Topology and allocator state are included in \(\widetilde\Xi\).
+
+---
+
+## 13. Concurrency lowering
+
+The deterministic reference is serial. A parallel backend may lower it to:
+
+```text
+immutable snapshot
+  -> shard 0 delta kernel --\
+  -> shard 1 delta kernel ----> deterministic reduction/barrier
+  -> ...                    --/
+  -> topology proposal aggregation
+  -> Pi_Lambda
+  -> atomic commit
+```
+
+Worker-owned mutation is restricted to private deltas/candidate shards. Workers may not perform structural mutation on the committed `std::vector`, adjacency store, sparse map or authoritative queue while other workers retain references.
+
+A GPU backend should therefore use the same broad split:
+
+```text
+CPU / authority plane:
+  routing, budgets, versions, commit, journal
+
+GPU / data plane:
+  force kernels, ANN propagation, codec kernels, spatial reductions
+```
+
+---
+
+## 14. Telemetry
+
+Every kinetic step reports at least:
+
+```text
+cycle
+nodes_before
+nodes_after
+operations_consumed
+propagated_events
+spawned_nodes
+pruned_synapses
+mean_activation
+mean_residual
+max_speed
+max_displacement
+committed
+rejection_reason
+```
+
+Production integrations additionally preserve the codec/field telemetry:
+
+```text
+reconstruction_mse
+anchor_mse
+rate / coded bytes
+model and mechanics versions
+resource usage
+measured latency / throughput
+```
+
+Logical node count, virtual depth and simulated cores are always reported separately from measured resident memory and physical execution throughput.
+
+---
+
+## 15. Reference C++17 implementation
+
+Files:
+
+```text
+cpp_runtime/include/jarvisx/kinetic_system.hpp
+cpp_runtime/src/kinetic_system_main.cpp
+cpp_runtime/tests/kinetic_system_tests.cpp
+```
+
+The reference deliberately optimizes for deterministic semantics and auditability. Its operation set currently exercises:
+
+```text
+ENCODE
+DECODE
+PHYSICS
+AI
+ECHO
+LEARN
+SWARM
+OPTIMIZE
+SPAWN
+PRUNE
+```
+
+`MERGE`, explicit STDP and production `Autoencoder3D` coupling remain later extensions and must preserve the transaction contract when added.
+
+---
+
+## 16. Conformance tests
+
+A conforming implementation demonstrates:
+
+1. physics/swarm forces use one frozen source snapshot;
+2. graph edges use stable IDs;
+3. direct routing reaches the requested stable ID;
+4. global routing visits the full frozen node set;
+5. echo stops under TTL/amplitude/event limits;
+6. spawn count is exact and unique IDs are committed transactionally;
+7. pruning does not invalidate unrelated edges;
+8. an out-of-bounds candidate is rejected with authoritative state unchanged;
+9. parameter learning remains finite and bounded;
+10. the runtime compiles warning-clean under the repository C++17 profile;
+11. a smoke workload completes multiple committed cycles.
+
+---
+
+## 17. Canonical operational interpretation
+
+Jarvis-X is not defined by the statement "everything is a neuron." The stronger abstraction is:
+
+\[
+\boxed{
+\text{everything admitted becomes a bounded operation on a common transactional state substrate.}
+}
+\]
+
+Geometry is state. Neural activity is state. Physics is a state transition. Encoding is contraction into a representation. Decoding is a typed outward reconstruction. Error is a corrective signal. Learning changes the transition parameters. Evolution changes topology. Rendering is a projection unless separately promoted. The commit boundary decides what becomes authoritative.
+
+The resulting loop is
+
+```text
+OBSERVE
+-> ENCODE
+-> ROUTE
+-> PROPAGATE / COMPUTE
+-> INTEGRATE
+-> DECODE
+-> MEASURE RESIDUAL
+-> LEARN / OPTIMIZE
+-> STAGE TOPOLOGY
+-> VERIFY
+-> COMMIT
+-> inward re-entry
+```
+
+and every arrow is bounded by explicit state types, resource ceilings and rollback semantics.

--- a/docs/adr/0006-dr-moagi-kinetic-system-loop.md
+++ b/docs/adr/0006-dr-moagi-kinetic-system-loop.md
@@ -1,0 +1,210 @@
+# ADR-006: Adopt the Dr Moagi kinetic system loop
+
+**Status:** Accepted  
+**Date:** 2026-08-15  
+**Extends:** ADR-002, ADR-003, ADR-004, ADR-005
+
+## Context
+
+Jarvis-X already separates the deterministic authority substrate from adaptive codec, sparse-field, multimodal and precision-verification research layers. The next requirement is to define how geometry, neural activation, physics, swarm propagation, learning and bounded topology changes evolve together without allowing worker threads or adaptive kernels to mutate authoritative state in place.
+
+Earlier swarm prototypes expressed these concerns as mutable per-neuron functions. That model is insufficient for a production runtime because structural mutation can invalidate storage, index-addressed synapses become stale after compaction, graph propagation can be accidentally rerouted by global arbitration, recursive echo can create unbounded event storms, and rejected topology changes can leak hidden state such as identifier allocation.
+
+## Decision
+
+Jarvis-X adopts a three-level kinetic model:
+
+```text
+Xi(t)     state kinetics
+Theta(t)  parameter / learning kinetics
+G(t)      topology kinetics
+```
+
+with the master interpretation
+
+```text
+dXi/dt = F_external
+       + F_neural
+       + F_physical
+       + F_swarm
+       + F_decode
+       - grad_Xi L
+
+dTheta/dt = -eta * grad_Theta L + M_Theta
+dG/dt = T_spawn - T_prune + T_rewire + T_merge
+```
+
+These equations are operational only through a bounded discrete transaction:
+
+```text
+committed state Xi_t
+-> immutable snapshot
+-> route operations
+-> compute local deltas / forces
+-> bounded graph propagation
+-> integrate candidate state
+-> stage topology mutations
+-> Pi_Lambda verification
+-> atomic COMMIT or complete ROLLBACK
+-> Xi_(t+1)
+```
+
+No worker, operation executor, renderer, learner or topology operator may structurally mutate the committed node store during the compute phase.
+
+## Stable identity and routing
+
+Nodes use immutable stable IDs. Synapses reference IDs rather than vector indices or storage addresses.
+
+Routing modes are explicit:
+
+```text
+DIRECT  -> exact stable node ID
+GLOBAL  -> every node in the frozen snapshot
+GRAPH   -> explicit synaptic target IDs during propagation
+```
+
+Graph propagation may not silently fall back to an unrelated global best-neuron selector.
+
+## Kinetic integration
+
+For node `i`, the mechanical state follows
+
+```text
+v_(i,t+1) = clamp_v(gamma_v * (v_i,t + dt * F_i,t))
+x_(i,t+1) = x_i,t + clamp_dx(dt * v_(i,t+1))
+```
+
+where the force may contain bounded physical, decoded, swarm and corrective components.
+
+Neural state follows the same transactional rule:
+
+```text
+p_(i,t+1) = decay_i * p_i,t + I_i,t
+a_(i,t+1) = sigmoid(k * (p_(i,t+1) - threshold_i))
+```
+
+Learning changes parameters only in the candidate copy. Topology changes are staged and applied only after state verification.
+
+## Echo stability and backpressure
+
+Propagated events carry an explicit TTL and amplitude. A propagation terminates when either
+
+```text
+ttl == 0
+```
+
+or
+
+```text
+abs(amplitude) < echo_epsilon.
+```
+
+Each step also has a hard event budget. A candidate exceeding that budget fails closed. For a linearized echo operator the desired stability condition remains
+
+```text
+rho(gamma_echo * W) < 1,
+```
+
+but runtime event bounds remain mandatory even when a spectral estimate is unavailable.
+
+## Codec relationship
+
+ADR-006 does not replace the same-space codec contract of ADR-003. Production kinetic encode/decode operators must bind to the declared codec closure
+
+```text
+A_theta = D_theta o E_theta
+R_theta(Psi) = Psi - A_theta(Psi)
+```
+
+and preserve the immutable anchor and rate/distortion telemetry defined by ADR-002/003.
+
+The C++ kinetic reference uses a deliberately small local encode/decode surrogate to exercise state-transition semantics. It is a scheduler/kinetics reference, not a claim that this surrogate is the canonical 3D codec.
+
+## Concurrency contract
+
+Permitted parallelism is:
+
+```text
+snapshot read
+-> shard-local delta computation in parallel
+-> deterministic reduction / barrier
+-> candidate verification
+-> single logical commit
+```
+
+Prohibited parallelism includes structural `push_back`, erasure, compaction, ID allocation, graph rewiring or authoritative queue mutation while another worker holds references into the committed node store.
+
+## Topology contract
+
+Topology operators are proposals, not immediate mutations.
+
+```text
+SPAWN(parent, count)
+PRUNE(node, threshold)
+REWIRE(...)
+MERGE(...)
+```
+
+A spawn count is represented explicitly and must create exactly that many children when admitted. ID allocation belongs to the transaction and rolls back when the candidate is rejected.
+
+## Required invariants
+
+1. One cycle reads one immutable committed snapshot.
+2. Stable node IDs survive storage relocation and compaction.
+3. Graph edges reference stable IDs, never transient vector positions.
+4. DIRECT, GLOBAL and GRAPH routing semantics are explicit and testable.
+5. Echo propagation is bounded by TTL, amplitude cutoff and per-step event budget.
+6. Velocity, displacement, coordinate, node-count and event-count ceilings are explicit.
+7. Structural mutations occur only at the commit barrier.
+8. A failed candidate leaves state, topology and ID allocation unchanged.
+9. Learning and optimization operate on measured residuals and candidate parameters.
+10. Measured execution is reported separately from simulated or logical scale.
+11. Rendering remains a projection unless separately admitted as authoritative input.
+12. The deterministic VM/policy/transaction boundary remains authoritative.
+
+## Reference implementation
+
+The bounded C++17 reference is:
+
+```text
+cpp_runtime/include/jarvisx/kinetic_system.hpp
+cpp_runtime/src/kinetic_system_main.cpp
+cpp_runtime/tests/kinetic_system_tests.cpp
+```
+
+The normative mathematical and operational specification is:
+
+```text
+docs/DR_MOAGI_KINETIC_SYSTEM_LOOP.md
+```
+
+## Validation
+
+Conformance requires tests demonstrating:
+
+- frozen-snapshot mechanical integration;
+- direct and global routing;
+- bounded echo propagation;
+- exact transactional spawn counts with unique stable IDs;
+- synapse pruning without index corruption;
+- failed projection rollback;
+- finite residual/learning updates;
+- warning-clean C++17 compilation;
+- a bounded runtime smoke cycle.
+
+## Consequences
+
+### Positive
+
+- the ANN/swarm/physics loop gains one coherent state-transition semantics;
+- concurrency hazards are moved behind an explicit snapshot/commit boundary;
+- topology evolution becomes reversible and auditable;
+- graph propagation and global scheduling are no longer conflated;
+- the kinetic abstraction can be lowered to CPU, SIMD, GPU or distributed backends without changing authority semantics.
+
+### Negative
+
+- topology mutation becomes at least one barrier behind proposal generation;
+- stable-ID lookup adds indexing overhead;
+- deterministic reference execution prioritizes correctness over peak throughput;
+- production codec integration still requires explicit binding to the existing 3D codec runtime rather than the local surrogate.


### PR DESCRIPTION
## What changed

- adopt ADR-006 for the Dr Moagi kinetic system loop;
- add the normative kinetic state/parameter/topology specification;
- add a deterministic C++17 `KineticSystemLoop` reference using stable node IDs and frozen-snapshot candidate execution;
- bound echo propagation with TTL, amplitude cutoff and per-step event budgets;
- stage spawn/prune topology changes behind the commit barrier, including transactional ID allocation;
- add a runnable `jarvisx-kinetic-loop` executable;
- add regression and smoke-test targets to the existing CMake harness.

## Why

The earlier mutable swarm model can invalidate storage during concurrent topology changes, stale index-addressed synapses after compaction, conflate graph routing with global arbitration, allow recursive echo storms, and leak hidden state on rejected mutations. This change makes the operational model `snapshot -> delta/force computation -> bounded propagation -> candidate integration -> topology proposal -> Pi_Lambda -> COMMIT/ROLLBACK`.

## Architectural impact

The kinetic extension preserves ADR-002/003 codec and field semantics rather than replacing them. Production encode/decode coupling must still use the same-space `D(E(Psi))` closure and immutable anchor contract. The C++ local encode/decode operation is explicitly a scheduler/kinetics surrogate used to test transition semantics, not a second canonical codec.

## Validation

Locally validated with the repository warning profile:

```text
g++ -std=c++17 -O2 -Wall -Wextra -Wpedantic -Wconversion -Wshadow
```

Checks passed:

- exact-layout kinetic executable compile;
- `--cycles 4 --nodes 16 --quiet` smoke run;
- kinetic regression binary;
- frozen-snapshot physics/swarm transition;
- bounded echo propagation;
- exact three-child transactional spawn with unique stable IDs;
- safe synapse pruning;
- out-of-bounds candidate rollback;
- finite learning/optimization update.

This PR is intentionally draft so CI/review can validate the new architecture before merge.