### PR TITLE
Add bounded deterministic 3D multiparallel pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ The project follows semantic versioning where practical during alpha development
 - analytic constant-forcing updates for `du/dt = -D(-Delta)^alpha u + Omega`;
 - `2×2×2` restriction, prolongation and coarse-to-fine fusion;
 - ordered mechanistic traces, mass drift, gradient energy, residual and convergence telemetry;
-- independent direct-DFT, spatial-stencil and semigroup validation tests.
+- independent direct-DFT, spatial-stencil and semigroup validation tests;
+- bounded deterministic 3D multiparallel package pipeline with sequential and process backends;
+- versioned `JXMP` framing, bounded zlib decode and per-chunk SHA-256 verification;
+- read-only Python code geometry, immutable branch snapshots and ordered typed merging;
+- seeded candidate-first topology search with wall-clock timing excluded from fitness;
+- `jarvisx-multiparallel` run, map-code and evolve command-line surface.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ At depth `D`:
 | Repository protection | required checks, secret scanning and private vulnerability reporting | Issue #49 |
 | Public profile | account-level profile README and pinned-project cleanup | Issue #50 |
 | Browser engines | bounded interactive 3D visual-computing demonstrations | Separate repository |
+| 3D multiparallel pipeline | deterministic packages, framing, branches and bounded topology search | Issue #113 / integration candidate |
 
 Draft status is intentional: experimental subsystems are not represented as canonical until CI, review and integration boundaries are satisfied.
 
@@ -227,6 +228,7 @@ Every canonical subsystem should provide:
 - [Architecture](docs/ARCHITECTURE.md)
 - [Project status](docs/PROJECT_STATUS.md)
 - [Hierarchical 3D fractional smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md)
+- [3D multiparallel pipeline](docs/JARVIS_X_3D_MULTIPARALLEL_PIPELINE.md)
 - [Roadmap](ROADMAP.md)
 - [Governance](GOVERNANCE.md)
 - [Security policy](SECURITY.md)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -111,6 +111,9 @@ Responsibilities may include:
 - parameter candidate generation;
 - shadow evaluation;
 - bounded schedule search;
+- bounded multiparallel package pipelines;
+- deterministic reconciliation of asynchronous package results;
+- versioned, integrity-checked multi-package framing;
 - coherence projection;
 - commit and rollback decisions.
 
@@ -121,6 +124,11 @@ For volumetric autoencoding systems, additive evolution terms must inhabit the s
 The Moagi-Helmholtz functional is the canonical Layer 5 orchestration contract for multimodal-conditioned geometry generation, refinement, archival coding and reverse inference. It does not require the canonical VM to depend on a neural, renderer or codec backend.
 
 Orthogonal transform adapters additionally inherit ADR-005: normalization is verified before transpose-as-inverse reconstruction, quantization error receives its own deterministic envelope, and a transform defect cannot be hidden by widening a multimedia distortion threshold.
+
+Multiparallel pipeline candidates additionally inherit ADR-010: worker completion order
+cannot affect reconciliation, topology data cannot carry arbitrary callables, source
+geometry remains observational, wall-clock telemetry cannot drive deterministic
+promotion, and an active topology changes only after candidate verification.
 
 ### Layer 6 — Interfaces and visualization
 
@@ -185,6 +193,9 @@ The research transform cannot make itself authoritative merely by computing a ca
 16. **Transform precision separation:** orthogonal transform/quantization error is measured against its own deterministic bound and is not absorbed into render, cycle or perceptual tolerances.
 17. **Normalize before inversion:** a backend may use `D^T` as the inverse only when the declared transform has passed its orthonormality contract within tolerance.
 18. **Diagnose before widening:** a precision-gate failure triggers transform/payload/precision diagnosis before any quantization threshold is relaxed.
+19. **Ordered reconciliation:** parallel package results are reconciled by declared source order rather than environmental completion order.
+20. **Observational code geometry:** geometric transforms of code coordinates cannot silently rewrite or reorder authoritative source.
+21. **Timing separation:** wall-clock measurements are telemetry unless a statistical benchmark contract explicitly admits them; they are not deterministic replay inputs.
 
 ## 5. Data contracts
 

--- a/docs/JARVIS_X_3D_MULTIPARALLEL_PIPELINE.md
+++ b/docs/JARVIS_X_3D_MULTIPARALLEL_PIPELINE.md
@@ -1,0 +1,376 @@
+# JARVIS X 3D Multiparallel Pipeline
+
+## Status
+
+Bounded Python reference proposed by issue #113. The implementation is isolated from
+the canonical bytecode VM and task-level system runtime.
+
+This subsystem operationalizes four parts of the supplied architecture:
+
+1. deterministic package splitting and multiprocess execution;
+2. typed 3D asset transforms and read-only source-code geometry;
+3. immutable branch snapshots and ordered reconciliation;
+4. seeded, candidate-first topology search over a finite safe family.
+
+It does **not** establish unrestricted self-modification, source-code rotation,
+continuous online learning, distributed execution or measured acceleration.
+
+## 1. Layer map
+
+| Layer | Reference component | Implemented responsibility |
+|---|---|---|
+| Data | `Vector3`, `VertexBatch`, `Mesh` | Immutable finite 3D values and index-safe triangle meshes |
+| Package | `WorkPackage`, `PackageReceipt` | Deterministic identities, source order, stage trace and failure receipt |
+| Pipeline | `PipelineNode`, `PipelineTopology`, `ParallelPipeline` | Closed stage vocabulary, validated linear DAG, sequential/process execution and ordered merge |
+| Encoding | `EncodedChunk`, `FramedArtifact` | UTF-8/binary/geometry encoding, bounded zlib decode, SHA-256 integrity and v1 framing |
+| Spatial | `SpatialProcessor`, `CodeGeometry` | AST-validated code observation and typed asset coordinate transforms |
+| Branching | `BranchSnapshot`, `JarvisX3DEngine` | Immutable snapshots, independent processing and typed merge |
+| Evolution | `TopologyEvolution` | Seeded finite search with deterministic fitness and candidate-first promotion |
+| Interface | `jarvisx-multiparallel` | `run`, `map-code` and `evolve` commands with strict JSON summaries |
+
+The reference uses immutable Python tuples rather than introducing NumPy as a required
+package dependency. A future NumPy adapter may accelerate `VertexBatch` operations if
+it preserves the same dimensional, serialization and determinism contracts.
+
+## 2. Operational state
+
+One engine state is
+
+\[
+\mathcal E_t = (T_t, R_t, B_t, S_t),
+\]
+
+where:
+
+- \(T_t\) is the active validated topology;
+- \(R_t\) is the last successfully reconciled main run;
+- \(B_t\) is the immutable branch map;
+- \(S_t\) is aggregate telemetry and bounded-search state.
+
+Research output is not authoritative VM state. There is no dependency from
+`jarvisx.core` or `jarvisx.system_runtime` to this module.
+
+## 3. Kinetic package flow
+
+Given input \(X\), topology \(T\) and worker ceiling \(P\), the splitter produces
+source-ordered packages:
+
+\[
+\operatorname{Split}(X;P,b)
+=
+(W_0,W_1,\ldots,W_{n-1}),
+\qquad
+n\leq \min(P,N_{\text{packages}}).
+\]
+
+Every package identity binds:
+
+\[
+\operatorname{id}(W_i)
+=
+H(\text{domain}\|H(T)\|H(X)\|i\|H(X_i)).
+\]
+
+Each worker evaluates the same ordered stage tuple:
+
+\[
+Y_i
+=
+f_m\circ f_{m-1}\circ\cdots\circ f_1(X_i).
+\]
+
+The v1 stage vocabulary is closed:
+
+| Stage | Input | Output | Behavior |
+|---|---|---|---|
+| `LOAD` | raw value | same type | Identity/load boundary |
+| `TRANSFORM` | text, bytes or geometry | same raw type | Text/bytes unchanged; typed geometry axis permutation and scale |
+| `ENCODE` | raw value | `EncodedChunk` | Canonical type-tagged bytes plus raw SHA-256 |
+| `COMPRESS` | `EncodedChunk` | `EncodedChunk` | Bounded zlib level `0..9` |
+| `DECOMPRESS` | `EncodedChunk` | `EncodedChunk` | Strict size-checked decompression |
+| `DECODE` | `EncodedChunk` | raw value | Exact typed reconstruction |
+| `VERIFY` | any supported value | same type | Integrity/type verification without mutation |
+
+Arbitrary callables are not accepted as stages. This keeps process messages
+serializable and prevents a topology document from becoming arbitrary execution
+authority.
+
+### Deterministic reconciliation
+
+Process completion may be out of order. Reconciliation is always:
+
+\[
+Y
+=
+\operatorname{Merge}
+\left(
+\operatorname{sort}_{i}
+\{(i,Y_i)\}
+\right).
+\]
+
+Merge rules are exact and typed:
+
+| Output type | Merge rule |
+|---|---|
+| text | direct source-order concatenation, with no inserted newline |
+| bytes | direct source-order concatenation |
+| `VertexBatch` | ordered vertex concatenation |
+| `EncodedChunk` | versioned `JXMP` framed artifact |
+| `Mesh` | one complete package only |
+| mixed types | reject |
+
+If any package or the merge gate fails, the run returns failure receipts and no new
+main run is committed:
+
+\[
+R_{t+1}
+=
+\begin{cases}
+R^{*}, & \forall i:\operatorname{valid}(Y_i)\land\operatorname{valid}(Y),\\
+R_t, & \text{otherwise}.
+\end{cases}
+\]
+
+## 4. Framed encoding
+
+The persisted multi-package envelope begins with:
+
+```text
+magic             4 bytes   "JXMP"
+version           1 byte    0x01
+data kind         1 byte
+chunk count       4 bytes   unsigned big-endian
+```
+
+Every chunk then contains:
+
+```text
+compression       1 byte    none or zlib
+raw size          8 bytes   unsigned big-endian
+raw SHA-256      32 bytes
+payload size      8 bytes   unsigned big-endian
+payload           N bytes
+```
+
+The decoder checks frame bytes, chunk count, cumulative decoded size, compression
+termination, trailing data, raw length and raw SHA-256 before returning a value. The
+declared raw size is validated before decompression to bound compressed expansion.
+
+Run telemetry records `zlib.ZLIB_RUNTIME_VERSION`. Exact compressed bytes and search
+results are reproducible under the same declared codec runtime; cross-version zlib
+byte identity is not assumed.
+
+SHA-256 provides integrity and provenance; it does not make a lossy operation
+reversible. The bundled encoders are exact for supported types.
+
+## 5. 3D spatial observation
+
+For validated Python source with line \(\ell\), the reference maps:
+
+\[
+g(\ell)
+=
+\left(
+\ell,
+\operatorname{indentColumns}(\ell),
+\operatorname{nameTokens}(\ell)
+\right).
+\]
+
+- `x` is the one-based line number;
+- `y` is expanded indentation width, using tab width four;
+- `z` is the number of non-keyword Python name tokens.
+
+Each line and the complete source have SHA-256 identities. A spatial permutation
+
+\[
+(x,y,z)\mapsto s(a_1,a_2,a_3)
+\]
+
+creates a transformed `CodeGeometry` only. It does not mutate, reconstruct, reorder or
+execute source. General line rotation is not semantics preserving because control
+flow, indentation, definitions and data dependencies are ordered.
+
+For `VertexBatch` and `Mesh`, the same axis permutation and uniform scale act on typed
+coordinates and may therefore be used as an actual asset transform.
+
+## 6. Branching and merging
+
+Creating a branch captures:
+
+\[
+B_j=(j,n,H(X_j),H(T_j),X_j,\varnothing).
+\]
+
+The payload is restricted to immutable supported types. Processing produces a run
+receipt attached to a replacement snapshot; it never mutates the original payload.
+
+`merge_branches([j_0,...,j_k])` requires every named branch to have a successful run
+and applies the same ordered type gate as package reconciliation. The call returns a
+value; it does not silently replace main or VM state.
+
+## 7. Bounded topology search
+
+The search space is deliberately finite. Candidates may change:
+
+- one of five type-safe stage templates;
+- worker hint within `RuntimeLimits.max_workers`;
+- positive batch size within `max_batch_size`;
+- zlib level `0..9`.
+
+The initial population includes the active topology. Selection retains the highest
+scoring fraction, crossover chooses bounded fields from two survivors, and mutation
+changes one bounded field. A seeded `random.Random` instance makes candidate generation
+replayable.
+
+### Fitness
+
+Wall-clock time is reported but cannot select the active topology. The deterministic
+fitness is:
+
+\[
+J(T)
+=
+0.50(1-r_T)
++0.30\frac{1}{1+\widehat W_T/U}
++0.20\frac{p_{\text{active}}}{n_{\text{packages}}}
+-0.02\max(0,|T|-4),
+\]
+
+where:
+
+- \(r_T\) is measured compressed payload size divided by raw size;
+- \(\widehat W_T\) is a documented stage-weight cost model;
+- \(U\) is bounded input size;
+- \(p_{\text{active}}\) is effective package parallelism;
+- \(|T|\) is node count.
+
+This is a constrained parameter/topology search objective, not autonomous objective
+discovery. It can still be gamed by an unrepresentative fixture, so promotion performs
+one final complete verification on the declared test data. The active topology changes
+only after that gate succeeds.
+
+Observed `elapsed_ns` and packages per second remain telemetry because process startup,
+scheduler load and host state are environmental signals.
+
+## 8. Resource bounds
+
+Default ceilings are:
+
+| Resource | Default bound |
+|---|---:|
+| workers | 8 |
+| packages per run | 256 |
+| nodes per topology | 16 |
+| input bytes | 16 MiB |
+| merged/frame bytes | 64 MiB |
+| vertices | 1,000,000 |
+| branches | 128 |
+| population | 64 |
+| generations | 64 |
+
+The process backend is local. Worker count is not a claim of CPU speedup; serialization,
+startup and workload size may make it slower than sequential execution.
+
+## 9. Python API
+
+```python
+from jarvisx.multiparallel import FramedArtifact, JarvisX3DEngine
+
+source = "def f(x):\n    return x + 1\n"
+engine = JarvisX3DEngine(code=source)
+
+run = engine.process_parallel(num_workers=4, backend="process")
+assert run.success
+assert isinstance(run.output, FramedArtifact)
+assert run.output.decode() == source
+
+geometry = engine.spatial_process(axis_order="yzx", scale=2.0)
+assert geometry.source_sha256 == engine.spatial_process().source_sha256
+```
+
+Branch exploration:
+
+```python
+left = engine.create_branch("left", "alpha")
+right = engine.create_branch("right", "beta")
+engine.process_branch(left)
+engine.process_branch(right)
+
+merged = engine.merge_branches((left, right))
+assert merged.decode() == "alphabeta"
+```
+
+Seeded search:
+
+```python
+from jarvisx.multiparallel import EvolutionConfig
+
+result = engine.auto_evolve(
+    source,
+    EvolutionConfig(generations=5, population_size=10, seed=7),
+)
+assert result.promoted
+```
+
+## 10. CLI
+
+Process and optionally persist a framed artifact:
+
+```bash
+jarvisx-multiparallel run program.py \
+  --workers 4 \
+  --backend process \
+  --output program.jxmp
+```
+
+Map code without rewriting it:
+
+```bash
+jarvisx-multiparallel map-code program.py --axis-order yzx --scale 2
+```
+
+Run deterministic bounded search:
+
+```bash
+jarvisx-multiparallel evolve program.py \
+  --generations 5 \
+  --population 10 \
+  --seed 7
+```
+
+The commands emit strict JSON. Fields suffixed `_telemetry` may vary across runs and do
+not participate in topology selection or provenance identities.
+
+## 11. Validation matrix
+
+`tests/test_multiparallel.py` and `tests/test_multiparallel_cli.py` cover:
+
+- finite vector and mesh-index validation;
+- topology cycle, fork and disconnection rejection;
+- sequential/process artifact equivalence;
+- completion-order-independent reconciliation;
+- text, bytes, vertex and mesh round trips;
+- frame truncation, tamper and compressed-expansion rejection;
+- observational source mapping and syntax rejection;
+- stage-type failure receipts and main-state preservation;
+- branch isolation, ordered merge and mixed-type rejection;
+- seeded evolution reproducibility;
+- candidate-first promotion and failed-configuration rollback;
+- worker, byte and branch ceilings;
+- CLI artifact, JSON and no-source-rewrite contracts.
+
+## 12. Promotion boundary
+
+Promotion to a canonical reference laboratory requires:
+
+1. Python 3.10–3.13 tests passing;
+2. package compilation and type checks passing;
+3. sequential/process equivalence on CI;
+4. dependency audit and package build passing;
+5. review of framing limits and process failure behavior;
+6. explicit acceptance of ADR-010.
+
+Even after promotion, the subsystem remains outside authoritative VM state unless a
+future ADR defines a capability-gated adapter through `jarvisx.system_runtime`.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,7 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-12  
+**Last reviewed:** 2026-08-17
+
 **Release line:** `0.1.x` alpha
 
 This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
@@ -36,6 +37,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
 | Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures, not production neural or MP4 implementations |
 | Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, `test_orthogonal_quantization.py`, ADR-005 | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production DCT/video codec kernel |
+| 3D multiparallel pipeline | Integration candidate | `multiparallel.py`, focused tests, ADR-010, issue #113 | local bounded pipeline; v1 linear DAG; tuple reference rather than NumPy kernel; timing is non-selection telemetry; no canonical VM authority |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |

--- a/docs/adr/0010-bounded-3d-multiparallel-pipeline.md
+++ b/docs/adr/0010-bounded-3d-multiparallel-pipeline.md
@@ -1,0 +1,107 @@
+# ADR-010: Bounded deterministic 3D multiparallel pipeline
+
+- **Status:** Proposed
+- **Date:** 2026-08-17
+- **Decision scope:** isolated Layer 5 Python research subsystem
+- **Tracking:** issue #113
+
+## Context
+
+The supplied JARVIS X multiparallel architecture combines package splitting, process
+parallelism, 3D code mapping, branch exploration, compression and genetic topology
+adaptation. Several parts need a stricter repository interpretation:
+
+- arbitrary source-line rotation is not generally semantics preserving;
+- asynchronous completion must not alter reconciliation order;
+- wall-clock duration is not a deterministic fitness input;
+- arbitrary stage callables would turn topology data into execution authority;
+- compressed packages require framing and bounded decode verification;
+- topology candidates must not mutate active state before admission;
+- a research pipeline must not become authoritative `CodexVM` state by naming.
+
+Older draft PRs #22 and #43 contain related visual and geometric concepts but predate
+the canonical separation and task-control boundaries. Reviving either wholesale would
+also import unrelated historical changes.
+
+## Decision
+
+Introduce `jarvisx.multiparallel` and `jarvisx.multiparallel_cli` as an isolated,
+dependency-free reference with these rules:
+
+1. accept only text, bytes, immutable vertex batches and complete triangular meshes;
+2. use a closed stage enum and a validated v1 linear DAG;
+3. derive package and run identities from canonical SHA-256 material;
+4. collect work asynchronously but reconcile only by source sequence;
+5. frame encoded chunks in a versioned, length-delimited `JXMP` envelope;
+6. validate declared and cumulative output bounds before decompression;
+7. map source to read-only code geometry and never regenerate source from transformed points;
+8. keep branches immutable and return merged results without silent main-state promotion;
+9. search a finite type-safe topology family with a seeded generator;
+10. use compression and deterministic estimated work for fitness while reporting timing separately;
+11. promote a topology only after a final complete verification run;
+12. keep the subsystem outside `jarvisx.core` and `jarvisx.system_runtime` authority.
+
+## Governing invariant
+
+```text
+parallel proposals
+  -> deterministic source-order reconciliation
+  -> integrity/resource verification
+  -> research-run commit or rollback
+```
+
+This is not:
+
+```text
+parallel completion -> arbitrary state mutation
+```
+
+## Consequences
+
+### Positive
+
+- the operational pipeline has executable and testable kinetics;
+- process scheduling cannot change merged bytes or run identity;
+- compressed outputs are independently verifiable and bounded;
+- topology search is replayable and cannot select on host timing noise;
+- code visualization no longer implies source transformation;
+- `CodexVM` and system-runtime semantics remain unchanged.
+
+### Trade-offs
+
+- v1 supports a linear DAG rather than arbitrary fan-out/fan-in graphs;
+- the standard-library tuple representation is a correctness reference, not a vectorized kernel;
+- process startup may dominate small workloads;
+- the finite fitness model cannot establish optimality beyond its fixture and objective;
+- meshes remain one package so face topology is not split incorrectly.
+
+## Alternatives considered
+
+### Use arbitrary Python processors in each node
+
+Rejected because pickled callables weaken auditability and allow topology data to carry
+unbounded execution behavior.
+
+### Rewrite code after rotating its spatial points
+
+Rejected because Python semantics depend on source order, indentation, binding and
+control flow. Read-only geometry preserves the visualization without a false
+semantics-equivalence claim.
+
+### Select topology using measured wall-clock speed
+
+Rejected for the reference selector because scheduler load and process startup make
+single-run timing nondeterministic. Timing remains telemetry for empirical benchmarks.
+
+### Merge old multiparallel draft PRs wholesale
+
+Rejected because they combine superseded core changes and unrelated integration
+dependencies. Issue #113 extracts a current, narrow subsystem.
+
+## Validation
+
+Acceptance requires the evidence enumerated in
+`docs/JARVIS_X_3D_MULTIPARALLEL_PIPELINE.md`, including process/sequential equivalence,
+stable reconciliation, frame tamper rejection, branch isolation, deterministic search,
+candidate-first promotion and resource-bound tests.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ Changelog = "https://github.com/Lord-Xido/Jarvis-X/blob/main/CHANGELOG.md"
 [project.scripts]
 jarvisx = "jarvisx.cli:main"
 jarvisx-hyperion = "jarvisx.hyperion_cli:main"
+jarvisx-multiparallel = "jarvisx.multiparallel_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/multiparallel.py
+++ b/src/jarvisx/multiparallel.py
@@ -1,0 +1,1605 @@
+"""Bounded deterministic reference for the Jarvis-X 3D multiparallel pipeline.
+
+The module implements a closed set of serializable pipeline stages, deterministic
+package ordering, framed compression artifacts, immutable branch snapshots and a
+seeded topology search.  It is a Layer 5 research subsystem: none of its results are
+authoritative ``CodexVM`` or ``SystemRuntime`` state.
+
+The reference deliberately maps source code into a read-only 3D observation.  Axis
+transforms never rewrite source text because line rotation or reordering is not a
+general semantics-preserving Python transform.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import io
+import json
+import keyword
+import math
+import random
+import struct
+import time
+import tokenize
+import zlib
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from dataclasses import dataclass, replace
+from enum import Enum
+from threading import RLock
+from typing import Iterable, Sequence, Union
+
+
+_FRAME_MAGIC = b"JXMP"
+_FRAME_VERSION = 1
+_MAX_TOPOLOGY_NODES = 32
+_DEFAULT_DECODE_LIMIT = 64 * 1024 * 1024
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _require_finite(name: str, value: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be numeric")
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} must be finite")
+    return numeric
+
+
+@dataclass(frozen=True, order=True)
+class Vector3:
+    """One finite three-dimensional vector."""
+
+    x: float
+    y: float
+    z: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "x", _require_finite("x", self.x))
+        object.__setattr__(self, "y", _require_finite("y", self.y))
+        object.__setattr__(self, "z", _require_finite("z", self.z))
+
+    def transform(self, axis_order: str = "xyz", scale: float = 1.0) -> "Vector3":
+        """Return an axis permutation followed by a finite uniform scale."""
+
+        if len(axis_order) != 3 or set(axis_order) != {"x", "y", "z"}:
+            raise ValueError("axis_order must be a permutation of 'xyz'")
+        factor = _require_finite("scale", scale)
+        if factor == 0.0:
+            raise ValueError("scale cannot be zero")
+        values = {"x": self.x, "y": self.y, "z": self.z}
+        return Vector3(
+            values[axis_order[0]] * factor,
+            values[axis_order[1]] * factor,
+            values[axis_order[2]] * factor,
+        )
+
+
+@dataclass(frozen=True)
+class VertexBatch:
+    """Immutable vector batch used by the dependency-free reference path."""
+
+    vertices: tuple[Vector3, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.vertices, tuple):
+            object.__setattr__(self, "vertices", tuple(self.vertices))
+        if not all(isinstance(vertex, Vector3) for vertex in self.vertices):
+            raise TypeError("vertices must contain only Vector3 values")
+
+    def __len__(self) -> int:
+        return len(self.vertices)
+
+    def transform(self, axis_order: str = "xyz", scale: float = 1.0) -> "VertexBatch":
+        return VertexBatch(tuple(vertex.transform(axis_order, scale) for vertex in self.vertices))
+
+
+@dataclass(frozen=True)
+class Mesh:
+    """Immutable triangular mesh contract.
+
+    Meshes are processed as one package in v1 so that face indices cannot be broken by
+    vertex chunking.
+    """
+
+    vertices: VertexBatch
+    faces: tuple[tuple[int, int, int], ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.vertices, VertexBatch):
+            raise TypeError("vertices must be a VertexBatch")
+        if not isinstance(self.faces, tuple):
+            object.__setattr__(self, "faces", tuple(self.faces))
+        vertex_count = len(self.vertices)
+        for face in self.faces:
+            if not isinstance(face, tuple) or len(face) != 3:
+                raise TypeError("faces must be integer index triples")
+            for index in face:
+                if isinstance(index, bool) or not isinstance(index, int):
+                    raise TypeError("face indices must be integers")
+                if index < 0 or index >= vertex_count:
+                    raise ValueError("face index lies outside the vertex batch")
+
+    def transform(self, axis_order: str = "xyz", scale: float = 1.0) -> "Mesh":
+        return Mesh(self.vertices.transform(axis_order, scale), self.faces)
+
+
+class DataKind(str, Enum):
+    TEXT = "text"
+    BYTES = "bytes"
+    VERTICES = "vertices"
+    MESH = "mesh"
+
+
+class Compression(str, Enum):
+    NONE = "none"
+    ZLIB = "zlib"
+
+
+PipelineValue = Union[str, bytes, VertexBatch, Mesh, "EncodedChunk", "FramedArtifact"]
+
+
+def _kind_code(kind: DataKind) -> int:
+    return {
+        DataKind.TEXT: 1,
+        DataKind.BYTES: 2,
+        DataKind.VERTICES: 3,
+        DataKind.MESH: 4,
+    }[kind]
+
+
+def _kind_from_code(code: int) -> DataKind:
+    for kind in DataKind:
+        if _kind_code(kind) == code:
+            return kind
+    raise ValueError(f"unsupported framed data kind {code}")
+
+
+def _raw_encode(value: Union[str, bytes, VertexBatch, Mesh]) -> tuple[DataKind, bytes]:
+    if isinstance(value, str):
+        return DataKind.TEXT, value.encode("utf-8")
+    if isinstance(value, bytes):
+        return DataKind.BYTES, value
+    if isinstance(value, VertexBatch):
+        payload = bytearray(struct.pack(">Q", len(value.vertices)))
+        for vertex in value.vertices:
+            payload.extend(struct.pack(">ddd", vertex.x, vertex.y, vertex.z))
+        return DataKind.VERTICES, bytes(payload)
+    if isinstance(value, Mesh):
+        payload = bytearray(
+            struct.pack(">QQ", len(value.vertices.vertices), len(value.faces))
+        )
+        for vertex in value.vertices.vertices:
+            payload.extend(struct.pack(">ddd", vertex.x, vertex.y, vertex.z))
+        for face in value.faces:
+            payload.extend(struct.pack(">III", *face))
+        return DataKind.MESH, bytes(payload)
+    raise TypeError("pipeline values must be text, bytes, VertexBatch or Mesh")
+
+
+def _raw_decode(kind: DataKind, payload: bytes) -> Union[str, bytes, VertexBatch, Mesh]:
+    if kind is DataKind.TEXT:
+        try:
+            return payload.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError("text payload is not valid UTF-8") from exc
+    if kind is DataKind.BYTES:
+        return payload
+    if kind is DataKind.VERTICES:
+        if len(payload) < 8:
+            raise ValueError("vertex payload is truncated")
+        (count,) = struct.unpack_from(">Q", payload, 0)
+        expected = 8 + count * 24
+        if expected != len(payload):
+            raise ValueError("vertex payload length does not match its count")
+        vertices_list: list[Vector3] = []
+        for index in range(count):
+            x, y, z = struct.unpack_from(">ddd", payload, 8 + index * 24)
+            vertices_list.append(Vector3(x, y, z))
+        vertices = tuple(vertices_list)
+        return VertexBatch(vertices)
+    if kind is DataKind.MESH:
+        if len(payload) < 16:
+            raise ValueError("mesh payload is truncated")
+        vertex_count, face_count = struct.unpack_from(">QQ", payload, 0)
+        expected = 16 + vertex_count * 24 + face_count * 12
+        if expected != len(payload):
+            raise ValueError("mesh payload length does not match its counts")
+        mesh_vertices: list[Vector3] = []
+        for index in range(vertex_count):
+            x, y, z = struct.unpack_from(">ddd", payload, 16 + index * 24)
+            mesh_vertices.append(Vector3(x, y, z))
+        vertices = tuple(mesh_vertices)
+        face_offset = 16 + vertex_count * 24
+        face_values: list[tuple[int, int, int]] = []
+        for index in range(face_count):
+            a, b, c = struct.unpack_from(">III", payload, face_offset + index * 12)
+            face_values.append((a, b, c))
+        faces = tuple(face_values)
+        return Mesh(VertexBatch(vertices), faces)
+    raise ValueError(f"unsupported data kind {kind!r}")
+
+
+def _bounded_zlib_decode(payload: bytes, expected_size: int, limit: int) -> bytes:
+    if expected_size < 0 or expected_size > limit:
+        raise ValueError("declared raw size exceeds the decode limit")
+    decoder = zlib.decompressobj()
+    try:
+        raw = decoder.decompress(payload, expected_size + 1)
+    except zlib.error as exc:
+        raise ValueError("compressed payload is invalid") from exc
+    if len(raw) != expected_size:
+        raise ValueError("compressed payload does not match its declared raw size")
+    if not decoder.eof or decoder.unconsumed_tail or decoder.unused_data:
+        raise ValueError("compressed payload has trailing or unconsumed data")
+    return raw
+
+
+@dataclass(frozen=True)
+class EncodedChunk:
+    """One independently verifiable encoded package."""
+
+    kind: DataKind
+    payload: bytes
+    raw_size: int
+    raw_sha256: str
+    compression: Compression = Compression.NONE
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, DataKind):
+            raise TypeError("kind must be a DataKind")
+        if not isinstance(self.payload, bytes):
+            raise TypeError("payload must be bytes")
+        if isinstance(self.raw_size, bool) or not isinstance(self.raw_size, int):
+            raise TypeError("raw_size must be an integer")
+        if self.raw_size < 0:
+            raise ValueError("raw_size must be non-negative")
+        if (
+            not isinstance(self.raw_sha256, str)
+            or len(self.raw_sha256) != 64
+            or any(character not in "0123456789abcdef" for character in self.raw_sha256)
+        ):
+            raise ValueError("raw_sha256 must be a lowercase SHA-256 digest")
+        if not isinstance(self.compression, Compression):
+            raise TypeError("compression must be a Compression value")
+        if self.compression is Compression.NONE:
+            if len(self.payload) != self.raw_size or _sha256(self.payload) != self.raw_sha256:
+                raise ValueError("uncompressed payload does not match its integrity fields")
+
+    @classmethod
+    def encode(cls, value: Union[str, bytes, VertexBatch, Mesh]) -> "EncodedChunk":
+        kind, raw = _raw_encode(value)
+        return cls(kind, raw, len(raw), _sha256(raw))
+
+    def compress(self, level: int = 6) -> "EncodedChunk":
+        if isinstance(level, bool) or not isinstance(level, int) or not 0 <= level <= 9:
+            raise ValueError("zlib compression level must be an integer in [0, 9]")
+        raw = self.raw_bytes()
+        return EncodedChunk(
+            kind=self.kind,
+            payload=zlib.compress(raw, level),
+            raw_size=len(raw),
+            raw_sha256=self.raw_sha256,
+            compression=Compression.ZLIB,
+        )
+
+    def raw_bytes(self, max_output_bytes: int = _DEFAULT_DECODE_LIMIT) -> bytes:
+        if self.raw_size > max_output_bytes:
+            raise ValueError("chunk exceeds the decode limit")
+        if self.compression is Compression.NONE:
+            raw = self.payload
+        elif self.compression is Compression.ZLIB:
+            raw = _bounded_zlib_decode(self.payload, self.raw_size, max_output_bytes)
+        else:  # pragma: no cover - Enum construction prevents this branch.
+            raise ValueError(f"unsupported compression {self.compression!r}")
+        if _sha256(raw) != self.raw_sha256:
+            raise ValueError("chunk integrity verification failed")
+        return raw
+
+    def decode(
+        self, max_output_bytes: int = _DEFAULT_DECODE_LIMIT
+    ) -> Union[str, bytes, VertexBatch, Mesh]:
+        return _raw_decode(self.kind, self.raw_bytes(max_output_bytes))
+
+    @property
+    def payload_sha256(self) -> str:
+        return _sha256(self.payload)
+
+
+@dataclass(frozen=True)
+class FramedArtifact:
+    """Ordered multi-package binary artifact with strict length framing."""
+
+    kind: DataKind
+    chunks: tuple[EncodedChunk, ...]
+
+    def __post_init__(self) -> None:
+        if not self.chunks:
+            raise ValueError("framed artifact requires at least one chunk")
+        if any(chunk.kind is not self.kind for chunk in self.chunks):
+            raise ValueError("all framed chunks must use the declared data kind")
+
+    def to_bytes(self) -> bytes:
+        frame = bytearray(_FRAME_MAGIC)
+        frame.extend(struct.pack(">BBI", _FRAME_VERSION, _kind_code(self.kind), len(self.chunks)))
+        for chunk in self.chunks:
+            compression_code = 0 if chunk.compression is Compression.NONE else 1
+            frame.extend(struct.pack(">BQ", compression_code, chunk.raw_size))
+            frame.extend(bytes.fromhex(chunk.raw_sha256))
+            frame.extend(struct.pack(">Q", len(chunk.payload)))
+            frame.extend(chunk.payload)
+        return bytes(frame)
+
+    @classmethod
+    def from_bytes(
+        cls,
+        frame: bytes,
+        *,
+        max_chunks: int = 256,
+        max_frame_bytes: int = _DEFAULT_DECODE_LIMIT,
+        max_output_bytes: int = _DEFAULT_DECODE_LIMIT,
+    ) -> "FramedArtifact":
+        if not isinstance(frame, bytes):
+            raise TypeError("frame must be bytes")
+        if len(frame) > max_frame_bytes:
+            raise ValueError("frame exceeds the configured byte limit")
+        header_size = len(_FRAME_MAGIC) + 6
+        if len(frame) < header_size or not frame.startswith(_FRAME_MAGIC):
+            raise ValueError("invalid multiparallel frame magic")
+        version, kind_code, count = struct.unpack_from(">BBI", frame, len(_FRAME_MAGIC))
+        if version != _FRAME_VERSION:
+            raise ValueError(f"unsupported multiparallel frame version {version}")
+        if count < 1 or count > max_chunks:
+            raise ValueError("framed chunk count is outside the configured bound")
+        kind = _kind_from_code(kind_code)
+        offset = header_size
+        chunks: list[EncodedChunk] = []
+        total_raw = 0
+        for _ in range(count):
+            metadata_size = 1 + 8 + 32 + 8
+            if offset + metadata_size > len(frame):
+                raise ValueError("multiparallel frame metadata is truncated")
+            compression_code, raw_size = struct.unpack_from(">BQ", frame, offset)
+            offset += 9
+            raw_sha256 = frame[offset : offset + 32].hex()
+            offset += 32
+            (payload_size,) = struct.unpack_from(">Q", frame, offset)
+            offset += 8
+            if payload_size > max_frame_bytes or offset + payload_size > len(frame):
+                raise ValueError("multiparallel frame payload is truncated or oversized")
+            payload = frame[offset : offset + payload_size]
+            offset += payload_size
+            if compression_code == 0:
+                compression = Compression.NONE
+            elif compression_code == 1:
+                compression = Compression.ZLIB
+            else:
+                raise ValueError("unsupported framed compression code")
+            total_raw += raw_size
+            if total_raw > max_output_bytes:
+                raise ValueError("framed artifact exceeds the decoded-output limit")
+            chunks.append(EncodedChunk(kind, payload, raw_size, raw_sha256, compression))
+        if offset != len(frame):
+            raise ValueError("multiparallel frame contains trailing bytes")
+        artifact = cls(kind, tuple(chunks))
+        artifact.decode(max_output_bytes=max_output_bytes)
+        return artifact
+
+    def decode(
+        self, max_output_bytes: int = _DEFAULT_DECODE_LIMIT
+    ) -> Union[str, bytes, VertexBatch, Mesh]:
+        total = sum(chunk.raw_size for chunk in self.chunks)
+        if total > max_output_bytes:
+            raise ValueError("framed artifact exceeds the decoded-output limit")
+        decoded = tuple(chunk.decode(max_output_bytes) for chunk in self.chunks)
+        if self.kind is DataKind.TEXT:
+            return "".join(value for value in decoded if isinstance(value, str))
+        if self.kind is DataKind.BYTES:
+            return b"".join(value for value in decoded if isinstance(value, bytes))
+        if self.kind is DataKind.VERTICES:
+            vertices: list[Vector3] = []
+            for value in decoded:
+                if not isinstance(value, VertexBatch):
+                    raise TypeError("decoded vertex artifact contains an incompatible chunk")
+                vertices.extend(value.vertices)
+            return VertexBatch(tuple(vertices))
+        if self.kind is DataKind.MESH:
+            if len(decoded) != 1 or not isinstance(decoded[0], Mesh):
+                raise ValueError("mesh artifacts must contain exactly one complete mesh chunk")
+            return decoded[0]
+        raise ValueError(f"unsupported artifact kind {self.kind!r}")
+
+    @property
+    def digest_sha256(self) -> str:
+        return _sha256(self.to_bytes())
+
+    @property
+    def compression_ratio(self) -> float:
+        raw = sum(chunk.raw_size for chunk in self.chunks)
+        payload = sum(len(chunk.payload) for chunk in self.chunks)
+        return payload / raw if raw else 1.0
+
+
+class StageKind(str, Enum):
+    LOAD = "load"
+    TRANSFORM = "transform"
+    ENCODE = "encode"
+    COMPRESS = "compress"
+    DECOMPRESS = "decompress"
+    DECODE = "decode"
+    VERIFY = "verify"
+
+
+ParameterValue = Union[str, int, float, bool]
+
+
+@dataclass(frozen=True)
+class PipelineNode:
+    """One closed, serializable processing stage."""
+
+    node_id: str
+    kind: StageKind
+    parameters: tuple[tuple[str, ParameterValue], ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.node_id or len(self.node_id) > 80:
+            raise ValueError("node_id must contain 1 to 80 characters")
+        if not isinstance(self.kind, StageKind):
+            raise TypeError("kind must be a StageKind")
+        names: set[str] = set()
+        for name, value in self.parameters:
+            if not name or name in names:
+                raise ValueError("node parameter names must be non-empty and unique")
+            names.add(name)
+            if not isinstance(value, (str, int, float, bool)):
+                raise TypeError("node parameters must be JSON scalar values")
+            if isinstance(value, float) and not math.isfinite(value):
+                raise ValueError("floating node parameters must be finite")
+
+    def parameter(self, name: str, default: ParameterValue) -> ParameterValue:
+        return dict(self.parameters).get(name, default)
+
+
+@dataclass(frozen=True)
+class PipelineTopology:
+    """Validated v1 linear DAG plus bounded execution hints."""
+
+    nodes: tuple[PipelineNode, ...]
+    edges: tuple[tuple[str, str], ...]
+    parallelism: int = 4
+    batch_size: int = 64
+    compression_level: int = 6
+    schema_version: int = 1
+
+    def __post_init__(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError("only topology schema version 1 is supported")
+        if not self.nodes or len(self.nodes) > _MAX_TOPOLOGY_NODES:
+            raise ValueError(f"topology must contain 1 to {_MAX_TOPOLOGY_NODES} nodes")
+        node_ids = tuple(node.node_id for node in self.nodes)
+        if len(set(node_ids)) != len(node_ids):
+            raise ValueError("topology node identifiers must be unique")
+        if isinstance(self.parallelism, bool) or not isinstance(self.parallelism, int):
+            raise TypeError("parallelism must be an integer")
+        if isinstance(self.batch_size, bool) or not isinstance(self.batch_size, int):
+            raise TypeError("batch_size must be an integer")
+        if self.parallelism < 1 or self.batch_size < 1:
+            raise ValueError("parallelism and batch_size must be positive")
+        if (
+            isinstance(self.compression_level, bool)
+            or not isinstance(self.compression_level, int)
+            or not 0 <= self.compression_level <= 9
+        ):
+            raise ValueError("compression_level must be an integer in [0, 9]")
+
+        valid_ids = set(node_ids)
+        if len(set(self.edges)) != len(self.edges):
+            raise ValueError("topology edges must be unique")
+        incoming = {node_id: 0 for node_id in node_ids}
+        outgoing: dict[str, str] = {}
+        for source, target in self.edges:
+            if source not in valid_ids or target not in valid_ids:
+                raise ValueError("topology edge references an unknown node")
+            if source == target:
+                raise ValueError("topology cannot contain self-edges")
+            incoming[target] += 1
+            if incoming[target] > 1 or source in outgoing:
+                raise ValueError("v1 topology must be a single linear DAG")
+            outgoing[source] = target
+
+        if len(self.nodes) == 1:
+            if self.edges:
+                raise ValueError("single-node topology cannot contain edges")
+            return
+        sources = [node_id for node_id, count in incoming.items() if count == 0]
+        sinks = [node_id for node_id in node_ids if node_id not in outgoing]
+        if len(sources) != 1 or len(sinks) != 1 or len(self.edges) != len(self.nodes) - 1:
+            raise ValueError("v1 topology must have one source, one sink and one path")
+        visited: list[str] = []
+        current = sources[0]
+        while current not in visited:
+            visited.append(current)
+            if current not in outgoing:
+                break
+            current = outgoing[current]
+        if len(visited) != len(self.nodes) or visited[-1] != sinks[0]:
+            raise ValueError("topology contains a cycle or disconnected node")
+
+    @property
+    def ordered_nodes(self) -> tuple[PipelineNode, ...]:
+        by_id = {node.node_id: node for node in self.nodes}
+        if len(self.nodes) == 1:
+            return self.nodes
+        incoming = {node.node_id: 0 for node in self.nodes}
+        outgoing: dict[str, str] = {}
+        for source, target in self.edges:
+            incoming[target] += 1
+            outgoing[source] = target
+        current = next(node_id for node_id, count in incoming.items() if count == 0)
+        ordered: list[PipelineNode] = []
+        while True:
+            ordered.append(by_id[current])
+            if current not in outgoing:
+                return tuple(ordered)
+            current = outgoing[current]
+
+    @property
+    def digest_sha256(self) -> str:
+        payload = {
+            "schema_version": self.schema_version,
+            "nodes": [
+                {
+                    "id": node.node_id,
+                    "kind": node.kind.value,
+                    "parameters": sorted(node.parameters),
+                }
+                for node in self.ordered_nodes
+            ],
+            "edges": list(self.edges),
+            "parallelism": self.parallelism,
+            "batch_size": self.batch_size,
+            "compression_level": self.compression_level,
+        }
+        encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return _sha256(encoded)
+
+
+def topology_from_stages(
+    stages: Sequence[StageKind],
+    *,
+    parallelism: int = 4,
+    batch_size: int = 64,
+    compression_level: int = 6,
+) -> PipelineTopology:
+    if not stages:
+        raise ValueError("at least one pipeline stage is required")
+    nodes = tuple(
+        PipelineNode(f"stage-{index:02d}-{kind.value}", kind)
+        for index, kind in enumerate(stages)
+    )
+    edges = tuple(
+        (nodes[index].node_id, nodes[index + 1].node_id)
+        for index in range(len(nodes) - 1)
+    )
+    return PipelineTopology(
+        nodes,
+        edges,
+        parallelism=parallelism,
+        batch_size=batch_size,
+        compression_level=compression_level,
+    )
+
+
+def default_topology(
+    *, parallelism: int = 4, batch_size: int = 64, compression_level: int = 6
+) -> PipelineTopology:
+    return topology_from_stages(
+        (StageKind.LOAD, StageKind.TRANSFORM, StageKind.ENCODE, StageKind.COMPRESS),
+        parallelism=parallelism,
+        batch_size=batch_size,
+        compression_level=compression_level,
+    )
+
+
+@dataclass(frozen=True)
+class RuntimeLimits:
+    """Resident and execution ceilings for the reference implementation."""
+
+    max_workers: int = 8
+    max_packages: int = 256
+    max_nodes: int = 16
+    max_input_bytes: int = 16 * 1024 * 1024
+    max_output_bytes: int = 64 * 1024 * 1024
+    max_vertices: int = 1_000_000
+    max_branches: int = 128
+    max_population: int = 64
+    max_generations: int = 64
+    max_batch_size: int = 1_048_576
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_workers",
+            "max_packages",
+            "max_nodes",
+            "max_input_bytes",
+            "max_output_bytes",
+            "max_vertices",
+            "max_branches",
+            "max_population",
+            "max_generations",
+            "max_batch_size",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value < 1:
+                raise ValueError(f"{name} must be positive")
+
+
+@dataclass(frozen=True)
+class WorkPackage:
+    package_id: str
+    sequence: int
+    priority: int
+    start_node: str
+    payload: Union[str, bytes, VertexBatch, Mesh]
+
+
+@dataclass(frozen=True)
+class PackageReceipt:
+    package_id: str
+    sequence: int
+    success: bool
+    output: PipelineValue | None
+    output_digest: str
+    stages: tuple[str, ...]
+    elapsed_ns: int
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class PipelineStats:
+    package_count: int
+    successful_packages: int
+    worker_count: int
+    backend: str
+    codec_runtime_version: str
+    elapsed_ns: int
+    throughput_packages_per_second: float
+    input_bytes: int
+    output_bytes: int
+    compression_ratio: float
+
+
+@dataclass(frozen=True)
+class PipelineRun:
+    run_id: str
+    topology_digest: str
+    input_digest: str
+    success: bool
+    receipts: tuple[PackageReceipt, ...]
+    output: PipelineValue | None
+    stats: PipelineStats
+
+
+def _value_bytes(value: PipelineValue) -> bytes:
+    if isinstance(value, EncodedChunk):
+        return value.payload
+    if isinstance(value, FramedArtifact):
+        return value.to_bytes()
+    _, raw = _raw_encode(value)
+    return raw
+
+
+def _value_digest(value: PipelineValue) -> str:
+    if isinstance(value, EncodedChunk):
+        payload = (
+            value.kind.value.encode("ascii")
+            + b"\0"
+            + value.compression.value.encode("ascii")
+            + b"\0"
+            + value.payload
+        )
+        return _sha256(payload)
+    if isinstance(value, FramedArtifact):
+        return value.digest_sha256
+    kind, raw = _raw_encode(value)
+    return _sha256(kind.value.encode("ascii") + b"\0" + raw)
+
+
+def _apply_stage(
+    value: PipelineValue,
+    node: PipelineNode,
+    topology: PipelineTopology,
+    max_output_bytes: int,
+) -> PipelineValue:
+    if node.kind is StageKind.LOAD:
+        return value
+    if node.kind is StageKind.TRANSFORM:
+        axis_order = str(node.parameter("axis_order", "xyz"))
+        scale = float(node.parameter("scale", 1.0))
+        if isinstance(value, VertexBatch):
+            return value.transform(axis_order, scale)
+        if isinstance(value, Mesh):
+            return value.transform(axis_order, scale)
+        if isinstance(value, (str, bytes)):
+            # Code and opaque bytes are intentionally unchanged by spatial transforms.
+            return value
+        raise TypeError("transform stage requires raw text, bytes, vertices or mesh")
+    if node.kind is StageKind.ENCODE:
+        if not isinstance(value, (str, bytes, VertexBatch, Mesh)):
+            raise TypeError("encode stage requires an unencoded value")
+        return EncodedChunk.encode(value)
+    if node.kind is StageKind.COMPRESS:
+        if not isinstance(value, EncodedChunk):
+            raise TypeError("compress stage requires an encoded chunk")
+        level = int(node.parameter("level", topology.compression_level))
+        return value.compress(level)
+    if node.kind is StageKind.DECOMPRESS:
+        if not isinstance(value, EncodedChunk):
+            raise TypeError("decompress stage requires an encoded chunk")
+        raw = value.raw_bytes(max_output_bytes)
+        return EncodedChunk(value.kind, raw, len(raw), value.raw_sha256)
+    if node.kind is StageKind.DECODE:
+        if not isinstance(value, EncodedChunk):
+            raise TypeError("decode stage requires an encoded chunk")
+        return value.decode(max_output_bytes)
+    if node.kind is StageKind.VERIFY:
+        if isinstance(value, EncodedChunk):
+            value.raw_bytes(max_output_bytes)
+        elif isinstance(value, FramedArtifact):
+            value.decode(max_output_bytes)
+        else:
+            _raw_encode(value)
+        return value
+    raise RuntimeError(f"unhandled stage {node.kind!r}")
+
+
+def _process_single(
+    package: WorkPackage,
+    nodes: tuple[PipelineNode, ...],
+    topology: PipelineTopology,
+    max_output_bytes: int,
+) -> PackageReceipt:
+    started = time.perf_counter_ns()
+    completed: list[str] = []
+    try:
+        value: PipelineValue = package.payload
+        for node in nodes:
+            value = _apply_stage(value, node, topology, max_output_bytes)
+            completed.append(node.node_id)
+        digest = _value_digest(value)
+        return PackageReceipt(
+            package.package_id,
+            package.sequence,
+            True,
+            value,
+            digest,
+            tuple(completed),
+            time.perf_counter_ns() - started,
+        )
+    except Exception as exc:  # The receipt is the package transaction boundary.
+        return PackageReceipt(
+            package.package_id,
+            package.sequence,
+            False,
+            None,
+            "",
+            tuple(completed),
+            time.perf_counter_ns() - started,
+            type(exc).__name__,
+            str(exc)[:512],
+        )
+
+
+class ParallelPipeline:
+    """Execute one validated topology with deterministic reconciliation."""
+
+    def __init__(
+        self, topology: PipelineTopology | None = None, limits: RuntimeLimits | None = None
+    ) -> None:
+        self.limits = limits or RuntimeLimits()
+        self.topology = topology or default_topology(
+            parallelism=min(4, self.limits.max_workers),
+            batch_size=min(64, self.limits.max_batch_size),
+        )
+        self._validate_topology(self.topology)
+
+    def _validate_topology(self, topology: PipelineTopology) -> None:
+        if len(topology.nodes) > self.limits.max_nodes:
+            raise ValueError("topology exceeds the configured node limit")
+        if topology.parallelism > self.limits.max_workers:
+            raise ValueError("topology parallelism exceeds the worker limit")
+        if topology.batch_size > self.limits.max_batch_size:
+            raise ValueError("topology batch_size exceeds the configured limit")
+
+    def _validate_input(self, value: Union[str, bytes, VertexBatch, Mesh]) -> int:
+        _, raw = _raw_encode(value)
+        if len(raw) > self.limits.max_input_bytes:
+            raise ValueError("input exceeds the configured byte limit")
+        vertex_count = 0
+        if isinstance(value, VertexBatch):
+            vertex_count = len(value)
+        elif isinstance(value, Mesh):
+            vertex_count = len(value.vertices)
+        if vertex_count > self.limits.max_vertices:
+            raise ValueError("input exceeds the configured vertex limit")
+        return len(raw)
+
+    def _split(
+        self, value: Union[str, bytes, VertexBatch, Mesh], workers: int
+    ) -> tuple[Union[str, bytes, VertexBatch, Mesh], ...]:
+        if isinstance(value, Mesh):
+            return (value,)
+        units = len(value) if not isinstance(value, VertexBatch) else len(value.vertices)
+        if units == 0:
+            return (value,)
+        by_batch = max(1, math.ceil(units / self.topology.batch_size))
+        package_count = min(workers, by_batch, units, self.limits.max_packages)
+        package_count = max(1, package_count)
+        base, remainder = divmod(units, package_count)
+        chunks: list[Union[str, bytes, VertexBatch, Mesh]] = []
+        offset = 0
+        for sequence in range(package_count):
+            width = base + (1 if sequence < remainder else 0)
+            end = offset + width
+            if isinstance(value, VertexBatch):
+                chunks.append(VertexBatch(value.vertices[offset:end]))
+            else:
+                chunks.append(value[offset:end])
+            offset = end
+        return tuple(chunks)
+
+    def _packages(
+        self, value: Union[str, bytes, VertexBatch, Mesh], workers: int
+    ) -> tuple[WorkPackage, ...]:
+        input_digest = _value_digest(value)
+        source_node = self.topology.ordered_nodes[0].node_id
+        packages: list[WorkPackage] = []
+        for sequence, chunk in enumerate(self._split(value, workers)):
+            material = (
+                b"jarvisx-multiparallel-package-v1\0"
+                + self.topology.digest_sha256.encode("ascii")
+                + input_digest.encode("ascii")
+                + struct.pack(">Q", sequence)
+                + _value_digest(chunk).encode("ascii")
+            )
+            packages.append(
+                WorkPackage(
+                    package_id=_sha256(material),
+                    sequence=sequence,
+                    priority=0,
+                    start_node=source_node,
+                    payload=chunk,
+                )
+            )
+        return tuple(packages)
+
+    @staticmethod
+    def merge_receipts(receipts: Iterable[PackageReceipt]) -> PipelineValue:
+        ordered = tuple(sorted(receipts, key=lambda receipt: receipt.sequence))
+        if not ordered or any(not receipt.success or receipt.output is None for receipt in ordered):
+            raise ValueError("only a non-empty set of successful receipts can be merged")
+        outputs = tuple(receipt.output for receipt in ordered)
+        first = outputs[0]
+        if isinstance(first, EncodedChunk):
+            if not all(isinstance(output, EncodedChunk) for output in outputs):
+                raise TypeError("package outputs have incompatible types")
+            chunks = tuple(output for output in outputs if isinstance(output, EncodedChunk))
+            if any(chunk.kind is not first.kind for chunk in chunks):
+                raise TypeError("encoded package outputs have incompatible data kinds")
+            return FramedArtifact(first.kind, chunks)
+        if isinstance(first, str):
+            if not all(isinstance(output, str) for output in outputs):
+                raise TypeError("package outputs have incompatible types")
+            return "".join(output for output in outputs if isinstance(output, str))
+        if isinstance(first, bytes):
+            if not all(isinstance(output, bytes) for output in outputs):
+                raise TypeError("package outputs have incompatible types")
+            return b"".join(output for output in outputs if isinstance(output, bytes))
+        if isinstance(first, VertexBatch):
+            if not all(isinstance(output, VertexBatch) for output in outputs):
+                raise TypeError("package outputs have incompatible types")
+            return VertexBatch(
+                tuple(
+                    vertex
+                    for output in outputs
+                    if isinstance(output, VertexBatch)
+                    for vertex in output.vertices
+                )
+            )
+        if isinstance(first, Mesh):
+            if len(outputs) != 1 or not isinstance(first, Mesh):
+                raise ValueError("mesh output cannot be merged from multiple packages")
+            return first
+        if isinstance(first, FramedArtifact):
+            if not all(isinstance(output, FramedArtifact) for output in outputs):
+                raise TypeError("package outputs have incompatible types")
+            artifacts = tuple(
+                output for output in outputs if isinstance(output, FramedArtifact)
+            )
+            if any(artifact.kind is not first.kind for artifact in artifacts):
+                raise TypeError("framed outputs have incompatible data kinds")
+            return FramedArtifact(
+                first.kind,
+                tuple(chunk for artifact in artifacts for chunk in artifact.chunks),
+            )
+        raise TypeError("unsupported package output type")
+
+    def run(
+        self,
+        value: Union[str, bytes, VertexBatch, Mesh],
+        *,
+        workers: int | None = None,
+        backend: str = "sequential",
+    ) -> PipelineRun:
+        input_bytes = self._validate_input(value)
+        worker_count = self.topology.parallelism if workers is None else workers
+        if isinstance(worker_count, bool) or not isinstance(worker_count, int):
+            raise TypeError("workers must be an integer")
+        if worker_count < 1 or worker_count > self.limits.max_workers:
+            raise ValueError("workers must lie inside the configured worker limit")
+        if backend not in {"sequential", "process"}:
+            raise ValueError("backend must be 'sequential' or 'process'")
+
+        packages = self._packages(value, worker_count)
+        nodes = self.topology.ordered_nodes
+        started = time.perf_counter_ns()
+        if backend == "sequential" or len(packages) == 1:
+            receipts = tuple(
+                _process_single(package, nodes, self.topology, self.limits.max_output_bytes)
+                for package in packages
+            )
+        else:
+            collected: list[PackageReceipt] = []
+            with ProcessPoolExecutor(max_workers=min(worker_count, len(packages))) as executor:
+                futures = {
+                    executor.submit(
+                        _process_single,
+                        package,
+                        nodes,
+                        self.topology,
+                        self.limits.max_output_bytes,
+                    ): package
+                    for package in packages
+                }
+                for future in as_completed(futures):
+                    package = futures[future]
+                    try:
+                        collected.append(future.result())
+                    except Exception as exc:
+                        collected.append(
+                            PackageReceipt(
+                                package.package_id,
+                                package.sequence,
+                                False,
+                                None,
+                                "",
+                                (),
+                                0,
+                                type(exc).__name__,
+                                str(exc)[:512],
+                            )
+                        )
+            receipts = tuple(collected)
+        receipts = tuple(sorted(receipts, key=lambda receipt: receipt.sequence))
+        elapsed_ns = time.perf_counter_ns() - started
+        success = all(receipt.success for receipt in receipts)
+        output: PipelineValue | None = None
+        if success:
+            try:
+                output = self.merge_receipts(receipts)
+                if len(_value_bytes(output)) > self.limits.max_output_bytes:
+                    raise ValueError("merged output exceeds the configured byte limit")
+                if isinstance(output, FramedArtifact):
+                    output.decode(self.limits.max_output_bytes)
+            except Exception as exc:
+                success = False
+                failed = PackageReceipt(
+                    package_id="merge",
+                    sequence=len(receipts),
+                    success=False,
+                    output=None,
+                    output_digest="",
+                    stages=(),
+                    elapsed_ns=0,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc)[:512],
+                )
+                receipts = receipts + (failed,)
+                output = None
+
+        output_bytes = len(_value_bytes(output)) if output is not None else 0
+        if isinstance(output, FramedArtifact):
+            compression_ratio = output.compression_ratio
+        elif input_bytes:
+            compression_ratio = output_bytes / input_bytes
+        else:
+            compression_ratio = 1.0
+        throughput = len(packages) / (elapsed_ns / 1_000_000_000) if elapsed_ns else 0.0
+        input_digest = _value_digest(value)
+        receipt_material = "".join(
+            f"{receipt.sequence}:{receipt.package_id}:{receipt.success}:{receipt.output_digest};"
+            for receipt in receipts
+        ).encode("utf-8")
+        run_id = _sha256(
+            b"jarvisx-multiparallel-run-v1\0"
+            + self.topology.digest_sha256.encode("ascii")
+            + input_digest.encode("ascii")
+            + receipt_material
+        )
+        stats = PipelineStats(
+            package_count=len(packages),
+            successful_packages=sum(receipt.success for receipt in receipts),
+            worker_count=min(worker_count, len(packages)),
+            backend=backend,
+            codec_runtime_version=zlib.ZLIB_RUNTIME_VERSION,
+            elapsed_ns=elapsed_ns,
+            throughput_packages_per_second=throughput,
+            input_bytes=input_bytes,
+            output_bytes=output_bytes,
+            compression_ratio=compression_ratio,
+        )
+        return PipelineRun(
+            run_id,
+            self.topology.digest_sha256,
+            input_digest,
+            success,
+            receipts,
+            output,
+            stats,
+        )
+
+
+@dataclass(frozen=True)
+class CodePoint:
+    line_number: int
+    coordinate: Vector3
+    line_sha256: str
+
+
+@dataclass(frozen=True)
+class CodeGeometry:
+    """Read-only spatial observation derived from validated Python source."""
+
+    source_sha256: str
+    source_line_count: int
+    points: tuple[CodePoint, ...]
+    axis_order: str = "xyz"
+    scale: float = 1.0
+
+    def transform(self, axis_order: str = "xyz", scale: float = 1.0) -> "CodeGeometry":
+        factor = _require_finite("scale", scale)
+        if factor == 0.0:
+            raise ValueError("scale cannot be zero")
+        return CodeGeometry(
+            self.source_sha256,
+            self.source_line_count,
+            tuple(
+                replace(point, coordinate=point.coordinate.transform(axis_order, factor))
+                for point in self.points
+            ),
+            axis_order,
+            factor,
+        )
+
+
+class SpatialProcessor:
+    """Map Python source into observational coordinates and transform typed assets."""
+
+    @staticmethod
+    def map_code(source: str, *, max_source_bytes: int = 4 * 1024 * 1024) -> CodeGeometry:
+        if not isinstance(source, str):
+            raise TypeError("source must be text")
+        encoded = source.encode("utf-8")
+        if len(encoded) > max_source_bytes:
+            raise ValueError("source exceeds the configured byte limit")
+        try:
+            ast.parse(source)
+        except SyntaxError as exc:
+            raise ValueError("source must be syntactically valid Python") from exc
+
+        identifier_counts: dict[int, int] = {}
+        try:
+            tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+            for token in tokens:
+                if token.type == tokenize.NAME and not keyword.iskeyword(token.string):
+                    identifier_counts[token.start[0]] = identifier_counts.get(token.start[0], 0) + 1
+        except tokenize.TokenError as exc:
+            raise ValueError("source tokenization failed") from exc
+
+        lines = source.splitlines()
+        points: list[CodePoint] = []
+        for line_number, line in enumerate(lines, start=1):
+            prefix = line[: len(line) - len(line.lstrip(" \t"))]
+            indent = len(prefix.expandtabs(4))
+            complexity = identifier_counts.get(line_number, 0)
+            points.append(
+                CodePoint(
+                    line_number,
+                    Vector3(float(line_number), float(indent), float(complexity)),
+                    _sha256(line.encode("utf-8")),
+                )
+            )
+        return CodeGeometry(_sha256(encoded), len(lines), tuple(points))
+
+    @staticmethod
+    def transform_asset(
+        asset: Union[VertexBatch, Mesh], *, axis_order: str = "xyz", scale: float = 1.0
+    ) -> Union[VertexBatch, Mesh]:
+        if isinstance(asset, VertexBatch):
+            return asset.transform(axis_order, scale)
+        if isinstance(asset, Mesh):
+            return asset.transform(axis_order, scale)
+        raise TypeError("asset must be a VertexBatch or Mesh")
+
+
+@dataclass(frozen=True)
+class BranchSnapshot:
+    branch_id: str
+    name: str
+    sequence: int
+    payload: Union[str, bytes, VertexBatch, Mesh]
+    payload_digest: str
+    topology_digest: str
+    run: PipelineRun | None = None
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    topology: PipelineTopology
+    fitness: float
+    compression_ratio: float
+    estimated_work_units: float
+    observed_elapsed_ns: int
+    success: bool
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class GenerationReport:
+    generation: int
+    population_size: int
+    best_fitness: float
+    best_topology_digest: str
+
+
+@dataclass(frozen=True)
+class EvolutionConfig:
+    generations: int = 5
+    population_size: int = 10
+    survivor_fraction: float = 0.5
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        if isinstance(self.generations, bool) or not isinstance(self.generations, int):
+            raise TypeError("generations must be an integer")
+        if isinstance(self.population_size, bool) or not isinstance(self.population_size, int):
+            raise TypeError("population_size must be an integer")
+        if self.generations < 1 or self.population_size < 2:
+            raise ValueError("generations must be positive and population_size at least 2")
+        fraction = _require_finite("survivor_fraction", self.survivor_fraction)
+        if not 0.1 <= fraction <= 0.9:
+            raise ValueError("survivor_fraction must lie in [0.1, 0.9]")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise TypeError("seed must be an integer")
+
+
+@dataclass(frozen=True)
+class EvolutionResult:
+    initial_topology_digest: str
+    selected_topology: PipelineTopology
+    best_score: CandidateScore
+    history: tuple[GenerationReport, ...]
+    promoted: bool = False
+
+
+_SAFE_STAGE_TEMPLATES: tuple[tuple[StageKind, ...], ...] = (
+    (StageKind.LOAD, StageKind.ENCODE),
+    (StageKind.LOAD, StageKind.TRANSFORM, StageKind.ENCODE),
+    (StageKind.LOAD, StageKind.ENCODE, StageKind.COMPRESS),
+    (StageKind.LOAD, StageKind.TRANSFORM, StageKind.ENCODE, StageKind.COMPRESS),
+    (
+        StageKind.LOAD,
+        StageKind.TRANSFORM,
+        StageKind.ENCODE,
+        StageKind.COMPRESS,
+        StageKind.VERIFY,
+    ),
+)
+
+
+class TopologyEvolution:
+    """Seeded bounded search over a finite, type-safe topology family."""
+
+    def __init__(self, limits: RuntimeLimits | None = None) -> None:
+        self.limits = limits or RuntimeLimits()
+
+    @staticmethod
+    def _stages(topology: PipelineTopology) -> tuple[StageKind, ...]:
+        return tuple(node.kind for node in topology.ordered_nodes)
+
+    def _mutate(self, topology: PipelineTopology, rng: random.Random) -> PipelineTopology:
+        stages = self._stages(topology)
+        parallelism = topology.parallelism
+        batch_size = topology.batch_size
+        compression_level = topology.compression_level
+        action = rng.randrange(4)
+        if action == 0:
+            parallelism = min(
+                self.limits.max_workers,
+                max(1, parallelism + rng.choice((-1, 1))),
+            )
+        elif action == 1:
+            if rng.random() < 0.5:
+                batch_size = max(1, batch_size // 2)
+            else:
+                batch_size = min(self.limits.max_batch_size, batch_size * 2)
+        elif action == 2:
+            compression_level = min(9, max(0, compression_level + rng.choice((-1, 1))))
+        else:
+            stages = rng.choice(_SAFE_STAGE_TEMPLATES)
+        return topology_from_stages(
+            stages,
+            parallelism=parallelism,
+            batch_size=batch_size,
+            compression_level=compression_level,
+        )
+
+    def _crossover(
+        self, left: PipelineTopology, right: PipelineTopology, rng: random.Random
+    ) -> PipelineTopology:
+        stages = self._stages(left if rng.random() < 0.5 else right)
+        return topology_from_stages(
+            stages,
+            parallelism=rng.choice((left.parallelism, right.parallelism)),
+            batch_size=rng.choice((left.batch_size, right.batch_size)),
+            compression_level=rng.choice((left.compression_level, right.compression_level)),
+        )
+
+    def evaluate(
+        self,
+        topology: PipelineTopology,
+        test_data: Union[str, bytes, VertexBatch, Mesh],
+    ) -> CandidateScore:
+        try:
+            pipeline = ParallelPipeline(topology, self.limits)
+            run = pipeline.run(test_data, workers=topology.parallelism, backend="sequential")
+        except Exception as exc:
+            return CandidateScore(
+                topology,
+                float("-inf"),
+                float("inf"),
+                float("inf"),
+                0,
+                False,
+                f"{type(exc).__name__}: {exc}",
+            )
+        if not run.success:
+            error = next(
+                (
+                    receipt.error_message
+                    for receipt in run.receipts
+                    if not receipt.success and receipt.error_message
+                ),
+                "candidate pipeline failed",
+            )
+            return CandidateScore(
+                topology,
+                float("-inf"),
+                run.stats.compression_ratio,
+                float("inf"),
+                run.stats.elapsed_ns,
+                False,
+                error,
+            )
+
+        stage_weight = {
+            StageKind.LOAD: 0.05,
+            StageKind.TRANSFORM: 0.20,
+            StageKind.ENCODE: 0.25,
+            StageKind.COMPRESS: 1.00 + topology.compression_level * 0.08,
+            StageKind.DECOMPRESS: 0.80,
+            StageKind.DECODE: 0.30,
+            StageKind.VERIFY: 0.20,
+        }
+        size = max(1, run.stats.input_bytes)
+        active_parallelism = max(1, min(topology.parallelism, run.stats.package_count))
+        estimated_work = (
+            size * sum(stage_weight[node.kind] for node in topology.ordered_nodes)
+        ) / active_parallelism
+        estimated_work += run.stats.package_count * 32.0 + len(topology.nodes) * 16.0
+        speed_score = 1.0 / (1.0 + estimated_work / size)
+        compression_gain = max(-1.0, min(1.0, 1.0 - run.stats.compression_ratio))
+        parallel_score = active_parallelism / max(1, run.stats.package_count)
+        node_penalty = max(0, len(topology.nodes) - 4) * 0.02
+        fitness = (
+            0.50 * compression_gain
+            + 0.30 * speed_score
+            + 0.20 * parallel_score
+            - node_penalty
+        )
+        return CandidateScore(
+            topology,
+            fitness,
+            run.stats.compression_ratio,
+            estimated_work,
+            run.stats.elapsed_ns,
+            True,
+        )
+
+    def evolve(
+        self,
+        base: PipelineTopology,
+        test_data: Union[str, bytes, VertexBatch, Mesh],
+        config: EvolutionConfig | None = None,
+    ) -> EvolutionResult:
+        selected_config = config or EvolutionConfig()
+        if selected_config.population_size > self.limits.max_population:
+            raise ValueError("population exceeds the configured limit")
+        if selected_config.generations > self.limits.max_generations:
+            raise ValueError("generations exceed the configured limit")
+        ParallelPipeline(base, self.limits)
+
+        rng = random.Random(selected_config.seed)
+        population = [base]
+        while len(population) < selected_config.population_size:
+            population.append(self._mutate(base, rng))
+
+        history: list[GenerationReport] = []
+        best: CandidateScore | None = None
+        for generation in range(selected_config.generations):
+            scores = [self.evaluate(topology, test_data) for topology in population]
+            scores.sort(key=lambda score: (-score.fitness, score.topology.digest_sha256))
+            if not scores[0].success:
+                raise RuntimeError("no admissible topology candidate completed successfully")
+            generation_best = scores[0]
+            if (
+                best is None
+                or generation_best.fitness > best.fitness
+                or (
+                    generation_best.fitness == best.fitness
+                    and generation_best.topology.digest_sha256
+                    < best.topology.digest_sha256
+                )
+            ):
+                best = generation_best
+            history.append(
+                GenerationReport(
+                    generation,
+                    len(scores),
+                    scores[0].fitness,
+                    scores[0].topology.digest_sha256,
+                )
+            )
+            survivor_count = max(
+                2,
+                min(
+                    len(scores),
+                    math.ceil(len(scores) * selected_config.survivor_fraction),
+                ),
+            )
+            survivors = scores[:survivor_count]
+            next_population = [score.topology for score in survivors]
+            while len(next_population) < selected_config.population_size:
+                left, right = rng.sample(survivors, 2)
+                child = self._crossover(left.topology, right.topology, rng)
+                if rng.random() < 0.8:
+                    child = self._mutate(child, rng)
+                next_population.append(child)
+            population = next_population
+        assert best is not None
+        return EvolutionResult(base.digest_sha256, best.topology, best, tuple(history))
+
+
+@dataclass(frozen=True)
+class EngineStats:
+    total_runs: int = 0
+    successful_runs: int = 0
+    failed_runs: int = 0
+    packages_processed: int = 0
+    branches_created: int = 0
+    evolution_generations: int = 0
+    best_fitness: float | None = None
+
+
+class JarvisX3DEngine:
+    """Central controller for the isolated multiparallel research subsystem."""
+
+    def __init__(
+        self,
+        *,
+        code: str | None = None,
+        assets: Sequence[Union[VertexBatch, Mesh]] = (),
+        topology: PipelineTopology | None = None,
+        limits: RuntimeLimits | None = None,
+    ) -> None:
+        if code is not None and not isinstance(code, str):
+            raise TypeError("code must be text when supplied")
+        if not all(isinstance(asset, (VertexBatch, Mesh)) for asset in assets):
+            raise TypeError("assets must contain VertexBatch or Mesh values")
+        self.code = code
+        self.assets = tuple(assets)
+        self.limits = limits or RuntimeLimits()
+        self._topology = topology or default_topology(
+            parallelism=min(4, self.limits.max_workers),
+            batch_size=min(64, self.limits.max_batch_size),
+        )
+        ParallelPipeline(self._topology, self.limits)
+        self._last_committed_run: PipelineRun | None = None
+        self._branches: dict[str, BranchSnapshot] = {}
+        self._branch_sequence = 0
+        self._stats = EngineStats()
+        self._lock = RLock()
+
+    @property
+    def topology(self) -> PipelineTopology:
+        with self._lock:
+            return self._topology
+
+    @property
+    def last_committed_run(self) -> PipelineRun | None:
+        with self._lock:
+            return self._last_committed_run
+
+    @property
+    def stats(self) -> EngineStats:
+        with self._lock:
+            return self._stats
+
+    def _default_input(self) -> Union[str, VertexBatch, Mesh]:
+        if self.code is not None:
+            return self.code
+        if len(self.assets) == 1:
+            return self.assets[0]
+        raise ValueError("data is required when the engine has no unique default input")
+
+    def process_parallel(
+        self,
+        data: Union[str, bytes, VertexBatch, Mesh, None] = None,
+        *,
+        num_workers: int | None = None,
+        backend: str = "sequential",
+    ) -> PipelineRun:
+        with self._lock:
+            supplied = self._default_input() if data is None else data
+            pipeline = ParallelPipeline(self._topology, self.limits)
+            run = pipeline.run(supplied, workers=num_workers, backend=backend)
+            self._stats = replace(
+                self._stats,
+                total_runs=self._stats.total_runs + 1,
+                successful_runs=self._stats.successful_runs + int(run.success),
+                failed_runs=self._stats.failed_runs + int(not run.success),
+                packages_processed=self._stats.packages_processed + run.stats.package_count,
+            )
+            if run.success:
+                self._last_committed_run = run
+            return run
+
+    def spatial_process(
+        self,
+        source: str | None = None,
+        *,
+        axis_order: str = "xyz",
+        scale: float = 1.0,
+    ) -> CodeGeometry:
+        selected = self.code if source is None else source
+        if selected is None:
+            raise ValueError("source is required when no code is loaded")
+        geometry = SpatialProcessor.map_code(selected, max_source_bytes=self.limits.max_input_bytes)
+        return geometry.transform(axis_order, scale)
+
+    def create_branch(
+        self, name: str, data: Union[str, bytes, VertexBatch, Mesh, None] = None
+    ) -> str:
+        if not isinstance(name, str) or not name.strip() or len(name) > 80:
+            raise ValueError("branch name must contain 1 to 80 non-blank characters")
+        with self._lock:
+            if len(self._branches) >= self.limits.max_branches:
+                raise ValueError("branch limit reached")
+            supplied = self._default_input() if data is None else data
+            ParallelPipeline(self._topology, self.limits)._validate_input(supplied)
+            sequence = self._branch_sequence
+            material = (
+                b"jarvisx-multiparallel-branch-v1\0"
+                + name.encode("utf-8")
+                + struct.pack(">Q", sequence)
+                + _value_digest(supplied).encode("ascii")
+                + self._topology.digest_sha256.encode("ascii")
+            )
+            branch_id = _sha256(material)
+            self._branch_sequence += 1
+            self._branches[branch_id] = BranchSnapshot(
+                branch_id,
+                name,
+                sequence,
+                supplied,
+                _value_digest(supplied),
+                self._topology.digest_sha256,
+            )
+            self._stats = replace(
+                self._stats, branches_created=self._stats.branches_created + 1
+            )
+            return branch_id
+
+    def branch(self, branch_id: str) -> BranchSnapshot:
+        with self._lock:
+            try:
+                return self._branches[branch_id]
+            except KeyError as exc:
+                raise KeyError("unknown branch identifier") from exc
+
+    def process_branch(
+        self,
+        branch_id: str,
+        *,
+        num_workers: int | None = None,
+        backend: str = "sequential",
+    ) -> PipelineRun:
+        with self._lock:
+            snapshot = self.branch(branch_id)
+            pipeline = ParallelPipeline(self._topology, self.limits)
+            run = pipeline.run(snapshot.payload, workers=num_workers, backend=backend)
+            self._stats = replace(
+                self._stats,
+                total_runs=self._stats.total_runs + 1,
+                successful_runs=self._stats.successful_runs + int(run.success),
+                failed_runs=self._stats.failed_runs + int(not run.success),
+                packages_processed=self._stats.packages_processed + run.stats.package_count,
+            )
+            if run.success:
+                self._branches[branch_id] = replace(snapshot, run=run)
+            return run
+
+    def merge_branches(self, branch_ids: Sequence[str]) -> PipelineValue:
+        if not branch_ids:
+            raise ValueError("at least one branch identifier is required")
+        if len(set(branch_ids)) != len(branch_ids):
+            raise ValueError("branch identifiers must be unique")
+        with self._lock:
+            snapshots = tuple(self.branch(branch_id) for branch_id in branch_ids)
+            receipts: list[PackageReceipt] = []
+            for index, snapshot in enumerate(snapshots):
+                run = snapshot.run
+                if run is None or not run.success or run.output is None:
+                    raise ValueError("every branch must have a successful processed output")
+                receipts.append(
+                    PackageReceipt(
+                        package_id=snapshot.branch_id,
+                        sequence=index,
+                        success=True,
+                        output=run.output,
+                        output_digest=_value_digest(run.output),
+                        stages=("branch-merge",),
+                        elapsed_ns=0,
+                    )
+                )
+            return ParallelPipeline.merge_receipts(receipts)
+
+    def auto_evolve(
+        self,
+        test_data: Union[str, bytes, VertexBatch, Mesh],
+        config: EvolutionConfig | None = None,
+    ) -> EvolutionResult:
+        with self._lock:
+            active_before = self._topology
+            evolution = TopologyEvolution(self.limits)
+            result = evolution.evolve(active_before, test_data, config)
+            verification = ParallelPipeline(result.selected_topology, self.limits).run(
+                test_data,
+                workers=result.selected_topology.parallelism,
+                backend="sequential",
+            )
+            if not verification.success:
+                raise RuntimeError("selected topology failed promotion verification")
+            self._topology = result.selected_topology
+            self._stats = replace(
+                self._stats,
+                evolution_generations=self._stats.evolution_generations + len(result.history),
+                best_fitness=result.best_score.fitness,
+            )
+            return replace(result, promoted=True)

--- a/src/jarvisx/multiparallel_cli.py
+++ b/src/jarvisx/multiparallel_cli.py
@@ -1,0 +1,197 @@
+"""Command-line surface for the bounded 3D multiparallel reference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .multiparallel import (
+    EvolutionConfig,
+    FramedArtifact,
+    JarvisX3DEngine,
+    RuntimeLimits,
+    default_topology,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx-multiparallel",
+        description="Bounded deterministic Jarvis-X 3D multiparallel reference",
+    )
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    run = subcommands.add_parser("run", help="process one UTF-8 text file")
+    run.add_argument("file", type=Path)
+    run.add_argument("--workers", type=int, default=4)
+    run.add_argument("--backend", choices=("sequential", "process"), default="sequential")
+    run.add_argument("--batch-size", type=int, default=64)
+    run.add_argument("--compression-level", type=int, default=6)
+    run.add_argument("--output", type=Path)
+
+    spatial = subcommands.add_parser("map-code", help="map Python source to read-only 3D points")
+    spatial.add_argument("file", type=Path)
+    spatial.add_argument("--axis-order", default="xyz")
+    spatial.add_argument("--scale", type=float, default=1.0)
+
+    evolve = subcommands.add_parser("evolve", help="run seeded bounded topology search")
+    evolve.add_argument("file", type=Path)
+    evolve.add_argument("--generations", type=int, default=5)
+    evolve.add_argument("--population", type=int, default=10)
+    evolve.add_argument("--seed", type=int, default=0)
+    evolve.add_argument("--workers", type=int, default=4)
+    evolve.add_argument("--batch-size", type=int, default=64)
+    return parser
+
+
+def _read_text(path: Path, limit: int) -> str:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ValueError(f"cannot inspect input file: {exc}") from exc
+    if size > limit:
+        raise ValueError("input file exceeds the configured byte limit")
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ValueError(f"cannot read input as UTF-8 text: {exc}") from exc
+
+
+def _emit(payload: dict[str, object]) -> None:
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    limits = RuntimeLimits()
+    try:
+        source = _read_text(args.file, limits.max_input_bytes)
+        if args.command == "run":
+            topology = default_topology(
+                parallelism=args.workers,
+                batch_size=args.batch_size,
+                compression_level=args.compression_level,
+            )
+            engine = JarvisX3DEngine(code=source, topology=topology, limits=limits)
+            run = engine.process_parallel(
+                num_workers=args.workers,
+                backend=args.backend,
+            )
+            if not run.success or run.output is None:
+                _emit(
+                    {
+                        "success": False,
+                        "run_id": run.run_id,
+                        "errors": [
+                            {
+                                "package_id": receipt.package_id,
+                                "type": receipt.error_type,
+                                "message": receipt.error_message,
+                            }
+                            for receipt in run.receipts
+                            if not receipt.success
+                        ],
+                    }
+                )
+                return 2
+            artifact = run.output
+            if not isinstance(artifact, FramedArtifact):
+                raise RuntimeError("default pipeline did not produce a framed artifact")
+            if args.output is not None:
+                args.output.write_bytes(artifact.to_bytes())
+            _emit(
+                {
+                    "success": True,
+                    "run_id": run.run_id,
+                    "topology_digest": run.topology_digest,
+                    "artifact_digest": artifact.digest_sha256,
+                    "artifact_path": str(args.output) if args.output is not None else None,
+                    "packages": run.stats.package_count,
+                    "workers": run.stats.worker_count,
+                    "backend": run.stats.backend,
+                    "codec_runtime_version": run.stats.codec_runtime_version,
+                    "input_bytes": run.stats.input_bytes,
+                    "output_bytes": run.stats.output_bytes,
+                    "compression_ratio": run.stats.compression_ratio,
+                    "elapsed_ns_telemetry": run.stats.elapsed_ns,
+                    "throughput_packages_per_second_telemetry": (
+                        run.stats.throughput_packages_per_second
+                    ),
+                }
+            )
+            return 0
+
+        if args.command == "map-code":
+            engine = JarvisX3DEngine(code=source, limits=limits)
+            geometry = engine.spatial_process(
+                axis_order=args.axis_order,
+                scale=args.scale,
+            )
+            _emit(
+                {
+                    "source_sha256": geometry.source_sha256,
+                    "source_line_count": geometry.source_line_count,
+                    "axis_order": geometry.axis_order,
+                    "scale": geometry.scale,
+                    "points": [
+                        {
+                            "line": point.line_number,
+                            "x": point.coordinate.x,
+                            "y": point.coordinate.y,
+                            "z": point.coordinate.z,
+                            "line_sha256": point.line_sha256,
+                        }
+                        for point in geometry.points
+                    ],
+                    "source_rewritten": False,
+                }
+            )
+            return 0
+
+        if args.command == "evolve":
+            topology = default_topology(
+                parallelism=args.workers,
+                batch_size=args.batch_size,
+            )
+            engine = JarvisX3DEngine(code=source, topology=topology, limits=limits)
+            result = engine.auto_evolve(
+                source,
+                EvolutionConfig(
+                    generations=args.generations,
+                    population_size=args.population,
+                    seed=args.seed,
+                ),
+            )
+            _emit(
+                {
+                    "success": True,
+                    "promoted": result.promoted,
+                    "initial_topology_digest": result.initial_topology_digest,
+                    "selected_topology_digest": result.selected_topology.digest_sha256,
+                    "fitness": result.best_score.fitness,
+                    "compression_ratio": result.best_score.compression_ratio,
+                    "estimated_work_units": result.best_score.estimated_work_units,
+                    "observed_elapsed_ns_telemetry": result.best_score.observed_elapsed_ns,
+                    "history": [
+                        {
+                            "generation": report.generation,
+                            "population": report.population_size,
+                            "best_fitness": report.best_fitness,
+                            "best_topology_digest": report.best_topology_digest,
+                        }
+                        for report in result.history
+                    ],
+                }
+            )
+            return 0
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
+        print(f"jarvisx-multiparallel: {exc}", file=sys.stderr)
+        return 2
+    raise RuntimeError("unreachable command state")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_multiparallel.py
+++ b/tests/test_multiparallel.py
@@ -1,0 +1,318 @@
+import math
+import struct
+
+import pytest
+
+from jarvisx.multiparallel import (
+    BranchSnapshot,
+    CodeGeometry,
+    Compression,
+    DataKind,
+    EncodedChunk,
+    EvolutionConfig,
+    FramedArtifact,
+    JarvisX3DEngine,
+    Mesh,
+    PackageReceipt,
+    ParallelPipeline,
+    PipelineNode,
+    PipelineTopology,
+    RuntimeLimits,
+    SpatialProcessor,
+    StageKind,
+    TopologyEvolution,
+    Vector3,
+    VertexBatch,
+    default_topology,
+    topology_from_stages,
+)
+
+
+def test_vector_batch_and_mesh_are_finite_and_index_safe() -> None:
+    batch = VertexBatch((Vector3(1, 2, 3), Vector3(-1, -2, -3)))
+    mesh = Mesh(batch, ((0, 1, 0),))
+
+    assert len(batch) == 2
+    assert mesh.vertices == batch
+
+    with pytest.raises(ValueError, match="finite"):
+        Vector3(math.inf, 0, 0)
+    with pytest.raises(ValueError, match="outside"):
+        Mesh(batch, ((0, 1, 2),))
+
+
+def test_topology_rejects_cycles_disconnected_nodes_and_duplicate_paths() -> None:
+    nodes = (
+        PipelineNode("a", StageKind.LOAD),
+        PipelineNode("b", StageKind.ENCODE),
+        PipelineNode("c", StageKind.COMPRESS),
+    )
+
+    with pytest.raises(ValueError, match="cycle|one source"):
+        PipelineTopology(nodes, (("a", "b"), ("b", "a")))
+    with pytest.raises(ValueError, match="one source|one path"):
+        PipelineTopology(nodes, (("a", "b"),))
+    with pytest.raises(ValueError, match="single linear DAG"):
+        PipelineTopology(nodes, (("a", "b"), ("a", "c")))
+
+
+def test_default_pipeline_preserves_text_exactly_and_frames_chunks() -> None:
+    source = "def kinetic(value):\n    return value * 3\n" * 12
+    topology = default_topology(parallelism=4, batch_size=32, compression_level=6)
+
+    run = ParallelPipeline(topology).run(source, workers=4)
+
+    assert run.success
+    assert isinstance(run.output, FramedArtifact)
+    assert run.output.decode() == source
+    assert run.stats.package_count == 4
+    assert run.stats.codec_runtime_version
+    assert [receipt.sequence for receipt in run.receipts] == [0, 1, 2, 3]
+    assert run.stats.compression_ratio > 0.0
+
+
+def test_process_and_sequential_backends_reconcile_to_same_artifact() -> None:
+    source = "parallel deterministic payload\n" * 80
+    topology = default_topology(parallelism=3, batch_size=64, compression_level=4)
+    pipeline = ParallelPipeline(topology)
+
+    sequential = pipeline.run(source, workers=3, backend="sequential")
+    process = pipeline.run(source, workers=3, backend="process")
+
+    assert sequential.success and process.success
+    assert isinstance(sequential.output, FramedArtifact)
+    assert isinstance(process.output, FramedArtifact)
+    assert sequential.output.to_bytes() == process.output.to_bytes()
+    assert sequential.run_id == process.run_id
+
+
+def test_merge_order_is_source_order_not_completion_order() -> None:
+    receipts = (
+        PackageReceipt("third", 2, True, "C", "c" * 64, (), 1),
+        PackageReceipt("first", 0, True, "A", "a" * 64, (), 100),
+        PackageReceipt("second", 1, True, "B", "b" * 64, (), 10),
+    )
+
+    assert ParallelPipeline.merge_receipts(receipts) == "ABC"
+
+
+def test_vertex_transform_is_typed_and_round_trips_through_frame() -> None:
+    batch = VertexBatch((Vector3(1, 2, 3), Vector3(4, 5, 6)))
+    nodes = (
+        PipelineNode("load", StageKind.LOAD),
+        PipelineNode(
+            "rotate",
+            StageKind.TRANSFORM,
+            (("axis_order", "yzx"), ("scale", 2.0)),
+        ),
+        PipelineNode("encode", StageKind.ENCODE),
+        PipelineNode("compress", StageKind.COMPRESS),
+    )
+    topology = PipelineTopology(
+        nodes,
+        (("load", "rotate"), ("rotate", "encode"), ("encode", "compress")),
+        parallelism=2,
+        batch_size=1,
+    )
+
+    run = ParallelPipeline(topology).run(batch, workers=2)
+
+    assert run.success
+    assert isinstance(run.output, FramedArtifact)
+    assert run.output.decode() == VertexBatch(
+        (Vector3(4, 6, 2), Vector3(10, 12, 8))
+    )
+
+
+def test_mesh_is_never_split_and_face_indices_survive_round_trip() -> None:
+    mesh = Mesh(
+        VertexBatch((Vector3(0, 0, 0), Vector3(1, 0, 0), Vector3(0, 1, 0))),
+        ((0, 1, 2),),
+    )
+
+    run = ParallelPipeline(default_topology(batch_size=1)).run(mesh, workers=4)
+
+    assert run.success
+    assert run.stats.package_count == 1
+    assert isinstance(run.output, FramedArtifact)
+    assert run.output.decode() == mesh
+
+
+def test_framed_artifact_round_trip_and_tamper_detection() -> None:
+    artifact = FramedArtifact(
+        DataKind.TEXT,
+        (
+            EncodedChunk.encode("alpha").compress(6),
+            EncodedChunk.encode("beta").compress(6),
+        ),
+    )
+    frame = artifact.to_bytes()
+
+    restored = FramedArtifact.from_bytes(frame)
+
+    assert restored == artifact
+    assert restored.decode() == "alphabeta"
+    tampered = frame[:-1] + bytes((frame[-1] ^ 0x01,))
+    with pytest.raises(ValueError, match="invalid|integrity|match"):
+        FramedArtifact.from_bytes(tampered)
+
+
+def test_framed_artifact_rejects_declared_zip_bomb_size() -> None:
+    chunk = EncodedChunk.encode("bounded").compress(6)
+    frame = bytearray(FramedArtifact(DataKind.TEXT, (chunk,)).to_bytes())
+    raw_size_offset = 4 + 6 + 1
+    struct.pack_into(">Q", frame, raw_size_offset, 1_000_000)
+
+    with pytest.raises(ValueError, match="decoded-output limit"):
+        FramedArtifact.from_bytes(bytes(frame), max_output_bytes=32)
+
+
+def test_code_geometry_is_observational_and_does_not_rewrite_source() -> None:
+    source = "def add(left, right):\n    total = left + right\n    return total\n"
+    geometry = SpatialProcessor.map_code(source)
+    rotated = geometry.transform("yzx", 2.0)
+
+    assert isinstance(geometry, CodeGeometry)
+    assert geometry.source_line_count == 3
+    assert geometry.points[0].coordinate == Vector3(1, 0, 3)
+    assert geometry.points[1].coordinate.y == 4
+    assert rotated.source_sha256 == geometry.source_sha256
+    assert rotated.points[0].coordinate == Vector3(0, 6, 2)
+    compile(source, "<test>", "exec")
+
+    with pytest.raises(ValueError, match="syntactically valid"):
+        SpatialProcessor.map_code("def broken(:\n")
+
+
+def test_stage_type_failure_returns_receipt_and_never_commits_engine_run() -> None:
+    topology = topology_from_stages((StageKind.LOAD, StageKind.COMPRESS))
+    engine = JarvisX3DEngine(topology=topology)
+
+    run = engine.process_parallel("not encoded")
+
+    assert not run.success
+    assert run.output is None
+    assert run.receipts[0].error_type == "TypeError"
+    assert engine.last_committed_run is None
+    assert engine.stats.failed_runs == 1
+
+
+def test_decode_pipeline_merges_raw_text_without_inserting_newlines() -> None:
+    topology = topology_from_stages(
+        (
+            StageKind.LOAD,
+            StageKind.ENCODE,
+            StageKind.COMPRESS,
+            StageKind.DECODE,
+        ),
+        parallelism=3,
+        batch_size=3,
+    )
+    source = "abcdefghi"
+
+    run = ParallelPipeline(topology).run(source, workers=3)
+
+    assert run.success
+    assert run.output == source
+
+
+def test_branches_are_immutable_isolated_and_merge_in_requested_order() -> None:
+    engine = JarvisX3DEngine(topology=default_topology(batch_size=2))
+    alpha_id = engine.create_branch("alpha", "alpha")
+    beta_id = engine.create_branch("beta", "beta")
+    before = engine.branch(alpha_id)
+
+    alpha_run = engine.process_branch(alpha_id, num_workers=2)
+    beta_run = engine.process_branch(beta_id, num_workers=2)
+    merged = engine.merge_branches((beta_id, alpha_id))
+
+    assert isinstance(before, BranchSnapshot)
+    assert before.payload == "alpha"
+    assert before.run is None
+    assert alpha_run.success and beta_run.success
+    assert isinstance(merged, FramedArtifact)
+    assert merged.decode() == "betaalpha"
+    assert engine.branch(alpha_id).payload == before.payload
+
+
+def test_branch_merge_rejects_mixed_data_kinds() -> None:
+    engine = JarvisX3DEngine()
+    text_id = engine.create_branch("text", "same bytes")
+    bytes_id = engine.create_branch("bytes", b"same bytes")
+    engine.process_branch(text_id)
+    engine.process_branch(bytes_id)
+
+    with pytest.raises(TypeError, match="incompatible data kinds"):
+        engine.merge_branches((text_id, bytes_id))
+
+
+def test_seeded_evolution_is_reproducible_and_ignores_wall_clock_in_fitness() -> None:
+    limits = RuntimeLimits(max_workers=4, max_population=12, max_generations=8)
+    base = default_topology(parallelism=2, batch_size=16)
+    data = "evolution payload with repeated structure\n" * 30
+    config = EvolutionConfig(generations=3, population_size=8, seed=1234)
+
+    left = TopologyEvolution(limits).evolve(base, data, config)
+    right = TopologyEvolution(limits).evolve(base, data, config)
+
+    assert left.selected_topology.digest_sha256 == right.selected_topology.digest_sha256
+    assert left.best_score.fitness == right.best_score.fitness
+    assert left.best_score.estimated_work_units == right.best_score.estimated_work_units
+    assert [report.best_topology_digest for report in left.history] == [
+        report.best_topology_digest for report in right.history
+    ]
+
+
+def test_engine_promotes_only_a_verified_candidate_topology() -> None:
+    limits = RuntimeLimits(max_workers=4, max_population=8, max_generations=4)
+    engine = JarvisX3DEngine(limits=limits)
+    data = "candidate-first topology search\n" * 20
+
+    result = engine.auto_evolve(
+        data,
+        EvolutionConfig(generations=2, population_size=6, seed=11),
+    )
+
+    assert result.promoted
+    assert engine.topology == result.selected_topology
+    assert engine.stats.evolution_generations == 2
+    assert engine.stats.best_fitness == result.best_score.fitness
+
+
+def test_failed_evolution_configuration_preserves_active_topology() -> None:
+    limits = RuntimeLimits(max_population=4, max_generations=2)
+    engine = JarvisX3DEngine(limits=limits)
+    before = engine.topology
+
+    with pytest.raises(ValueError, match="population exceeds"):
+        engine.auto_evolve(
+            "bounded",
+            EvolutionConfig(generations=1, population_size=5),
+        )
+
+    assert engine.topology == before
+
+
+def test_resource_bounds_reject_workers_input_and_branch_overflow() -> None:
+    limits = RuntimeLimits(max_workers=2, max_input_bytes=16, max_branches=1)
+    engine = JarvisX3DEngine(limits=limits)
+
+    with pytest.raises(ValueError, match="worker limit"):
+        engine.process_parallel("small", num_workers=3)
+    with pytest.raises(ValueError, match="byte limit"):
+        engine.process_parallel("x" * 17)
+
+    engine.create_branch("one", "small")
+    with pytest.raises(ValueError, match="branch limit"):
+        engine.create_branch("two", "small")
+
+
+def test_encoded_chunk_validates_integrity_and_compression_level() -> None:
+    chunk = EncodedChunk.encode(b"payload")
+
+    assert chunk.compression is Compression.NONE
+    assert chunk.decode() == b"payload"
+    with pytest.raises(ValueError, match="compression level"):
+        chunk.compress(10)
+    with pytest.raises(ValueError, match="integrity"):
+        EncodedChunk(DataKind.BYTES, b"wrong", 5, "0" * 64)

--- a/tests/test_multiparallel_cli.py
+++ b/tests/test_multiparallel_cli.py
@@ -1,0 +1,59 @@
+import json
+
+from jarvisx.multiparallel import FramedArtifact
+from jarvisx.multiparallel_cli import main
+
+
+def test_run_cli_emits_strict_summary_and_verifiable_artifact(tmp_path, capsys) -> None:
+    source = "def value(x):\n    return x + 1\n" * 8
+    input_path = tmp_path / "input.py"
+    output_path = tmp_path / "output.jxmp"
+    input_path.write_text(source, encoding="utf-8")
+
+    status = main(
+        (
+            "run",
+            str(input_path),
+            "--workers",
+            "2",
+            "--batch-size",
+            "16",
+            "--output",
+            str(output_path),
+        )
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert status == 0
+    assert payload["success"] is True
+    assert payload["packages"] == 2
+    assert output_path.exists()
+    assert FramedArtifact.from_bytes(output_path.read_bytes()).decode() == source
+
+
+def test_map_code_cli_reports_observation_without_source_rewrite(tmp_path, capsys) -> None:
+    input_path = tmp_path / "input.py"
+    input_path.write_text("answer = input_value + 1\n", encoding="utf-8")
+
+    status = main(("map-code", str(input_path), "--axis-order", "yzx", "--scale", "2"))
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert status == 0
+    assert payload["source_rewritten"] is False
+    assert payload["axis_order"] == "yzx"
+    assert payload["points"][0]["x"] == 0.0
+    assert payload["points"][0]["z"] == 2.0
+
+
+def test_cli_rejects_invalid_python_source_for_spatial_mapping(tmp_path, capsys) -> None:
+    input_path = tmp_path / "broken.py"
+    input_path.write_text("def broken(:\n", encoding="utf-8")
+
+    status = main(("map-code", str(input_path)))
+    captured = capsys.readouterr()
+
+    assert status == 2
+    assert "syntactically valid" in captured.err
+


### PR DESCRIPTION
## What changed

- add `jarvisx.multiparallel`, an isolated Layer 5 reference for deterministic package splitting, sequential/process execution, typed reconciliation and atomic main-run commit
- add immutable `Vector3`, `VertexBatch`, `Mesh`, `WorkPackage`, receipt, topology, branch and engine contracts
- add exact text/bytes/vertex/mesh encoding with bounded zlib decode, per-chunk SHA-256 verification and the versioned `JXMP` framed artifact
- add AST-validated read-only Python code geometry and typed transforms for actual 3D assets
- add immutable branch snapshots, independent processing and requested-order typed merge
- add seeded bounded topology search over a finite safe stage family
- add `jarvisx-multiparallel run|map-code|evolve`
- add focused tests, ADR-010, the complete operational specification and status/architecture documentation

## Why

The supplied operational breakdown combined useful pipeline mechanics with four unsafe or non-reproducible assumptions:

1. asynchronous completion could influence merge order;
2. spatial rotation of source lines was described as generally semantics preserving;
3. wall-clock duration drove evolutionary selection;
4. arbitrary processors/topology mutation lacked an authority boundary.

This reference keeps the kinetic model while making those transitions explicit, bounded and auditable.

## Operational contract

```text
immutable input
  -> deterministic package identities
  -> closed stage sequence
  -> sequential or ProcessPool execution
  -> source-order reconciliation
  -> integrity/resource verification
  -> research-run commit or rollback
```

Topology evolution is candidate-first. Timing is telemetry only; deterministic fitness uses compressed payload ratio, a declared stage-cost model, effective package parallelism and node overhead. Source geometry is observational and never regenerates or reorders Python.

## Developer impact

- no new dependency is introduced
- canonical `CodexVM` and `jarvisx.system_runtime` imports and semantics are unchanged
- v1 supports a validated linear DAG, not arbitrary fan-out/fan-in
- meshes remain one package so face indices cannot be invalidated by chunking
- exact compressed-byte reproducibility is scoped to the recorded zlib runtime version

## Validation

Completed locally:

- `git diff --check`
- `python -m compileall -q src tests`
- 19 directly executed focused runtime/invariant tests
- 3 directly executed CLI tests
- real sequential vs `ProcessPoolExecutor` artifact and run-ID equivalence
- frame encode/decode, tamper, truncation and declared-expansion checks
- branch isolation/mixed-type rejection
- seeded search replay and candidate-first promotion checks
- changed Python line-length scan at 100 columns

The local environment did not contain pytest, mypy, Black, isort or flake8, and dependency installation was unavailable. The canonical GitHub workflows subsequently completed successfully:\n\n- [Jarvis-X CI #689](https://github.com/Lord-Xido/Jarvis-X/actions/runs/32075980300) — Python 3.10–3.13 tests/coverage, quality/type checks, dependency audit and package build\n- [CodeQL #290](https://github.com/Lord-Xido/Jarvis-X/actions/runs/32075980305)\n- [Empirical Validation #181](https://github.com/Lord-Xido/Jarvis-X/actions/runs/32075980315)\n- [Hyperion Operational Service #36](https://github.com/Lord-Xido/Jarvis-X/actions/runs/32075980296)

## Capability boundary

This does not claim unrestricted self-modification, source-code rotation, NumPy/GPU acceleration, distributed execution, measured speedup, production compression, or canonical VM authority.

Closes #113.