### PR TITLE
Permeate native DM 6400 VRAM swarm ISA

### DIFF
--- a/.github/workflows/dm-vram-swarm-windows.yml
+++ b/.github/workflows/dm-vram-swarm-windows.yml
@@ -1,0 +1,77 @@
+name: DM VRAM Swarm Windows
+
+on:
+  pull_request:
+    paths:
+      - "apps/windows/dm-vomega-xi-6400-swarm/**"
+      - "tests/test_dm_vram_swarm_isa.py"
+      - "docs/adr/0009-dm-vomega-xi-6400-swarm-isa.md"
+      - ".github/workflows/dm-vram-swarm-windows.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/windows/dm-vomega-xi-6400-swarm/**"
+      - "tests/test_dm_vram_swarm_isa.py"
+      - "docs/adr/0009-dm-vomega-xi-6400-swarm-isa.md"
+      - ".github/workflows/dm-vram-swarm-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM PE toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld llvm python3 python3-pytest zip binutils
+
+      - name: Check ISA conformance test
+        run: python3 -m pytest -q tests/test_dm_vram_swarm_isa.py
+
+      - name: Build twice and prove reproducibility
+        shell: bash
+        run: |
+          cp -a apps/windows/dm-vomega-xi-6400-swarm /tmp/dm-a
+          cp -a apps/windows/dm-vomega-xi-6400-swarm /tmp/dm-b
+          /tmp/dm-a/build-windows.sh
+          /tmp/dm-b/build-windows.sh
+          cmp /tmp/dm-a/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe /tmp/dm-b/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe
+
+      - name: Verify PE structure and import surface
+        shell: bash
+        run: |
+          APP=/tmp/dm-a
+          file "$APP/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe" | tee /tmp/dm-file.txt
+          grep -q 'PE32+ executable.*x86-64' /tmp/dm-file.txt
+          objdump -x "$APP/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe" > /tmp/dm-pe.txt
+          grep -q 'Subsystem.*Windows CUI' /tmp/dm-pe.txt
+          grep -q 'DLL Name: KERNEL32.dll' /tmp/dm-pe.txt
+          test "$(grep -c 'DLL Name:' /tmp/dm-pe.txt)" -eq 1
+          grep -q 'GetStdHandle' /tmp/dm-pe.txt
+          grep -q 'WriteFile' /tmp/dm-pe.txt
+          grep -q 'Sleep' /tmp/dm-pe.txt
+          grep -q 'ExitProcess' /tmp/dm-pe.txt
+
+      - name: Package Windows artifact
+        shell: bash
+        run: |
+          APP=/tmp/dm-a
+          cd "$APP"
+          zip -9 DM-vOmegaXi-6400GB-3D-VRAM-Swarm-ISA-Windows-x64.zip \
+            DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe README.md ISA.md SHA256SUMS.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: DM-vOmegaXi-6400GB-3D-VRAM-Swarm-ISA-Windows-x64
+          path: |
+            /tmp/dm-a/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe
+            /tmp/dm-a/DM-vOmegaXi-6400GB-3D-VRAM-Swarm-ISA-Windows-x64.zip
+            /tmp/dm-a/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/dm-vram-swarm-windows.yml
+++ b/.github/workflows/dm-vram-swarm-windows.yml
@@ -24,15 +24,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
 
       - name: Install LLVM PE toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang lld llvm python3 python3-pytest zip binutils
+          sudo apt-get install -y clang lld llvm zip binutils
+
+      - name: Install repository test dependencies
+        run: python -m pip install -e ".[test]"
 
       - name: Check ISA conformance test
-        run: python3 -m pytest -q tests/test_dm_vram_swarm_isa.py
+        run: python -m pytest -q tests/test_dm_vram_swarm_isa.py
 
       - name: Build twice and prove reproducibility
         shell: bash

--- a/.github/workflows/dm-vram-swarm-windows.yml
+++ b/.github/workflows/dm-vram-swarm-windows.yml
@@ -41,7 +41,7 @@ jobs:
         run: python -m pip install -e ".[test]"
 
       - name: Check ISA conformance test
-        run: python -m pytest -q tests/test_dm_vram_swarm_isa.py
+        run: python -m pytest -q --no-cov tests/test_dm_vram_swarm_isa.py
 
       - name: Build twice and prove reproducibility
         shell: bash

--- a/.github/workflows/dm-vram-swarm-windows.yml
+++ b/.github/workflows/dm-vram-swarm-windows.yml
@@ -48,8 +48,8 @@ jobs:
         run: |
           cp -a apps/windows/dm-vomega-xi-6400-swarm /tmp/dm-a
           cp -a apps/windows/dm-vomega-xi-6400-swarm /tmp/dm-b
-          /tmp/dm-a/build-windows.sh
-          /tmp/dm-b/build-windows.sh
+          bash /tmp/dm-a/build-windows.sh
+          bash /tmp/dm-b/build-windows.sh
           cmp /tmp/dm-a/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe /tmp/dm-b/DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe
 
       - name: Verify PE structure and import surface

--- a/apps/windows/dm-vomega-xi-6400-swarm/ISA.md
+++ b/apps/windows/dm-vomega-xi-6400-swarm/ISA.md
@@ -1,0 +1,63 @@
+# DM–vΩΞ⁺ 32-bit Swarm ISA Contract
+
+## Word format
+
+```text
+bits 31:24  opcode
+bits 23:20  Rd, or Ra for store
+bits 19:16  Rs1, or Rv for store
+bits 15:12  Rs2
+bits 11:0   immediate/sub-op
+```
+
+For `HASH_ADDR`, `imm[11:8]` carries `Rs3`; `imm[7:0]` remains available as a sub-op field.
+
+## Registers
+
+| Register | Role | Interpretation |
+|---|---|---|
+| R0 | zero | hardwired 0 |
+| R1-R3 | POS_X/Y/Z | Q16.16 spatial coordinates |
+| R4-R6 | VEL_X/Y/Z | Q16.16 velocities |
+| R7-R9 | FRC_X/Y/Z | Q16.16 forces/intermediates |
+| R10 | VOX_ADDR | raw 32-bit resident-page handle |
+| R11 | LATENT_VAL | Q16.16 latent value |
+| R12 | ERR_GRAD | Q16.16 local gradient |
+| R13 | SYS_MODE | raw mode (`0` encode, `1` decode) |
+| R14 | SYNC_CTR / scalar | typed control/scalar; v1.1 uses Q16.16 `dt` |
+| R15 | SCRATCH | Q16.16 scratch/voxel value |
+
+The phrase "32-bit Q16.16 register file" refers to the arithmetic datapath. Address and control instructions interpret their designated registers as raw 32-bit typed values.
+
+## Opcodes
+
+| Hex | Mnemonic | Semantics |
+|---|---|---|
+| 0x0F | SYNC_SWARM | global barrier |
+| 0x10 | VREAD3D | `Rd <- VRAM[Rs1]` |
+| 0x11 | VWRITE3D | `VRAM[Ra] <- Rv` |
+| 0x20 | Q16MUL | saturating `Rd <- (Rs1 * Rs2) >> 16` |
+| 0x21 | Q16ADD | saturating addition |
+| 0x22 | Q16SUB | saturating subtraction |
+| 0x30 | EVAL_FGRAD | local residual-gradient force |
+| 0x31 | EVAL_FLATENT | latent-core attraction |
+| 0x32 | EVAL_FREPEL | deterministic collision-avoidance term |
+| 0x40 | ENCODE_STEP | bounded local compression |
+| 0x41 | DECODE_STEP | bounded local expansion |
+| 0x50 | HASH_ADDR | position tuple to sparse page-table handle |
+| 0xFF | HALT | terminate the agent epoch |
+
+## Addressing invariant
+
+A 32-bit `VOX_ADDR` is a **handle**, not the full 3D address. The sparse page table stores the collision-resolving tuple `(page_x, page_y, page_z)` and returns a resident-slot handle. This is required because the complete 3D virtual key is wider than 32 bits.
+
+## Q16.16 invariants
+
+- additions and subtractions saturate to signed 32-bit limits;
+- multiplication uses a signed 64-bit intermediate followed by a 16-bit fractional shift and saturation;
+- the fixed-point representation of `0.01` used by v1.1 is `655 / 65536 = 0.0099945068359375`;
+- the 6400-coordinate axis range is representable in signed Q16.16.
+
+## Reality boundary
+
+The ISA models deterministic local swarm computation and sparse virtual VRAM. It does not, by itself, grant external side-effect authority or convert a browser/native research state into authoritative system state.

--- a/apps/windows/dm-vomega-xi-6400-swarm/README.md
+++ b/apps/windows/dm-vomega-xi-6400-swarm/README.md
@@ -1,0 +1,71 @@
+# DM–vΩΞ⁺ 6400³ Virtual VRAM Swarm ISA
+
+This Windows research artifact implements the 32-bit fixed-width swarm ISA for the DM–vΩΞ⁺ 3D auto-encoding/decoding model.
+
+## Scope
+
+The logical address fabric spans **6400 GiB per axis**. It is a sparse 3D virtual coordinate space, not a literal `6400^3 GiB` allocation. The reference executable materializes only 2,048 resident 64 KiB page slots and runs 64 virtual agents.
+
+The machine word is:
+
+```text
+31         24 23     20 19     16 15     12 11                      0
++---------------+-------+---------+---------+------------------------+
+| Opcode (8-bit)| Rd/Ra | Rs1/Rv  | Rs2     | Immediate / SubOp (12) |
++---------------+-------+---------+---------+------------------------+
+```
+
+Arithmetic instructions interpret their operands as signed saturating Q16.16. `R10` is a raw resident-page handle, `R13` is a raw mode value, and `R14` is a typed scalar/synchronization register. The storage width remains 32 bits for all registers.
+
+## Canonical stream and executable stream
+
+`PROGRAM_CANONICAL_V1` preserves the supplied 13-word stream bit-for-bit, including:
+
+```text
+0x50A12300  HASH_ADDR R10,R1,R2,R3
+0x10FA0000  VREAD3D R15,R10
+0x30CF0000  EVAL_FGRAD R12,R15
+0x31710000  EVAL_FLATENT R7,R1
+0x32810000  EVAL_FREPEL R8,R1
+0x21778000  Q16ADD R7,R7,R8
+0x2177C000  Q16ADD R7,R7,R12
+0x21447000  Q16ADD R4,R4,R7
+0x21114000  Q16ADD R1,R1,R4
+0x40BF0000  ENCODE_STEP R11,R15
+0x11AB0000  VWRITE3D R10,R11
+0x0F000000  SYNC_SWARM
+0xFF000000  HALT
+```
+
+The comment in the supplied kernel states Euler `dt = 0.01`, but the two raw `Q16ADD` words above are mathematically a unit step. `PROGRAM_ENCODE_DT001` is therefore the executable v1.1 stream: it inserts `Q16MUL` operations using `R14 = 655`, the nearest Q16.16 encoding of 0.01, before the velocity and position additions.
+
+`HASH_ADDR` uses `imm[11:8]` as the third register selector, which is why `0x50A12300` encodes `R3`. `VWRITE3D` uses store-specific field semantics: `[23:20]` is the address register and `[19:16]` is the value register, making `0x11AB0000` mean `VRAM[R10] <- R11`.
+
+## Auto-execution
+
+Each virtual agent alternates between an encode epoch and a decode epoch:
+
+```text
+position -> HASH_ADDR -> VREAD3D
+        -> error/latent/repulsion forces
+        -> Q16.16 kinetic integration
+        -> ENCODE_STEP -> VWRITE3D
+        -> SYNC_SWARM -> HALT
+        -> DECODE epoch -> repeat
+```
+
+`SYNC_SWARM` is a real global barrier in the reference scheduler: an agent cannot advance beyond it until every active agent is waiting or halted.
+
+## Build
+
+From Linux with LLVM installed:
+
+```bash
+./build-windows.sh
+```
+
+The build generates a deterministic Windows x86-64 PE32+ console executable without a C runtime dependency.
+
+## Trust boundary
+
+This is a bounded research/runtime surface. Its sparse VRAM writes are **not authoritative Jarvis-X commits**. It has no network, filesystem, market, medical, infrastructure, or device authority. Authoritative Jarvis-X state still flows through `jarvisx.system_runtime` and its verification/audit/commit boundary.

--- a/apps/windows/dm-vomega-xi-6400-swarm/build-windows.sh
+++ b/apps/windows/dm-vomega-xi-6400-swarm/build-windows.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
+CC="${CC:-clang}"
+LLD="${LLD:-lld-link}"
+DLLTOOL="${DLLTOOL:-llvm-dlltool}"
+SRC=dm_vomega_xi_6400gib_swarm_isa.c
+OBJ=dm_vomega_xi_6400gib_swarm_isa.obj
+OUT=DM_vOmegaXi_6400GB_3D_VRAM_Swarm_ISA.exe
+
+cat > kernel32.def <<'DEF'
+LIBRARY KERNEL32.dll
+EXPORTS
+GetStdHandle
+WriteFile
+Sleep
+ExitProcess
+DEF
+
+"$DLLTOOL" -m i386:x86-64 -d kernel32.def -l kernel32.lib
+"$CC" --target=x86_64-pc-windows-msvc -O2 -ffreestanding -fno-builtin -fno-stack-protector -c "$SRC" -o "$OBJ"
+"$LLD" /Brepro /entry:start /subsystem:console /nodefaultlib /dynamicbase /nxcompat /out:"$OUT" "$OBJ" kernel32.lib
+sha256sum "$OUT" > SHA256SUMS.txt

--- a/apps/windows/dm-vomega-xi-6400-swarm/dm_vomega_xi_6400gib_swarm_isa.c
+++ b/apps/windows/dm-vomega-xi-6400-swarm/dm_vomega_xi_6400gib_swarm_isa.c
@@ -1,0 +1,326 @@
+/*
+ * DM-vOmegaXi+ 6400 GiB x 6400 GiB x 6400 GiB Virtual VRAM Swarm ISA Engine
+ * Windows x86-64 PE32+, freestanding, no CRT.
+ *
+ * ISA word: [31:24] opcode | [23:20] rd/ra | [19:16] rs1/rv |
+ *           [15:12] rs2 | [11:0] immediate/subop
+ *
+ * Arithmetic registers use deterministic signed Q16.16.  R10 (VOX_ADDR),
+ * R13 (SYS_MODE), and R14 (SYNC/SCALAR) are typed 32-bit control values.
+ * The 3D address fabric is virtual and sparse; no 6400^3 GiB allocation occurs.
+ */
+
+typedef void* HANDLE;
+typedef unsigned long DWORD;
+typedef int BOOL;
+typedef unsigned long long U64;
+typedef long long I64;
+typedef unsigned int U32;
+typedef int I32;
+
+__declspec(dllimport) HANDLE __stdcall GetStdHandle(DWORD nStdHandle);
+__declspec(dllimport) BOOL __stdcall WriteFile(HANDLE hFile, const void* lpBuffer, DWORD nNumberOfBytesToWrite, DWORD* lpNumberOfBytesWritten, void* lpOverlapped);
+__declspec(dllimport) void __stdcall Sleep(DWORD dwMilliseconds);
+__declspec(dllimport) void __stdcall ExitProcess(unsigned int uExitCode);
+
+#define STD_OUTPUT_HANDLE ((DWORD)-11)
+#define Q16_ONE 65536
+#define Q16_HALF 32768
+#define Q16_DT_001 655 /* nearest Q16.16 value to 0.01 = 0.0099945068 */
+#define Q16_MIN ((I32)0x80000000u)
+#define Q16_MAX ((I32)0x7fffffffu)
+
+#define GIB_BYTES 1073741824ULL
+#define AXIS_GIB 6400ULL
+#define AXIS_BYTES (AXIS_GIB * GIB_BYTES)
+#define PAGE_BYTES 65536ULL
+#define AXIS_PAGES (AXIS_BYTES / PAGE_BYTES)
+#define RESIDENT_PAGES 2048U
+#define ACTIVE_AGENTS 64U
+#define MAX_SCHED_CYCLES 6400U
+#define CORE_Q16 (3200 * Q16_ONE)
+
+#define OP_SYNC_SWARM    0x0FU
+#define OP_VREAD3D       0x10U
+#define OP_VWRITE3D      0x11U
+#define OP_Q16MUL        0x20U
+#define OP_Q16ADD        0x21U
+#define OP_Q16SUB        0x22U
+#define OP_EVAL_FGRAD    0x30U
+#define OP_EVAL_FLATENT  0x31U
+#define OP_EVAL_FREPEL   0x32U
+#define OP_ENCODE_STEP   0x40U
+#define OP_DECODE_STEP   0x41U
+#define OP_HASH_ADDR     0x50U
+#define OP_HALT          0xFFU
+
+#define R_ZERO 0
+#define R_POS_X 1
+#define R_POS_Y 2
+#define R_POS_Z 3
+#define R_VEL_X 4
+#define R_VEL_Y 5
+#define R_VEL_Z 6
+#define R_FRC_X 7
+#define R_FRC_Y 8
+#define R_FRC_Z 9
+#define R_VOX_ADDR 10
+#define R_LATENT_VAL 11
+#define R_ERR_GRAD 12
+#define R_SYS_MODE 13
+#define R_SYNC_CTR 14
+#define R_SCRATCH 15
+
+static HANDLE g_out;
+
+static U32 slen(const char* s){U32 n=0;while(s[n])++n;return n;}
+static void out(const char* s){DWORD n=0;WriteFile(g_out,s,slen(s),&n,0);}
+static void out_ch(char c){DWORD n=0;WriteFile(g_out,&c,1,&n,0);}
+static void out_u64(U64 v){char b[32];U32 i=0;if(!v){out_ch('0');return;}while(v&&i<31){b[i++]=(char)('0'+(v%10ULL));v/=10ULL;}while(i)out_ch(b[--i]);}
+static void out_i32(I32 v){I64 x=v;if(x<0){out_ch('-');x=-x;}out_u64((U64)x);}
+static void out_hex32(U32 v){static const char h[]="0123456789ABCDEF";out("0x");for(int s=28;s>=0;s-=4)out_ch(h[(v>>s)&15]);}
+static void out_q16(I32 v){I64 x=v;if(x<0){out_ch('-');x=-x;}U64 w=(U64)(x>>16),f=(U64)(x&0xFFFF),d=(f*10000ULL+32768ULL)>>16;if(d>=10000){w++;d-=10000;}out_u64(w);out_ch('.');if(d<1000)out_ch('0');if(d<100)out_ch('0');if(d<10)out_ch('0');out_u64(d);}
+static void nl(void){out("\r\n");}
+static void rule(void){out("--------------------------------------------------------------------------------\r\n");}
+
+static I32 sat64(I64 x){if(x>2147483647LL)return 2147483647;if(x<-2147483648LL)return (I32)0x80000000u;return (I32)x;}
+static I32 qadd(I32 a,I32 b){return sat64((I64)a+(I64)b);}
+static I32 qsub(I32 a,I32 b){return sat64((I64)a-(I64)b);}
+static I32 qmul(I32 a,I32 b){return sat64(((I64)a*(I64)b)>>16);}
+static I32 qabs(I32 x){if(x==(I32)0x80000000u)return 0x7fffffff;return x<0?-x:x;}
+static I32 qact(I32 x){I64 ax=qabs(x);I64 den=(I64)Q16_ONE+ax;return den?sat64(((I64)x*(I64)Q16_ONE)/den):0;}
+static I32 qclamp(I32 x,I32 lo,I32 hi){return x<lo?lo:(x>hi?hi:x);}
+
+static U32 op(U32 w){return w>>24;}
+static U32 rd(U32 w){return (w>>20)&0xF;}
+static U32 rs1(U32 w){return (w>>16)&0xF;}
+static U32 rs2(U32 w){return (w>>12)&0xF;}
+static U32 imm12(U32 w){return w&0xFFF;}
+static U32 hash_rs3(U32 w){return (imm12(w)>>8)&0xF;}
+
+static const U32 PROGRAM_CANONICAL_V1[] = {
+    0x50A12300U, 0x10FA0000U, 0x30CF0000U, 0x31710000U,
+    0x32810000U, 0x21778000U, 0x2177C000U, 0x21447000U,
+    0x21114000U, 0x40BF0000U, 0x11AB0000U, 0x0F000000U,
+    0xFF000000U
+};
+#define PROGRAM_CANONICAL_V1_WORDS 13U
+
+static const U32 PROGRAM_ENCODE_DT001[] = {
+    0x50A12300U,
+    0x10FA0000U,
+    0x30CF0000U,
+    0x31710000U,
+    0x32810000U,
+    0x21778000U,
+    0x2177C000U,
+    0x2087E000U,
+    0x21448000U,
+    0x2084E000U,
+    0x21118000U,
+    0x40BF0000U,
+    0x11AB0000U,
+    0x0F000000U,
+    0xFF000000U
+};
+#define PROGRAM_ENCODE_DT001_WORDS 15U
+
+static const U32 PROGRAM_DECODE[] = {
+    0x50A12300U,
+    0x10FA0000U,
+    0x41BF0000U,
+    0x11AB0000U,
+    0x0F000000U,
+    0xFF000000U
+};
+#define PROGRAM_DECODE_WORDS 6U
+
+typedef struct {
+    U32 px,py,pz;
+    U32 age;
+    U32 valid;
+    U32 committed;
+    I32 value;
+} Page;
+
+static Page g_pages[RESIDENT_PAGES];
+static U32 g_resident=0,g_evict_cursor=0,g_page_hits=0,g_page_faults=0,g_evictions=0;
+static U64 g_logical_touched=0;
+
+static U32 coord_to_page(I32 q){
+    I64 lo=0,hi=(I64)AXIS_GIB*Q16_ONE,x=q;
+    if(x<lo)x=lo;if(x>hi)x=hi;
+    U64 p=((U64)x*(AXIS_PAGES-1ULL))/(U64)hi;
+    return (U32)p;
+}
+
+static U32 find_or_touch(U32 px,U32 py,U32 pz,U32 cycle){
+    for(U32 i=0;i<g_resident;i++){
+        Page* p=&g_pages[i];
+        if(p->valid&&p->px==px&&p->py==py&&p->pz==pz){p->age=cycle;g_page_hits++;return i;}
+    }
+    g_page_faults++;
+    U32 slot;
+    if(g_resident<RESIDENT_PAGES)slot=g_resident++;
+    else{slot=g_evict_cursor++%RESIDENT_PAGES;g_evictions++;}
+    g_pages[slot].px=px;g_pages[slot].py=py;g_pages[slot].pz=pz;g_pages[slot].age=cycle;
+    g_pages[slot].valid=1;g_pages[slot].committed=0;g_pages[slot].value=0;
+    g_logical_touched+=PAGE_BYTES;
+    return slot;
+}
+
+typedef struct {
+    I32 R[16];
+    U32 pc;
+    U32 waiting;
+    U32 halted;
+    U32 id;
+    U32 epoch;
+} Agent;
+
+static Agent A[ACTIVE_AGENTS];
+static U32 g_sched_cycles=0,g_epochs=0,g_vram_writes=0,g_verify_fail=0;
+
+static void enforce_r0(Agent* a){a->R[R_ZERO]=0;}
+
+static void init_agent(Agent* a,U32 id){
+    for(U32 i=0;i<16;i++)a->R[i]=0;
+    a->id=id;a->pc=0;a->waiting=0;a->halted=0;a->epoch=0;
+    I32 dx=(I32)((int)(id%8)-4)*Q16_ONE*8;
+    I32 dy=(I32)((int)((id/8)%8)-4)*Q16_ONE*8;
+    I32 dz=(I32)((int)(id%5)-2)*Q16_ONE*6;
+    a->R[R_POS_X]=CORE_Q16+dx;
+    a->R[R_POS_Y]=CORE_Q16+dy;
+    a->R[R_POS_Z]=CORE_Q16+dz;
+    a->R[R_VEL_X]=(I32)((int)(id%3)-1)*1024;
+    a->R[R_SYNC_CTR]=Q16_DT_001;
+    a->R[R_SYS_MODE]=0;
+    enforce_r0(a);
+}
+
+static I32 eval_fgrad(I32 voxel){return qmul(-8192,voxel);}
+static I32 eval_flatent(I32 pos){return qmul(-1024,qsub(pos,CORE_Q16));}
+static I32 eval_frepel(U32 id,I32 pos){
+    I32 base=(id&1U)?768:-768;
+    I32 side=pos>=CORE_Q16?1:-1;
+    return side>0?base:-base;
+}
+static I32 encode_step(I32 voxel){return qact(voxel);}
+static I32 decode_step(I32 latent){return qadd(latent,qmul(32768,latent));}
+
+static const U32* agent_program(const Agent* a,U32* words){
+    if(a->R[R_SYS_MODE]){*words=PROGRAM_DECODE_WORDS;return PROGRAM_DECODE;}
+    *words=PROGRAM_ENCODE_DT001_WORDS;return PROGRAM_ENCODE_DT001;
+}
+
+static void exec_word(Agent* a,U32 w){
+    U32 opcode=op(w),d=rd(w),s1=rs1(w),s2=rs2(w);
+    switch(opcode){
+        case OP_HASH_ADDR:{
+            U32 s3=hash_rs3(w);
+            U32 px=coord_to_page(a->R[s1]),py=coord_to_page(a->R[s2]),pz=coord_to_page(a->R[s3]);
+            a->R[d]=(I32)find_or_touch(px,py,pz,g_sched_cycles);
+            break;
+        }
+        case OP_VREAD3D:{
+            U32 h=(U32)a->R[s1];
+            a->R[d]=(h<g_resident&&g_pages[h].valid)?g_pages[h].value:0;
+            break;
+        }
+        case OP_VWRITE3D:{
+            U32 h=(U32)a->R[d];
+            if(h<g_resident&&g_pages[h].valid){g_pages[h].value=a->R[s1];g_pages[h].committed=1;g_pages[h].age=g_sched_cycles;g_vram_writes++;}
+            break;
+        }
+        case OP_Q16MUL:a->R[d]=qmul(a->R[s1],a->R[s2]);break;
+        case OP_Q16ADD:a->R[d]=qadd(a->R[s1],a->R[s2]);break;
+        case OP_Q16SUB:a->R[d]=qsub(a->R[s1],a->R[s2]);break;
+        case OP_EVAL_FGRAD:a->R[d]=eval_fgrad(a->R[s1]);break;
+        case OP_EVAL_FLATENT:a->R[d]=eval_flatent(a->R[s1]);break;
+        case OP_EVAL_FREPEL:a->R[d]=eval_frepel(a->id,a->R[s1]);break;
+        case OP_ENCODE_STEP:a->R[d]=encode_step(a->R[s1]);break;
+        case OP_DECODE_STEP:a->R[d]=decode_step(a->R[s1]);break;
+        case OP_SYNC_SWARM:a->waiting=1;break;
+        case OP_HALT:a->halted=1;break;
+        default:g_verify_fail++;a->halted=1;break;
+    }
+    enforce_r0(a);
+}
+
+static void step_agent(Agent* a){
+    if(a->waiting||a->halted)return;
+    U32 words=0;const U32* p=agent_program(a,&words);
+    if(a->pc>=words){a->halted=1;return;}
+    U32 w=p[a->pc];exec_word(a,w);
+    if(!a->waiting&&!a->halted)a->pc++;
+}
+
+static U32 all_waiting_or_halted(void){
+    for(U32 i=0;i<ACTIVE_AGENTS;i++)if(!A[i].waiting&&!A[i].halted)return 0;
+    return 1;
+}
+static U32 all_halted(void){for(U32 i=0;i<ACTIVE_AGENTS;i++)if(!A[i].halted)return 0;return 1;}
+
+static void release_barrier(void){
+    if(!all_waiting_or_halted())return;
+    for(U32 i=0;i<ACTIVE_AGENTS;i++)if(A[i].waiting){A[i].waiting=0;A[i].pc++;A[i].R[R_SYNC_CTR]=Q16_DT_001;}
+}
+
+static void next_epoch(void){
+    g_epochs++;
+    for(U32 i=0;i<ACTIVE_AGENTS;i++){
+        Agent* a=&A[i];
+        a->halted=0;a->waiting=0;a->pc=0;a->epoch++;
+        a->R[R_SYS_MODE]=(I32)(a->epoch&1U);
+        a->R[R_SYNC_CTR]=Q16_DT_001;
+    }
+}
+
+static void print_program(void){
+    out("Canonical V1 stream supplied by architecture:\r\n");
+    for(U32 i=0;i<PROGRAM_CANONICAL_V1_WORDS;i++){
+        out("  ");out_hex32(i*4);out("  ");out_hex32(PROGRAM_CANONICAL_V1[i]);nl();
+    }
+    out("\r\nExecutable V1.1 adds dt=0.01 Q16MUL scaling while preserving 32-bit format.\r\n");
+}
+
+static void telemetry(void){
+    Agent* a=&A[0];
+    out("cycle=");out_u64(g_sched_cycles);
+    out(" epoch=");out_u64(g_epochs);
+    out(" mode=");out(a->R[R_SYS_MODE]?"DECODE":"ENCODE");
+    out(" pages=");out_u64(g_resident);
+    out(" vram_writes=");out_u64(g_vram_writes);
+    out(" faults=");out_u64(g_page_faults);
+    out(" hits=");out_u64(g_page_hits);
+    out(" evict=");out_u64(g_evictions);nl();
+    out("A0 pos=");out_q16(a->R[R_POS_X]);out(",");out_q16(a->R[R_POS_Y]);out(",");out_q16(a->R[R_POS_Z]);
+    out(" velX=");out_q16(a->R[R_VEL_X]);
+    out(" latent=");out_q16(a->R[R_LATENT_VAL]);
+    out(" handle=");out_i32(a->R[R_VOX_ADDR]);nl();
+}
+
+void start(void){
+    g_out=GetStdHandle(STD_OUTPUT_HANDLE);
+    out("DM-vOmegaXi+ 6400^3 VIRTUAL VRAM 3D SWARM ISA ENGINE\r\n");
+    out("Windows x86-64 | 32-bit fixed-width ISA | Q16.16 arithmetic | 64 virtual agents\r\n");
+    out("Virtual extent per axis: 6400 GiB | sparse pages: 64 KiB | resident slots: 2048\r\n");
+    out("R10/R13/R14 are typed control registers; arithmetic registers are saturating Q16.16.\r\n");
+    rule();print_program();rule();
+    for(U32 i=0;i<ACTIVE_AGENTS;i++)init_agent(&A[i],i);
+
+    while(g_sched_cycles<MAX_SCHED_CYCLES){
+        for(U32 i=0;i<ACTIVE_AGENTS;i++)step_agent(&A[i]);
+        release_barrier();
+        if(all_halted())next_epoch();
+        g_sched_cycles++;
+        if((g_sched_cycles%256U)==0U)telemetry();
+        Sleep(1);
+    }
+    rule();
+    out("FINAL ");telemetry();
+    out("logical sparse bytes materialized=");out_u64(g_logical_touched);nl();
+    out("verify_failures=");out_u64(g_verify_fail);nl();
+    out("HALT: bounded scheduler cycle budget reached.\r\n");
+    ExitProcess(g_verify_fail?2U:0U);
+}

--- a/docs/adr/0009-dm-vomega-xi-6400-swarm-isa.md
+++ b/docs/adr/0009-dm-vomega-xi-6400-swarm-isa.md
@@ -1,0 +1,64 @@
+# ADR-009: DM–vΩΞ⁺ 6400³ Virtual VRAM Swarm ISA
+
+- **Status:** Proposed
+- **Date:** 2026-08-16
+- **Decision scope:** native Windows research/runtime surface
+
+## Context
+
+ADR-008 established QSOL kinetic 3D visualization as a non-authoritative research surface. The next layer is a native fixed-width instruction engine that can express the same spatial recurrence with deterministic Q16.16 arithmetic and a bounded sparse 3D virtual address fabric.
+
+The architecture specifies a 32-bit word containing an 8-bit opcode, three 4-bit register fields, and a 12-bit immediate/sub-op field. It also specifies a 16-entry register file, sparse 3D VRAM access, kinetic force operators, encode/decode operations, a swarm barrier, and halt semantics.
+
+## Decision
+
+Add `apps/windows/dm-vomega-xi-6400-swarm/` as the reference native ISA implementation.
+
+The reference engine:
+
+1. preserves the supplied 13-word encode stream bit-for-bit as `PROGRAM_CANONICAL_V1`;
+2. defines missing opcode `0x50` as `HASH_ADDR`;
+3. defines `HASH_ADDR` third-source encoding as `imm[11:8]`;
+4. defines `VWRITE3D` store fields as address `[23:20]` and value `[19:16]`;
+5. uses saturating signed Q16.16 arithmetic with 64-bit multiply intermediates;
+6. treats `R10`, `R13`, and control uses of `R14` as typed 32-bit values rather than arithmetic Q16.16 values;
+7. treats `R10` as a sparse resident-page handle, while the page table retains the full 3D page tuple;
+8. adds an executable v1.1 stream that inserts Q16 multiplications for the stated Euler `dt=0.01`;
+9. runs 64 bounded virtual agents over 2,048 resident 64 KiB sparse pages;
+10. alternates encode and decode epochs behind a real global barrier.
+
+## Why the dt-corrected stream exists
+
+The supplied V1 sequence describes `dt=0.01`, but
+
+```text
+VEL_X <- VEL_X + FRC_X
+POS_X <- POS_X + VEL_X
+```
+
+is a unit-step update under the declared `Q16ADD` semantics. The reference therefore retains those original words for compatibility and executes a V1.1 sequence containing explicit `Q16MUL` steps by the Q16.16 scalar `655`, which is the nearest representable value to `0.01`.
+
+## Virtual-memory interpretation
+
+`6400 GiB × 6400 GiB × 6400 GiB` names the coordinate extent of the virtual 3D fabric. It is not physically allocated. Each axis is mapped to 64 KiB page coordinates, and only a bounded resident working set is materialized.
+
+A 32-bit `VOX_ADDR` cannot uniquely contain the full 3D key. It is therefore an opaque resident-page handle returned by `HASH_ADDR`; the page table stores the collision-resolving `(page_x, page_y, page_z)` tuple.
+
+## Trust boundary
+
+This native swarm engine remains outside the authoritative Jarvis-X task-state path. `VWRITE3D` mutates only the engine's research VRAM state. It is not equivalent to a `jarvisx.system_runtime` commit and cannot bypass capability projection, verification, audit, or authoritative commit.
+
+## Validation
+
+Repository validation must check:
+
+- exact preservation of the supplied 13 canonical machine words;
+- presence of the dt-corrected execution stream;
+- sparse-address and typed-register invariants;
+- deterministic cross-build of a Windows x86-64 PE32+ artifact;
+- expected `KERNEL32.dll`-only import surface;
+- no external side-effect adapters.
+
+## Promotion
+
+Promote this ADR to **Accepted** only after the implementation PR and Windows artifact workflow pass repository validation.

--- a/tests/test_dm_vram_swarm_isa.py
+++ b/tests/test_dm_vram_swarm_isa.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "apps" / "windows" / "dm-vomega-xi-6400-swarm"
+SRC = APP / "dm_vomega_xi_6400gib_swarm_isa.c"
+ISA = APP / "ISA.md"
+README = APP / "README.md"
+
+
+def test_canonical_machine_words_are_preserved() -> None:
+    source = SRC.read_text(encoding="utf-8")
+    words = (
+        "0x50A12300U",
+        "0x10FA0000U",
+        "0x30CF0000U",
+        "0x31710000U",
+        "0x32810000U",
+        "0x21778000U",
+        "0x2177C000U",
+        "0x21447000U",
+        "0x21114000U",
+        "0x40BF0000U",
+        "0x11AB0000U",
+        "0x0F000000U",
+        "0xFF000000U",
+    )
+    for word in words:
+        assert word in source
+
+
+def test_fixed_width_and_sparse_address_invariants_are_documented() -> None:
+    source = SRC.read_text(encoding="utf-8")
+    isa = ISA.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    assert "PROGRAM_ENCODE_DT001" in source
+    assert "Q16_DT_001 655" in source
+    assert "RESIDENT_PAGES 2048" in source
+    assert "ACTIVE_AGENTS 64" in source
+    assert "hash_rs3" in source
+    assert "raw 32-bit resident-page handle" in isa
+    assert "not authoritative Jarvis-X commits" in readme
+    assert "jarvisx.system_runtime" in readme


### PR DESCRIPTION
Adds the native DM–vΩΞ⁺ 32-bit fixed-width swarm ISA reference engine, preserves the supplied canonical 13-word stream, adds a dt-corrected Q16.16 execution stream, sparse 6400-GiB-per-axis virtual VRAM semantics, 64-agent barrier execution, conformance tests, ADR-009, and a reproducible Windows PE32+ artifact workflow. The native research VRAM remains outside the authoritative jarvisx.system_runtime commit boundary.