### PR TITLE
Add Dr Moagi Cloud transactional runtime v1

### DIFF
--- a/.github/workflows/dr-moagi-cloud-runtime.yml
+++ b/.github/workflows/dr-moagi-cloud-runtime.yml
@@ -1,0 +1,38 @@
+name: Dr Moagi Cloud Runtime
+
+on:
+  pull_request:
+    paths:
+      - "src/jarvisx/dr_moagi_cloud_*.py"
+      - "src/jarvisx/dr_moagi_field_runtime.py"
+      - "tests/test_dr_moagi_cloud_*.py"
+      - "deploy/dr_moagi_cloud.Dockerfile"
+      - "docs/DR_MOAGI_CLOUD_RUNTIME_V1.md"
+      - "docs/adr/0010-dr-moagi-cloud-transaction-runtime.md"
+      - ".github/workflows/dr-moagi-cloud-runtime.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_cloud_*.py"
+      - "src/jarvisx/dr_moagi_field_runtime.py"
+      - "tests/test_dr_moagi_cloud_*.py"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install -e ".[test]"
+      - run: >-
+          python -m pytest
+          tests/test_dr_moagi_cloud_runtime.py
+          tests/test_dr_moagi_cloud_service.py
+          tests/test_dr_moagi_cloud_operations.py
+          --no-cov

--- a/deploy/dr_moagi_cloud.Dockerfile
+++ b/deploy/dr_moagi_cloud.Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    DR_MOAGI_CLOUD_DATA_DIR=/var/lib/dr-moagi-cloud \
+    DR_MOAGI_CLOUD_REQUIRE_API_KEY=true
+
+WORKDIR /app
+COPY . /app
+RUN python -m pip install --no-cache-dir .
+
+RUN useradd --create-home --uid 10001 jarvisx \
+    && mkdir -p /var/lib/dr-moagi-cloud \
+    && chown -R jarvisx:jarvisx /var/lib/dr-moagi-cloud
+
+USER jarvisx
+EXPOSE 8080
+
+CMD ["uvicorn", "jarvisx.dr_moagi_cloud_service:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/docs/DR_MOAGI_CLOUD_RUNTIME_V1.md
+++ b/docs/DR_MOAGI_CLOUD_RUNTIME_V1.md
@@ -1,0 +1,122 @@
+# Dr Moagi Cloud Runtime v1
+
+This document describes the first production-oriented vertical slice of the Dr Moagi Cloud control plane. It is deliberately small: a request becomes a durable, verifiable job before larger agent, queue, model, or market subsystems are added.
+
+## Runtime law
+
+```text
+X -> Validate -> Plan -> Dispatch -> Execute -> Verify -> Pi_Lambda -> Commit
+```
+
+A result is only authoritative when both verification and policy gates pass.
+
+## Run locally
+
+```bash
+python -m pip install -e .
+uvicorn jarvisx.dr_moagi_cloud_service:app --host 0.0.0.0 --port 8080
+```
+
+For production-like bootstrap authentication:
+
+```bash
+export DR_MOAGI_CLOUD_REQUIRE_API_KEY=true
+export DR_MOAGI_CLOUD_API_KEY='replace-with-secret'
+export DR_MOAGI_CLOUD_DATA_DIR='/var/lib/dr-moagi-cloud'
+uvicorn jarvisx.dr_moagi_cloud_service:app --host 0.0.0.0 --port 8080
+```
+
+## Create a deterministic conformance job
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/v1/jobs \
+  -H 'content-type: application/json' \
+  -H 'X-Dr-Moagi-Key: replace-with-secret' \
+  -H 'X-Dr-Moagi-Principal: user:operator' \
+  -d '{
+    "operation":"echo.v1",
+    "request_id":"smoke-001",
+    "input":{"message":"Dr Moagi Cloud"}
+  }'
+```
+
+The response includes the canonical `job_id`, full transition journal, verification outcome, result digest, and envelope digest.
+
+## Execute one bounded Dr Moagi field step
+
+```bash
+curl -sS -X POST http://127.0.0.1:8080/api/v1/jobs \
+  -H 'content-type: application/json' \
+  -H 'X-Dr-Moagi-Key: replace-with-secret' \
+  -H 'X-Dr-Moagi-Principal: user:operator' \
+  -d '{
+    "operation":"dr-moagi-field-step.v1",
+    "input":{
+      "config":{
+        "side":5,
+        "alpha":0.0,
+        "lambda_residual":0.0,
+        "eta":0.0,
+        "dt":0.1,
+        "expand_halo":false
+      },
+      "field":[{"x":2,"y":2,"z":2,"value":0.5}]
+    }
+  }'
+```
+
+This adapter invokes the canonical bounded field runtime with an identity codec. The field runtime still owns coordinate bounds, sparse support, stability guards, projection, anchor semantics, and candidate commit.
+
+## Replay and evidence
+
+Given a `job_id`:
+
+```text
+GET  /api/v1/jobs/{job_id}
+GET  /api/v1/jobs/{job_id}/events
+POST /api/v1/jobs/{job_id}/verify
+```
+
+`verify` recomputes:
+
+1. protocol identity;
+2. envelope SHA-256;
+3. every event SHA-256;
+4. previous-event links;
+5. event sequence numbers;
+6. terminal state/event agreement;
+7. result SHA-256 when a result exists.
+
+A modified stored record therefore fails verification unless every dependent digest is recomputed. This is tamper-evidence, not cryptographic non-repudiation; signatures or external transparency logs can be layered on later.
+
+## Environment variables
+
+| Variable | Default | Meaning |
+|---|---:|---|
+| `DR_MOAGI_CLOUD_DATA_DIR` | `state/dr-moagi-cloud` | Durable reference job store |
+| `DR_MOAGI_CLOUD_REQUIRE_API_KEY` | `false` | Enforce bootstrap API-key auth |
+| `DR_MOAGI_CLOUD_API_KEY` | unset | Shared bootstrap API key |
+| `DR_MOAGI_CLOUD_MAX_INPUT_BYTES` | `1000000` | Canonical request-input ceiling |
+| `DR_MOAGI_CLOUD_MAX_OUTPUT_BYTES` | `2000000` | Canonical result ceiling |
+| `DR_MOAGI_CLOUD_MAX_RUNTIME_MS` | `5000` | Executor elapsed-time ceiling |
+
+## Production hardening path
+
+The v1 state machine is intentionally designed so these components can be replaced without changing the authority contract:
+
+```text
+bootstrap API key   -> OIDC/JWT/mTLS identity gateway
+filesystem store    -> transactional database + immutable object evidence
+in-process dispatch -> durable queue
+local executor      -> isolated worker/sandbox
+basic metrics       -> OpenTelemetry + Prometheus + traces
+SHA-256 journal     -> signed evidence / transparency anchoring
+single verifier     -> policy engine + schema tests + deterministic replay + shadow validation
+```
+
+The key invariant is unchanged throughout:
+
+```text
+candidate execution != authoritative state
+candidate + verification + policy pass = eligible commit
+```

--- a/docs/adr/0010-dr-moagi-cloud-transaction-runtime.md
+++ b/docs/adr/0010-dr-moagi-cloud-transaction-runtime.md
@@ -1,0 +1,175 @@
+# ADR-010: Adopt the Dr Moagi Cloud transactional runtime boundary
+
+**Status:** Proposed  
+**Date:** 2026-08-18  
+**Extends:** ADR-002, ADR-003
+
+## Context
+
+Jarvis-X already separates deterministic authority from adaptive and spatial research layers. The Dr Moagi field runtime is candidate-first and fail-closed, but a cloud deployment also needs an execution boundary above individual numerical kernels: identity, job lifecycle, resource ceilings, verification, durable evidence, replay, and explicit promotion to authoritative state.
+
+A web interface, agent plan, or executor result is not authoritative merely because it was produced successfully. Cloud execution must preserve the same rule already used by the field runtime: compute a candidate, verify it, then commit or reject it atomically.
+
+## Decision
+
+Jarvis-X adopts a Layer 6/7 reference control plane with the canonical transaction path:
+
+```text
+RECEIVED
+  -> VALIDATED
+  -> PLANNED
+  -> DISPATCHED
+  -> RUNNING
+  -> VERIFIED
+  -> COMMITTED
+```
+
+Any policy, resource, execution, or verification failure ends in `REJECTED` or `FAILED` without promotion.
+
+The transaction envelope is identified by a durable `job_id` and records:
+
+```text
+T_i = (
+  protocol,
+  job_id,
+  request_id,
+  principal,
+  operation,
+  input,
+  input_digest,
+  plan,
+  result,
+  result_digest,
+  verification,
+  resource_usage,
+  events,
+  envelope_digest
+)
+```
+
+The cloud promotion law is:
+
+```text
+Omega_(t+1) = Commit(Omega_t, DeltaOmega_t)
+              iff verifier == PASS and policy == PASS
+otherwise Omega_(t+1) = Omega_t
+```
+
+This is the operational cloud interpretation of `Pi_Lambda`: an explicit policy and verification gate, not an implied trust boundary.
+
+## Durable evidence
+
+Every transition appends a canonical JSON event containing:
+
+```text
+sequence
+state
+timestamp_ms
+details
+previous_digest
+event_digest
+```
+
+Events form a SHA-256 hash chain rooted at a fixed genesis digest. The complete job envelope is separately SHA-256 sealed. Replay verification recomputes the envelope digest, the event chain, terminal-state coherence, and result digest.
+
+The reference filesystem store uses atomic replacement and canonical JSON. This is a reference durability mechanism, not a substitute for a replicated production database or object store.
+
+## Identity and authorization
+
+The reference FastAPI surface supports bootstrap API-key authentication and an authenticated principal field. Production deployments should terminate stronger identity at a trusted gateway or identity provider and map it to the coordinator principal. Operation authorization is fail-closed through an explicit allowlist.
+
+## Resource contract
+
+Every job is bounded by:
+
+- maximum canonical input bytes;
+- maximum canonical output bytes;
+- maximum executor runtime;
+- operation-specific limits inside the selected executor.
+
+Exceeding a post-execution runtime or output ceiling rejects the candidate result rather than committing it.
+
+## Executor boundary
+
+Executors are adapters, not authorities. They receive an immutable JSON-compatible input plus resource limits and return a candidate result. They cannot mark a job committed.
+
+The initial reference operations are:
+
+- `echo.v1` for deterministic transaction-spine conformance;
+- `dr-moagi-field-step.v1` for one bounded same-space Dr Moagi field step using the existing `DrMoagiFieldRuntime`.
+
+## HTTP contract
+
+The reference service exposes:
+
+```text
+GET  /health/live
+GET  /health/ready
+POST /api/v1/jobs
+GET  /api/v1/jobs/{job_id}
+GET  /api/v1/jobs/{job_id}/events
+POST /api/v1/jobs/{job_id}/verify
+GET  /metrics
+```
+
+The first implementation is intentionally synchronous. The state machine includes `DISPATCHED` so a durable external queue can replace the in-process dispatch path later without changing the transaction semantics.
+
+## Architectural placement
+
+```text
+Layer 0-3  canonical deterministic VM, policy, transactions, provenance
+Layer 4    sparse geometric state and spatial operators
+Layer 5    codec/residual/adaptive research runtimes
+Layer 6    Dr Moagi Cloud transaction coordinator and operation adapters
+Layer 7    HTTP/UI/agent interfaces and deployment integrations
+```
+
+The cloud layer does not modify the canonical VM instruction format and does not let visualization or agent output bypass lower authority boundaries.
+
+## Required invariants
+
+1. Every accepted request receives exactly one canonical UUID `job_id`.
+2. No executor may directly set `COMMITTED`.
+3. Verification and policy are fail-closed.
+4. Job events are ordered and hash chained.
+5. The envelope is independently integrity sealed.
+6. Result digests bind committed output to the job record.
+7. Input, output, and runtime ceilings are explicit.
+8. Disallowed operations fail before execution.
+9. Executor exceptions are durably journalled as `FAILED`.
+10. A stored job can be integrity-verified from `job_id` alone.
+11. Field execution remains bounded by ADR-003 resource, support, anchor, and projection rules.
+12. Queueing, distributed workers, learning, or self-modification may extend the runtime only without weakening these invariants.
+
+## Consequences
+
+### Positive
+
+- Dr Moagi Cloud gains an executable authority boundary rather than a UI-only architecture;
+- cloud jobs become reconstructable and tamper-evident;
+- the existing field runtime can be invoked through a verified transaction envelope;
+- a future queue, worker pool, database, agent planner, or model gateway can plug into stable contracts;
+- adaptive proposals remain candidate-first and reversible.
+
+### Negative
+
+- the reference filesystem store is single-node and not horizontally replicated;
+- API-key authentication is bootstrap-grade rather than full enterprise identity;
+- synchronous dispatch does not yet provide durable distributed scheduling;
+- elapsed wall-clock limits detect overruns after executor return and are not a hard process-kill sandbox.
+
+## Validation
+
+The decision may move to **Accepted** when CI demonstrates:
+
+- successful `RECEIVED -> ... -> COMMITTED` execution;
+- verifier rejection with no committed result;
+- policy rejection before execution;
+- resource-ceiling rejection;
+- executor exception journaling;
+- tamper detection for stored envelopes;
+- authenticated API behavior;
+- create/fetch/events/verify HTTP round trip;
+- successful bounded `dr-moagi-field-step.v1` execution against the canonical field runtime.
+
+The normative operations guide is `docs/DR_MOAGI_CLOUD_RUNTIME_V1.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "black>=25.0",
     "build>=1.2",
     "flake8>=7.0",
+    "httpx2",
     "isort>=5.13",
     "mypy>=1.10",
     "pip-audit>=2.7",
@@ -48,6 +49,7 @@ dev = [
     "twine>=6.0",
 ]
 test = [
+    "httpx2",
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]

--- a/src/jarvisx/dr_moagi_cloud_operations.py
+++ b/src/jarvisx/dr_moagi_cloud_operations.py
@@ -1,0 +1,87 @@
+"""Bounded Dr Moagi domain operations exposed through the cloud coordinator."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Mapping
+
+from .dr_moagi_cloud_runtime import ResourceLimits
+from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime, IdentityFieldCodec
+
+
+class DrMoagiFieldStepExecutor:
+    """Execute one candidate/commit field-runtime step from a sparse JSON payload."""
+
+    _CONFIG_FIELDS = frozenset(
+        {
+            "side",
+            "alpha",
+            "lambda_residual",
+            "eta",
+            "dt",
+            "value_min",
+            "value_max",
+            "max_active_cells",
+            "expand_halo",
+            "prune_epsilon",
+            "enforce_conservative_step_bound",
+        }
+    )
+
+    def execute(self, payload: Mapping[str, Any], limits: ResourceLimits) -> Mapping[str, Any]:
+        del limits
+        raw_field = payload.get("field")
+        if not isinstance(raw_field, list):
+            raise ValueError("field must be a list of sparse cells")
+        raw_config = payload.get("config", {})
+        if not isinstance(raw_config, dict):
+            raise ValueError("config must be an object")
+        unknown = set(raw_config).difference(self._CONFIG_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown field config keys: {sorted(unknown)}")
+
+        config = DrMoagiFieldConfig(**raw_config)
+        field: dict[tuple[int, int, int], float] = {}
+        for index, cell in enumerate(raw_field):
+            if not isinstance(cell, dict):
+                raise ValueError(f"field[{index}] must be an object")
+            required = {"x", "y", "z", "value"}
+            if set(cell) != required:
+                raise ValueError(f"field[{index}] must contain exactly x, y, z, value")
+            coordinate = (
+                self._integer(cell["x"], f"field[{index}].x"),
+                self._integer(cell["y"], f"field[{index}].y"),
+                self._integer(cell["z"], f"field[{index}].z"),
+            )
+            if coordinate in field:
+                raise ValueError(f"duplicate sparse coordinate at field[{index}]")
+            field[coordinate] = self._number(cell["value"], f"field[{index}].value")
+
+        runtime = DrMoagiFieldRuntime(IdentityFieldCodec(), config)
+        runtime.load(field)
+        metrics = runtime.step()
+        state = runtime.snapshot()
+        cells = [
+            {"x": x, "y": y, "z": z, "value": value}
+            for (x, y, z), value in sorted(state.items())
+        ]
+        return {
+            "operation": "dr-moagi-field-step.v1",
+            "virtual_cell_count": runtime.virtual_cell_count,
+            "active_cell_count": runtime.active_cell_count,
+            "cycle": runtime.cycle,
+            "metrics": asdict(metrics),
+            "field": cells,
+        }
+
+    @staticmethod
+    def _integer(value: object, name: str) -> int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"{name} must be an integer")
+        return value
+
+    @staticmethod
+    def _number(value: object, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{name} must be numeric")
+        return float(value)

--- a/src/jarvisx/dr_moagi_cloud_runtime.py
+++ b/src/jarvisx/dr_moagi_cloud_runtime.py
@@ -22,7 +22,7 @@ import uuid
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, Mapping, Protocol, Sequence
+from typing import Any, Callable, Mapping, Protocol, Sequence, cast
 
 JsonObject = dict[str, Any]
 Verifier = Callable[[Mapping[str, Any], Mapping[str, Any]], tuple[bool, str]]
@@ -101,7 +101,28 @@ def sha256_hex(value: object) -> str:
 
 
 def _json_compatible(value: object) -> Any:
+    """Canonicalize a value through JSON serialization.
+
+    This low-level helper intentionally returns ``Any`` because ``json.loads``
+    does. Public typed boundaries validate the resulting container shape before
+    returning it.
+    """
+
     return json.loads(canonical_json_bytes(value).decode("utf-8"))
+
+
+def _json_object(value: object, *, name: str = "value") -> JsonObject:
+    converted = _json_compatible(value)
+    if not isinstance(converted, dict):
+        raise TypeError(f"{name} must canonicalize to a JSON object")
+    return cast(JsonObject, converted)
+
+
+def _json_event_sequence(value: object) -> Sequence[Mapping[str, Any]]:
+    converted = _json_compatible(value)
+    if not isinstance(converted, list) or any(not isinstance(item, dict) for item in converted):
+        raise TypeError("events must canonicalize to a list of JSON objects")
+    return cast(list[Mapping[str, Any]], converted)
 
 
 def default_verifier(result: Mapping[str, Any], context: Mapping[str, Any]) -> tuple[bool, str]:
@@ -156,10 +177,10 @@ class AtomicJobStore:
             value = json.loads(path.read_text(encoding="utf-8"))
         if not isinstance(value, dict):
             raise ValueError("stored job must be a JSON object")
-        return value
+        return cast(JsonObject, value)
 
     def count(self) -> int:
-        return sum(1 for p in self.root.glob("*.json") if p.is_file())
+        return sum(1 for path in self.root.glob("*.json") if path.is_file())
 
     def ready(self) -> bool:
         probe = self.root / ".ready"
@@ -211,7 +232,7 @@ class DrMoagiCloudCoordinator:
     ) -> JsonObject:
         principal = self._validate_principal(principal)
         operation = self._validate_operation(operation)
-        payload_json = _json_compatible(payload)
+        payload_json = _json_object(payload, name="payload")
         input_bytes = canonical_json_bytes(payload_json)
         if len(input_bytes) > self.policy.limits.max_input_bytes:
             raise ValueError("input exceeds max_input_bytes")
@@ -260,7 +281,7 @@ class DrMoagiCloudCoordinator:
             started_ns = time.perf_counter_ns()
             result = self.executors[operation].execute(payload_json, self.policy.limits)
             runtime_ms = (time.perf_counter_ns() - started_ns) / 1_000_000.0
-            result_json = _json_compatible(result)
+            result_json = _json_object(result, name="executor result")
             output_bytes = canonical_json_bytes(result_json)
             resource_usage = {
                 "input_bytes": len(input_bytes),
@@ -294,7 +315,7 @@ class DrMoagiCloudCoordinator:
                 {"result_digest": envelope["result_digest"]},
             )
             self._transition(envelope, JobState.COMMITTED, {"committed": True})
-            return _json_compatible(envelope)
+            return _json_object(envelope, name="job envelope")
         except Exception as error:
             self._fail(envelope, error)
             raise
@@ -322,7 +343,7 @@ class DrMoagiCloudCoordinator:
         events = envelope.get("events")
         if not isinstance(events, list):
             raise ValueError("job events are invalid")
-        return _json_compatible(events)
+        return _json_event_sequence(events)
 
     def _transition(
         self, envelope: JsonObject, state: JobState, details: Mapping[str, Any]
@@ -339,7 +360,7 @@ class DrMoagiCloudCoordinator:
             "reason": reason,
         }
         self._transition(envelope, JobState.REJECTED, {"reason": reason})
-        return _json_compatible(envelope)
+        return _json_object(envelope, name="job envelope")
 
     def _fail(self, envelope: JsonObject, error: Exception) -> None:
         if envelope.get("state") in {state.value for state in TERMINAL_STATES}:
@@ -362,7 +383,7 @@ class DrMoagiCloudCoordinator:
             "sequence": len(events),
             "state": state.value,
             "timestamp_ms": self.clock_ms(),
-            "details": _json_compatible(details),
+            "details": _json_object(details, name="event details"),
             "previous_digest": previous,
         }
         event = dict(core)
@@ -371,7 +392,7 @@ class DrMoagiCloudCoordinator:
 
     @staticmethod
     def _seal(envelope: JsonObject) -> None:
-        unsigned = {k: v for k, v in envelope.items() if k != "envelope_digest"}
+        unsigned = {key: value for key, value in envelope.items() if key != "envelope_digest"}
         envelope["envelope_digest"] = sha256_hex(unsigned)
 
     @staticmethod
@@ -381,7 +402,7 @@ class DrMoagiCloudCoordinator:
         expected = envelope.get("envelope_digest")
         if not isinstance(expected, str):
             return False, "envelope digest missing"
-        unsigned = {k: v for k, v in envelope.items() if k != "envelope_digest"}
+        unsigned = {key: value for key, value in envelope.items() if key != "envelope_digest"}
         if expected != sha256_hex(unsigned):
             return False, "envelope digest mismatch"
         events = envelope.get("events")
@@ -392,7 +413,7 @@ class DrMoagiCloudCoordinator:
             if not isinstance(event, dict):
                 return False, f"event {index} invalid"
             digest = event.get("event_digest")
-            core = {k: v for k, v in event.items() if k != "event_digest"}
+            core = {key: value for key, value in event.items() if key != "event_digest"}
             if event.get("sequence") != index:
                 return False, f"event {index} sequence mismatch"
             if event.get("previous_digest") != previous:

--- a/src/jarvisx/dr_moagi_cloud_runtime.py
+++ b/src/jarvisx/dr_moagi_cloud_runtime.py
@@ -1,0 +1,422 @@
+"""Transactional cloud control plane for bounded Jarvis-X execution.
+
+The coordinator turns a request into an auditable state-machine transaction:
+
+    RECEIVED -> VALIDATED -> PLANNED -> DISPATCHED -> RUNNING
+             -> VERIFIED -> COMMITTED
+
+or a terminal REJECTED/FAILED state. Executors remain non-authoritative:
+results are committed only after verifier and policy approval. The durable
+store uses canonical JSON, atomic replacement, and a hash-chained event log so
+a job can be replayed and independently integrity-checked by job_id.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Mapping, Protocol, Sequence
+
+JsonObject = dict[str, Any]
+Verifier = Callable[[Mapping[str, Any], Mapping[str, Any]], tuple[bool, str]]
+
+PROTOCOL = "jarvisx.dr-moagi-cloud.v1"
+GENESIS_DIGEST = "0" * 64
+
+
+class JobState(str, Enum):
+    RECEIVED = "RECEIVED"
+    VALIDATED = "VALIDATED"
+    PLANNED = "PLANNED"
+    DISPATCHED = "DISPATCHED"
+    RUNNING = "RUNNING"
+    VERIFIED = "VERIFIED"
+    COMMITTED = "COMMITTED"
+    REJECTED = "REJECTED"
+    FAILED = "FAILED"
+
+
+TERMINAL_STATES = {JobState.COMMITTED, JobState.REJECTED, JobState.FAILED}
+
+
+class Executor(Protocol):
+    """Bounded execution adapter selected by operation name."""
+
+    def execute(self, payload: Mapping[str, Any], limits: "ResourceLimits") -> Mapping[str, Any]:
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceLimits:
+    max_input_bytes: int = 1_000_000
+    max_output_bytes: int = 2_000_000
+    max_runtime_ms: int = 5_000
+
+    def __post_init__(self) -> None:
+        for name in ("max_input_bytes", "max_output_bytes", "max_runtime_ms"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True, slots=True)
+class JobPolicy:
+    allowed_operations: frozenset[str]
+    limits: ResourceLimits = ResourceLimits()
+
+    def __post_init__(self) -> None:
+        if not self.allowed_operations:
+            raise ValueError("at least one operation must be allowed")
+        if any(not op or len(op) > 128 for op in self.allowed_operations):
+            raise ValueError("operation names must be non-empty and <= 128 characters")
+
+
+class EchoExecutor:
+    """Deterministic reference executor used to prove the transaction spine."""
+
+    def execute(self, payload: Mapping[str, Any], limits: ResourceLimits) -> Mapping[str, Any]:
+        del limits
+        return {"echo": _json_compatible(payload)}
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(value: object) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def _json_compatible(value: object) -> Any:
+    return json.loads(canonical_json_bytes(value).decode("utf-8"))
+
+
+def default_verifier(result: Mapping[str, Any], context: Mapping[str, Any]) -> tuple[bool, str]:
+    del context
+    try:
+        canonical_json_bytes(result)
+    except (TypeError, ValueError):
+        return False, "result is not finite canonical JSON"
+    return True, "verified"
+
+
+class AtomicJobStore:
+    """Durable job documents with atomic replacement and hash-chained events."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.root.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+
+    @staticmethod
+    def _validate_job_id(job_id: str) -> None:
+        try:
+            parsed = uuid.UUID(job_id)
+        except (ValueError, AttributeError) as error:
+            raise ValueError("job_id must be a canonical UUID") from error
+        if str(parsed) != job_id:
+            raise ValueError("job_id must be a canonical UUID")
+
+    def _path(self, job_id: str) -> Path:
+        self._validate_job_id(job_id)
+        return self.root / f"{job_id}.json"
+
+    def create(self, envelope: Mapping[str, Any]) -> None:
+        job_id = str(envelope["job_id"])
+        destination = self._path(job_id)
+        with self._lock:
+            if destination.exists():
+                raise RuntimeError("job already exists")
+            self._write(destination, envelope)
+
+    def replace(self, envelope: Mapping[str, Any]) -> None:
+        job_id = str(envelope["job_id"])
+        destination = self._path(job_id)
+        with self._lock:
+            if not destination.exists():
+                raise FileNotFoundError(job_id)
+            self._write(destination, envelope)
+
+    def get(self, job_id: str) -> JsonObject:
+        path = self._path(job_id)
+        with self._lock:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(value, dict):
+            raise ValueError("stored job must be a JSON object")
+        return value
+
+    def count(self) -> int:
+        return sum(1 for p in self.root.glob("*.json") if p.is_file())
+
+    def ready(self) -> bool:
+        probe = self.root / ".ready"
+        try:
+            probe.write_text("ok", encoding="utf-8")
+            probe.unlink()
+        except OSError:
+            return False
+        return True
+
+    def _write(self, destination: Path, envelope: Mapping[str, Any]) -> None:
+        encoded = canonical_json_bytes(envelope)
+        temporary = destination.with_suffix(f".tmp-{os.getpid()}-{threading.get_ident()}")
+        with temporary.open("wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+
+
+class DrMoagiCloudCoordinator:
+    """Synchronous reference control plane with fail-closed commit semantics."""
+
+    def __init__(
+        self,
+        *,
+        executors: Mapping[str, Executor],
+        policy: JobPolicy,
+        store: AtomicJobStore,
+        verifier: Verifier = default_verifier,
+        clock_ms: Callable[[], int] | None = None,
+    ) -> None:
+        missing = policy.allowed_operations.difference(executors)
+        if missing:
+            raise ValueError(f"no executor registered for: {sorted(missing)}")
+        self.executors = dict(executors)
+        self.policy = policy
+        self.store = store
+        self.verifier = verifier
+        self.clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+
+    def submit(
+        self,
+        *,
+        principal: str,
+        operation: str,
+        payload: Mapping[str, Any],
+        request_id: str | None = None,
+    ) -> JsonObject:
+        principal = self._validate_principal(principal)
+        operation = self._validate_operation(operation)
+        payload_json = _json_compatible(payload)
+        input_bytes = canonical_json_bytes(payload_json)
+        if len(input_bytes) > self.policy.limits.max_input_bytes:
+            raise ValueError("input exceeds max_input_bytes")
+
+        job_id = str(uuid.uuid4())
+        now = self.clock_ms()
+        envelope: JsonObject = {
+            "protocol": PROTOCOL,
+            "job_id": job_id,
+            "request_id": request_id,
+            "principal": principal,
+            "operation": operation,
+            "state": JobState.RECEIVED.value,
+            "created_at_ms": now,
+            "updated_at_ms": now,
+            "input": payload_json,
+            "input_digest": sha256_hex(payload_json),
+            "plan": None,
+            "result": None,
+            "result_digest": None,
+            "verification": None,
+            "resource_usage": None,
+            "events": [],
+            "envelope_digest": None,
+        }
+        self._append_event(envelope, JobState.RECEIVED, {"request_id": request_id})
+        self._seal(envelope)
+        self.store.create(envelope)
+
+        try:
+            self._transition(envelope, JobState.VALIDATED, {"input_bytes": len(input_bytes)})
+            plan = {
+                "operation": operation,
+                "executor": type(self.executors[operation]).__name__,
+                "limits": {
+                    "max_input_bytes": self.policy.limits.max_input_bytes,
+                    "max_output_bytes": self.policy.limits.max_output_bytes,
+                    "max_runtime_ms": self.policy.limits.max_runtime_ms,
+                },
+            }
+            envelope["plan"] = plan
+            self._transition(envelope, JobState.PLANNED, {"plan_digest": sha256_hex(plan)})
+            self._transition(envelope, JobState.DISPATCHED, {})
+            self._transition(envelope, JobState.RUNNING, {})
+
+            started_ns = time.perf_counter_ns()
+            result = self.executors[operation].execute(payload_json, self.policy.limits)
+            runtime_ms = (time.perf_counter_ns() - started_ns) / 1_000_000.0
+            result_json = _json_compatible(result)
+            output_bytes = canonical_json_bytes(result_json)
+            resource_usage = {
+                "input_bytes": len(input_bytes),
+                "output_bytes": len(output_bytes),
+                "runtime_ms": runtime_ms,
+            }
+            envelope["resource_usage"] = resource_usage
+            if runtime_ms > self.policy.limits.max_runtime_ms:
+                return self._reject(envelope, "runtime limit exceeded")
+            if len(output_bytes) > self.policy.limits.max_output_bytes:
+                return self._reject(envelope, "output exceeds max_output_bytes")
+
+            context = {
+                "job_id": job_id,
+                "principal": principal,
+                "operation": operation,
+                "input_digest": envelope["input_digest"],
+                "plan": plan,
+                "resource_usage": resource_usage,
+            }
+            verified, reason = self.verifier(result_json, context)
+            envelope["verification"] = {"passed": bool(verified), "reason": str(reason)}
+            if not verified:
+                return self._reject(envelope, f"verification failed: {reason}")
+
+            envelope["result"] = result_json
+            envelope["result_digest"] = sha256_hex(result_json)
+            self._transition(
+                envelope,
+                JobState.VERIFIED,
+                {"result_digest": envelope["result_digest"]},
+            )
+            self._transition(envelope, JobState.COMMITTED, {"committed": True})
+            return _json_compatible(envelope)
+        except Exception as error:
+            self._fail(envelope, error)
+            raise
+
+    def get(self, job_id: str) -> JsonObject:
+        return self.store.get(job_id)
+
+    def verify_job(self, job_id: str) -> JsonObject:
+        envelope = self.store.get(job_id)
+        ok, reason = self._verify_envelope(envelope)
+        return {
+            "job_id": job_id,
+            "verified": ok,
+            "reason": reason,
+            "state": envelope.get("state"),
+            "event_count": (
+                len(envelope.get("events", []))
+                if isinstance(envelope.get("events"), list)
+                else 0
+            ),
+        }
+
+    def events(self, job_id: str) -> Sequence[Mapping[str, Any]]:
+        envelope = self.store.get(job_id)
+        events = envelope.get("events")
+        if not isinstance(events, list):
+            raise ValueError("job events are invalid")
+        return _json_compatible(events)
+
+    def _transition(
+        self, envelope: JsonObject, state: JobState, details: Mapping[str, Any]
+    ) -> None:
+        envelope["state"] = state.value
+        envelope["updated_at_ms"] = self.clock_ms()
+        self._append_event(envelope, state, details)
+        self._seal(envelope)
+        self.store.replace(envelope)
+
+    def _reject(self, envelope: JsonObject, reason: str) -> JsonObject:
+        envelope["verification"] = envelope.get("verification") or {
+            "passed": False,
+            "reason": reason,
+        }
+        self._transition(envelope, JobState.REJECTED, {"reason": reason})
+        return _json_compatible(envelope)
+
+    def _fail(self, envelope: JsonObject, error: Exception) -> None:
+        if envelope.get("state") in {state.value for state in TERMINAL_STATES}:
+            return
+        envelope["verification"] = {"passed": False, "reason": "execution failure"}
+        self._transition(
+            envelope,
+            JobState.FAILED,
+            {"error_type": type(error).__name__, "reason": str(error)[:512]},
+        )
+
+    def _append_event(
+        self, envelope: JsonObject, state: JobState, details: Mapping[str, Any]
+    ) -> None:
+        events = envelope["events"]
+        if not isinstance(events, list):
+            raise TypeError("events must be a list")
+        previous = events[-1]["event_digest"] if events else GENESIS_DIGEST
+        core = {
+            "sequence": len(events),
+            "state": state.value,
+            "timestamp_ms": self.clock_ms(),
+            "details": _json_compatible(details),
+            "previous_digest": previous,
+        }
+        event = dict(core)
+        event["event_digest"] = sha256_hex(core)
+        events.append(event)
+
+    @staticmethod
+    def _seal(envelope: JsonObject) -> None:
+        unsigned = {k: v for k, v in envelope.items() if k != "envelope_digest"}
+        envelope["envelope_digest"] = sha256_hex(unsigned)
+
+    @staticmethod
+    def _verify_envelope(envelope: Mapping[str, Any]) -> tuple[bool, str]:
+        if envelope.get("protocol") != PROTOCOL:
+            return False, "unsupported protocol"
+        expected = envelope.get("envelope_digest")
+        if not isinstance(expected, str):
+            return False, "envelope digest missing"
+        unsigned = {k: v for k, v in envelope.items() if k != "envelope_digest"}
+        if expected != sha256_hex(unsigned):
+            return False, "envelope digest mismatch"
+        events = envelope.get("events")
+        if not isinstance(events, list) or not events:
+            return False, "event journal missing"
+        previous = GENESIS_DIGEST
+        for index, event in enumerate(events):
+            if not isinstance(event, dict):
+                return False, f"event {index} invalid"
+            digest = event.get("event_digest")
+            core = {k: v for k, v in event.items() if k != "event_digest"}
+            if event.get("sequence") != index:
+                return False, f"event {index} sequence mismatch"
+            if event.get("previous_digest") != previous:
+                return False, f"event {index} chain mismatch"
+            if digest != sha256_hex(core):
+                return False, f"event {index} digest mismatch"
+            previous = str(digest)
+        if envelope.get("state") != events[-1].get("state"):
+            return False, "terminal state does not match event journal"
+        result = envelope.get("result")
+        result_digest = envelope.get("result_digest")
+        if result is not None and result_digest != sha256_hex(result):
+            return False, "result digest mismatch"
+        return True, "verified"
+
+    def _validate_operation(self, operation: str) -> str:
+        if not isinstance(operation, str) or not operation or len(operation) > 128:
+            raise ValueError("operation must be a non-empty string <= 128 characters")
+        if operation not in self.policy.allowed_operations:
+            raise PermissionError("operation is not allowed by policy")
+        return operation
+
+    @staticmethod
+    def _validate_principal(principal: str) -> str:
+        if not isinstance(principal, str) or not principal.strip() or len(principal) > 256:
+            raise ValueError("principal must be a non-empty string <= 256 characters")
+        return principal.strip()

--- a/src/jarvisx/dr_moagi_cloud_service.py
+++ b/src/jarvisx/dr_moagi_cloud_service.py
@@ -17,6 +17,7 @@ from .dr_moagi_cloud_runtime import (
     DrMoagiCloudCoordinator,
     EchoExecutor,
     JobPolicy,
+    JsonObject,
     ResourceLimits,
 )
 
@@ -156,9 +157,9 @@ def create_app(
     def create_job(
         request: JobRequest,
         principal: str = Depends(authenticated_principal),
-    ) -> Mapping[str, object]:
+    ) -> JsonObject:
         try:
-            job = runtime.submit(
+            return runtime.submit(
                 principal=principal,
                 operation=request.operation,
                 payload=request.input,
@@ -168,13 +169,12 @@ def create_app(
             raise HTTPException(status_code=403, detail=str(error)) from error
         except ValueError as error:
             raise HTTPException(status_code=422, detail=str(error)) from error
-        return job
 
     @app.get("/api/v1/jobs/{job_id}")
     def get_job(
         job_id: str,
         principal: str = Depends(authenticated_principal),
-    ) -> Mapping[str, object]:
+    ) -> JsonObject:
         del principal
         try:
             return runtime.get(job_id)
@@ -187,7 +187,7 @@ def create_app(
     def get_events(
         job_id: str,
         principal: str = Depends(authenticated_principal),
-    ) -> Mapping[str, object]:
+    ) -> JsonObject:
         del principal
         try:
             return {"job_id": job_id, "events": runtime.events(job_id)}
@@ -200,7 +200,7 @@ def create_app(
     def verify_job(
         job_id: str,
         principal: str = Depends(authenticated_principal),
-    ) -> Mapping[str, object]:
+    ) -> JsonObject:
         del principal
         try:
             return runtime.verify_job(job_id)

--- a/src/jarvisx/dr_moagi_cloud_service.py
+++ b/src/jarvisx/dr_moagi_cloud_service.py
@@ -1,0 +1,230 @@
+"""FastAPI control surface for the Dr Moagi Cloud transactional runtime."""
+
+from __future__ import annotations
+
+import hmac
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Response, status
+from pydantic import BaseModel, ConfigDict, Field
+
+from .dr_moagi_cloud_operations import DrMoagiFieldStepExecutor
+from .dr_moagi_cloud_runtime import (
+    AtomicJobStore,
+    DrMoagiCloudCoordinator,
+    EchoExecutor,
+    JobPolicy,
+    ResourceLimits,
+)
+
+DEFAULT_DATA_DIR = Path("state/dr-moagi-cloud")
+
+
+class JobRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation: str = Field(min_length=1, max_length=128)
+    input: dict[str, Any] = Field(default_factory=dict)
+    request_id: str | None = Field(default=None, max_length=256)
+
+
+@dataclass(frozen=True, slots=True)
+class CloudServiceSettings:
+    data_dir: Path = DEFAULT_DATA_DIR
+    api_key: str | None = None
+    require_api_key: bool = False
+    max_input_bytes: int = 1_000_000
+    max_output_bytes: int = 2_000_000
+    max_runtime_ms: int = 5_000
+
+    def __post_init__(self) -> None:
+        if self.require_api_key and not self.api_key:
+            raise ValueError("DR_MOAGI_CLOUD_API_KEY is required when authentication is enforced")
+        ResourceLimits(
+            max_input_bytes=self.max_input_bytes,
+            max_output_bytes=self.max_output_bytes,
+            max_runtime_ms=self.max_runtime_ms,
+        )
+
+    @classmethod
+    def from_env(cls) -> "CloudServiceSettings":
+        return cls(
+            data_dir=Path(os.getenv("DR_MOAGI_CLOUD_DATA_DIR", str(DEFAULT_DATA_DIR))),
+            api_key=os.getenv("DR_MOAGI_CLOUD_API_KEY") or None,
+            require_api_key=_env_bool("DR_MOAGI_CLOUD_REQUIRE_API_KEY", False),
+            max_input_bytes=_env_int("DR_MOAGI_CLOUD_MAX_INPUT_BYTES", 1_000_000),
+            max_output_bytes=_env_int("DR_MOAGI_CLOUD_MAX_OUTPUT_BYTES", 2_000_000),
+            max_runtime_ms=_env_int("DR_MOAGI_CLOUD_MAX_RUNTIME_MS", 5_000),
+        )
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError(f"{name} must be a boolean")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(f"{name} must be an integer") from error
+    if value <= 0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def build_default_coordinator(settings: CloudServiceSettings) -> DrMoagiCloudCoordinator:
+    limits = ResourceLimits(
+        max_input_bytes=settings.max_input_bytes,
+        max_output_bytes=settings.max_output_bytes,
+        max_runtime_ms=settings.max_runtime_ms,
+    )
+    return DrMoagiCloudCoordinator(
+        executors={
+            "echo.v1": EchoExecutor(),
+            "dr-moagi-field-step.v1": DrMoagiFieldStepExecutor(),
+        },
+        policy=JobPolicy(
+            allowed_operations=frozenset({"echo.v1", "dr-moagi-field-step.v1"}),
+            limits=limits,
+        ),
+        store=AtomicJobStore(settings.data_dir),
+    )
+
+
+def create_app(
+    settings: CloudServiceSettings | None = None,
+    coordinator: DrMoagiCloudCoordinator | None = None,
+) -> FastAPI:
+    settings = settings or CloudServiceSettings.from_env()
+    runtime = coordinator or build_default_coordinator(settings)
+
+    app = FastAPI(
+        title="Dr Moagi Cloud Runtime",
+        version="1.0.0",
+        description=(
+            "Transactional Jarvis-X execution control plane. Executors cannot commit results "
+            "until verification and policy gates pass."
+        ),
+    )
+    app.state.settings = settings
+    app.state.runtime = runtime
+
+    def authenticated_principal(
+        x_dr_moagi_key: str | None = Header(default=None, alias="X-Dr-Moagi-Key"),
+        x_dr_moagi_principal: str | None = Header(default=None, alias="X-Dr-Moagi-Principal"),
+    ) -> str:
+        if settings.require_api_key:
+            if x_dr_moagi_key is None or settings.api_key is None or not hmac.compare_digest(
+                x_dr_moagi_key, settings.api_key
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail="invalid API key",
+                )
+        default_principal = "api-key" if settings.require_api_key else "local-dev"
+        principal = (x_dr_moagi_principal or default_principal).strip()
+        if not principal or len(principal) > 256:
+            raise HTTPException(status_code=400, detail="invalid principal")
+        return principal
+
+    @app.get("/health/live")
+    def live() -> Mapping[str, object]:
+        return {"status": "live", "protocol": "jarvisx.dr-moagi-cloud.v1"}
+
+    @app.get("/health/ready")
+    def ready(response: Response) -> Mapping[str, object]:
+        is_ready = runtime.store.ready()
+        if not is_ready:
+            response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+        return {"status": "ready" if is_ready else "not-ready", "store_ready": is_ready}
+
+    @app.post("/api/v1/jobs", status_code=status.HTTP_201_CREATED)
+    def create_job(
+        request: JobRequest,
+        principal: str = Depends(authenticated_principal),
+    ) -> Mapping[str, object]:
+        try:
+            job = runtime.submit(
+                principal=principal,
+                operation=request.operation,
+                payload=request.input,
+                request_id=request.request_id,
+            )
+        except PermissionError as error:
+            raise HTTPException(status_code=403, detail=str(error)) from error
+        except ValueError as error:
+            raise HTTPException(status_code=422, detail=str(error)) from error
+        return job
+
+    @app.get("/api/v1/jobs/{job_id}")
+    def get_job(
+        job_id: str,
+        principal: str = Depends(authenticated_principal),
+    ) -> Mapping[str, object]:
+        del principal
+        try:
+            return runtime.get(job_id)
+        except FileNotFoundError as error:
+            raise HTTPException(status_code=404, detail="job not found") from error
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+
+    @app.get("/api/v1/jobs/{job_id}/events")
+    def get_events(
+        job_id: str,
+        principal: str = Depends(authenticated_principal),
+    ) -> Mapping[str, object]:
+        del principal
+        try:
+            return {"job_id": job_id, "events": runtime.events(job_id)}
+        except FileNotFoundError as error:
+            raise HTTPException(status_code=404, detail="job not found") from error
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+
+    @app.post("/api/v1/jobs/{job_id}/verify")
+    def verify_job(
+        job_id: str,
+        principal: str = Depends(authenticated_principal),
+    ) -> Mapping[str, object]:
+        del principal
+        try:
+            return runtime.verify_job(job_id)
+        except FileNotFoundError as error:
+            raise HTTPException(status_code=404, detail="job not found") from error
+        except ValueError as error:
+            raise HTTPException(status_code=400, detail=str(error)) from error
+
+    @app.get("/metrics", response_class=Response)
+    def metrics(principal: str = Depends(authenticated_principal)) -> Response:
+        del principal
+        ready_value = 1 if runtime.store.ready() else 0
+        body = "\n".join(
+            [
+                "# TYPE dr_moagi_cloud_jobs_stored gauge",
+                f"dr_moagi_cloud_jobs_stored {runtime.store.count()}",
+                "# TYPE dr_moagi_cloud_store_ready gauge",
+                f"dr_moagi_cloud_store_ready {ready_value}",
+                "",
+            ]
+        )
+        return Response(content=body, media_type="text/plain; version=0.0.4; charset=utf-8")
+
+    return app
+
+
+app = create_app()

--- a/tests/test_dr_moagi_cloud_operations.py
+++ b/tests/test_dr_moagi_cloud_operations.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dr_moagi_cloud_operations import DrMoagiFieldStepExecutor
+from jarvisx.dr_moagi_cloud_runtime import ResourceLimits
+
+
+def test_field_step_operation_uses_canonical_bounded_runtime():
+    executor = DrMoagiFieldStepExecutor()
+    result = executor.execute(
+        {
+            "config": {
+                "side": 5,
+                "alpha": 0.0,
+                "lambda_residual": 0.0,
+                "eta": 0.0,
+                "dt": 0.1,
+                "expand_halo": False,
+            },
+            "field": [{"x": 2, "y": 2, "z": 2, "value": 0.5}],
+        },
+        ResourceLimits(),
+    )
+
+    assert result["operation"] == "dr-moagi-field-step.v1"
+    assert result["virtual_cell_count"] == 125
+    assert result["active_cell_count"] == 1
+    assert result["cycle"] == 1
+    assert result["metrics"]["committed"] is True
+    assert result["field"] == [
+        {"x": 2, "y": 2, "z": 2, "value": pytest.approx(0.5)}
+    ]
+
+
+def test_field_step_rejects_duplicate_sparse_coordinates():
+    executor = DrMoagiFieldStepExecutor()
+    with pytest.raises(ValueError, match="duplicate sparse coordinate"):
+        executor.execute(
+            {
+                "config": {"side": 5, "expand_halo": False},
+                "field": [
+                    {"x": 2, "y": 2, "z": 2, "value": 0.5},
+                    {"x": 2, "y": 2, "z": 2, "value": 0.6},
+                ],
+            },
+            ResourceLimits(),
+        )

--- a/tests/test_dr_moagi_cloud_runtime.py
+++ b/tests/test_dr_moagi_cloud_runtime.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from jarvisx.dr_moagi_cloud_runtime import (
+    AtomicJobStore,
+    DrMoagiCloudCoordinator,
+    EchoExecutor,
+    JobPolicy,
+    JobState,
+    ResourceLimits,
+)
+
+
+def coordinator(tmp_path: Path, verifier=None):
+    kwargs = {}
+    if verifier is not None:
+        kwargs["verifier"] = verifier
+    return DrMoagiCloudCoordinator(
+        executors={"echo.v1": EchoExecutor()},
+        policy=JobPolicy(
+            allowed_operations=frozenset({"echo.v1"}),
+            limits=ResourceLimits(
+                max_input_bytes=1024,
+                max_output_bytes=2048,
+                max_runtime_ms=1000,
+            ),
+        ),
+        store=AtomicJobStore(tmp_path),
+        clock_ms=iter(range(1000, 2000)).__next__,
+        **kwargs,
+    )
+
+
+def test_successful_job_commits_with_replayable_hash_chain(tmp_path):
+    runtime = coordinator(tmp_path)
+    job = runtime.submit(principal="user:doctor", operation="echo.v1", payload={"x": 7})
+
+    assert job["state"] == JobState.COMMITTED.value
+    assert job["result"] == {"echo": {"x": 7}}
+    assert [event["state"] for event in job["events"]] == [
+        "RECEIVED",
+        "VALIDATED",
+        "PLANNED",
+        "DISPATCHED",
+        "RUNNING",
+        "VERIFIED",
+        "COMMITTED",
+    ]
+    verification = runtime.verify_job(job["job_id"])
+    assert verification == {
+        "job_id": job["job_id"],
+        "verified": True,
+        "reason": "verified",
+        "state": "COMMITTED",
+        "event_count": 7,
+    }
+
+
+def test_verifier_rejection_prevents_commit(tmp_path):
+    runtime = coordinator(
+        tmp_path,
+        verifier=lambda result, context: (False, "policy test failed"),
+    )
+    job = runtime.submit(principal="user:doctor", operation="echo.v1", payload={"x": 7})
+
+    assert job["state"] == JobState.REJECTED.value
+    assert job["result"] is None
+    assert job["result_digest"] is None
+    assert job["verification"] == {"passed": False, "reason": "policy test failed"}
+    assert job["events"][-1]["details"]["reason"].startswith("verification failed")
+
+
+def test_input_limit_fails_before_job_creation(tmp_path):
+    runtime = coordinator(tmp_path)
+    with pytest.raises(ValueError, match="max_input_bytes"):
+        runtime.submit(
+            principal="user:doctor",
+            operation="echo.v1",
+            payload={"x": "z" * 2000},
+        )
+    assert runtime.store.count() == 0
+
+
+def test_operation_policy_is_fail_closed(tmp_path):
+    runtime = coordinator(tmp_path)
+    with pytest.raises(PermissionError, match="not allowed"):
+        runtime.submit(principal="user:doctor", operation="shell.exec", payload={})
+    assert runtime.store.count() == 0
+
+
+def test_tampering_is_detected(tmp_path):
+    runtime = coordinator(tmp_path)
+    job = runtime.submit(principal="user:doctor", operation="echo.v1", payload={"x": 7})
+    path = tmp_path / f"{job['job_id']}.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["result"]["echo"]["x"] = 8
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    verification = runtime.verify_job(job["job_id"])
+    assert not verification["verified"]
+    assert verification["reason"] == "envelope digest mismatch"
+
+
+def test_executor_exception_is_journalled_failed(tmp_path):
+    class Boom:
+        def execute(self, payload, limits):
+            raise RuntimeError("boom")
+
+    runtime = DrMoagiCloudCoordinator(
+        executors={"boom.v1": Boom()},
+        policy=JobPolicy(allowed_operations=frozenset({"boom.v1"})),
+        store=AtomicJobStore(tmp_path),
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        runtime.submit(principal="user:doctor", operation="boom.v1", payload={})
+
+    paths = list(tmp_path.glob("*.json"))
+    assert len(paths) == 1
+    failed = json.loads(paths[0].read_text(encoding="utf-8"))
+    assert failed["state"] == JobState.FAILED.value
+    assert failed["events"][-1]["state"] == JobState.FAILED.value

--- a/tests/test_dr_moagi_cloud_service.py
+++ b/tests/test_dr_moagi_cloud_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from jarvisx.dr_moagi_cloud_runtime import (
+    AtomicJobStore,
+    DrMoagiCloudCoordinator,
+    EchoExecutor,
+    JobPolicy,
+)
+from jarvisx.dr_moagi_cloud_service import CloudServiceSettings, create_app
+
+
+def make_client(tmp_path: Path, *, auth: bool = False) -> TestClient:
+    settings = CloudServiceSettings(
+        data_dir=tmp_path,
+        api_key="secret" if auth else None,
+        require_api_key=auth,
+    )
+    runtime = DrMoagiCloudCoordinator(
+        executors={"echo.v1": EchoExecutor()},
+        policy=JobPolicy(allowed_operations=frozenset({"echo.v1"})),
+        store=AtomicJobStore(tmp_path),
+    )
+    return TestClient(create_app(settings, runtime))
+
+
+def test_end_to_end_job_api(tmp_path):
+    client = make_client(tmp_path)
+    response = client.post(
+        "/api/v1/jobs",
+        json={"operation": "echo.v1", "input": {"value": 42}, "request_id": "r-1"},
+    )
+    assert response.status_code == 201
+    job = response.json()
+    assert job["state"] == "COMMITTED"
+
+    fetched = client.get(f"/api/v1/jobs/{job['job_id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["result"] == {"echo": {"value": 42}}
+
+    verified = client.post(f"/api/v1/jobs/{job['job_id']}/verify")
+    assert verified.status_code == 200
+    assert verified.json()["verified"] is True
+
+    events = client.get(f"/api/v1/jobs/{job['job_id']}/events")
+    assert events.status_code == 200
+    assert events.json()["events"][-1]["state"] == "COMMITTED"
+
+
+def test_api_key_and_principal_are_enforced(tmp_path):
+    client = make_client(tmp_path, auth=True)
+    request = {"operation": "echo.v1", "input": {"value": 1}}
+    assert client.post("/api/v1/jobs", json=request).status_code == 401
+
+    response = client.post(
+        "/api/v1/jobs",
+        json=request,
+        headers={"X-Dr-Moagi-Key": "secret", "X-Dr-Moagi-Principal": "user:test"},
+    )
+    assert response.status_code == 201
+    assert response.json()["principal"] == "user:test"
+
+
+def test_policy_denial_is_403(tmp_path):
+    client = make_client(tmp_path)
+    response = client.post("/api/v1/jobs", json={"operation": "shell.exec", "input": {}})
+    assert response.status_code == 403
+
+
+def test_health_and_metrics(tmp_path):
+    client = make_client(tmp_path)
+    assert client.get("/health/live").json()["status"] == "live"
+    assert client.get("/health/ready").json()["store_ready"] is True
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    assert "dr_moagi_cloud_jobs_stored 0" in metrics.text


### PR DESCRIPTION
## What changed

Introduces the first production-oriented Dr Moagi Cloud execution spine:

- durable `job_id` transaction envelope and explicit lifecycle (`RECEIVED` → `COMMITTED` / terminal failure);
- SHA-256 hash-chained event journal plus envelope/result integrity verification;
- fail-closed operation policy and verifier gate;
- explicit input/output/runtime ceilings;
- FastAPI control surface for create, fetch, events, replay verification, health and metrics;
- bootstrap API-key authentication with principal propagation;
- bounded `dr-moagi-field-step.v1` adapter over the canonical `DrMoagiFieldRuntime`;
- canonical JSON shape validation at typed coordinator/API boundaries;
- container recipe and dedicated conformance workflow;
- ADR-010 and operations documentation;
- `httpx2` in test/dev extras to satisfy the current Starlette `TestClient` contract.

## Why

The deployed Dr Moagi Cloud needs an authority boundary that distinguishes generated/executed candidates from committed system state. This preserves the existing Jarvis-X deterministic-core and candidate-first invariants while giving cloud jobs durable identity, evidence, policy enforcement, replay and rollback semantics.

## Current scope

- base: `main` at `5b3554789ff1fc8f24c9f7af71932558bdf6acc8`;
- head: `37a2dc7cb40bdc7a0dd83d01f80f08c5f64f4fa2`;
- 11 changed files;
- `main` remains untouched pending review/merge.

## Validation — green on current head

- **Dr Moagi Cloud Runtime** dedicated conformance workflow;
- **Jarvis-X CI** quality gate, including compile, undefined-name checks and `mypy`;
- Python **3.10, 3.11, 3.12 and 3.13** test matrix;
- dependency audit;
- source/wheel build, metadata validation and built-wheel smoke test;
- **Hyperion Operational Service** compatibility workflow;
- **Empirical Validation** workflow;
- **CodeQL** Python analysis.

CI also caught and drove two corrections during this PR: the missing `httpx2` test dependency and six `mypy` `no-any-return` violations at JSON boundaries. Both are fixed on the current head and the corresponding gates now pass.

## Deliberate v1 limits

- synchronous dispatch (state machine is queue-ready, but no external durable queue yet);
- filesystem evidence store (atomic single-node reference implementation, not replicated storage);
- API-key bootstrap authentication rather than OIDC/mTLS;
- runtime ceiling is post-execution elapsed-time rejection, not a hard sandbox kill.

ADR-010 remains **Proposed** while the change is a draft PR; its acceptance criteria are now demonstrated by CI and it can be promoted as part of the merge decision.