### PR TITLE
Permeate 3D geometric diffusion kinetic runtime across Jarvis-X

### DIFF
--- a/docs/DR_MOAGI_3D_GEOMETRIC_DIFFUSION_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_GEOMETRIC_DIFFUSION_RUNTIME.md
@@ -1,0 +1,483 @@
+# Dr Moagi 3D Geometric Diffusion Kinetic Runtime
+
+## Status
+
+Canonical bounded Layer 5 research specification implementing ADR-006.
+
+This document defines a virtual 3D geometric auto-encoding/decoding, graph-diffusion, verification and bounded auto-evolution loop. It is intended as an executable systems contract. It does not claim that an LLM literally contains a physical 3D Euclidean substrate, nor that arbitrary images are exactly reconstructible from underspecified prompts.
+
+---
+
+## 1. End-to-end runtime
+
+```text
+OBSERVE
+  -> ENCODE
+  -> RELATIONAL GEOMETRY
+  -> ROUTE / BRANCH
+  -> GRAPH DIFFUSION
+  -> INWARD REFINEMENT
+  -> MEMORY
+  -> TOOL / ACTION CANDIDATES
+  -> DECODE / MANIFEST
+  -> VERIFY
+  -> TELEMETRY
+  -> BOUNDED EVOLUTION
+  -> PROMOTE or ROLLBACK
+  -> RE-ENTER
+```
+
+The fast loop solves a task. The slow loop proposes and evaluates bounded runtime-configuration changes.
+
+```text
+tau_cognition << tau_evolution
+```
+
+---
+
+## 2. Virtual 3D state
+
+A conventional hidden state may be written as
+
+```text
+H in R^(N x d).
+```
+
+The Jarvis-X research representation lifts relational state into
+
+```text
+Xi^3D = {xi_i}
+xi_i = (p_i, h_i)
+p_i in R^3
+h_i in R^d.
+```
+
+The virtual axes are application-defined. A valid mapping may encode, for example:
+
+```text
+x -> sequence/spatial locality
+y -> depth/refinement state
+z -> branch/modality/control depth.
+```
+
+The mapping must be versioned and must not be described as physical geometry unless it actually corresponds to measured physical coordinates.
+
+---
+
+## 3. Relational geometry
+
+The semantic structure is
+
+```text
+G = (V, E).
+```
+
+Each node stores a virtual coordinate and feature vector. Edges express declared relationships. The canonical reference graph is finite, undirected and topology-validated.
+
+The graph acts as the sparse structural scaffold:
+
+```text
+observation
+-> salient nodes
+-> connectivity
+-> axes / frames
+-> local neighborhoods
+-> volumes or higher-level decoded structures.
+```
+
+This mirrors the coarse-to-fine manifestation principle:
+
+```text
+intent
+-> gesture
+-> construction
+-> volume
+-> surface
+-> artifact.
+```
+
+---
+
+## 4. Kinetic interpretation
+
+For a node
+
+```text
+q_i = (p_i, v_i, h_i),
+```
+
+one may interpret virtual transport through
+
+```text
+dp_i/dt = v_i
+
+dv_i/dt =
+    F_attention
+  + F_graph
+  + F_constraint
+  + F_memory
+  + F_diffusion
+  - gamma v_i.
+```
+
+This is an architectural interpretation, not a claim that the underlying model performs literal Newtonian mechanics.
+
+For a transformer-like attention matrix
+
+```text
+A_ij = softmax(Q_i K_j^T / sqrt(d)),
+```
+
+a virtual transport visualization may define
+
+```text
+F_i^attn = sum_j A_ij (p_j - p_i).
+```
+
+The authoritative computation remains the declared implementation; the virtual force picture is a useful coordination model.
+
+---
+
+## 5. Forward graphical diffusion
+
+For any state component `z`, the bounded reference corruption law is
+
+```text
+q(z_tau | z_(tau-1))
+  = N(sqrt(1-beta_tau) z_(tau-1), beta_tau I).
+```
+
+The dependency-free conformance implementation evaluates the equivalent seeded fixture
+
+```text
+z_tau
+  = sqrt(1-beta) z_(tau-1)
+  + sqrt(beta) epsilon,
+```
+
+with a deterministic pseudo-random stream.
+
+The reference operator may corrupt both virtual positions and feature channels. `beta` is explicitly constrained to `[0,1]`.
+
+---
+
+## 6. Geometry-conditioned reverse diffusion
+
+Let `a_i` denote the immutable per-cycle observation/anchor and `N(i)` the graph neighborhood. The reference denoising step is
+
+```text
+p_i' = p_i + g (a_i^p - p_i)
+```
+
+and
+
+```text
+h_i' = h_i
+       + g (a_i^h - h_i)
+       + gamma (mean_{j in N(i)} h_j - h_i)
+       + mu Omega_i.
+```
+
+The three effects are intentionally separated:
+
+```text
+anchor contraction  -> reconstruction fidelity
+graph smoothing      -> relational coherence
+memory residual      -> bounded recurrent correction.
+```
+
+A candidate is projected after reverse steps:
+
+```text
+candidate -> Pi_Lambda -> bounded candidate.
+```
+
+The reference projection clamps each position and feature displacement relative to the per-cycle observation.
+
+---
+
+## 7. Graph energy
+
+The reference implementation reports a deterministic edge-dispersion metric
+
+```text
+E_G
+  = mean_(i,j in E) ||h_i - h_j||^2.
+```
+
+This quantity is deliberately called `edge_energy`, not Shannon entropy. Production systems may expose a true entropy estimate separately.
+
+---
+
+## 8. Auto-encoding and decoding interpretation
+
+The virtual runtime can be placed around a learned or deterministic encoder/decoder:
+
+```text
+X
+-> E_theta
+-> Xi^3D
+-> G
+-> D_tau^graph
+-> R^<-
+-> Pi_Lambda
+-> D_phi
+-> Y.
+```
+
+For language, the coarse-to-fine decoder may be interpreted as
+
+```text
+intent
+-> argument/task graph
+-> section/operation structure
+-> sentence/action candidates
+-> tokens or tool calls.
+```
+
+For images:
+
+```text
+intent
+-> gesture
+-> topology
+-> volumes
+-> surfaces
+-> texture / radiance
+-> pixels.
+```
+
+For software:
+
+```text
+goal
+-> architecture graph
+-> modules
+-> functions
+-> code
+-> tests
+-> deployable artifact.
+```
+
+The graph runtime itself does not supply a trained language, image or code model.
+
+---
+
+## 9. Branching
+
+A bounded family of exploratory states is
+
+```text
+P_(1:M)^<-(Xi_t)
+  = {Xi_t^(1), ..., Xi_t^(M)}.
+```
+
+`M` is a configured resource bound. The reference implementation generates deterministic seeded diffusion branches.
+
+Branch candidates are not authoritative. They must flow through scoring, projection and verification before any downstream publication or action.
+
+---
+
+## 10. Memory
+
+Working residual memory is updated as
+
+```text
+Omega_(t+1)
+  = rho Omega_t
+  + (1-rho) (h_observation - h_candidate).
+```
+
+Memory is intentionally feature-shaped and bounded. It cannot bypass topology, resource, projection or verification checks.
+
+---
+
+## 11. Verification
+
+The reference runtime computes position and feature reconstruction residuals:
+
+```text
+E_p = RMS(p_observation - p_candidate)
+E_h = RMS(h_observation - h_candidate)
+E_total = RMS(concatenate(position residuals, feature residuals)).
+```
+
+The conformance verification score is
+
+```text
+V = 1 / (1 + E_total).
+```
+
+A candidate commits only when
+
+```text
+E_total <= E_max
+AND V >= theta_verify
+AND external_validator(candidate) == PASS, when supplied.
+```
+
+On failure, the previously committed state remains authoritative.
+
+---
+
+## 12. Exact image semantics
+
+"Exact image" is defined only relative to an explicit target and metric contract.
+
+A useful multi-objective distance is
+
+```text
+d_total
+  = w_g d_geometry
+  + w_p d_perceptual
+  + w_s d_semantic
+  + w_x d_pixel.
+```
+
+An exactness claim requires
+
+```text
+d_total(target, generated) <= epsilon
+```
+
+for a declared `epsilon` and declared metric implementations.
+
+Pixel equality is a separate and stricter condition:
+
+```text
+X_generated == X_target.
+```
+
+Jarvis-X does not infer pixel-identical exactness merely because geometry or semantics match.
+
+---
+
+## 13. Dr Moagi system recurrence
+
+At architecture level, the full kinetic research notation is
+
+```text
+Xi_(t+1)^3D = Pi_Lambda[
+    Xi_t^3D
+    + A_3D(Xi_t)
+    + MLP(Xi_t)
+    + P_(1:M)^<-(Xi_t)
+    + lambda_t D_tau^graph(Xi_t)
+    + Omega_t
+    - E_t
+    + kappa_t R_t^<-
+    - eta_t grad_Theta L_t
+    - zeta_t grad_H C_t
+    + U_tool,t
+].
+```
+
+Operational mapping:
+
+```text
+A_3D        -> attention / relational transport adapter
+MLP         -> local feature transformation adapter
+P_(1:M)     -> bounded branch generator
+D_tau^graph -> graphical diffusion / propagation
+Omega       -> bounded memory field
+E           -> reconstruction / intent residual
+R^<-        -> inward refinement operator
+grad L      -> task optimization signal
+grad C      -> coherence / constraint signal
+U_tool      -> validated tool-result input
+Pi_Lambda   -> resource, policy, topology and numerical projection.
+```
+
+The equation is not executable until every term has a concrete type, units/scale, and adapter contract.
+
+---
+
+## 14. Bounded system auto-evolution
+
+The mechanics loop is slower than the task loop:
+
+```text
+runtime
+-> telemetry
+-> diagnosis
+-> versioned configuration mutation
+-> sandbox
+-> benchmark
+-> verification
+-> promote or rollback.
+```
+
+A normalized reference fitness is
+
+```text
+F
+  = 0.30 Q
+  + 0.30 R
+  + 0.20 Eff
+  + 0.20 C
+  - 0.25 P_fault.
+```
+
+A mutation `mu` is promoted only if
+
+```text
+F_candidate > F_current
+AND V_candidate >= theta_verify.
+```
+
+The reference `RuntimeMutation` changes only a `GeometricDiffusionConfig`. Arbitrary source-code rewriting is outside ADR-006.
+
+---
+
+## 15. Resource boundary
+
+Every runtime instance declares at least:
+
+```text
+max_nodes
+max_edges
+branch_width
+beta
+denoise_steps
+max_position_step
+max_feature_step
+max_cycle_rms
+verification_threshold
+memory_retention.
+```
+
+A logical 3D extent does not imply dense materialization. Production sparse backends must separately state resident working-set limits.
+
+---
+
+## 16. Security and authority boundary
+
+The geometric runtime is not a security sandbox.
+
+Untrusted graph, feature, model, image, codec, tool and side-information payloads require validation before allocation or execution. Tool calls remain behind Jarvis-X policy and transaction control.
+
+The following are explicitly non-authoritative until verified:
+
+```text
+visualization
+candidate branches
+predicted tool actions
+runtime mutations
+diffused graph states
+generated images
+inverse reconstructions.
+```
+
+---
+
+## 17. Reference implementation
+
+```text
+src/jarvisx/geometric_diffusion_runtime.py
+tests/test_geometric_diffusion_runtime.py
+docs/adr/0006-3d-geometric-diffusion-kinetic-runtime.md
+```
+
+The implementation is dependency-free and correctness-oriented. It is not a production transformer, diffusion model, renderer, GPU kernel or distributed scheduler.
+
+Accelerated Python/NumPy, PyTorch/CUDA, C++, SIMD, FPGA, distributed or browser implementations may replace kernels only when they preserve the declared graph validation, resource, deterministic-fixture, projection, verification, candidate-first and promotion semantics.

--- a/docs/adr/0006-3d-geometric-diffusion-kinetic-runtime.md
+++ b/docs/adr/0006-3d-geometric-diffusion-kinetic-runtime.md
@@ -1,0 +1,179 @@
+# ADR-006: Adopt the 3D geometric diffusion kinetic runtime boundary
+
+**Status:** Accepted  
+**Date:** 2026-08-15  
+**Extends:** ADR-004, ADR-005
+
+## Context
+
+Jarvis-X already defines a bounded same-space field runtime, the Moagi-Helmholtz generative/orchestration contract, and an orthogonal transform precision boundary. The next research step requires one explicit contract for the recurring system pattern discussed across the 3D auto-encoding/decoding work:
+
+```text
+observe
+-> encode
+-> relational geometry
+-> bounded branching
+-> graph diffusion
+-> inward refinement
+-> decode / manifest
+-> reverse verification
+-> memory
+-> bounded mechanics evolution
+-> re-enter
+```
+
+Without a precise boundary, phrases such as "3D LLM", "graphical diffusion", "exact image generation" and "self-evolution" can be mistaken for claims about physical model internals, arbitrary inversion, or unrestricted source-code mutation.
+
+Jarvis-X therefore needs a deterministic reference semantics that keeps the useful geometry while preserving the repository's existing authority, evidence, rollback and scale rules.
+
+## Decision
+
+Jarvis-X adopts a **virtual 3D geometric diffusion kinetic runtime** as a Layer 5 research contract.
+
+The 3D coordinates are a computational representation. They do not imply that a transformer or language model physically stores its hidden state in Euclidean 3D space.
+
+A relational state is represented by an undirected finite graph
+
+```text
+G = (V, E)
+```
+
+where each node contains
+
+```text
+(position in R^3, feature in R^d).
+```
+
+The graph is topology-validated before diffusion or publication.
+
+### Forward graphical diffusion
+
+For a state component `z` and declared `beta in [0,1]`, the reference corruption law is
+
+```text
+z_tau = sqrt(1-beta) * z_(tau-1) + sqrt(beta) * epsilon
+```
+
+where the reference implementation uses a seeded deterministic pseudo-random stream for reproducible conformance fixtures.
+
+This is a research corruption operator. It is not evidence that a production diffusion model, image generator, or LLM uses this exact implementation.
+
+### Geometry-conditioned reverse step
+
+The reference reverse operator contracts a candidate toward an immutable per-cycle observation/anchor while smoothing feature state over graph adjacency:
+
+```text
+p_i' = p_i + g (p_i^anchor - p_i)
+
+h_i' = h_i
+       + g (h_i^anchor - h_i)
+       + gamma (mean_{j in N(i)} h_j - h_i)
+       + mu Omega_i.
+```
+
+The implementation then applies an explicit projection to bound per-component position and feature displacement.
+
+### Candidate-first transaction
+
+One runtime cycle is
+
+```text
+observation
+-> validate topology/resources
+-> forward graphical diffusion
+-> geometry-conditioned reverse denoising
+-> bounded memory injection
+-> projection Pi_Lambda
+-> reconstruction metrics
+-> verification threshold
+-> optional external validator
+-> COMMIT or ROLLBACK
+-> provenance / telemetry
+```
+
+No candidate becomes authoritative before the complete gate passes.
+
+### Bounded branching
+
+Exploration may construct multiple seeded diffusion candidates, but branch width is an explicit positive integer resource bound. Branch generation does not itself authorize execution or publication.
+
+### Exactness semantics
+
+Jarvis-X does not define "exact image generation" as a promise that an underspecified prompt uniquely determines an arbitrary target image.
+
+Exactness is meaningful only relative to an explicit target, representation, metric and tolerance, for example
+
+```text
+d(target, reconstruction) <= epsilon.
+```
+
+Geometric, perceptual, semantic and pixel metrics are distinct and must not be conflated.
+
+### Memory
+
+Working memory stores bounded residual feature information. Memory is state, not authority: it is an input to the next candidate and remains subordinate to projection and verification.
+
+### System auto-evolution
+
+The reference evolution layer is restricted to **versioned runtime-configuration candidates**. It does not rewrite arbitrary source code.
+
+A candidate mutation `mu` is promoted only when
+
+```text
+Fitness(candidate) > Fitness(current)
+AND verification(candidate) >= threshold
+AND all existing policy/resource/invariant gates pass.
+```
+
+Otherwise the current configuration remains authoritative.
+
+The reference fitness score combines normalized quality, reliability, efficiency and coherence, with an explicit fault penalty. Production systems may use other declared objectives, but they must preserve candidate-first promotion and rollback semantics.
+
+## Relationship to the Dr Moagi recurrence
+
+The architecture-level recurrence remains a compositional research notation:
+
+```text
+Xi_(t+1)^3D = Pi_Lambda[
+    Xi_t^3D
+    + A_3D(Xi_t)
+    + MLP(Xi_t)
+    + P_(1:M)^<-(Xi_t)
+    + lambda D_tau^graph(Xi_t)
+    + Omega_t
+    - E_t
+    + kappa R_t^<-
+    - eta grad L_t
+    - zeta grad C_t
+    + U_tool
+].
+```
+
+Terms combined in an executable implementation must still satisfy the existing same-space/type/units rule. This ADR does not permit arbitrary addition of incompatible latent, field, token, image or tool-state values.
+
+## Architectural consequences
+
+1. The canonical 64-bit VM is unchanged.
+2. The new runtime is a Layer 5 research primitive and may depend on Layer 4 sparse/graph representations, never the reverse.
+3. Visualization remains Layer 6 and is non-authoritative unless separately promoted.
+4. Graph diffusion is explicitly separated from pixel diffusion and from ordinary transformer attention.
+5. Virtual 3D coordinates are representation metadata, not a hardware-performance claim.
+6. Reverse decoding is inference unless side information and a restricted domain establish exact replay.
+7. Self-evolution is bounded configuration adaptation, not unrestricted self-modification.
+8. Tool actions remain behind the existing policy/transaction boundary.
+9. Numerical or perceptual tolerances may not hide malformed topology, non-finite state or a failed lower-level precision gate.
+
+## Validation
+
+Acceptance requires executable tests for:
+
+- graph topology normalization and invalid-edge rejection;
+- seeded deterministic forward diffusion;
+- reverse denoising reducing distance to an immutable anchor in the declared fixture;
+- explicit graph smoothness/dispersion telemetry;
+- candidate rollback on numerical or validator failure;
+- bounded deterministic branch generation;
+- finite, shape-correct working memory;
+- mutation promotion only when both fitness and verification gates pass.
+
+The dependency-free reference implementation is `src/jarvisx/geometric_diffusion_runtime.py` with focused tests in `tests/test_geometric_diffusion_runtime.py`.

--- a/src/jarvisx/geometric_diffusion_runtime.py
+++ b/src/jarvisx/geometric_diffusion_runtime.py
@@ -1,10 +1,9 @@
 """Bounded 3D geometric diffusion and kinetic adaptation reference runtime.
 
-This module is deliberately small and dependency-free.  It provides a deterministic
-research fixture for geometry-conditioned diffusion, candidate-first publication,
-working-memory residuals, and bounded runtime-mutation promotion.  It does not claim
-that a language model literally stores state in physical 3D space, nor that diffusion
-can reproduce an arbitrary target image exactly from an underspecified prompt.
+The module is dependency-free and deterministic under an explicit seed. It is a
+research fixture for virtual 3D relational state, geometry-conditioned diffusion,
+candidate-first publication, bounded residual memory, and configuration promotion.
+It does not claim that an LLM physically stores hidden state in Euclidean 3D space.
 """
 
 from __future__ import annotations
@@ -19,34 +18,48 @@ Feature = tuple[float, ...]
 Edge = tuple[int, int]
 
 
-def _finite_sequence(values: Sequence[float], *, name: str) -> tuple[float, ...]:
-    result = tuple(float(v) for v in values)
+def _finite(values: Sequence[float], *, name: str) -> tuple[float, ...]:
+    result = tuple(float(value) for value in values)
     if not result:
         raise ValueError(f"{name} must not be empty")
-    if not all(math.isfinite(v) for v in result):
+    if not all(math.isfinite(value) for value in result):
         raise ValueError(f"{name} must contain only finite values")
     return result
 
 
+def _unit(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must be finite and within [0, 1]")
+    return value
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return value
+
+
 @dataclass(frozen=True)
 class GeometricNode:
-    """One virtual 3D node with an associated semantic/latent feature vector."""
+    """One virtual 3D point and its semantic/latent feature vector."""
 
     position: Vec3
     feature: Feature
 
     def __post_init__(self) -> None:
-        position = _finite_sequence(self.position, name="position")
+        position = _finite(self.position, name="position")
         if len(position) != 3:
             raise ValueError("position must contain exactly three coordinates")
-        feature = _finite_sequence(self.feature, name="feature")
+        feature = _finite(self.feature, name="feature")
         object.__setattr__(self, "position", (position[0], position[1], position[2]))
         object.__setattr__(self, "feature", feature)
 
 
 @dataclass(frozen=True)
 class GeometricGraph:
-    """Finite undirected graph used as the relational geometry boundary."""
+    """Finite validated undirected relational graph."""
 
     nodes: tuple[GeometricNode, ...]
     edges: tuple[Edge, ...]
@@ -54,8 +67,8 @@ class GeometricGraph:
     def __post_init__(self) -> None:
         if not self.nodes:
             raise ValueError("graph must contain at least one node")
-        feature_width = len(self.nodes[0].feature)
-        if any(len(node.feature) != feature_width for node in self.nodes):
+        width = len(self.nodes[0].feature)
+        if any(len(node.feature) != width for node in self.nodes):
             raise ValueError("all graph nodes must use the same feature width")
 
         count = len(self.nodes)
@@ -89,7 +102,7 @@ class GeometricGraph:
 
 @dataclass(frozen=True)
 class GeometricDiffusionConfig:
-    """Resource and numerical bounds for one geometric diffusion cycle."""
+    """Numerical, verification, exploration and resource bounds."""
 
     beta: float = 0.15
     denoise_steps: int = 4
@@ -106,21 +119,21 @@ class GeometricDiffusionConfig:
     verification_threshold: float = 0.90
 
     def __post_init__(self) -> None:
-        unit_fields = (
+        for name in (
             "beta",
             "geometry_gain",
             "graph_gain",
             "memory_retention",
             "verification_threshold",
-        )
-        for name in unit_fields:
-            value = float(getattr(self, name))
-            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
-                raise ValueError(f"{name} must be finite and within [0, 1]")
-        for name in ("memory_gain", "max_position_step", "max_feature_step", "max_cycle_rms"):
-            value = float(getattr(self, name))
-            if not math.isfinite(value) or value < 0.0:
-                raise ValueError(f"{name} must be finite and non-negative")
+        ):
+            _unit(getattr(self, name), name=name)
+        for name in (
+            "memory_gain",
+            "max_position_step",
+            "max_feature_step",
+            "max_cycle_rms",
+        ):
+            _non_negative(getattr(self, name), name=name)
         for name in ("denoise_steps", "max_nodes", "max_edges", "branch_width"):
             value = getattr(self, name)
             if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
@@ -151,61 +164,61 @@ StateValidator = Callable[[DiffusionState], bool]
 
 
 def _rms(values: Iterable[float]) -> float:
-    data = tuple(float(v) for v in values)
-    if not data:
-        return 0.0
-    return math.sqrt(sum(v * v for v in data) / len(data))
+    data = tuple(float(value) for value in values)
+    return math.sqrt(sum(value * value for value in data) / len(data)) if data else 0.0
+
+
+def _same_topology(left: GeometricGraph, right: GeometricGraph) -> None:
+    if len(left.nodes) != len(right.nodes) or left.edges != right.edges:
+        raise ValueError("graphs must share node count and edge topology")
+    if left.feature_width != right.feature_width:
+        raise ValueError("graphs must share feature width")
 
 
 def graph_rms(reference: GeometricGraph, candidate: GeometricGraph) -> tuple[float, float, float]:
-    """Return position, feature and combined RMS for topology-compatible graphs."""
+    """Return position, feature and combined RMS residuals."""
 
-    _require_same_topology(reference, candidate)
+    _same_topology(reference, candidate)
     position_delta: list[float] = []
     feature_delta: list[float] = []
     for left, right in zip(reference.nodes, candidate.nodes):
         position_delta.extend(a - b for a, b in zip(left.position, right.position))
         feature_delta.extend(a - b for a, b in zip(left.feature, right.feature))
-    pos = _rms(position_delta)
-    feat = _rms(feature_delta)
-    combined = _rms((*position_delta, *feature_delta))
-    return pos, feat, combined
+    return (
+        _rms(position_delta),
+        _rms(feature_delta),
+        _rms((*position_delta, *feature_delta)),
+    )
 
 
 def edge_energy(graph: GeometricGraph) -> float:
-    """Mean squared feature difference across graph edges.
+    """Mean squared feature difference over edges; not Shannon entropy."""
 
-    This is a deterministic smoothness/dispersion metric, not Shannon entropy.
-    """
-
-    if not graph.edges:
-        return 0.0
-    total = 0.0
-    samples = 0
-    for a, b in graph.edges:
-        left = graph.nodes[a].feature
-        right = graph.nodes[b].feature
-        for x, y in zip(left, right):
-            total += (x - y) ** 2
-            samples += 1
-    return total / samples if samples else 0.0
+    residuals = [
+        x - y
+        for a, b in graph.edges
+        for x, y in zip(graph.nodes[a].feature, graph.nodes[b].feature)
+    ]
+    return sum(value * value for value in residuals) / len(residuals) if residuals else 0.0
 
 
 def forward_diffuse(graph: GeometricGraph, *, beta: float, seed: int) -> GeometricGraph:
-    """Apply deterministic seeded Gaussian corruption to position and feature state."""
+    """Apply reproducible Gaussian corruption to positions and feature state."""
 
-    beta = float(beta)
-    if not math.isfinite(beta) or not 0.0 <= beta <= 1.0:
-        raise ValueError("beta must be finite and within [0, 1]")
+    beta = _unit(beta, name="beta")
     keep = math.sqrt(1.0 - beta)
-    noise_scale = math.sqrt(beta)
+    noise = math.sqrt(beta)
     rng = random.Random(seed)
     nodes: list[GeometricNode] = []
     for node in graph.nodes:
-        position = tuple(keep * x + noise_scale * rng.gauss(0.0, 1.0) for x in node.position)
-        feature = tuple(keep * x + noise_scale * rng.gauss(0.0, 1.0) for x in node.feature)
-        nodes.append(GeometricNode(position=position, feature=feature))
-    return GeometricGraph(nodes=tuple(nodes), edges=graph.edges)
+        position: Vec3 = (
+            keep * node.position[0] + noise * rng.gauss(0.0, 1.0),
+            keep * node.position[1] + noise * rng.gauss(0.0, 1.0),
+            keep * node.position[2] + noise * rng.gauss(0.0, 1.0),
+        )
+        feature = tuple(keep * value + noise * rng.gauss(0.0, 1.0) for value in node.feature)
+        nodes.append(GeometricNode(position, feature))
+    return GeometricGraph(tuple(nodes), graph.edges)
 
 
 def reverse_denoise_step(
@@ -217,53 +230,51 @@ def reverse_denoise_step(
     memory: Sequence[Feature] | None = None,
     memory_gain: float = 0.0,
 ) -> GeometricGraph:
-    """One geometry-conditioned reverse step.
+    """Contract toward the anchor and smooth features over graph adjacency."""
 
-    The step contracts state toward the immutable anchor and applies a graph-Laplacian
-    feature smoother.  Optional memory is additive but remains bounded by the caller's
-    projection gate.
-    """
-
-    _require_same_topology(current, anchor)
-    for name, value in (("geometry_gain", geometry_gain), ("graph_gain", graph_gain)):
-        value = float(value)
-        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
-            raise ValueError(f"{name} must be finite and within [0, 1]")
-    if not math.isfinite(float(memory_gain)) or memory_gain < 0.0:
-        raise ValueError("memory_gain must be finite and non-negative")
-
+    _same_topology(current, anchor)
+    geometry_gain = _unit(geometry_gain, name="geometry_gain")
+    graph_gain = _unit(graph_gain, name="graph_gain")
+    memory_gain = _non_negative(memory_gain, name="memory_gain")
     if memory is None:
         memory = tuple((0.0,) * current.feature_width for _ in current.nodes)
     if len(memory) != len(current.nodes):
         raise ValueError("memory must provide one feature vector per node")
     if any(len(item) != current.feature_width for item in memory):
         raise ValueError("memory feature width must match the graph")
-    if any(not all(math.isfinite(float(x)) for x in item) for item in memory):
+    if any(not all(math.isfinite(float(value)) for value in item) for item in memory):
         raise ValueError("memory must contain only finite values")
 
     adjacency = current.adjacency()
     nodes: list[GeometricNode] = []
     for index, (node, target) in enumerate(zip(current.nodes, anchor.nodes)):
-        position = tuple(
-            x + geometry_gain * (a - x) for x, a in zip(node.position, target.position)
+        position: Vec3 = (
+            node.position[0] + geometry_gain * (target.position[0] - node.position[0]),
+            node.position[1] + geometry_gain * (target.position[1] - node.position[1]),
+            node.position[2] + geometry_gain * (target.position[2] - node.position[2]),
         )
         neighbors = adjacency[index]
-        if neighbors:
-            neighbor_mean = tuple(
+        neighbor_mean = (
+            tuple(
                 sum(current.nodes[j].feature[k] for j in neighbors) / len(neighbors)
                 for k in range(current.feature_width)
             )
-        else:
-            neighbor_mean = node.feature
-        feature = tuple(
-            x
-            + geometry_gain * (a - x)
-            + graph_gain * (neighbor_mean[k] - x)
-            + memory_gain * float(memory[index][k])
-            for k, (x, a) in enumerate(zip(node.feature, target.feature))
+            if neighbors
+            else node.feature
         )
-        nodes.append(GeometricNode(position=position, feature=feature))
-    return GeometricGraph(nodes=tuple(nodes), edges=current.edges)
+        feature = tuple(
+            value
+            + geometry_gain * (target.feature[k] - value)
+            + graph_gain * (neighbor_mean[k] - value)
+            + memory_gain * float(memory[index][k])
+            for k, value in enumerate(node.feature)
+        )
+        nodes.append(GeometricNode(position, feature))
+    return GeometricGraph(tuple(nodes), current.edges)
+
+
+def _bounded(value: float, anchor: float, limit: float) -> float:
+    return anchor + max(-limit, min(limit, value - anchor))
 
 
 def project_candidate(
@@ -273,54 +284,49 @@ def project_candidate(
     max_position_step: float,
     max_feature_step: float,
 ) -> GeometricGraph:
-    """Project candidate node deltas into explicit per-component limits."""
+    """Project candidate deltas into explicit component-wise bounds."""
 
-    _require_same_topology(candidate, anchor)
-    if max_position_step < 0.0 or max_feature_step < 0.0:
-        raise ValueError("projection bounds must be non-negative")
-    if not math.isfinite(max_position_step) or not math.isfinite(max_feature_step):
-        raise ValueError("projection bounds must be finite")
-
+    _same_topology(candidate, anchor)
+    max_position_step = _non_negative(max_position_step, name="max_position_step")
+    max_feature_step = _non_negative(max_feature_step, name="max_feature_step")
     nodes: list[GeometricNode] = []
     for node, base in zip(candidate.nodes, anchor.nodes):
-        position = tuple(
-            a + max(-max_position_step, min(max_position_step, x - a))
-            for x, a in zip(node.position, base.position)
+        position: Vec3 = (
+            _bounded(node.position[0], base.position[0], max_position_step),
+            _bounded(node.position[1], base.position[1], max_position_step),
+            _bounded(node.position[2], base.position[2], max_position_step),
         )
         feature = tuple(
-            a + max(-max_feature_step, min(max_feature_step, x - a))
-            for x, a in zip(node.feature, base.feature)
+            _bounded(value, origin, max_feature_step)
+            for value, origin in zip(node.feature, base.feature)
         )
-        nodes.append(GeometricNode(position=position, feature=feature))
-    return GeometricGraph(nodes=tuple(nodes), edges=candidate.edges)
-
-
-def _require_same_topology(left: GeometricGraph, right: GeometricGraph) -> None:
-    if len(left.nodes) != len(right.nodes) or left.edges != right.edges:
-        raise ValueError("graphs must share node count and edge topology")
-    if left.feature_width != right.feature_width:
-        raise ValueError("graphs must share feature width")
+        nodes.append(GeometricNode(position, feature))
+    return GeometricGraph(tuple(nodes), candidate.edges)
 
 
 class GeometricDiffusionRuntime:
-    """Candidate-first encode/diffuse/denoise/project/verify reference loop."""
+    """Candidate-first diffuse, denoise, project, verify and commit loop."""
 
-    def __init__(self, anchor: GeometricGraph, config: GeometricDiffusionConfig | None = None):
+    def __init__(
+        self,
+        anchor: GeometricGraph,
+        config: GeometricDiffusionConfig | None = None,
+    ) -> None:
         self.config = config or GeometricDiffusionConfig()
         self._check_budget(anchor)
         self._anchor = anchor
-        zero_memory = tuple((0.0,) * anchor.feature_width for _ in anchor.nodes)
+        memory = tuple((0.0,) * anchor.feature_width for _ in anchor.nodes)
         metrics = DiffusionMetrics(
-            cycle=0,
-            node_count=len(anchor.nodes),
-            edge_count=len(anchor.edges),
-            position_rms=0.0,
-            feature_rms=0.0,
-            combined_rms=0.0,
-            edge_energy=edge_energy(anchor),
-            verification_score=1.0,
+            0,
+            len(anchor.nodes),
+            len(anchor.edges),
+            0.0,
+            0.0,
+            0.0,
+            edge_energy(anchor),
+            1.0,
         )
-        self._state = DiffusionState(cycle=0, graph=anchor, memory=zero_memory, metrics=metrics)
+        self._state = DiffusionState(0, anchor, memory, metrics)
 
     @property
     def anchor(self) -> GeometricGraph:
@@ -337,13 +343,10 @@ class GeometricDiffusionRuntime:
         seed: int = 0,
         validator: StateValidator | None = None,
     ) -> DiffusionState:
-        """Execute one full candidate cycle and publish only after all gates pass."""
+        """Publish a new state only after numerical and optional external gates pass."""
 
         self._check_budget(observation)
-        _require_same_topology(self._anchor, observation)
-
-        # The observation is the immutable per-cycle reconstruction target.  Forward
-        # corruption models exploratory diffusion; reverse steps are geometry-conditioned.
+        _same_topology(self._anchor, observation)
         candidate = forward_diffuse(observation, beta=self.config.beta, seed=seed)
         for _ in range(self.config.denoise_steps):
             candidate = reverse_denoise_step(
@@ -360,65 +363,65 @@ class GeometricDiffusionRuntime:
             max_position_step=self.config.max_position_step,
             max_feature_step=self.config.max_feature_step,
         )
-
-        pos_rms, feat_rms, combined_rms = graph_rms(observation, candidate)
-        verification_score = 1.0 / (1.0 + combined_rms)
-        next_cycle = self._state.cycle + 1
-        next_memory = self._update_memory(observation, candidate)
-        metrics = DiffusionMetrics(
-            cycle=next_cycle,
-            node_count=len(candidate.nodes),
-            edge_count=len(candidate.edges),
-            position_rms=pos_rms,
-            feature_rms=feat_rms,
-            combined_rms=combined_rms,
-            edge_energy=edge_energy(candidate),
-            verification_score=verification_score,
-        )
+        position_rms, feature_rms, combined_rms = graph_rms(observation, candidate)
+        verification = 1.0 / (1.0 + combined_rms)
+        cycle = self._state.cycle + 1
         pending = DiffusionState(
-            cycle=next_cycle,
-            graph=candidate,
-            memory=next_memory,
-            metrics=metrics,
+            cycle,
+            candidate,
+            self._update_memory(observation, candidate),
+            DiffusionMetrics(
+                cycle,
+                len(candidate.nodes),
+                len(candidate.edges),
+                position_rms,
+                feature_rms,
+                combined_rms,
+                edge_energy(candidate),
+                verification,
+            ),
         )
-
         if combined_rms > self.config.max_cycle_rms:
             raise RuntimeError("candidate exceeds configured cycle RMS")
-        if verification_score < self.config.verification_threshold:
+        if verification < self.config.verification_threshold:
             raise RuntimeError("candidate verification score is below threshold")
         if validator is not None and not bool(validator(pending)):
             raise RuntimeError("candidate rejected by geometric diffusion validator")
-
-        # Atomic publication boundary.
         self._state = pending
         return pending
 
     def branch_candidates(
-        self, observation: GeometricGraph, *, seed: int = 0
+        self,
+        observation: GeometricGraph,
+        *,
+        seed: int = 0,
     ) -> tuple[GeometricGraph, ...]:
-        """Generate a bounded deterministic family of exploratory diffusion candidates."""
+        """Generate a bounded deterministic family of exploratory candidates."""
 
         self._check_budget(observation)
-        _require_same_topology(self._anchor, observation)
+        _same_topology(self._anchor, observation)
         return tuple(
-            forward_diffuse(observation, beta=self.config.beta, seed=seed + branch)
-            for branch in range(self.config.branch_width)
+            forward_diffuse(observation, beta=self.config.beta, seed=seed + index)
+            for index in range(self.config.branch_width)
         )
 
     def _update_memory(
-        self, observation: GeometricGraph, candidate: GeometricGraph
+        self,
+        observation: GeometricGraph,
+        candidate: GeometricGraph,
     ) -> tuple[Feature, ...]:
         retention = self.config.memory_retention
-        memory: list[Feature] = []
-        for previous, source, result in zip(self._state.memory, observation.nodes, candidate.nodes):
-            residual = tuple(a - b for a, b in zip(source.feature, result.feature))
-            memory.append(
-                tuple(
-                    retention * old + (1.0 - retention) * err
-                    for old, err in zip(previous, residual)
-                )
+        return tuple(
+            tuple(
+                retention * old + (1.0 - retention) * (source - result)
+                for old, source, result in zip(previous, left.feature, right.feature)
             )
-        return tuple(memory)
+            for previous, left, right in zip(
+                self._state.memory,
+                observation.nodes,
+                candidate.nodes,
+            )
+        )
 
     def _check_budget(self, graph: GeometricGraph) -> None:
         if len(graph.nodes) > self.config.max_nodes:
@@ -429,8 +432,6 @@ class GeometricDiffusionRuntime:
 
 @dataclass(frozen=True)
 class FitnessMetrics:
-    """Normalized system-level metrics used by the bounded mutation gate."""
-
     quality: float
     reliability: float
     efficiency: float
@@ -438,10 +439,14 @@ class FitnessMetrics:
     fault_probability: float = 0.0
 
     def __post_init__(self) -> None:
-        for name in ("quality", "reliability", "efficiency", "coherence", "fault_probability"):
-            value = float(getattr(self, name))
-            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
-                raise ValueError(f"{name} must be finite and within [0, 1]")
+        for name in (
+            "quality",
+            "reliability",
+            "efficiency",
+            "coherence",
+            "fault_probability",
+        ):
+            _unit(getattr(self, name), name=name)
 
     @property
     def score(self) -> float:
@@ -456,7 +461,7 @@ class FitnessMetrics:
 
 @dataclass(frozen=True)
 class RuntimeMutation:
-    """Versioned bounded configuration candidate; never executable source-code mutation."""
+    """Versioned configuration candidate, not arbitrary source-code mutation."""
 
     identifier: str
     config: GeometricDiffusionConfig
@@ -483,38 +488,22 @@ def evaluate_mutation(
     candidate_metrics: FitnessMetrics,
     verification_score: float,
 ) -> PromotionReceipt:
-    """Apply the system-wide candidate-first promotion/rollback law."""
+    """Promote only a verified configuration whose fitness strictly improves."""
 
-    verification_score = float(verification_score)
-    if not math.isfinite(verification_score) or not 0.0 <= verification_score <= 1.0:
-        raise ValueError("verification_score must be finite and within [0, 1]")
-
+    verification_score = _unit(verification_score, name="verification_score")
     current = current_metrics.score
     candidate = candidate_metrics.score
-    threshold = mutation.config.verification_threshold
-    if verification_score < threshold:
-        return PromotionReceipt(
-            mutation_id=mutation.identifier,
-            current_fitness=current,
-            candidate_fitness=candidate,
-            verification_score=verification_score,
-            promoted=False,
-            reason="verification threshold not met",
-        )
-    if candidate <= current:
-        return PromotionReceipt(
-            mutation_id=mutation.identifier,
-            current_fitness=current,
-            candidate_fitness=candidate,
-            verification_score=verification_score,
-            promoted=False,
-            reason="candidate fitness did not improve",
-        )
+    if verification_score < mutation.config.verification_threshold:
+        promoted, reason = False, "verification threshold not met"
+    elif candidate <= current:
+        promoted, reason = False, "candidate fitness did not improve"
+    else:
+        promoted, reason = True, "fitness improved and verification gate passed"
     return PromotionReceipt(
-        mutation_id=mutation.identifier,
-        current_fitness=current,
-        candidate_fitness=candidate,
-        verification_score=verification_score,
-        promoted=True,
-        reason="fitness improved and verification gate passed",
+        mutation.identifier,
+        current,
+        candidate,
+        verification_score,
+        promoted,
+        reason,
     )

--- a/src/jarvisx/geometric_diffusion_runtime.py
+++ b/src/jarvisx/geometric_diffusion_runtime.py
@@ -1,0 +1,520 @@
+"""Bounded 3D geometric diffusion and kinetic adaptation reference runtime.
+
+This module is deliberately small and dependency-free.  It provides a deterministic
+research fixture for geometry-conditioned diffusion, candidate-first publication,
+working-memory residuals, and bounded runtime-mutation promotion.  It does not claim
+that a language model literally stores state in physical 3D space, nor that diffusion
+can reproduce an arbitrary target image exactly from an underspecified prompt.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Callable, Iterable, Sequence
+
+Vec3 = tuple[float, float, float]
+Feature = tuple[float, ...]
+Edge = tuple[int, int]
+
+
+def _finite_sequence(values: Sequence[float], *, name: str) -> tuple[float, ...]:
+    result = tuple(float(v) for v in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if not all(math.isfinite(v) for v in result):
+        raise ValueError(f"{name} must contain only finite values")
+    return result
+
+
+@dataclass(frozen=True)
+class GeometricNode:
+    """One virtual 3D node with an associated semantic/latent feature vector."""
+
+    position: Vec3
+    feature: Feature
+
+    def __post_init__(self) -> None:
+        position = _finite_sequence(self.position, name="position")
+        if len(position) != 3:
+            raise ValueError("position must contain exactly three coordinates")
+        feature = _finite_sequence(self.feature, name="feature")
+        object.__setattr__(self, "position", (position[0], position[1], position[2]))
+        object.__setattr__(self, "feature", feature)
+
+
+@dataclass(frozen=True)
+class GeometricGraph:
+    """Finite undirected graph used as the relational geometry boundary."""
+
+    nodes: tuple[GeometricNode, ...]
+    edges: tuple[Edge, ...]
+
+    def __post_init__(self) -> None:
+        if not self.nodes:
+            raise ValueError("graph must contain at least one node")
+        feature_width = len(self.nodes[0].feature)
+        if any(len(node.feature) != feature_width for node in self.nodes):
+            raise ValueError("all graph nodes must use the same feature width")
+
+        count = len(self.nodes)
+        normalized: set[Edge] = set()
+        for edge in self.edges:
+            if len(edge) != 2:
+                raise ValueError("edges must contain exactly two node indices")
+            a, b = edge
+            if isinstance(a, bool) or isinstance(b, bool):
+                raise TypeError("edge indices must be integers")
+            if not isinstance(a, int) or not isinstance(b, int):
+                raise TypeError("edge indices must be integers")
+            if a == b:
+                raise ValueError("self edges are not admissible")
+            if a < 0 or b < 0 or a >= count or b >= count:
+                raise ValueError("edge index is outside the node buffer")
+            normalized.add((a, b) if a < b else (b, a))
+        object.__setattr__(self, "edges", tuple(sorted(normalized)))
+
+    @property
+    def feature_width(self) -> int:
+        return len(self.nodes[0].feature)
+
+    def adjacency(self) -> tuple[tuple[int, ...], ...]:
+        neighbors: list[list[int]] = [[] for _ in self.nodes]
+        for a, b in self.edges:
+            neighbors[a].append(b)
+            neighbors[b].append(a)
+        return tuple(tuple(sorted(items)) for items in neighbors)
+
+
+@dataclass(frozen=True)
+class GeometricDiffusionConfig:
+    """Resource and numerical bounds for one geometric diffusion cycle."""
+
+    beta: float = 0.15
+    denoise_steps: int = 4
+    geometry_gain: float = 0.55
+    graph_gain: float = 0.15
+    memory_retention: float = 0.75
+    memory_gain: float = 0.10
+    max_position_step: float = 0.75
+    max_feature_step: float = 2.0
+    max_cycle_rms: float = 0.35
+    max_nodes: int = 100_000
+    max_edges: int = 400_000
+    branch_width: int = 4
+    verification_threshold: float = 0.90
+
+    def __post_init__(self) -> None:
+        unit_fields = (
+            "beta",
+            "geometry_gain",
+            "graph_gain",
+            "memory_retention",
+            "verification_threshold",
+        )
+        for name in unit_fields:
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be finite and within [0, 1]")
+        for name in ("memory_gain", "max_position_step", "max_feature_step", "max_cycle_rms"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        for name in ("denoise_steps", "max_nodes", "max_edges", "branch_width"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class DiffusionMetrics:
+    cycle: int
+    node_count: int
+    edge_count: int
+    position_rms: float
+    feature_rms: float
+    combined_rms: float
+    edge_energy: float
+    verification_score: float
+
+
+@dataclass(frozen=True)
+class DiffusionState:
+    cycle: int
+    graph: GeometricGraph
+    memory: tuple[Feature, ...]
+    metrics: DiffusionMetrics
+
+
+StateValidator = Callable[[DiffusionState], bool]
+
+
+def _rms(values: Iterable[float]) -> float:
+    data = tuple(float(v) for v in values)
+    if not data:
+        return 0.0
+    return math.sqrt(sum(v * v for v in data) / len(data))
+
+
+def graph_rms(reference: GeometricGraph, candidate: GeometricGraph) -> tuple[float, float, float]:
+    """Return position, feature and combined RMS for topology-compatible graphs."""
+
+    _require_same_topology(reference, candidate)
+    position_delta: list[float] = []
+    feature_delta: list[float] = []
+    for left, right in zip(reference.nodes, candidate.nodes):
+        position_delta.extend(a - b for a, b in zip(left.position, right.position))
+        feature_delta.extend(a - b for a, b in zip(left.feature, right.feature))
+    pos = _rms(position_delta)
+    feat = _rms(feature_delta)
+    combined = _rms((*position_delta, *feature_delta))
+    return pos, feat, combined
+
+
+def edge_energy(graph: GeometricGraph) -> float:
+    """Mean squared feature difference across graph edges.
+
+    This is a deterministic smoothness/dispersion metric, not Shannon entropy.
+    """
+
+    if not graph.edges:
+        return 0.0
+    total = 0.0
+    samples = 0
+    for a, b in graph.edges:
+        left = graph.nodes[a].feature
+        right = graph.nodes[b].feature
+        for x, y in zip(left, right):
+            total += (x - y) ** 2
+            samples += 1
+    return total / samples if samples else 0.0
+
+
+def forward_diffuse(graph: GeometricGraph, *, beta: float, seed: int) -> GeometricGraph:
+    """Apply deterministic seeded Gaussian corruption to position and feature state."""
+
+    beta = float(beta)
+    if not math.isfinite(beta) or not 0.0 <= beta <= 1.0:
+        raise ValueError("beta must be finite and within [0, 1]")
+    keep = math.sqrt(1.0 - beta)
+    noise_scale = math.sqrt(beta)
+    rng = random.Random(seed)
+    nodes: list[GeometricNode] = []
+    for node in graph.nodes:
+        position = tuple(keep * x + noise_scale * rng.gauss(0.0, 1.0) for x in node.position)
+        feature = tuple(keep * x + noise_scale * rng.gauss(0.0, 1.0) for x in node.feature)
+        nodes.append(GeometricNode(position=position, feature=feature))
+    return GeometricGraph(nodes=tuple(nodes), edges=graph.edges)
+
+
+def reverse_denoise_step(
+    current: GeometricGraph,
+    anchor: GeometricGraph,
+    *,
+    geometry_gain: float,
+    graph_gain: float,
+    memory: Sequence[Feature] | None = None,
+    memory_gain: float = 0.0,
+) -> GeometricGraph:
+    """One geometry-conditioned reverse step.
+
+    The step contracts state toward the immutable anchor and applies a graph-Laplacian
+    feature smoother.  Optional memory is additive but remains bounded by the caller's
+    projection gate.
+    """
+
+    _require_same_topology(current, anchor)
+    for name, value in (("geometry_gain", geometry_gain), ("graph_gain", graph_gain)):
+        value = float(value)
+        if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+            raise ValueError(f"{name} must be finite and within [0, 1]")
+    if not math.isfinite(float(memory_gain)) or memory_gain < 0.0:
+        raise ValueError("memory_gain must be finite and non-negative")
+
+    if memory is None:
+        memory = tuple((0.0,) * current.feature_width for _ in current.nodes)
+    if len(memory) != len(current.nodes):
+        raise ValueError("memory must provide one feature vector per node")
+    if any(len(item) != current.feature_width for item in memory):
+        raise ValueError("memory feature width must match the graph")
+    if any(not all(math.isfinite(float(x)) for x in item) for item in memory):
+        raise ValueError("memory must contain only finite values")
+
+    adjacency = current.adjacency()
+    nodes: list[GeometricNode] = []
+    for index, (node, target) in enumerate(zip(current.nodes, anchor.nodes)):
+        position = tuple(
+            x + geometry_gain * (a - x) for x, a in zip(node.position, target.position)
+        )
+        neighbors = adjacency[index]
+        if neighbors:
+            neighbor_mean = tuple(
+                sum(current.nodes[j].feature[k] for j in neighbors) / len(neighbors)
+                for k in range(current.feature_width)
+            )
+        else:
+            neighbor_mean = node.feature
+        feature = tuple(
+            x
+            + geometry_gain * (a - x)
+            + graph_gain * (neighbor_mean[k] - x)
+            + memory_gain * float(memory[index][k])
+            for k, (x, a) in enumerate(zip(node.feature, target.feature))
+        )
+        nodes.append(GeometricNode(position=position, feature=feature))
+    return GeometricGraph(nodes=tuple(nodes), edges=current.edges)
+
+
+def project_candidate(
+    candidate: GeometricGraph,
+    anchor: GeometricGraph,
+    *,
+    max_position_step: float,
+    max_feature_step: float,
+) -> GeometricGraph:
+    """Project candidate node deltas into explicit per-component limits."""
+
+    _require_same_topology(candidate, anchor)
+    if max_position_step < 0.0 or max_feature_step < 0.0:
+        raise ValueError("projection bounds must be non-negative")
+    if not math.isfinite(max_position_step) or not math.isfinite(max_feature_step):
+        raise ValueError("projection bounds must be finite")
+
+    nodes: list[GeometricNode] = []
+    for node, base in zip(candidate.nodes, anchor.nodes):
+        position = tuple(
+            a + max(-max_position_step, min(max_position_step, x - a))
+            for x, a in zip(node.position, base.position)
+        )
+        feature = tuple(
+            a + max(-max_feature_step, min(max_feature_step, x - a))
+            for x, a in zip(node.feature, base.feature)
+        )
+        nodes.append(GeometricNode(position=position, feature=feature))
+    return GeometricGraph(nodes=tuple(nodes), edges=candidate.edges)
+
+
+def _require_same_topology(left: GeometricGraph, right: GeometricGraph) -> None:
+    if len(left.nodes) != len(right.nodes) or left.edges != right.edges:
+        raise ValueError("graphs must share node count and edge topology")
+    if left.feature_width != right.feature_width:
+        raise ValueError("graphs must share feature width")
+
+
+class GeometricDiffusionRuntime:
+    """Candidate-first encode/diffuse/denoise/project/verify reference loop."""
+
+    def __init__(self, anchor: GeometricGraph, config: GeometricDiffusionConfig | None = None):
+        self.config = config or GeometricDiffusionConfig()
+        self._check_budget(anchor)
+        self._anchor = anchor
+        zero_memory = tuple((0.0,) * anchor.feature_width for _ in anchor.nodes)
+        metrics = DiffusionMetrics(
+            cycle=0,
+            node_count=len(anchor.nodes),
+            edge_count=len(anchor.edges),
+            position_rms=0.0,
+            feature_rms=0.0,
+            combined_rms=0.0,
+            edge_energy=edge_energy(anchor),
+            verification_score=1.0,
+        )
+        self._state = DiffusionState(cycle=0, graph=anchor, memory=zero_memory, metrics=metrics)
+
+    @property
+    def anchor(self) -> GeometricGraph:
+        return self._anchor
+
+    @property
+    def state(self) -> DiffusionState:
+        return self._state
+
+    def step(
+        self,
+        observation: GeometricGraph,
+        *,
+        seed: int = 0,
+        validator: StateValidator | None = None,
+    ) -> DiffusionState:
+        """Execute one full candidate cycle and publish only after all gates pass."""
+
+        self._check_budget(observation)
+        _require_same_topology(self._anchor, observation)
+
+        # The observation is the immutable per-cycle reconstruction target.  Forward
+        # corruption models exploratory diffusion; reverse steps are geometry-conditioned.
+        candidate = forward_diffuse(observation, beta=self.config.beta, seed=seed)
+        for _ in range(self.config.denoise_steps):
+            candidate = reverse_denoise_step(
+                candidate,
+                observation,
+                geometry_gain=self.config.geometry_gain,
+                graph_gain=self.config.graph_gain,
+                memory=self._state.memory,
+                memory_gain=self.config.memory_gain,
+            )
+        candidate = project_candidate(
+            candidate,
+            observation,
+            max_position_step=self.config.max_position_step,
+            max_feature_step=self.config.max_feature_step,
+        )
+
+        pos_rms, feat_rms, combined_rms = graph_rms(observation, candidate)
+        verification_score = 1.0 / (1.0 + combined_rms)
+        next_cycle = self._state.cycle + 1
+        next_memory = self._update_memory(observation, candidate)
+        metrics = DiffusionMetrics(
+            cycle=next_cycle,
+            node_count=len(candidate.nodes),
+            edge_count=len(candidate.edges),
+            position_rms=pos_rms,
+            feature_rms=feat_rms,
+            combined_rms=combined_rms,
+            edge_energy=edge_energy(candidate),
+            verification_score=verification_score,
+        )
+        pending = DiffusionState(
+            cycle=next_cycle,
+            graph=candidate,
+            memory=next_memory,
+            metrics=metrics,
+        )
+
+        if combined_rms > self.config.max_cycle_rms:
+            raise RuntimeError("candidate exceeds configured cycle RMS")
+        if verification_score < self.config.verification_threshold:
+            raise RuntimeError("candidate verification score is below threshold")
+        if validator is not None and not bool(validator(pending)):
+            raise RuntimeError("candidate rejected by geometric diffusion validator")
+
+        # Atomic publication boundary.
+        self._state = pending
+        return pending
+
+    def branch_candidates(
+        self, observation: GeometricGraph, *, seed: int = 0
+    ) -> tuple[GeometricGraph, ...]:
+        """Generate a bounded deterministic family of exploratory diffusion candidates."""
+
+        self._check_budget(observation)
+        _require_same_topology(self._anchor, observation)
+        return tuple(
+            forward_diffuse(observation, beta=self.config.beta, seed=seed + branch)
+            for branch in range(self.config.branch_width)
+        )
+
+    def _update_memory(
+        self, observation: GeometricGraph, candidate: GeometricGraph
+    ) -> tuple[Feature, ...]:
+        retention = self.config.memory_retention
+        memory: list[Feature] = []
+        for previous, source, result in zip(self._state.memory, observation.nodes, candidate.nodes):
+            residual = tuple(a - b for a, b in zip(source.feature, result.feature))
+            memory.append(
+                tuple(
+                    retention * old + (1.0 - retention) * err
+                    for old, err in zip(previous, residual)
+                )
+            )
+        return tuple(memory)
+
+    def _check_budget(self, graph: GeometricGraph) -> None:
+        if len(graph.nodes) > self.config.max_nodes:
+            raise RuntimeError("graph exceeds configured node budget")
+        if len(graph.edges) > self.config.max_edges:
+            raise RuntimeError("graph exceeds configured edge budget")
+
+
+@dataclass(frozen=True)
+class FitnessMetrics:
+    """Normalized system-level metrics used by the bounded mutation gate."""
+
+    quality: float
+    reliability: float
+    efficiency: float
+    coherence: float
+    fault_probability: float = 0.0
+
+    def __post_init__(self) -> None:
+        for name in ("quality", "reliability", "efficiency", "coherence", "fault_probability"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be finite and within [0, 1]")
+
+    @property
+    def score(self) -> float:
+        return (
+            0.30 * self.quality
+            + 0.30 * self.reliability
+            + 0.20 * self.efficiency
+            + 0.20 * self.coherence
+            - 0.25 * self.fault_probability
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeMutation:
+    """Versioned bounded configuration candidate; never executable source-code mutation."""
+
+    identifier: str
+    config: GeometricDiffusionConfig
+
+    def __post_init__(self) -> None:
+        if not self.identifier or not self.identifier.strip():
+            raise ValueError("mutation identifier must not be empty")
+
+
+@dataclass(frozen=True)
+class PromotionReceipt:
+    mutation_id: str
+    current_fitness: float
+    candidate_fitness: float
+    verification_score: float
+    promoted: bool
+    reason: str
+
+
+def evaluate_mutation(
+    mutation: RuntimeMutation,
+    *,
+    current_metrics: FitnessMetrics,
+    candidate_metrics: FitnessMetrics,
+    verification_score: float,
+) -> PromotionReceipt:
+    """Apply the system-wide candidate-first promotion/rollback law."""
+
+    verification_score = float(verification_score)
+    if not math.isfinite(verification_score) or not 0.0 <= verification_score <= 1.0:
+        raise ValueError("verification_score must be finite and within [0, 1]")
+
+    current = current_metrics.score
+    candidate = candidate_metrics.score
+    threshold = mutation.config.verification_threshold
+    if verification_score < threshold:
+        return PromotionReceipt(
+            mutation_id=mutation.identifier,
+            current_fitness=current,
+            candidate_fitness=candidate,
+            verification_score=verification_score,
+            promoted=False,
+            reason="verification threshold not met",
+        )
+    if candidate <= current:
+        return PromotionReceipt(
+            mutation_id=mutation.identifier,
+            current_fitness=current,
+            candidate_fitness=candidate,
+            verification_score=verification_score,
+            promoted=False,
+            reason="candidate fitness did not improve",
+        )
+    return PromotionReceipt(
+        mutation_id=mutation.identifier,
+        current_fitness=current,
+        candidate_fitness=candidate,
+        verification_score=verification_score,
+        promoted=True,
+        reason="fitness improved and verification gate passed",
+    )

--- a/tests/test_geometric_diffusion_runtime.py
+++ b/tests/test_geometric_diffusion_runtime.py
@@ -1,0 +1,174 @@
+import math
+
+import pytest
+
+from jarvisx.geometric_diffusion_runtime import (
+    FitnessMetrics,
+    GeometricDiffusionConfig,
+    GeometricDiffusionRuntime,
+    GeometricGraph,
+    GeometricNode,
+    RuntimeMutation,
+    edge_energy,
+    evaluate_mutation,
+    forward_diffuse,
+    graph_rms,
+    reverse_denoise_step,
+)
+
+
+def fixture_graph() -> GeometricGraph:
+    return GeometricGraph(
+        nodes=(
+            GeometricNode((0.0, 0.0, 0.0), (1.0, 0.0)),
+            GeometricNode((1.0, 0.0, 0.0), (0.5, 0.5)),
+            GeometricNode((1.0, 1.0, 0.0), (0.0, 1.0)),
+            GeometricNode((0.0, 1.0, 0.0), (0.5, 0.5)),
+        ),
+        edges=((0, 1), (1, 2), (2, 3), (3, 0)),
+    )
+
+
+def test_graph_normalizes_undirected_edges_and_rejects_invalid_topology():
+    graph = GeometricGraph(
+        nodes=(
+            GeometricNode((0, 0, 0), (1,)),
+            GeometricNode((1, 0, 0), (2,)),
+        ),
+        edges=((1, 0), (0, 1)),
+    )
+    assert graph.edges == ((0, 1),)
+    with pytest.raises(ValueError, match="self edges"):
+        GeometricGraph(nodes=graph.nodes, edges=((0, 0),))
+    with pytest.raises(ValueError, match="outside"):
+        GeometricGraph(nodes=graph.nodes, edges=((0, 2),))
+
+
+def test_forward_diffusion_is_seeded_and_reverse_step_reduces_anchor_rms():
+    anchor = fixture_graph()
+    noisy_a = forward_diffuse(anchor, beta=0.25, seed=7)
+    noisy_b = forward_diffuse(anchor, beta=0.25, seed=7)
+    noisy_c = forward_diffuse(anchor, beta=0.25, seed=8)
+    assert noisy_a == noisy_b
+    assert noisy_a != noisy_c
+
+    before = graph_rms(anchor, noisy_a)[2]
+    denoised = reverse_denoise_step(
+        noisy_a,
+        anchor,
+        geometry_gain=0.65,
+        graph_gain=0.0,
+    )
+    after = graph_rms(anchor, denoised)[2]
+    assert after < before
+
+
+def test_edge_energy_is_explicit_smoothness_metric():
+    graph = fixture_graph()
+    assert edge_energy(graph) > 0.0
+    flat = GeometricGraph(
+        nodes=tuple(GeometricNode(n.position, (1.0, 1.0)) for n in graph.nodes),
+        edges=graph.edges,
+    )
+    assert edge_energy(flat) == 0.0
+
+
+def test_runtime_commits_only_passing_candidate_and_rolls_back_on_validator_failure():
+    anchor = fixture_graph()
+    config = GeometricDiffusionConfig(
+        beta=0.05,
+        denoise_steps=5,
+        geometry_gain=0.8,
+        graph_gain=0.0,
+        max_cycle_rms=0.20,
+        verification_threshold=0.90,
+    )
+    runtime = GeometricDiffusionRuntime(anchor, config)
+    committed = runtime.step(anchor, seed=11)
+    assert committed.cycle == 1
+    previous = runtime.state
+
+    with pytest.raises(RuntimeError, match="validator"):
+        runtime.step(anchor, seed=12, validator=lambda _: False)
+    assert runtime.state is previous
+
+
+def test_runtime_rejects_candidate_when_numerical_gate_is_too_strict():
+    anchor = fixture_graph()
+    config = GeometricDiffusionConfig(
+        beta=0.30,
+        denoise_steps=1,
+        geometry_gain=0.05,
+        graph_gain=0.0,
+        max_cycle_rms=0.01,
+        verification_threshold=0.0,
+    )
+    runtime = GeometricDiffusionRuntime(anchor, config)
+    with pytest.raises(RuntimeError, match="cycle RMS"):
+        runtime.step(anchor, seed=3)
+    assert runtime.state.cycle == 0
+
+
+def test_branch_generation_is_bounded_and_deterministic():
+    anchor = fixture_graph()
+    runtime = GeometricDiffusionRuntime(anchor, GeometricDiffusionConfig(branch_width=3))
+    left = runtime.branch_candidates(anchor, seed=100)
+    right = runtime.branch_candidates(anchor, seed=100)
+    assert len(left) == 3
+    assert left == right
+    assert len(set(left)) == 3
+
+
+def test_memory_shape_and_values_remain_finite_after_commit():
+    anchor = fixture_graph()
+    runtime = GeometricDiffusionRuntime(
+        anchor,
+        GeometricDiffusionConfig(
+            beta=0.04,
+            denoise_steps=6,
+            geometry_gain=0.8,
+            graph_gain=0.0,
+            verification_threshold=0.90,
+        ),
+    )
+    state = runtime.step(anchor, seed=21)
+    assert len(state.memory) == len(anchor.nodes)
+    assert all(len(item) == anchor.feature_width for item in state.memory)
+    assert all(math.isfinite(x) for item in state.memory for x in item)
+
+
+def test_mutation_promotion_requires_both_fitness_gain_and_verification():
+    mutation = RuntimeMutation(
+        "diffusion-tune-001",
+        GeometricDiffusionConfig(verification_threshold=0.90),
+    )
+    current = FitnessMetrics(.70, .75, .70, .72, .05)
+    improved = FitnessMetrics(.82, .86, .76, .84, .03)
+    degraded = FitnessMetrics(.60, .65, .60, .62, .08)
+
+    low_verify = evaluate_mutation(
+        mutation,
+        current_metrics=current,
+        candidate_metrics=improved,
+        verification_score=.89,
+    )
+    assert not low_verify.promoted
+    assert "verification" in low_verify.reason
+
+    no_gain = evaluate_mutation(
+        mutation,
+        current_metrics=current,
+        candidate_metrics=degraded,
+        verification_score=.99,
+    )
+    assert not no_gain.promoted
+    assert "did not improve" in no_gain.reason
+
+    accepted = evaluate_mutation(
+        mutation,
+        current_metrics=current,
+        candidate_metrics=improved,
+        verification_score=.99,
+    )
+    assert accepted.promoted
+    assert accepted.candidate_fitness > accepted.current_fitness


### PR DESCRIPTION
## Purpose

Permeate the current 3D geometric auto-encoding/decoding, graph-diffusion, kinetic LLM abstraction, verification, memory and bounded system-evolution work into Jarvis-X without weakening the deterministic VM boundary.

## Changes

- adopt ADR-006 for the virtual 3D geometric diffusion kinetic runtime;
- add the normative `DR_MOAGI_3D_GEOMETRIC_DIFFUSION_RUNTIME.md` specification;
- add a dependency-free `geometric_diffusion_runtime.py` reference implementation;
- add focused tests for topology validation, seeded forward diffusion, geometry-conditioned reverse denoising, candidate rollback, bounded branching, memory integrity and mutation promotion;
- define exact-image language only against an explicit target/metric/tolerance;
- keep self-evolution limited to versioned runtime-configuration candidates with promotion/rollback gates.

## Architectural boundary

The canonical 64-bit VM remains unchanged. Virtual 3D coordinates are a computational representation, not a claim about physical LLM internals. Graph diffusion is distinct from pixel diffusion and transformer attention. Generated states, tool actions and runtime mutations remain non-authoritative until validation and commit.

## Verification performed before push

Local isolated reference tests: `8 passed`.

Coverage of the new module in the isolated fixture: approximately `84%` branch-aware coverage.

CI on this PR is the repository-level admission gate before merge.