### PR TITLE
Add kinetic bytecode wavefront runtime

### DIFF
--- a/docs/DR_MOAGI_3D_KINETIC_BYTECODE_RUNTIME.md
+++ b/docs/DR_MOAGI_3D_KINETIC_BYTECODE_RUNTIME.md
@@ -1,0 +1,242 @@
+# Dr Moagi 3D Kinetic Bytecode Runtime
+
+## Scope
+
+This document operationalizes the 3D swarm-bytecode architecture as a bounded kinetic execution
+model. The virtual computer may name an enormous coordinate space, but only a finite working
+front is ever resident.
+
+For the requested symbolic extent:
+
+\[
+N = 1{,}000{,}000^{1{,}000{,}000} = 10^{6{,}000{,}000}
+\]
+
+and
+
+\[
+|V| = N^3 = 10^{18{,}000{,}000}.
+\]
+
+`PowerExtent` stores the pair `(1_000_000, 1_000_000)` instead of materializing `N`.
+
+## End-to-end kinetic path
+
+```text
+program
+  |
+  v
+FETCH -> DECODE -> RESOLVE -> ACTIVATE -> MATERIALIZE
+                                             |
+                                             v
+                                        sparse resident set
+                                             |
+                                             v
+EXECUTE -> PROJECT -> VERIFY -> ENCODE -> COMMIT -> EVICT
+                          |
+                          +---- failure ----> ROLLBACK
+```
+
+A logical tick advances each in-flight packet by at most one stage. Therefore different
+instructions can occupy different stages concurrently:
+
+```text
+clock c:
+  packet 7  EXECUTE
+  packet 8  MATERIALIZE
+  packet 9  ACTIVATE
+  packet 10 RESOLVE
+  packet 11 DECODE
+
+clock c+1:
+  packet 7  PROJECT
+  packet 8  EXECUTE
+  packet 9  MATERIALIZE
+  packet 10 ACTIVATE
+  packet 11 RESOLVE
+```
+
+The runtime trace makes that motion observable.
+
+## Sparse addressing
+
+The symbolic universe is not a Python list, tensor, or voxel cube. A finite 64-bit region
+reference selects a `RegionDescriptor`:
+
+```text
+region_ref -> descriptor -> active packet -> optional resident state
+```
+
+Only entries in these sets consume reference-runtime state:
+
+```text
+inflight
+activity
+resident
+committed
+```
+
+The virtual volume itself consumes no per-coordinate storage.
+
+## Activation kinetics
+
+For a region activity value `a_t`:
+
+```text
+a_(t+1) = retention * a_t
+```
+
+and an activation-stage packet injects bounded activity:
+
+```text
+a <- min(1, a + injection).
+```
+
+The active front is the subset satisfying
+
+```text
+a >= activation_threshold.
+```
+
+This is a scheduler/control abstraction, not a physical electromagnetic field claim.
+
+## Candidate dynamics
+
+For the research `G3D` macro:
+
+\[
+E_t = X_t - P_t
+\]
+
+\[
+\widetilde{\Xi}_{t+1}
+=
+\Xi_t + P_t - E_t + \Omega_t + U_t.
+\]
+
+The scalar fixture maps these terms to:
+
+```text
+error     = observation - prediction
+candidate = current + prediction - error + omega + immediate
+```
+
+The candidate is then projected:
+
+\[
+\widehat{\Xi}_{t+1}
+=
+\Pi_\Lambda(\widetilde{\Xi}_{t+1}),
+\]
+
+implemented by a finite symmetric bound in the reference runtime.
+
+## Verification collision
+
+A candidate crosses the commit boundary only when both gates pass:
+
+```text
+instruction.verification_score >= verification_threshold
+AND
+validator(packet, instruction) == True
+```
+
+Otherwise:
+
+```text
+VERIFY -> ROLLBACK -> EVICT/DROP
+```
+
+with no committed-state mutation.
+
+## Encoding and commit
+
+A verified projected value is deterministically quantized before publication:
+
+```text
+projected
+-> round(projected, quantization_digits)
+-> committed[region_ref]
+```
+
+That state is local research state. It does not authorize external actions and is not equivalent
+to an authoritative Jarvis-X transaction.
+
+## Residency pressure
+
+`max_resident_regions` bounds the materialized working set.
+
+When full:
+
+```text
+MATERIALIZE
+    |
+    +-- resident capacity available --> EXECUTE
+    |
+    +-- full -------------------------> STALL at MATERIALIZE
+```
+
+After another packet reaches `EVICT`, the stalled packet may enter.
+
+This yields a concrete kinetic pressure relation:
+
+\[
+p_t \propto
+\frac{\text{materialization demand}}
+     {\text{available resident capacity}}.
+\]
+
+The reference telemetry records the number of stalls.
+
+## Lifecycle of one packet
+
+```text
+FETCH
+DECODE
+RESOLVE
+ACTIVATE
+MATERIALIZE
+EXECUTE
+PROJECT
+VERIFY
+ENCODE
+COMMIT
+EVICT
+COMPLETE
+```
+
+On failure:
+
+```text
+... -> VERIFY -> ROLLBACK -> DROP
+```
+
+No packet skips projection or verification to reach commit.
+
+## Operational invariant
+
+The core scalability statement is:
+
+\[
+\boxed{
+\text{virtual scale} \gg \text{physical working set}
+}
+\]
+
+and specifically:
+
+\[
+\boxed{
+M_{\text{physical}}(t)
+=
+O(|A_t| + |R_t| + |Q_t|)
+\neq
+O(N^3)
+}
+\]
+
+where `A_t` is the finite active-region map, `R_t` the finite resident set, and `Q_t` the finite
+in-flight packet queue.
+
+That is the operational meaning of the million-power 3D virtual computer: a huge symbolic
+address manifold with a bounded moving bytecode frontier.

--- a/docs/adr/0010-kinetic-bytecode-wavefront-runtime.md
+++ b/docs/adr/0010-kinetic-bytecode-wavefront-runtime.md
@@ -1,0 +1,148 @@
+# ADR-010: Kinetic Bytecode Wavefront Runtime
+
+- **Status:** Proposed
+- **Date:** 2026-08-16
+- **Extends:** ADR-006, ADR-009
+- **Decision scope:** bounded research/runtime semantics
+
+## Context
+
+ADR-006 defines Jarvis-X's accepted 3D geometric-diffusion kinetic boundary. ADR-009 defines
+an accepted sparse native swarm ISA with deterministic fixed-width arithmetic and a bounded
+resident working set. The missing link is an executable reference for the operational model in
+which bytecode behaves as a moving wavefront:
+
+```text
+FETCH
+-> DECODE
+-> RESOLVE
+-> ACTIVATE
+-> MATERIALIZE
+-> EXECUTE
+-> PROJECT
+-> VERIFY
+-> ENCODE
+-> COMMIT
+-> EVICT
+```
+
+The declared virtual scale may be much larger than any physical allocation. In particular, one
+requested research extent is
+
+```text
+N = 1,000,000 ^ 1,000,000 = 10 ^ 6,000,000
+V = N ^ 3 = 10 ^ 18,000,000 virtual coordinates.
+```
+
+The repository must not turn that notation into a claim that the machine allocates or executes
+all of those coordinates.
+
+## Decision
+
+Add `src/jarvisx/kinetic_bytecode_runtime.py` as a dependency-free deterministic reference
+runtime for a sparse kinetic bytecode wave.
+
+### Symbolic scale
+
+The virtual axis extent is represented by `PowerExtent(base, exponent)`. The implementation
+computes logarithmic scale and approximate address-bit requirements without evaluating or
+allocating `base ** exponent`.
+
+`canonical_million_power_space()` therefore represents
+
+```text
+1,000,000 ^ 1,000,000
+```
+
+per axis without constructing the full integer or a dense 3D array.
+
+### Sparse region boundary
+
+Physical work is identified by finite `RegionDescriptor` objects carrying 64-bit region
+references. Runtime collections contain only active, resident, in-flight, and committed region
+references.
+
+The invariant is:
+
+```text
+physical_work(t) proportional to active/resident working set
+physical_work(t) not proportional to declared virtual volume
+```
+
+### Kinetic pipeline
+
+Each packet advances by at most one pipeline stage per logical tick. Multiple packets may occupy
+different stages simultaneously, producing an observable wavefront rather than a monolithic
+instantaneous operation.
+
+The runtime records `(clock, packet_id, stage)` trace tuples so conformance tests can verify the
+motion.
+
+### Candidate-first execution
+
+The reference `G3D` scalar projection is
+
+```text
+error     = observation - prediction
+candidate = current + prediction - error + omega + immediate
+```
+
+where `current` is the last committed region value or the immutable observation for a new region.
+
+The result does not become authoritative immediately. The pipeline applies:
+
+```text
+candidate
+-> bounded projection
+-> declared verification threshold
+-> optional pure validator
+-> deterministic quantization
+-> research-state commit
+```
+
+A verification failure transitions to rollback and never updates the committed research state.
+
+### Residency pressure
+
+`max_resident_regions` is a hard physical-working-set bound. If a packet reaches
+`MATERIALIZE` while the resident set is full, that packet stalls in place and increments
+telemetry. It may proceed only after another packet reaches `EVICT`.
+
+This gives the scheduler a concrete pressure/stall mechanism without pretending to materialize
+the symbolic universe.
+
+### Trust boundary
+
+This runtime is a research-layer simulator. Its `committed` dictionary is local reference state;
+it is **not** an authoritative `jarvisx.system_runtime` commit, tool authorization, external side
+effect, or evidence that hardware executes the declared virtual volume.
+
+The deterministic canonical VM and existing policy/transaction boundary remain authoritative.
+
+## Consequences
+
+1. The 64-bit canonical VM is unchanged.
+2. The accepted native DM-vOmega-Xi swarm ISA is unchanged.
+3. Kinetic wave semantics become executable and testable in Python.
+4. Virtual scale is explicit but non-materializing.
+5. Residency, stalls, projection, verification, rollback, and eviction become measurable.
+6. Research-state commit remains below the authoritative system-control boundary.
+7. Higher-dimensional or tensor payloads may replace the scalar fixture only if type, units,
+   projection, verification, and resource bounds remain explicit.
+
+## Validation
+
+The focused test suite must verify:
+
+- the `10 ^ 6,000,000` per-axis scale symbolically, with `10 ^ 18,000,000` virtual volume;
+- full `G3D` packet traversal through the kinetic pipeline;
+- projection before verification/commit;
+- rollback on verification failure;
+- bounded residency causing stalls rather than dense allocation;
+- external validators being able to reject candidates deterministically.
+
+## Promotion
+
+Promote this ADR to **Accepted** only after the implementation PR passes the repository Python
+matrix, formatting/lint/type checks, security/dependency checks, and focused kinetic-runtime
+tests.

--- a/src/jarvisx/kinetic_bytecode_runtime.py
+++ b/src/jarvisx/kinetic_bytecode_runtime.py
@@ -1,0 +1,433 @@
+"""Deterministic kinetic bytecode-wave reference runtime.
+
+This module models bytecode as a bounded wave moving through a sparse, symbolic
+3D address fabric. It is a research-layer simulator: it does not allocate the
+declared virtual extent and it cannot perform authoritative Jarvis-X commits or
+external side effects.
+
+The runtime deliberately separates three things:
+
+* virtual scale: represented symbolically by ``PowerExtent``;
+* kinetic execution: packets advance one pipeline stage per tick;
+* physical work: only referenced/resident regions occupy runtime collections.
+
+The executable path is candidate-first. A packet may materialize and execute,
+but its candidate value is published only after projection and verification.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import dataclass, replace
+from enum import Enum
+from typing import Callable, Iterable
+
+
+class PipelineStage(str, Enum):
+    FETCH = "fetch"
+    DECODE = "decode"
+    RESOLVE = "resolve"
+    ACTIVATE = "activate"
+    MATERIALIZE = "materialize"
+    EXECUTE = "execute"
+    PROJECT = "project"
+    VERIFY = "verify"
+    ENCODE = "encode"
+    COMMIT = "commit"
+    EVICT = "evict"
+    COMPLETE = "complete"
+    ROLLBACK = "rollback"
+
+
+PIPELINE: tuple[PipelineStage, ...] = (
+    PipelineStage.FETCH,
+    PipelineStage.DECODE,
+    PipelineStage.RESOLVE,
+    PipelineStage.ACTIVATE,
+    PipelineStage.MATERIALIZE,
+    PipelineStage.EXECUTE,
+    PipelineStage.PROJECT,
+    PipelineStage.VERIFY,
+    PipelineStage.ENCODE,
+    PipelineStage.COMMIT,
+    PipelineStage.EVICT,
+    PipelineStage.COMPLETE,
+)
+
+
+class KineticOp(str, Enum):
+    """Research macro-operations lowered onto the kinetic pipeline."""
+
+    G3D = "G3D"
+    DELTA = "DELTA"
+    ENCODE = "ENCODE"
+    DECODE = "DECODE"
+
+
+@dataclass(frozen=True)
+class PowerExtent:
+    """Symbolic axis extent ``base ** exponent`` without materializing the integer."""
+
+    base: int
+    exponent: int
+
+    def __post_init__(self) -> None:
+        if isinstance(self.base, bool) or not isinstance(self.base, int) or self.base < 2:
+            raise ValueError("base must be an integer >= 2")
+        if (
+            isinstance(self.exponent, bool)
+            or not isinstance(self.exponent, int)
+            or self.exponent <= 0
+        ):
+            raise ValueError("exponent must be a positive integer")
+
+    @property
+    def log10_axis(self) -> float:
+        return self.exponent * math.log10(self.base)
+
+    @property
+    def log10_volume(self) -> float:
+        return 3.0 * self.log10_axis
+
+    @property
+    def approximate_axis_bits(self) -> int:
+        return math.ceil(self.exponent * math.log2(self.base))
+
+
+@dataclass(frozen=True)
+class RegionDescriptor:
+    """Finite descriptor for one sparse region inside a symbolic 3D fabric."""
+
+    ref: int
+    level: int = 0
+    tile_count_hint: int = 1
+
+    def __post_init__(self) -> None:
+        if isinstance(self.ref, bool) or not isinstance(self.ref, int) or not 0 <= self.ref < 2**64:
+            raise ValueError("ref must be an unsigned 64-bit integer")
+        if isinstance(self.level, bool) or not isinstance(self.level, int) or self.level < 0:
+            raise ValueError("level must be a non-negative integer")
+        if (
+            isinstance(self.tile_count_hint, bool)
+            or not isinstance(self.tile_count_hint, int)
+            or self.tile_count_hint <= 0
+        ):
+            raise ValueError("tile_count_hint must be a positive integer")
+
+
+@dataclass(frozen=True)
+class KineticInstruction:
+    """One bounded research instruction.
+
+    ``observation`` is the immutable per-instruction anchor. ``prediction`` and
+    ``omega`` are finite scalar projections used by the reference G3D
+    recurrence. Production runtimes may substitute typed tensors provided they
+    preserve the same candidate-first boundary.
+    """
+
+    op: KineticOp
+    region_ref: int
+    observation: float = 0.0
+    prediction: float = 0.0
+    omega: float = 0.0
+    immediate: float = 0.0
+    verification_score: float = 1.0
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.region_ref, bool)
+            or not isinstance(self.region_ref, int)
+            or not 0 <= self.region_ref < 2**64
+        ):
+            raise ValueError("region_ref must be an unsigned 64-bit integer")
+        for name in ("observation", "prediction", "omega", "immediate", "verification_score"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+            object.__setattr__(self, name, value)
+        if not 0.0 <= self.verification_score <= 1.0:
+            raise ValueError("verification_score must be within [0, 1]")
+
+
+@dataclass(frozen=True)
+class KineticConfig:
+    """Resource, activation, projection and verification bounds."""
+
+    max_inflight: int = 64
+    max_resident_regions: int = 8
+    activation_injection: float = 1.0
+    activation_retention: float = 0.75
+    activation_threshold: float = 0.5
+    projection_limit: float = 1_000_000.0
+    verification_threshold: float = 0.90
+    quantization_digits: int = 6
+
+    def __post_init__(self) -> None:
+        for name in ("max_inflight", "max_resident_regions"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("activation_injection", "activation_retention", "activation_threshold"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be finite and within [0, 1]")
+        limit = float(self.projection_limit)
+        if not math.isfinite(limit) or limit <= 0.0:
+            raise ValueError("projection_limit must be finite and positive")
+        threshold = float(self.verification_threshold)
+        if not math.isfinite(threshold) or not 0.0 <= threshold <= 1.0:
+            raise ValueError("verification_threshold must be finite and within [0, 1]")
+        if (
+            isinstance(self.quantization_digits, bool)
+            or not isinstance(self.quantization_digits, int)
+            or not 0 <= self.quantization_digits <= 12
+        ):
+            raise ValueError("quantization_digits must be an integer within [0, 12]")
+
+
+@dataclass(frozen=True)
+class WavePacket:
+    packet_id: int
+    instruction_index: int
+    stage: PipelineStage
+    region_ref: int
+    candidate: float | None = None
+    projected: float | None = None
+    encoded: float | None = None
+    verified: bool | None = None
+    stall_count: int = 0
+
+
+@dataclass(frozen=True)
+class KineticSnapshot:
+    clock: int
+    pc: int
+    inflight: int
+    resident_regions: tuple[int, ...]
+    active_regions: tuple[int, ...]
+    committed_regions: tuple[int, ...]
+    commits: int
+    rollbacks: int
+    stalls: int
+    stage_counts: tuple[tuple[str, int], ...]
+
+
+PacketValidator = Callable[[WavePacket, KineticInstruction], bool]
+
+
+def default_validator(packet: WavePacket, instruction: KineticInstruction) -> bool:
+    """Accept finite projected candidates whose declared score is checked by runtime."""
+
+    del instruction
+    return packet.projected is not None and math.isfinite(packet.projected)
+
+
+class KineticBytecodeRuntime:
+    """Bounded sparse pipeline for kinetic bytecode-wave conformance fixtures."""
+
+    def __init__(
+        self,
+        *,
+        space: PowerExtent,
+        regions: Iterable[RegionDescriptor],
+        program: Iterable[KineticInstruction],
+        config: KineticConfig | None = None,
+        validator: PacketValidator | None = None,
+    ) -> None:
+        self.space = space
+        self.config = config or KineticConfig()
+        self.validator = validator or default_validator
+        self.regions = {region.ref: region for region in regions}
+        self.program = tuple(program)
+        if len(self.regions) == 0:
+            raise ValueError("at least one region descriptor is required")
+        if len(self.program) == 0:
+            raise ValueError("program must contain at least one instruction")
+        missing = sorted({instr.region_ref for instr in self.program} - self.regions.keys())
+        if missing:
+            raise ValueError(f"program references unknown regions: {missing}")
+
+        self.clock = 0
+        self.pc = 0
+        self._next_packet_id = 0
+        self.inflight: list[WavePacket] = []
+        self.activity: dict[int, float] = {}
+        self.resident: set[int] = set()
+        self.committed: dict[int, float] = {}
+        self.commits = 0
+        self.rollbacks = 0
+        self.stalls = 0
+        self.trace: list[tuple[int, int, PipelineStage]] = []
+
+    def _decay_activity(self) -> None:
+        retention = self.config.activation_retention
+        threshold = self.config.activation_threshold
+        next_activity: dict[int, float] = {}
+        for ref, value in self.activity.items():
+            decayed = value * retention
+            if decayed >= threshold:
+                next_activity[ref] = decayed
+        self.activity = next_activity
+
+    def _inject(self) -> None:
+        if self.pc >= len(self.program) or len(self.inflight) >= self.config.max_inflight:
+            return
+        instruction = self.program[self.pc]
+        packet = WavePacket(
+            packet_id=self._next_packet_id,
+            instruction_index=self.pc,
+            stage=PipelineStage.FETCH,
+            region_ref=instruction.region_ref,
+        )
+        self._next_packet_id += 1
+        self.pc += 1
+        self.inflight.append(packet)
+
+    @staticmethod
+    def _next_stage(stage: PipelineStage) -> PipelineStage:
+        index = PIPELINE.index(stage)
+        if index + 1 >= len(PIPELINE):
+            return PipelineStage.COMPLETE
+        return PIPELINE[index + 1]
+
+    def _candidate(self, instruction: KineticInstruction) -> float:
+        current = self.committed.get(instruction.region_ref, instruction.observation)
+        if instruction.op is KineticOp.G3D:
+            error = instruction.observation - instruction.prediction
+            return (
+                current
+                + instruction.prediction
+                - error
+                + instruction.omega
+                + instruction.immediate
+            )
+        if instruction.op is KineticOp.DELTA:
+            return current + instruction.immediate
+        if instruction.op is KineticOp.ENCODE:
+            return math.tanh(current + instruction.immediate)
+        if instruction.op is KineticOp.DECODE:
+            return current + 0.5 * current + instruction.immediate
+        raise RuntimeError(f"unsupported kinetic op: {instruction.op}")
+
+    def _advance_packet(self, packet: WavePacket) -> WavePacket | None:
+        instruction = self.program[packet.instruction_index]
+        stage = packet.stage
+        self.trace.append((self.clock, packet.packet_id, stage))
+
+        if stage is PipelineStage.RESOLVE:
+            if packet.region_ref not in self.regions:
+                self.rollbacks += 1
+                return replace(packet, stage=PipelineStage.ROLLBACK)
+
+        elif stage is PipelineStage.ACTIVATE:
+            prior = self.activity.get(packet.region_ref, 0.0)
+            injected = min(1.0, prior + self.config.activation_injection)
+            self.activity[packet.region_ref] = injected
+
+        elif stage is PipelineStage.MATERIALIZE:
+            if packet.region_ref not in self.resident:
+                if len(self.resident) >= self.config.max_resident_regions:
+                    self.stalls += 1
+                    return replace(packet, stall_count=packet.stall_count + 1)
+                self.resident.add(packet.region_ref)
+
+        elif stage is PipelineStage.EXECUTE:
+            candidate = self._candidate(instruction)
+            if not math.isfinite(candidate):
+                self.rollbacks += 1
+                return replace(packet, stage=PipelineStage.ROLLBACK, candidate=candidate)
+            packet = replace(packet, candidate=candidate)
+
+        elif stage is PipelineStage.PROJECT:
+            if packet.candidate is None:
+                raise RuntimeError("candidate missing before projection")
+            limit = self.config.projection_limit
+            projected = max(-limit, min(limit, packet.candidate))
+            packet = replace(packet, projected=projected)
+
+        elif stage is PipelineStage.VERIFY:
+            score_ok = instruction.verification_score >= self.config.verification_threshold
+            validator_ok = self.validator(packet, instruction)
+            if not score_ok or not validator_ok:
+                self.rollbacks += 1
+                return replace(packet, stage=PipelineStage.ROLLBACK, verified=False)
+            packet = replace(packet, verified=True)
+
+        elif stage is PipelineStage.ENCODE:
+            if packet.projected is None or packet.verified is not True:
+                raise RuntimeError("verified projected candidate required before encoding")
+            encoded = round(packet.projected, self.config.quantization_digits)
+            packet = replace(packet, encoded=encoded)
+
+        elif stage is PipelineStage.COMMIT:
+            if packet.encoded is None or packet.verified is not True:
+                raise RuntimeError("encoded verified candidate required before commit")
+            self.committed[packet.region_ref] = packet.encoded
+            self.commits += 1
+
+        elif stage is PipelineStage.EVICT:
+            self.resident.discard(packet.region_ref)
+
+        elif stage is PipelineStage.COMPLETE:
+            return None
+
+        elif stage is PipelineStage.ROLLBACK:
+            self.resident.discard(packet.region_ref)
+            return None
+
+        next_stage = self._next_stage(packet.stage)
+        return replace(packet, stage=next_stage)
+
+    def tick(self) -> KineticSnapshot:
+        """Advance every in-flight packet by at most one stage and inject one packet."""
+
+        self.clock += 1
+        self._decay_activity()
+        advanced: list[WavePacket] = []
+        for packet in self.inflight:
+            updated = self._advance_packet(packet)
+            if updated is not None:
+                advanced.append(updated)
+        self.inflight = advanced
+        self._inject()
+        return self.snapshot()
+
+    def run(self, *, max_ticks: int = 10_000) -> KineticSnapshot:
+        """Run until the program and in-flight wavefront drain."""
+
+        if isinstance(max_ticks, bool) or not isinstance(max_ticks, int) or max_ticks <= 0:
+            raise ValueError("max_ticks must be a positive integer")
+        for _ in range(max_ticks):
+            snapshot = self.tick()
+            if self.pc >= len(self.program) and not self.inflight:
+                return snapshot
+        raise RuntimeError("kinetic runtime did not quiesce within max_ticks")
+
+    def snapshot(self) -> KineticSnapshot:
+        stage_counts = Counter(packet.stage.value for packet in self.inflight)
+        active = tuple(
+            sorted(
+                ref
+                for ref, value in self.activity.items()
+                if value >= self.config.activation_threshold
+            )
+        )
+        return KineticSnapshot(
+            clock=self.clock,
+            pc=self.pc,
+            inflight=len(self.inflight),
+            resident_regions=tuple(sorted(self.resident)),
+            active_regions=active,
+            committed_regions=tuple(sorted(self.committed)),
+            commits=self.commits,
+            rollbacks=self.rollbacks,
+            stalls=self.stalls,
+            stage_counts=tuple(sorted(stage_counts.items())),
+        )
+
+
+def canonical_million_power_space() -> PowerExtent:
+    """Return one axis of ``1_000_000 ** 1_000_000`` symbolically."""
+
+    return PowerExtent(base=1_000_000, exponent=1_000_000)

--- a/tests/test_kinetic_bytecode_runtime.py
+++ b/tests/test_kinetic_bytecode_runtime.py
@@ -1,0 +1,114 @@
+import pytest
+
+from jarvisx.kinetic_bytecode_runtime import (
+    KineticBytecodeRuntime,
+    KineticConfig,
+    KineticInstruction,
+    KineticOp,
+    PipelineStage,
+    RegionDescriptor,
+    canonical_million_power_space,
+)
+
+
+def test_symbolic_extent_matches_requested_scale_without_materialization() -> None:
+    space = canonical_million_power_space()
+    assert space.base == 1_000_000
+    assert space.exponent == 1_000_000
+    assert space.log10_axis == pytest.approx(6_000_000.0)
+    assert space.log10_volume == pytest.approx(18_000_000.0)
+    assert 19_931_568 <= space.approximate_axis_bits <= 19_931_570
+
+
+def test_g3d_packet_traverses_pipeline_and_commits() -> None:
+    runtime = KineticBytecodeRuntime(
+        space=canonical_million_power_space(),
+        regions=[RegionDescriptor(7)],
+        program=[
+            KineticInstruction(
+                KineticOp.G3D,
+                7,
+                observation=2.0,
+                prediction=2.5,
+                omega=0.25,
+                immediate=0.5,
+                verification_score=0.99,
+            )
+        ],
+    )
+    final = runtime.run()
+    assert final.commits == 1
+    assert final.rollbacks == 0
+    assert final.inflight == 0
+    assert final.resident_regions == ()
+    assert runtime.committed[7] == pytest.approx(5.75)
+    stages = [stage for _, packet_id, stage in runtime.trace if packet_id == 0]
+    assert stages == list(PipelineStage)[:12]
+
+
+def test_verification_failure_rolls_back_without_commit() -> None:
+    runtime = KineticBytecodeRuntime(
+        space=canonical_million_power_space(),
+        regions=[RegionDescriptor(9)],
+        program=[
+            KineticInstruction(
+                KineticOp.DELTA,
+                9,
+                observation=1.0,
+                immediate=4.0,
+                verification_score=0.1,
+            )
+        ],
+    )
+    final = runtime.run()
+    assert final.commits == 0
+    assert final.rollbacks == 1
+    assert 9 not in runtime.committed
+    assert final.resident_regions == ()
+
+
+def test_projection_applies_before_verification_and_commit() -> None:
+    runtime = KineticBytecodeRuntime(
+        space=canonical_million_power_space(),
+        regions=[RegionDescriptor(1)],
+        program=[
+            KineticInstruction(
+                KineticOp.DELTA,
+                1,
+                observation=0.0,
+                immediate=100.0,
+                verification_score=1.0,
+            )
+        ],
+        config=KineticConfig(projection_limit=3.0),
+    )
+    runtime.run()
+    assert runtime.committed[1] == 3.0
+
+
+def test_residency_bound_stalls_but_eventually_drains() -> None:
+    runtime = KineticBytecodeRuntime(
+        space=canonical_million_power_space(),
+        regions=[RegionDescriptor(1), RegionDescriptor(2)],
+        program=[
+            KineticInstruction(KineticOp.DELTA, 1, immediate=1.0),
+            KineticInstruction(KineticOp.DELTA, 2, immediate=2.0),
+        ],
+        config=KineticConfig(max_resident_regions=1),
+    )
+    final = runtime.run()
+    assert final.commits == 2
+    assert final.stalls > 0
+    assert runtime.committed == {1: 1.0, 2: 2.0}
+
+
+def test_external_validator_can_reject_candidate() -> None:
+    runtime = KineticBytecodeRuntime(
+        space=canonical_million_power_space(),
+        regions=[RegionDescriptor(3)],
+        program=[KineticInstruction(KineticOp.DELTA, 3, immediate=1.0)],
+        validator=lambda packet, instruction: False,
+    )
+    final = runtime.run()
+    assert final.rollbacks == 1
+    assert final.commits == 0


### PR DESCRIPTION
## What changed

- add a dependency-free `kinetic_bytecode_runtime` research runtime
- represent `1,000,000 ^ 1,000,000` per axis symbolically rather than materializing the integer or dense volume
- advance in-flight bytecode packets one pipeline stage per logical tick
- enforce bounded residency with observable stalls
- apply candidate projection, verification, deterministic encoding, commit, rollback, and eviction
- add focused tests for scale, traversal, rollback, projection, residency pressure, and validator rejection
- document the operational mathematics and propose ADR-010

## Why

The repository already has an accepted geometric-diffusion kinetic boundary and an accepted sparse native swarm ISA, but it lacks a small executable reference connecting bytecode execution to a moving sparse wavefront over an arbitrarily large symbolic 3D address space.

## Boundary

This remains a research-layer simulator. Its local `committed` state is not an authoritative `jarvisx.system_runtime` commit and cannot authorize external side effects or bypass existing policy/verification gates.

## Validation

The focused runtime fixture was exercised in isolation with six passing tests before publication. Repository-wide CI should remain the acceptance gate for ADR-010.