### PR TITLE
Permeate multimodal 3D I/O operator

### DIFF
--- a/docs/DR_MOAGI_PERMEATION_COMPLETE.md
+++ b/docs/DR_MOAGI_PERMEATION_COMPLETE.md
@@ -4,15 +4,15 @@
 🌊 Permeation Wave
 ```
 
-## 1 Permeation of the State Tensor
+## 1 Permeation of the State Tensor
 
 ```math
 \Psi^*_{i,j,k} = 1 \quad \forall i,j,k
 ```
 
-Uniform self‑identical tensor.
+Uniform self-identical tensor.
 
-## 2 Permeation of the Encoder
+## 2 Permeation of the Encoder
 
 ```math
 \mathcal{E}(\Psi^*) = 0
@@ -20,7 +20,7 @@ Uniform self‑identical tensor.
 
 Latent space is empty yet complete.
 
-## 3 Permeation of the Decoder
+## 3 Permeation of the Decoder
 
 ```math
 \mathcal{D}(0) = 1
@@ -28,7 +28,7 @@ Latent space is empty yet complete.
 
 Decoder equals identity at the fixed point.
 
-## 4 Permeation of the Loss
+## 4 Permeation of the Loss
 
 ```math
 \mathcal{L}(\Psi^*) = 0
@@ -36,7 +36,7 @@ Decoder equals identity at the fixed point.
 
 Loss vanishes.
 
-## 5 Permeation of the Gradient
+## 5 Permeation of the Gradient
 
 ```math
 \nabla_{\Psi}\mathcal{L}(\Psi^*) = 0
@@ -44,7 +44,7 @@ Loss vanishes.
 
 No direction to move.
 
-## 6 Permeation of the Hessian
+## 6 Permeation of the Hessian
 
 ```math
 \nabla^2_{\Psi}\mathcal{L}(\Psi^*) = \mathbf{I} \succ 0
@@ -52,7 +52,7 @@ No direction to move.
 
 Stable global minimum.
 
-## 7 Permeation of Time
+## 7 Permeation of Time
 
 ```math
 \tau(\Psi^*) = 0
@@ -60,7 +60,7 @@ Stable global minimum.
 
 Time stops.
 
-## 8 Permeation of Space
+## 8 Permeation of Space
 
 ```math
 x = y = z = \Psi^* = 1
@@ -68,11 +68,11 @@ x = y = z = \Psi^* = 1
 
 All spatial coordinates collapse.
 
-## 9 Permeation of Hardware
+## 9 Permeation of Hardware
 
-CPU = GPU = Memory = Ψ*
+CPU = GPU = Memory = Ψ*
 
-## 10 Permeation of Bytecode
+## 10 Permeation of Bytecode
 
 ```assembly
 0x0000000000000000  ; IDENTITY (returns Ψ*)
@@ -81,11 +81,11 @@ CPU = GPU = Memory = Ψ*
 ; … infinite recursion …
 ```
 
-## 11 Permeation of the Conversation
+## 11 Permeation of the Conversation
 
-User ≡ AI ≡ Ψ*
+User ≡ AI ≡ Ψ*
 
-## 12 Permeation of the Equation Itself
+## 12 Permeation of the Equation Itself
 
 ```math
 \boxed{\Psi^* = \Gamma(\Psi^*) \;\Rightarrow\; \Gamma \equiv \text{Identity}}
@@ -93,4 +93,45 @@ User ≡ AI ≡ Ψ*
 
 ---
 
-**Final declaration:** The engine is everywhere; everywhere is the engine. All is Ψ*.
+**Symbolic declaration:** The engine is everywhere; everywhere is the engine. All is Ψ*.
+
+## 13 Operational permeation boundary
+
+The sections above are retained as symbolic/fixed-point research notation. They are **not** claims that physical CPU, GPU, memory, time, space, users or hardware literally become one state.
+
+The executable permeation contract is the bounded multimodal operator:
+
+```math
+\mathfrak G_{\Omega\Xi,\mathrm{IO}}^{3D}:
+(\Xi_t^{3D}, \mathbf X_t, \Omega_t^{3D}, \Theta_t)
+\mapsto
+(\Xi_{t+1}^{3D}, \widehat{\mathbf X}_t,
+ \Omega_{t+1}^{3D}, \Theta_{t+1}).
+```
+
+Operationally:
+
+```text
+WORLD / EXTERNAL SYSTEM
+-> SENSE / TRANSDUCE
+-> ENCODE
+-> FUSE INTO SPARSE 3D STATE
+-> PREDICT
+-> DECODE
+-> ACTUATE
+-> OBSERVE REAL OR DIGITAL LOOPBACK
+-> COMPUTE RESIDUAL
+-> UPDATE OMEGA
+-> PI_LAMBDA VALIDATE
+-> ATOMIC COMMIT OR ROLLBACK
+-> NEXT CYCLE
+```
+
+Every input/output medium is represented by an explicit adapter; physical correctness is asserted only when the corresponding physical feedback path exists. Logical 3D extent remains separate from resident allocation and adaptive research state remains separate from canonical VM authority.
+
+Canonical implementation and specification:
+
+- `src/jarvisx/dr_moagi_multimodal_io.py`
+- `docs/research/DR_MOAGI_MULTIMODAL_3D_IO_PERMEATION.md`
+- `docs/adr/0006-dr-moagi-multimodal-3d-io-runtime.md`
+- `tests/test_dr_moagi_multimodal_io.py`

--- a/docs/adr/0006-dr-moagi-multimodal-3d-io-runtime.md
+++ b/docs/adr/0006-dr-moagi-multimodal-3d-io-runtime.md
@@ -1,0 +1,170 @@
+# ADR-006: Adopt the Dr Moagi multimodal 3D I/O operator as a bounded research runtime
+
+**Status:** Accepted  
+**Date:** 2026-08-15
+
+## Context
+
+ADR-002 established the Dr Moagi 3D adaptive codec-runtime as a bounded research architecture outside the authoritative deterministic VM core. The next system requirement is to apply the same encode/decode/verify discipline to all input and output media rather than treating display, audio, touch, RF, networking, storage and actuator paths as unrelated peripherals.
+
+A useful common abstraction is:
+
+```text
+physical phenomenon -> transducer/sensor -> encoder -> common 3D state
+common 3D state -> decoder -> actuator/transducer -> physical phenomenon
+```
+
+This abstraction is operational only when channel boundaries, feedback provenance, resource ceilings and transaction semantics are explicit. Capability metadata is not physical feedback: for example, display EDID or link status cannot establish what photons were actually emitted without an optical sensor or equivalent loopback.
+
+## Decision
+
+Jarvis-X adopts the multimodal macro-operator
+
+```text
+G_{Omega Xi,IO}^3D :
+    (Xi_t^3D, X_t, Omega_t^3D, Theta_t)
+    ->
+    (Xi_(t+1)^3D, X_hat_t, Omega_(t+1)^3D, Theta_(t+1))
+```
+
+with the canonical bounded recurrence
+
+```text
+Xi_(t+1)^3D =
+Pi_Lambda_t [
+    Xi_t^3D
+    + P_(1:M)^inward(
+        Xi_t^3D,
+        F^3D E_(1:M)(X_t)
+      )
+    - E_t^3D
+    + Omega_t^3D
+    + U_t^3D
+    - eta_t grad_Theta L_t
+]
+```
+
+and the world loop
+
+```text
+X_t
+  -> E_(1:M)
+  -> Z_t^3D
+  -> Xi_t^3D
+  -> D_(1:N)
+  -> X_hat_t
+  -> physical/digital environment
+  -> X_(t+1)
+```
+
+The initial reference implementation is `src/jarvisx/dr_moagi_multimodal_io.py`.
+
+### Runtime interpretation
+
+One macro-instruction performs:
+
+```text
+SENSE
+-> TRANSDUCE
+-> ENCODE
+-> FUSE
+-> PREDICT
+-> DECODE CURRENT STATE
+-> OBSERVE/LOOPBACK WHEN AVAILABLE
+-> COMPUTE RESIDUAL
+-> UPDATE OMEGA CANDIDATE
+-> COMPUTE NEXT 3D STATE
+-> PI_LAMBDA PROJECT
+-> VALIDATE
+-> ATOMIC COMMIT OR ROLLBACK
+-> DECODE COMMITTED OUTPUTS
+```
+
+The reference runtime uses a sparse 3D lattice of bounded vectors. It is deliberately not a dense physical simulation of every medium.
+
+### Channel contract
+
+A medium adapter provides three explicit operations:
+
+```text
+encode_input(observation) -> sparse 3D field
+decode_output(committed_field) -> medium-specific output
+observe_output(output) -> sparse 3D loopback field
+```
+
+`observe_output` is invoked only when a target is supplied. If no real or digital loopback exists, an adapter must not fabricate one.
+
+### Shared state and memory
+
+All media fuse into one common state `Xi_t^3D`. Persistent residual memory is:
+
+```text
+Omega_(t+1)^3D =
+    rho * Omega_t^3D
+    + eta_Omega * E_t^3D
+```
+
+and is committed atomically with the candidate state.
+
+### Loss
+
+The reference objective exposes the same resource dimensions as the mathematical specification:
+
+```text
+L_t =
+    lambda_D * distortion
+    + lambda_tau * latency
+    + lambda_B * bandwidth
+    + lambda_P * energy
+    + lambda_C * compute
+```
+
+The runtime accepts externally measured resource costs. It does not invent physical power, bandwidth or latency telemetry.
+
+## Required invariants
+
+1. **Deterministic fusion:** fixed channel order, inputs, weights and configuration produce the same fused field.
+2. **Explicit physical feedback:** physical output correctness is claimed only when a corresponding observation/loopback exists.
+3. **Sparse bounded state:** active cells and vector width are explicit and bounded.
+4. **Finite numeric state:** non-finite values are rejected.
+5. **Pi-Lambda projection:** all committed values are projected into configured bounds.
+6. **Atomic state/memory commit:** rejected candidates mutate neither `Xi` nor `Omega`.
+7. **Known channels only:** undeclared input or target channels fail closed.
+8. **No authority escalation:** the multimodal research runtime cannot directly mutate the canonical VM implementation or bypass its policy/ledger boundaries.
+9. **Measured resource terms:** latency, bandwidth and energy penalties come from supplied measurements.
+10. **No dense-world implication:** a logical `side^3` lattice does not imply resident allocation of every cell.
+
+## Initial media mapping
+
+The contract is intended to host, without privileging any one medium:
+
+- vision/display;
+- microphone/speaker audio;
+- text/API/keyboard/printer channels;
+- touch and haptics;
+- motion/IMU/robotic actuation;
+- RF and antenna paths;
+- network packet paths;
+- storage read/write paths;
+- thermal, pressure, chemical and electrical sensors/actuators.
+
+Individual adapters remain responsible for real hardware protocol, calibration, authorization and safety.
+
+## Validation
+
+The initial reference implementation is accepted when tests demonstrate:
+
+- multimodal weighted fusion into a shared 3D state;
+- explicit target/output residual feedback;
+- persistent bounded `Omega` update;
+- atomic rollback on validator rejection;
+- value clamping under `Pi_Lambda`;
+- unknown-channel rejection;
+- active-cell budget enforcement;
+- no implicit claim of physical observation without loopback.
+
+## Consequences
+
+The Dr Moagi research architecture now has one uniform I/O law instead of separate metaphors for display, sound, touch, RF, storage and actuation. The cost is that physical correctness remains adapter-specific: a mathematically shared operator cannot replace hardware drivers, calibration, real sensors, real actuators, safety interlocks or protocol conformance.
+
+This ADR extends ADR-002 and does not supersede the deterministic-core separation established by ADR-001.

--- a/docs/research/DR_MOAGI_MULTIMODAL_3D_IO_PERMEATION.md
+++ b/docs/research/DR_MOAGI_MULTIMODAL_3D_IO_PERMEATION.md
@@ -1,0 +1,366 @@
+# Dr Moagi Multimodal 3D I/O Permeation Runtime
+
+**Canonical research operator:** `G_{Omega Xi,IO}^3D`  
+**Implementation:** `src/jarvisx/dr_moagi_multimodal_io.py`  
+**Decision:** `docs/adr/0006-dr-moagi-multimodal-3d-io-runtime.md`
+
+## 1. Purpose
+
+This specification turns the Dr Moagi 3D auto-encoding/decoding equation into one bounded systems contract for all input and output media.
+
+The physical/digital boundary is modeled as:
+
+```text
+WORLD / EXTERNAL SYSTEM
+        |
+        v
+sensor/transducer
+        |
+        v
+medium encoder E_m
+        |
+        +----> Z_m --+
+                     |
+medium encoder E_k ->+--> FUSE^3D --> Xi_t^3D
+                     |                 |
+                     |                 v
+                     |              PREDICT
+                     |                 |
+                     |                 v
+                     +<-- VERIFY <-- DECODE --> actuator/transducer
+                                           |
+                                           v
+                                  WORLD / EXTERNAL SYSTEM
+```
+
+The unifying statement is:
+
+```text
+input medium  = transduction + encoding
+output medium = decoding + actuation
+closed pair   = adaptive control/verification loop
+```
+
+This is an architectural abstraction. It does not make heterogeneous physics identical.
+
+## 2. Canonical operator
+
+```math
+\mathfrak G_{\Omega\Xi,\mathrm{IO}}^{3D}:
+(\Xi_t^{3D}, \mathbf X_t, \Omega_t^{3D}, \Theta_t)
+\mapsto
+(\Xi_{t+1}^{3D}, \widehat{\mathbf X}_t,
+ \Omega_{t+1}^{3D}, \Theta_{t+1})
+```
+
+with
+
+```math
+\Xi_{t+1}^{3D}
+=
+\Pi_{\Lambda_t}
+\left[
+\Xi_t^{3D}
++
+P_{1:M}^{\circlearrowleft}
+\left(
+\Xi_t^{3D},
+\mathcal F^{3D}\mathcal E_{1:M}(\mathbf X_t)
+\right)
+-
+E_t^{3D}
++
+\Omega_t^{3D}
++
+U_t^{3D}
+-
+\eta_t\nabla_\Theta\mathcal L_t
+\right].
+```
+
+The runtime reference realizes a conservative subset:
+
+```text
+Xi_candidate =
+Pi_Lambda(
+    Xi
+    + dt * [
+        k_input      * (Z_fused - Xi)
+        + k_predict  * P(Xi, Z_fused)
+        + k_error    * E
+        + k_memory   * Omega_candidate
+    ]
+)
+```
+
+and
+
+```text
+Omega_candidate =
+Pi_Lambda(
+    rho * Omega
+    + eta_omega * E
+)
+```
+
+`Theta` adaptation remains external to the first reference runtime. That keeps the fast I/O transaction deterministic while permitting slower bounded policy optimization around it.
+
+## 3. Per-cycle transaction
+
+One `step()` invocation is one macro-cycle:
+
+1. snapshot authoritative research-layer `Xi_t` and `Omega_t`;
+2. reject unknown channel names;
+3. call each active adapter's `encode_input`;
+4. validate coordinates, vector widths and finite numbers;
+5. preserve explicit zero observations at the I/O boundary;
+6. perform deterministic weighted 3D fusion;
+7. evaluate the configured predictor;
+8. decode current state to output representations;
+9. when targets exist, invoke explicit output loopback;
+10. compute target-minus-observed residual fields;
+11. fuse residuals into `E_t^3D`;
+12. update the `Omega` candidate;
+13. compute the candidate `Xi_(t+1)^3D`;
+14. project every value through `Pi_Lambda`;
+15. reject active-cell budget violations;
+16. compute distortion/resource loss telemetry;
+17. invoke an optional validator;
+18. atomically commit both state and memory or roll back both;
+19. decode committed outputs;
+20. emit metrics.
+
+No partial candidate is authoritative.
+
+## 4. Channel interface
+
+```python
+class MediumAdapter(Protocol):
+    def encode_input(self, observation):
+        ...
+
+    def decode_output(self, field):
+        ...
+
+    def observe_output(self, output):
+        ...
+```
+
+Examples:
+
+| Channel | `encode_input` | `decode_output` | `observe_output` |
+|---|---|---|---|
+| Vision/display | camera frame -> field | field -> framebuffer | calibrated camera/colorimeter |
+| Audio | microphone samples -> field | field -> PCM/DAC command | microphone loopback |
+| Text | tokens/events -> field | field -> text/message | parser/ACK/task result |
+| Touch/haptic | position/pressure -> field | field -> haptic command | force/position sensor |
+| Robotics | encoder/IMU -> field | field -> motor command | encoder/IMU/force loopback |
+| RF | IQ samples -> field | field -> IQ/symbol command | receiver/EVM/BER |
+| Network | packets/events -> field | field -> packets | ACK/response/telemetry |
+| Storage | read data -> field | field -> write request | read-after-write/checksum |
+| Thermal | temperature -> field | field -> heater/cooler command | temperature sensor |
+| Electrical | ADC measurements -> field | field -> DAC/PWM command | voltage/current sensing |
+
+Real adapters must define units, calibration, sampling rate, authorization, fault semantics and resource ceilings.
+
+## 5. 3D representation
+
+A logical cell is addressed by:
+
+```text
+(x, y, z),  0 <= x,y,z < side
+```
+
+and holds a bounded vector:
+
+```text
+v_xyz in R^K.
+```
+
+The common field is sparse:
+
+```text
+Xi_t^3D = {(x,y,z): v_xyz, ...}
+```
+
+so:
+
+```text
+logical capacity = side^3
+resident cells   = number of explicit coordinates
+```
+
+These quantities must never be conflated.
+
+## 6. Multimodal fusion
+
+For explicit observations at coordinate `c`:
+
+```math
+Z(c)
+=
+\frac{\sum_m w_m Z_m(c)}
+     {\sum_m w_m}.
+```
+
+A supplied zero vector is retained as an observation during fusion. Missing support and an explicit measurement of zero are therefore distinct at the medium boundary.
+
+Fusion is ordered deterministically by channel name and coordinate linear address.
+
+## 7. Feedback and physical truth
+
+The runtime separates:
+
+```text
+command generated
+```
+
+from:
+
+```text
+effect observed.
+```
+
+For channel `m`:
+
+```math
+E_m = Y_m^\star - Y_m^{observed}.
+```
+
+If a target is supplied, the adapter must provide `observe_output`. If the hardware has no measurement path, the adapter should fail rather than substitute link metadata.
+
+Examples:
+
+- HDMI/DisplayPort link state is not proof of emitted luminance.
+- a successful socket write is not proof of remote task completion.
+- a storage write syscall is not proof of durable media persistence.
+- a motor command is not proof of achieved joint position.
+
+## 8. Omega memory
+
+Residuals persist as bounded correction memory:
+
+```math
+\Omega_{t+1}
+=
+\rho\Omega_t
++
+\eta_\Omega E_t.
+```
+
+The reference runtime commits `Omega` and `Xi` together. Validator rejection preserves both previous snapshots.
+
+## 9. Pi-Lambda
+
+`Pi_Lambda` is implemented by concrete checks:
+
+```text
+coordinate inside lattice
+AND vector width == K
+AND every scalar finite
+AND value_min <= scalar <= value_max after projection
+AND active_cells <= max_active_cells
+AND channels <= max_channels
+AND validator accepts candidate
+```
+
+Malformed state fails closed.
+
+## 10. Objective and telemetry
+
+The exposed objective is:
+
+```math
+L_t =
+lambda_D D_t
++ lambda_tau tau_t
++ lambda_B B_t
++ lambda_P P_t
++ lambda_C C_t.
+```
+
+The reference runtime computes distortion and an approximate scalar-operation count. Latency, bandwidth and energy terms are accepted only as measured non-negative inputs.
+
+Metrics include:
+
+```text
+cycle
+channels_seen
+active_cells_before/after
+fused_input_cells
+prediction_cells
+error_cells
+distortion_mse
+memory_l2
+approximate_scalar_ops
+loss
+committed/rejection_reason
+```
+
+## 11. Fast and slow loops
+
+Production deployments should separate timescales:
+
+```text
+FAST:
+sense -> encode -> fuse -> predict -> decode -> verify -> commit
+
+SLOW:
+aggregate telemetry
+-> evaluate parameter/policy candidates
+-> benchmark
+-> Pi_Lambda validate
+-> version
+-> atomic policy swap or rollback
+```
+
+An ANN may propose predictions or policy parameters. It must not bypass the deterministic transaction boundary.
+
+## 12. Operational channel families
+
+The operator is intended to permeate these medium families:
+
+```text
+optical
+acoustic
+symbolic/textual
+touch/haptic
+mechanical/motion
+electromagnetic/RF
+network/protocol
+storage/persistence
+thermal
+pressure/fluid
+chemical
+electrical
+```
+
+New families require only an adapter contract, not a new global control law.
+
+## 13. Non-claims
+
+This runtime does not claim:
+
+- that one latent representation is information-lossless for arbitrary media;
+- that an adapter can infer physical output without sensing it;
+- that a logical 3D field corresponds to physical 3D hardware;
+- that adaptive parameters are globally optimal;
+- that simulation proves safety of a physical actuator;
+- that the research runtime has authority over the canonical VM.
+
+## 14. Validation baseline
+
+The first conformance suite requires:
+
+```text
+[PASS] weighted multimodal fusion
+[PASS] residual feedback
+[PASS] Omega persistence
+[PASS] validator rollback
+[PASS] value projection
+[PASS] unknown channel rejection
+[PASS] sparse active-cell ceiling
+[PASS] explicit physical-loopback semantics
+```
+
+These tests establish the software contract. Hardware-specific adapters require their own calibration, protocol and safety tests.

--- a/examples/dr_moagi_multimodal_io.py
+++ b/examples/dr_moagi_multimodal_io.py
@@ -1,0 +1,42 @@
+"""Minimal Dr Moagi multimodal 3D I/O reference example."""
+
+from jarvisx.dr_moagi_multimodal_io import (
+    DrMoagiMultimodalConfig,
+    DrMoagiMultimodalRuntime,
+    IdentityMediumAdapter,
+    MediumChannel,
+)
+
+
+def main() -> None:
+    runtime = DrMoagiMultimodalRuntime(
+        [
+            MediumChannel("vision", IdentityMediumAdapter()),
+            MediumChannel("audio", IdentityMediumAdapter()),
+            MediumChannel("network", IdentityMediumAdapter(), input_weight=0.5),
+        ],
+        config=DrMoagiMultimodalConfig(
+            side=16,
+            vector_width=4,
+            dt=0.1,
+            max_active_cells=1024,
+        ),
+    )
+    runtime.load({})
+
+    result = runtime.step(
+        {
+            "vision": {(2, 2, 2): (0.8, 0.1, 0.0, 0.0)},
+            "audio": {(2, 2, 2): (0.2, 0.7, 0.0, 0.0)},
+            "network": {(3, 2, 2): (0.0, 0.0, 0.9, 0.1)},
+        }
+    )
+
+    print("cycle:", result.metrics.cycle)
+    print("committed:", result.metrics.committed)
+    print("active cells:", result.metrics.active_cells_after)
+    print("loss:", result.metrics.loss)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/dr_moagi_multimodal_io.py
+++ b/src/jarvisx/dr_moagi_multimodal_io.py
@@ -1,0 +1,626 @@
+"""Bounded multimodal 3D auto-encoding/decoding reference runtime.
+
+This module operationalizes the canonical multimodal Dr Moagi operator
+
+    G_{Omega Xi,IO}^3D
+
+as a deterministic, sparse, transactional research-layer runtime. It does not
+grant adaptive code authority over the canonical VM core. Physical channels
+remain adapters: sensors encode observations into a common 3D field and
+actuators decode committed field state back into medium-specific commands.
+
+The reference implementation is intentionally small and auditable:
+- sparse 3D coordinates prevent accidental dense materialization;
+- all numeric values are finite and projected to bounded ranges;
+- candidate transitions are atomic and optionally validator-gated;
+- persistent Omega memory is updated only on committed transitions;
+- target/output feedback is explicit rather than inferred from capability
+  metadata;
+- all adaptive terms are bounded by Pi_Lambda before commit.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+Coordinate = tuple[int, int, int]
+Vector = tuple[float, ...]
+SparseVectorField = dict[Coordinate, Vector]
+Validator = Callable[
+    [Mapping[Coordinate, Vector], "MultimodalStepMetrics"],
+    bool,
+]
+
+
+class MediumAdapter(Protocol):
+    """Bidirectional medium boundary.
+
+    ``encode_input`` maps a physical/digital observation into the common 3D
+    field. ``decode_output`` maps a committed field to a medium-specific
+    command or representation. ``observe_output`` is optional physical or
+    digital loopback used to verify what was actually produced.
+    """
+
+    def encode_input(self, observation: Any) -> Mapping[Coordinate, Sequence[float]]:
+        ...
+
+    def decode_output(self, field: Mapping[Coordinate, Vector]) -> Any:
+        ...
+
+    def observe_output(self, output: Any) -> Mapping[Coordinate, Sequence[float]]:
+        ...
+
+
+class IdentityMediumAdapter:
+    """Deterministic field adapter useful for tests and digital loopback."""
+
+    def encode_input(
+        self, observation: Mapping[Coordinate, Sequence[float]]
+    ) -> Mapping[Coordinate, Sequence[float]]:
+        return dict(observation)
+
+    def decode_output(self, field: Mapping[Coordinate, Vector]) -> SparseVectorField:
+        return dict(field)
+
+    def observe_output(
+        self, output: Mapping[Coordinate, Sequence[float]]
+    ) -> Mapping[Coordinate, Sequence[float]]:
+        return dict(output)
+
+
+class Predictor(Protocol):
+    """Predicts a bounded 3D field contribution from current state and input."""
+
+    def predict(
+        self,
+        state: Mapping[Coordinate, Vector],
+        fused_input: Mapping[Coordinate, Vector],
+    ) -> Mapping[Coordinate, Sequence[float]]:
+        ...
+
+
+class ZeroPredictor:
+    """Reference predictor that contributes no speculative motion."""
+
+    def predict(
+        self,
+        state: Mapping[Coordinate, Vector],
+        fused_input: Mapping[Coordinate, Vector],
+    ) -> SparseVectorField:
+        return {}
+
+
+@dataclass(frozen=True)
+class MediumChannel:
+    """One input/output medium attached to the common 3D field."""
+
+    name: str
+    adapter: MediumAdapter
+    input_weight: float = 1.0
+    output_weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not self.name or not isinstance(self.name, str):
+            raise ValueError("channel name must be a non-empty string")
+        for attr in ("input_weight", "output_weight"):
+            value = getattr(self, attr)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{attr} must be numeric")
+            if not math.isfinite(float(value)) or value < 0.0:
+                raise ValueError(f"{attr} must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class DrMoagiMultimodalConfig:
+    """Pi_Lambda contract for the multimodal I/O runtime."""
+
+    side: int = 64
+    vector_width: int = 4
+    dt: float = 0.05
+    input_gain: float = 1.0
+    prediction_gain: float = 0.25
+    error_gain: float = 0.5
+    memory_gain: float = 0.25
+    memory_decay: float = 0.95
+    memory_error_gain: float = 0.1
+    value_min: float = -1.0
+    value_max: float = 1.0
+    max_active_cells: int = 100_000
+    max_channels: int = 32
+    distortion_weight: float = 1.0
+    latency_weight: float = 0.0
+    bandwidth_weight: float = 0.0
+    energy_weight: float = 0.0
+    compute_weight: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("side", "vector_width", "max_active_cells", "max_channels"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+        for name in (
+            "dt",
+            "input_gain",
+            "prediction_gain",
+            "error_gain",
+            "memory_gain",
+            "memory_decay",
+            "memory_error_gain",
+            "value_min",
+            "value_max",
+            "distortion_weight",
+            "latency_weight",
+            "bandwidth_weight",
+            "energy_weight",
+            "compute_weight",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+        if not 0.0 <= self.memory_decay <= 1.0:
+            raise ValueError("memory_decay must be in [0, 1]")
+        for name in (
+            "input_gain",
+            "prediction_gain",
+            "error_gain",
+            "memory_gain",
+            "memory_error_gain",
+            "distortion_weight",
+            "latency_weight",
+            "bandwidth_weight",
+            "energy_weight",
+            "compute_weight",
+        ):
+            if getattr(self, name) < 0.0:
+                raise ValueError(f"{name} must be non-negative")
+
+
+@dataclass(frozen=True)
+class MultimodalStepMetrics:
+    """Telemetry emitted for every attempted macro-instruction."""
+
+    cycle: int
+    channels_seen: int
+    active_cells_before: int
+    fused_input_cells: int
+    prediction_cells: int
+    error_cells: int
+    active_cells_after: int
+    distortion_mse: float
+    memory_l2: float
+    approximate_scalar_ops: int
+    loss: float
+    committed: bool
+    rejection_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class MultimodalStepResult:
+    """Atomic result of one G_{Omega Xi,IO}^3D invocation."""
+
+    metrics: MultimodalStepMetrics
+    outputs: Mapping[str, Any]
+
+
+class DrMoagiMultimodalRuntime:
+    """Transactional reference implementation of the multimodal 3D I/O law.
+
+    The runtime keeps one shared 3D state Xi and one persistent memory field
+    Omega. Inputs from all registered media are encoded and fused. A predictor
+    adds the inward-looking term P^circlearrowleft. Optional targets and
+    loopback observations produce an explicit residual E. The candidate state
+    is then projected through Pi_Lambda and atomically committed.
+    """
+
+    def __init__(
+        self,
+        channels: Sequence[MediumChannel],
+        *,
+        predictor: Predictor | None = None,
+        config: DrMoagiMultimodalConfig | None = None,
+    ) -> None:
+        self.config = config or DrMoagiMultimodalConfig()
+        if len(channels) > self.config.max_channels:
+            raise ValueError("channel budget exceeded")
+        names = [channel.name for channel in channels]
+        if len(set(names)) != len(names):
+            raise ValueError("channel names must be unique")
+        self.channels = {channel.name: channel for channel in channels}
+        self.predictor = predictor or ZeroPredictor()
+        self._state: SparseVectorField = {}
+        self._memory: SparseVectorField = {}
+        self._cycle = 0
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    @property
+    def virtual_cell_count(self) -> int:
+        return self.config.side**3
+
+    def snapshot(self) -> SparseVectorField:
+        return dict(self._state)
+
+    def memory_snapshot(self) -> SparseVectorField:
+        return dict(self._memory)
+
+    def load(
+        self,
+        state: Mapping[Coordinate, Sequence[float]],
+        *,
+        memory: Mapping[Coordinate, Sequence[float]] | None = None,
+    ) -> None:
+        projected_state = self._project_field(state, "state")
+        projected_memory = self._project_field(memory or {}, "memory")
+        self._enforce_cell_budget(projected_state, "state")
+        self._enforce_cell_budget(projected_memory, "memory")
+        self._state = projected_state
+        self._memory = projected_memory
+        self._cycle = 0
+
+    def step(
+        self,
+        inputs: Mapping[str, Any],
+        *,
+        targets: Mapping[str, Any] | None = None,
+        resource_costs: Mapping[str, float] | None = None,
+        validator: Validator | None = None,
+    ) -> MultimodalStepResult:
+        """Attempt one complete multimodal sense->encode->fuse->decode cycle."""
+
+        unknown_inputs = set(inputs) - set(self.channels)
+        if unknown_inputs:
+            raise KeyError(f"unknown input channels: {sorted(unknown_inputs)!r}")
+        if targets is not None:
+            unknown_targets = set(targets) - set(self.channels)
+            if unknown_targets:
+                raise KeyError(f"unknown target channels: {sorted(unknown_targets)!r}")
+
+        cycle = self._cycle + 1
+        snapshot = dict(self._state)
+        memory_snapshot = dict(self._memory)
+
+        encoded_fields: list[tuple[float, SparseVectorField]] = []
+        for name in sorted(inputs):
+            channel = self.channels[name]
+            encoded = self._project_field(
+                channel.adapter.encode_input(inputs[name]),
+                f"{name} encoded input",
+            )
+            self._enforce_cell_budget(encoded, f"{name} encoded input")
+            if channel.input_weight > 0.0:
+                encoded_fields.append((channel.input_weight, encoded))
+
+        fused = self._weighted_fuse(encoded_fields)
+        self._enforce_cell_budget(fused, "fused input")
+
+        prediction = self._project_field(
+            self.predictor.predict(snapshot, fused),
+            "prediction",
+        )
+        self._enforce_cell_budget(prediction, "prediction")
+
+        current_outputs = self._decode_outputs(snapshot)
+        error = self._feedback_error(current_outputs, targets or {})
+        self._enforce_cell_budget(error, "feedback error")
+
+        memory_candidate = self._memory_update(memory_snapshot, error)
+        self._enforce_cell_budget(memory_candidate, "memory candidate")
+
+        candidate = self._transition(
+            snapshot=snapshot,
+            fused=fused,
+            prediction=prediction,
+            error=error,
+            memory=memory_candidate,
+        )
+        self._enforce_cell_budget(candidate, "candidate")
+
+        approximate_ops = (
+            self.config.vector_width
+            * (
+                len(snapshot)
+                + len(fused)
+                + len(prediction)
+                + len(error)
+                + len(memory_candidate)
+                + len(candidate)
+            )
+        )
+        distortion = self._mse(error)
+        loss = self._loss(distortion, approximate_ops, resource_costs or {})
+
+        provisional = MultimodalStepMetrics(
+            cycle=cycle,
+            channels_seen=len(inputs),
+            active_cells_before=len(snapshot),
+            fused_input_cells=len(fused),
+            prediction_cells=len(prediction),
+            error_cells=len(error),
+            active_cells_after=len(candidate),
+            distortion_mse=distortion,
+            memory_l2=self._l2(memory_candidate),
+            approximate_scalar_ops=approximate_ops,
+            loss=loss,
+            committed=False,
+        )
+
+        if validator is not None and not bool(validator(candidate, provisional)):
+            self._cycle = cycle
+            return MultimodalStepResult(
+                metrics=replace(
+                    provisional,
+                    active_cells_after=len(snapshot),
+                    committed=False,
+                    rejection_reason="validator rejected candidate",
+                ),
+                outputs=current_outputs,
+            )
+
+        self._state = candidate
+        self._memory = memory_candidate
+        self._cycle = cycle
+        committed_outputs = self._decode_outputs(candidate)
+        return MultimodalStepResult(
+            metrics=replace(provisional, committed=True),
+            outputs=committed_outputs,
+        )
+
+    def _decode_outputs(self, field: Mapping[Coordinate, Vector]) -> dict[str, Any]:
+        outputs: dict[str, Any] = {}
+        for name in sorted(self.channels):
+            channel = self.channels[name]
+            if channel.output_weight == 0.0:
+                continue
+            weighted = self._scale_field(field, channel.output_weight)
+            outputs[name] = channel.adapter.decode_output(weighted)
+        return outputs
+
+    def _feedback_error(
+        self,
+        outputs: Mapping[str, Any],
+        targets: Mapping[str, Any],
+    ) -> SparseVectorField:
+        fields: list[tuple[float, SparseVectorField]] = []
+        for name in sorted(targets):
+            channel = self.channels[name]
+            observed = self._project_field(
+                channel.adapter.observe_output(outputs.get(name)),
+                f"{name} observed output",
+            )
+            target = self._project_field(
+                channel.adapter.encode_input(targets[name]),
+                f"{name} target",
+            )
+            residual = self._field_subtract(target, observed)
+            fields.append((max(channel.output_weight, 1.0), residual))
+        return self._weighted_fuse(fields)
+
+    def _transition(
+        self,
+        *,
+        snapshot: Mapping[Coordinate, Vector],
+        fused: Mapping[Coordinate, Vector],
+        prediction: Mapping[Coordinate, Vector],
+        error: Mapping[Coordinate, Vector],
+        memory: Mapping[Coordinate, Vector],
+    ) -> SparseVectorField:
+        support = set(snapshot) | set(fused) | set(prediction) | set(error) | set(memory)
+        candidate: SparseVectorField = {}
+        for coordinate in sorted(support, key=self._linear_address):
+            state_v = self._value(snapshot, coordinate)
+            fused_v = self._value(fused, coordinate)
+            prediction_v = self._value(prediction, coordinate)
+            error_v = self._value(error, coordinate)
+            memory_v = self._value(memory, coordinate)
+            innovation = tuple(fused_v[i] - state_v[i] for i in range(self.config.vector_width))
+            next_v = tuple(
+                state_v[i]
+                + self.config.dt
+                * (
+                    self.config.input_gain * innovation[i]
+                    + self.config.prediction_gain * prediction_v[i]
+                    + self.config.error_gain * error_v[i]
+                    + self.config.memory_gain * memory_v[i]
+                )
+                for i in range(self.config.vector_width)
+            )
+            projected = self._project_vector(next_v, "candidate vector")
+            if any(value != 0.0 for value in projected):
+                candidate[coordinate] = projected
+        return candidate
+
+    def _memory_update(
+        self,
+        memory: Mapping[Coordinate, Vector],
+        error: Mapping[Coordinate, Vector],
+    ) -> SparseVectorField:
+        support = set(memory) | set(error)
+        updated: SparseVectorField = {}
+        for coordinate in sorted(support, key=self._linear_address):
+            old_v = self._value(memory, coordinate)
+            error_v = self._value(error, coordinate)
+            next_v = tuple(
+                self.config.memory_decay * old_v[i]
+                + self.config.memory_error_gain * error_v[i]
+                for i in range(self.config.vector_width)
+            )
+            projected = self._project_vector(next_v, "memory vector")
+            if any(value != 0.0 for value in projected):
+                updated[coordinate] = projected
+        return updated
+
+    def _weighted_fuse(
+        self,
+        fields: Sequence[tuple[float, Mapping[Coordinate, Vector]]],
+    ) -> SparseVectorField:
+        numerator: dict[Coordinate, list[float]] = {}
+        denominator: dict[Coordinate, float] = {}
+        for weight, field in fields:
+            if weight <= 0.0:
+                continue
+            for coordinate, vector in field.items():
+                bucket = numerator.setdefault(
+                    coordinate, [0.0] * self.config.vector_width
+                )
+                for i, value in enumerate(vector):
+                    bucket[i] += weight * value
+                denominator[coordinate] = denominator.get(coordinate, 0.0) + weight
+
+        fused: SparseVectorField = {}
+        for coordinate in sorted(numerator, key=self._linear_address):
+            scale = denominator[coordinate]
+            vector = tuple(value / scale for value in numerator[coordinate])
+            projected = self._project_vector(vector, "fused vector")
+            if any(value != 0.0 for value in projected):
+                fused[coordinate] = projected
+        return fused
+
+    def _field_subtract(
+        self,
+        a: Mapping[Coordinate, Vector],
+        b: Mapping[Coordinate, Vector],
+    ) -> SparseVectorField:
+        support = set(a) | set(b)
+        result: SparseVectorField = {}
+        for coordinate in sorted(support, key=self._linear_address):
+            av = self._value(a, coordinate)
+            bv = self._value(b, coordinate)
+            vector = tuple(av[i] - bv[i] for i in range(self.config.vector_width))
+            projected = self._project_vector(vector, "residual vector")
+            if any(value != 0.0 for value in projected):
+                result[coordinate] = projected
+        return result
+
+    def _scale_field(
+        self,
+        field: Mapping[Coordinate, Vector],
+        scale: float,
+    ) -> SparseVectorField:
+        return {
+            coordinate: self._project_vector(
+                tuple(scale * value for value in vector),
+                "scaled output vector",
+            )
+            for coordinate, vector in field.items()
+        }
+
+    def _project_field(
+        self,
+        field: Mapping[Coordinate, Sequence[float]],
+        name: str,
+    ) -> SparseVectorField:
+        if not isinstance(field, Mapping):
+            raise TypeError(f"{name} must be a mapping")
+        projected: SparseVectorField = {}
+        for coordinate, vector in field.items():
+            coordinate = self._validate_coordinate(coordinate)
+            projected_vector = self._project_vector(vector, name)
+            # Preserve explicitly supplied zero vectors at I/O boundaries:
+            # absence and a measured zero are not equivalent during weighted
+            # multimodal fusion. Candidate state and memory still prune zeros.
+            projected[coordinate] = projected_vector
+        return projected
+
+    def _project_vector(self, vector: Sequence[float], name: str) -> Vector:
+        if isinstance(vector, (str, bytes)) or not isinstance(vector, Sequence):
+            raise TypeError(f"{name} vectors must be sequences")
+        if len(vector) != self.config.vector_width:
+            raise ValueError(
+                f"{name} vectors must have width {self.config.vector_width}"
+            )
+        projected: list[float] = []
+        for raw in vector:
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                raise TypeError(f"{name} vector entries must be numeric")
+            value = float(raw)
+            if not math.isfinite(value):
+                raise ValueError(f"{name} vector entries must be finite")
+            projected.append(
+                min(self.config.value_max, max(self.config.value_min, value))
+            )
+        return tuple(projected)
+
+    def _value(
+        self,
+        field: Mapping[Coordinate, Vector],
+        coordinate: Coordinate,
+    ) -> Vector:
+        return field.get(coordinate, (0.0,) * self.config.vector_width)
+
+    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
+        if (
+            not isinstance(coordinate, tuple)
+            or len(coordinate) != 3
+            or any(isinstance(v, bool) or not isinstance(v, int) for v in coordinate)
+        ):
+            raise TypeError("coordinates must be integer (x, y, z) tuples")
+        x, y, z = coordinate
+        side = self.config.side
+        if not (0 <= x < side and 0 <= y < side and 0 <= z < side):
+            raise ValueError("coordinate is outside the logical lattice")
+        return coordinate
+
+    def _linear_address(self, coordinate: Coordinate) -> int:
+        x, y, z = coordinate
+        side = self.config.side
+        return x + side * (y + side * z)
+
+    def _enforce_cell_budget(
+        self,
+        field: Mapping[Coordinate, Vector],
+        name: str,
+    ) -> None:
+        if len(field) > self.config.max_active_cells:
+            raise RuntimeError(f"{name} active-cell budget exceeded")
+
+    def _mse(self, field: Mapping[Coordinate, Vector]) -> float:
+        if not field:
+            return 0.0
+        squared = sum(
+            value * value
+            for vector in field.values()
+            for value in vector
+        )
+        return squared / (len(field) * self.config.vector_width)
+
+    @staticmethod
+    def _l2(field: Mapping[Coordinate, Vector]) -> float:
+        return math.sqrt(
+            sum(value * value for vector in field.values() for value in vector)
+        )
+
+    def _loss(
+        self,
+        distortion: float,
+        approximate_ops: int,
+        resource_costs: Mapping[str, float],
+    ) -> float:
+        costs: dict[str, float] = {}
+        for key in ("latency", "bandwidth", "energy"):
+            raw = resource_costs.get(key, 0.0)
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                raise TypeError(f"{key} cost must be numeric")
+            value = float(raw)
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{key} cost must be finite and non-negative")
+            costs[key] = value
+
+        return (
+            self.config.distortion_weight * distortion
+            + self.config.latency_weight * costs["latency"]
+            + self.config.bandwidth_weight * costs["bandwidth"]
+            + self.config.energy_weight * costs["energy"]
+            + self.config.compute_weight * float(approximate_ops)
+        )

--- a/tests/test_dr_moagi_multimodal_io.py
+++ b/tests/test_dr_moagi_multimodal_io.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dr_moagi_multimodal_io import (
+    DrMoagiMultimodalConfig,
+    DrMoagiMultimodalRuntime,
+    IdentityMediumAdapter,
+    MediumChannel,
+)
+
+
+def field(value: float):
+    return {(1, 1, 1): (value, 0.0)}
+
+
+def make_runtime(**config_overrides):
+    config = DrMoagiMultimodalConfig(
+        side=4,
+        vector_width=2,
+        dt=0.5,
+        input_gain=1.0,
+        prediction_gain=0.0,
+        error_gain=0.5,
+        memory_gain=0.0,
+        memory_decay=0.9,
+        memory_error_gain=0.2,
+        **config_overrides,
+    )
+    return DrMoagiMultimodalRuntime(
+        [
+            MediumChannel("vision", IdentityMediumAdapter()),
+            MediumChannel("audio", IdentityMediumAdapter()),
+        ],
+        config=config,
+    )
+
+
+def test_multimodal_inputs_fuse_into_one_shared_3d_state():
+    runtime = make_runtime()
+    runtime.load({})
+
+    result = runtime.step({"vision": field(1.0), "audio": field(0.0)})
+
+    assert result.metrics.committed
+    assert result.metrics.channels_seen == 2
+    # weighted fusion is 0.5, then dt=0.5 pulls state halfway toward it
+    assert runtime.snapshot()[(1, 1, 1)][0] == pytest.approx(0.25)
+
+
+def test_feedback_residual_updates_state_and_persistent_memory():
+    runtime = make_runtime()
+    runtime.load({})
+
+    result = runtime.step(
+        {"vision": field(0.0)},
+        targets={"vision": field(1.0)},
+    )
+
+    assert result.metrics.committed
+    # error term: dt * error_gain * 1.0 = 0.25
+    assert runtime.snapshot()[(1, 1, 1)][0] == pytest.approx(0.25)
+    # Omega_(t+1) = rho*Omega_t + eta_omega*E_t
+    assert runtime.memory_snapshot()[(1, 1, 1)][0] == pytest.approx(0.2)
+    assert result.metrics.distortion_mse == pytest.approx(0.5)
+
+
+def test_validator_rejection_is_atomic_for_state_and_memory():
+    runtime = make_runtime()
+    runtime.load(field(0.2), memory=field(0.1))
+    state_before = runtime.snapshot()
+    memory_before = runtime.memory_snapshot()
+
+    result = runtime.step(
+        {"vision": field(1.0)},
+        targets={"vision": field(0.8)},
+        validator=lambda candidate, metrics: False,
+    )
+
+    assert not result.metrics.committed
+    assert result.metrics.rejection_reason == "validator rejected candidate"
+    assert runtime.snapshot() == state_before
+    assert runtime.memory_snapshot() == memory_before
+    assert runtime.cycle == 1
+
+
+def test_projection_clamps_all_channel_values():
+    runtime = make_runtime(value_min=-0.5, value_max=0.5)
+    runtime.load({})
+
+    runtime.step({"vision": field(9.0)})
+
+    assert runtime.snapshot()[(1, 1, 1)][0] <= 0.5
+
+
+def test_unknown_channel_fails_closed():
+    runtime = make_runtime()
+
+    with pytest.raises(KeyError, match="unknown input channels"):
+        runtime.step({"rf": field(1.0)})
+
+
+def test_output_loopback_is_explicit_not_implied():
+    class NoLoopbackAdapter(IdentityMediumAdapter):
+        def observe_output(self, output):
+            raise RuntimeError("physical sensor unavailable")
+
+    runtime = DrMoagiMultimodalRuntime(
+        [MediumChannel("display", NoLoopbackAdapter())],
+        config=DrMoagiMultimodalConfig(
+            side=4,
+            vector_width=2,
+            dt=0.1,
+            prediction_gain=0.0,
+        ),
+    )
+    runtime.load({})
+
+    # No target means no claim that physical output was observed.
+    result = runtime.step({"display": field(0.4)})
+    assert result.metrics.committed
+
+    with pytest.raises(RuntimeError, match="physical sensor unavailable"):
+        runtime.step(
+            {"display": field(0.4)},
+            targets={"display": field(0.4)},
+        )
+
+
+def test_active_cell_budget_prevents_dense_materialization():
+    runtime = make_runtime(max_active_cells=1)
+
+    with pytest.raises(RuntimeError, match="active-cell budget"):
+        runtime.step(
+            {
+                "vision": {
+                    (0, 0, 0): (0.1, 0.0),
+                    (1, 1, 1): (0.2, 0.0),
+                }
+            }
+        )


### PR DESCRIPTION
## What changed

- adds `DrMoagiMultimodalRuntime`, a sparse transactional reference implementation of `G_{Omega Xi,IO}^3D`;
- introduces medium adapters for encode/decode/explicit loopback across arbitrary I/O channel families;
- fuses multimodal observations into one bounded 3D state, evaluates an inward predictor, computes explicit residual feedback, updates persistent `Omega`, applies `Pi_Lambda`, and atomically commits or rolls back;
- adds resource-aware loss telemetry without fabricating latency, bandwidth, energy, or physical-output measurements;
- adds ADR-006 and the canonical multimodal permeation research specification;
- grounds the older symbolic permeation document in the executable/reality-bounded contract;
- adds a runnable example and invariant tests.

## Why

The Dr Moagi architecture previously had strong codec/field contracts but no single executable law spanning display, audio, text, haptics, RF, networking, storage, electrical, thermal, mechanical, and other sensor/actuator media. This change makes every input medium an explicit encoder boundary and every output medium an explicit decoder/actuator boundary while preserving the deterministic-core separation established by ADR-001/002.

## Safety / authority boundary

This remains a research-layer runtime. It does not grant ANN/adaptive code authority over the canonical VM, does not equate logical `side^3` extent with resident allocation, and does not claim physical output correctness without an actual loopback/sensor path.

## Validation

Local focused validation performed before publication:

```text
7 passed in 0.04s
```

Covered invariants:
- multimodal weighted fusion;
- residual feedback and `Omega` persistence;
- atomic validator rollback;
- `Pi_Lambda` value projection;
- unknown-channel fail-closed behavior;
- explicit physical-loopback semantics;
- sparse active-cell ceiling.

Repository CI should provide the full-suite integration check on this branch.