### PR TITLE
Add Dr Moagi permeation transport v1

### DIFF
--- a/.github/workflows/dr-moagi-permeation.yml
+++ b/.github/workflows/dr-moagi-permeation.yml
@@ -26,12 +26,17 @@ permissions:
 
 jobs:
   conformance:
+    name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Install test dependencies
         run: python -m pip install -e ".[test]"
@@ -41,3 +46,50 @@ jobs:
           tests/test_dr_moagi_permeation.py
           tests/test_dr_moagi_permeation_cloud.py
           --no-cov
+
+  quality:
+    name: Permeation quality gate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+      - name: Compile permeation sources and tests
+        run: >-
+          python -m compileall -q
+          src/jarvisx/dr_moagi_permeation.py
+          src/jarvisx/dr_moagi_permeation_operation.py
+          src/jarvisx/dr_moagi_cloud_service.py
+          tests/test_dr_moagi_permeation.py
+          tests/test_dr_moagi_permeation_cloud.py
+      - name: Reject syntax errors and undefined names
+        run: >-
+          flake8
+          src/jarvisx/dr_moagi_permeation.py
+          src/jarvisx/dr_moagi_permeation_operation.py
+          src/jarvisx/dr_moagi_cloud_service.py
+          tests/test_dr_moagi_permeation.py
+          tests/test_dr_moagi_permeation_cloud.py
+          --select=E9,F63,F7,F82
+          --show-source
+          --statistics
+      - name: Check permeation formatting
+        run: >-
+          black --check --diff
+          src/jarvisx/dr_moagi_permeation.py
+          src/jarvisx/dr_moagi_permeation_operation.py
+          tests/test_dr_moagi_permeation.py
+          tests/test_dr_moagi_permeation_cloud.py
+      - name: Check permeation import order
+        run: >-
+          isort --check-only --diff
+          src/jarvisx/dr_moagi_permeation.py
+          src/jarvisx/dr_moagi_permeation_operation.py
+          tests/test_dr_moagi_permeation.py
+          tests/test_dr_moagi_permeation_cloud.py
+      - name: Type-check package
+        run: mypy src/jarvisx --ignore-missing-imports

--- a/.github/workflows/dr-moagi-permeation.yml
+++ b/.github/workflows/dr-moagi-permeation.yml
@@ -1,0 +1,43 @@
+name: Dr Moagi Permeation Transport
+
+on:
+  pull_request:
+    paths:
+      - "src/jarvisx/dr_moagi_permeation.py"
+      - "src/jarvisx/dr_moagi_permeation_operation.py"
+      - "src/jarvisx/dr_moagi_cloud_service.py"
+      - "tests/test_dr_moagi_permeation.py"
+      - "tests/test_dr_moagi_permeation_cloud.py"
+      - "docs/DR_MOAGI_PERMEATION_TRANSPORT_V1.md"
+      - "docs/adr/0011-dr-moagi-permeation-transport-v1.md"
+      - ".github/workflows/dr-moagi-permeation.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/jarvisx/dr_moagi_permeation.py"
+      - "src/jarvisx/dr_moagi_permeation_operation.py"
+      - "src/jarvisx/dr_moagi_cloud_service.py"
+      - "tests/test_dr_moagi_permeation.py"
+      - "tests/test_dr_moagi_permeation_cloud.py"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install test dependencies
+        run: python -m pip install -e ".[test]"
+      - name: Run permeation conformance tests
+        run: >-
+          python -m pytest
+          tests/test_dr_moagi_permeation.py
+          tests/test_dr_moagi_permeation_cloud.py
+          --no-cov

--- a/docs/DR_MOAGI_PERMEATION_TRANSPORT_V1.md
+++ b/docs/DR_MOAGI_PERMEATION_TRANSPORT_V1.md
@@ -1,0 +1,178 @@
+# Dr Moagi Permeation Transport v1
+
+## Purpose
+
+This module turns the permeation concept into a bounded, replayable software transport path:
+
+```text
+state -> encode -> modulate -> channel -> demodulate -> verify -> reconstruct
+```
+
+It is intentionally a **simulation/transport layer**. It does not transmit RF energy and does not access radio hardware.
+
+## Runtime equation
+
+For one BPSK symbol `s_n in {-1, +1}` the reference channel is:
+
+```text
+y_n = h s_n + noise_n
+```
+
+where
+
+```text
+h = Q * A(theta) / (4 pi r) * exp(i k r)
+k = 2 pi / lambda
+lambda = c / f
+A(theta) = w0 + w2 * (3 cos(theta)^2 - 1) / 2
+```
+
+The receiver uses the known simulated coefficient:
+
+```text
+s_hat_n = y_n / h
+bit_n = 1 if Re(s_hat_n) >= 0 else 0
+```
+
+The reconstructed byte stream is accepted only when its SHA-256 digest equals the digest bound before modulation.
+
+## Defaults
+
+| Parameter | Default |
+|---|---:|
+| carrier frequency | 333,330,000 Hz |
+| propagation speed | 299,792,458 m/s |
+| source strength `Q` | 0.941 |
+| coherence metadata | 0.967 |
+| range | 1 m |
+| monopole weight | 0.6 |
+| quadrupole weight | 0.4 |
+| axis | `[0, 1, 0]` |
+| receiver direction | `[0, 1, 0]` |
+| noise standard deviation | 0 |
+| payload ceiling | 65,536 bytes |
+
+At the defaults:
+
+```text
+wavelength ~= 0.8993863679 m
+wave number ~= 6.9860802117 rad/m
+1 m propagation delay ~= 3.335640952 ns
+aligned scalar amplitude ~= 0.0748824007
+```
+
+## Operational commands
+
+### FOCUS
+
+Software meaning:
+
+```python
+focused = config.focused((x, y, z))
+```
+
+This rotates the quadrupole axis used by the scalar angular-gain model. The v1 quadrupole is symmetric about both directions of the axis.
+
+### MODULATE
+
+Software meaning:
+
+```python
+frame = modulate(state, config)
+```
+
+The state is serialized as canonical JSON, hashed, converted to bits, and mapped to BPSK symbols.
+
+### PROPAGATE
+
+Software meaning:
+
+```python
+received = propagate(frame, config)
+```
+
+Each symbol receives the configured `1/r` amplitude, carrier phase, angular gain, and optional seeded Gaussian complex noise.
+
+### ABSORB
+
+Software meaning:
+
+```python
+state_hat = absorb(received)
+```
+
+The receiver equalizes the simulated channel, demodulates bits, reconstructs bytes, verifies the digest, and parses the JSON state. Digest mismatch fails closed.
+
+## Cloud operation
+
+The default Dr Moagi Cloud coordinator registers:
+
+```text
+permeate-roundtrip.v1
+```
+
+Example request:
+
+```json
+{
+  "operation": "permeate-roundtrip.v1",
+  "request_id": "permeation-demo-001",
+  "input": {
+    "state": {
+      "latent": [0.1, 0.2, 0.3],
+      "intent": "externalize-and-reconstruct"
+    },
+    "config": {
+      "carrier_hz": 333330000.0,
+      "range_m": 1.0,
+      "axis": [0.0, 1.0, 0.0],
+      "receiver_direction": [0.0, 1.0, 0.0]
+    }
+  }
+}
+```
+
+A successful result contains transport telemetry similar to:
+
+```json
+{
+  "operation": "permeate-roundtrip.v1",
+  "protocol": "jarvisx.dr-moagi-permeation.v1",
+  "physical_rf": false,
+  "model": "deterministic-bpsk-scalar-free-space-simulation",
+  "carrier_hz": 333330000.0,
+  "wavelength_m": 0.8993863678636786,
+  "range_m": 1.0,
+  "propagation_delay_ns": 3.3356409519815204,
+  "verified": true,
+  "reconstructed": {}
+}
+```
+
+The result is still only a candidate until the Cloud Runtime verification and promotion gate records `COMMITTED`.
+
+## Resource behavior
+
+The transport rejects a payload before BPSK symbol expansion if its canonical JSON representation exceeds `max_payload_bytes`.
+
+The cloud adapter additionally prevents `max_payload_bytes` from exceeding the enclosing cloud job input budget.
+
+A payload of `N` encoded bytes produces exactly:
+
+```text
+8N BPSK symbols
+```
+
+so symbol-memory cost remains explicit and bounded.
+
+## Interpretation boundary
+
+`carrier_hz`, `wavelength_m`, `range_m`, `propagation_delay_ns`, and `amplitude_at_receiver` describe the **software channel model**. They do not establish that an RF carrier exists outside the process.
+
+Every transport result therefore exposes:
+
+```text
+physical_rf = false
+```
+
+A future hardware adapter must be implemented and validated separately.

--- a/docs/adr/0011-dr-moagi-permeation-transport-v1.md
+++ b/docs/adr/0011-dr-moagi-permeation-transport-v1.md
@@ -1,0 +1,187 @@
+# ADR-011: Adopt Dr Moagi permeation transport v1 as a bounded software channel
+
+**Status:** Proposed  
+**Date:** 2026-08-18  
+**Extends:** ADR-010, ADR-003
+
+## Context
+
+The Dr Moagi architecture uses **permeation** to describe externalising an internal state so that another endpoint can reconstruct the same representation. Earlier mathematical descriptions used a 333.33 MHz carrier, scalar Green-function propagation, a mixed monopole/quadrupole angular pattern, and the commands `FOCUS`, `MODULATE`, and `ABSORB`.
+
+Those descriptions must not be interpreted as proof that Jarvis-X radiates a physical electromagnetic field. The repository currently has no RF device driver, SDR backend, antenna model, transmitter power stage, spectrum-control layer, or receiver hardware integration.
+
+The useful executable contract is therefore the information-transport path:
+
+```text
+internal state
+-> canonical serialization
+-> modulation
+-> bounded channel model
+-> equalization / demodulation
+-> digest verification
+-> reconstructed state
+```
+
+This can be implemented and tested now while keeping physical-RF claims explicitly false.
+
+## Decision
+
+Jarvis-X adopts `jarvisx.dr-moagi-permeation.v1` as a deterministic **software channel simulator and transport contract**.
+
+The reference path is:
+
+```text
+Xi*
+-> canonical JSON
+-> SHA-256 frame identity
+-> BPSK symbols
+-> scalar 1/r Green-function channel
+-> carrier phase e^(ikr)
+-> optional deterministic Gaussian noise
+-> equalization
+-> BPSK demodulation
+-> SHA-256 verification
+-> JSON reconstruction
+-> Pi_Lambda / cloud commit
+```
+
+The scalar channel coefficient is
+
+```text
+h(r, theta) = Q * A(theta) / (4 pi r) * exp(i k r)
+```
+
+with
+
+```text
+k = 2 pi / lambda
+lambda = c / f
+```
+
+and the v1 angular pattern
+
+```text
+A(theta) = w0 + w2 * P2(cos(theta))
+P2(x) = (3x^2 - 1) / 2.
+```
+
+The default numerical parameters are:
+
+```text
+f = 333.33 MHz
+c = 299,792,458 m/s
+Q = 0.941
+coherence = 0.967
+w0 = 0.6
+w2 = 0.4
+range = 1 m
+```
+
+which produce approximately:
+
+```text
+lambda = 0.899386 m
+k = 6.986080 rad/m
+delay(1 m) = 3.335641 ns
+|h|(1 m, aligned axis) = 0.0748824
+```
+
+`coherence` is retained as declared transport metadata in v1; it is not silently converted into transmitter power, SNR, or a physical coherence model.
+
+## Command semantics
+
+### `FOCUS Phi [x,y,z]`
+
+Rotates the simulated quadrupole axis. Because the v1 `l=2` pattern uses `P2`, the pattern is symmetric about `+axis` and `-axis`. It is **not** one-sided beamforming. One-sided steering would require a separately accepted phased-array or vector-field model.
+
+### `MODULATE Phi [state]`
+
+Canonicalizes the JSON state and maps each bit to deterministic BPSK:
+
+```text
+0 -> -1
+1 -> +1
+```
+
+The canonical payload digest is bound to the frame before channel propagation.
+
+### `ABSORB Phi`
+
+Equalizes the known software-channel coefficient, demodulates the BPSK symbols, reconstructs bytes, verifies the SHA-256 digest, parses canonical JSON, and rejects corrupted frames.
+
+## Cloud integration
+
+The reference cloud operation is:
+
+```text
+permeate-roundtrip.v1
+```
+
+with request shape:
+
+```json
+{
+  "operation": "permeate-roundtrip.v1",
+  "input": {
+    "state": {"latent": [0, 1, 2]},
+    "config": {
+      "carrier_hz": 333330000.0,
+      "range_m": 1.0,
+      "axis": [0.0, 1.0, 0.0],
+      "receiver_direction": [0.0, 1.0, 0.0]
+    }
+  }
+}
+```
+
+The operation runs inside the ADR-010 job transaction. A transport result becomes authoritative only after the cloud verifier/policy gate commits the job.
+
+Every result includes:
+
+```text
+physical_rf = false
+```
+
+so simulated carrier parameters cannot be mistaken for actual transmitter activity.
+
+## Required invariants
+
+1. Physical-RF status is explicit and false for this implementation.
+2. Payloads are canonicalized before hashing and modulation.
+3. The payload digest is verified after demodulation before reconstruction is accepted.
+4. Symbol corruption must fail closed.
+5. Payload size is bounded before bit/symbol expansion.
+6. Channel configuration values are finite and bounded.
+7. A channel null is rejected before execution.
+8. `FOCUS` rotates only the software angular model.
+9. The quadrupole pattern is not described as one-sided beamforming.
+10. The cloud operation remains subject to ADR-010 job identity, resource limits, verification, evidence journaling, and commit semantics.
+
+## Non-goals
+
+This ADR does not implement or authorize:
+
+- an SDR or RF transmitter;
+- antenna control;
+- spectrum selection or regulatory compliance;
+- radiated-power accounting;
+- hardware beamforming;
+- wireless key exchange;
+- physical receiver synchronization;
+- a Maxwell-equation vector-field solver.
+
+Any future physical-RF adapter requires its own architecture decision, hardware abstraction, safety/resource controls, and jurisdiction-appropriate spectrum compliance.
+
+## Validation
+
+Acceptance requires:
+
+- exact 16D latent round-trip reconstruction in the zero-noise reference case;
+- numerical regression checks for wavelength, wave number, 1 m delay, and default 1/r amplitude;
+- quadrupole-axis rotation tests;
+- digest rejection after symbol corruption;
+- payload-budget rejection before symbol expansion;
+- authenticated cloud create -> execute -> verify -> committed-event replay;
+- CI quality/type/security gates on the stacked branch.
+
+The normative operational specification is maintained in `docs/DR_MOAGI_PERMEATION_TRANSPORT_V1.md`.

--- a/src/jarvisx/dr_moagi_cloud_service.py
+++ b/src/jarvisx/dr_moagi_cloud_service.py
@@ -20,6 +20,7 @@ from .dr_moagi_cloud_runtime import (
     JsonObject,
     ResourceLimits,
 )
+from .dr_moagi_permeation_operation import DrMoagiPermeationExecutor
 
 DEFAULT_DATA_DIR = Path("state/dr-moagi-cloud")
 
@@ -93,13 +94,21 @@ def build_default_coordinator(settings: CloudServiceSettings) -> DrMoagiCloudCoo
         max_output_bytes=settings.max_output_bytes,
         max_runtime_ms=settings.max_runtime_ms,
     )
+    operations = frozenset(
+        {
+            "echo.v1",
+            "dr-moagi-field-step.v1",
+            "permeate-roundtrip.v1",
+        }
+    )
     return DrMoagiCloudCoordinator(
         executors={
             "echo.v1": EchoExecutor(),
             "dr-moagi-field-step.v1": DrMoagiFieldStepExecutor(),
+            "permeate-roundtrip.v1": DrMoagiPermeationExecutor(),
         },
         policy=JobPolicy(
-            allowed_operations=frozenset({"echo.v1", "dr-moagi-field-step.v1"}),
+            allowed_operations=operations,
             limits=limits,
         ),
         store=AtomicJobStore(settings.data_dir),

--- a/src/jarvisx/dr_moagi_permeation.py
+++ b/src/jarvisx/dr_moagi_permeation.py
@@ -1,0 +1,255 @@
+"""Deterministic software transport model for Dr Moagi permeation.
+
+This module models encode -> modulate -> scalar free-space channel -> demodulate
+-> verify -> reconstruct. Carrier frequency and propagation are simulation
+parameters only; the implementation does not access RF hardware or radiate.
+"""
+
+from __future__ import annotations
+
+import cmath
+import hashlib
+import json
+import math
+import random
+from dataclasses import dataclass, replace
+from typing import Any, Mapping, Sequence
+
+PROTOCOL = "jarvisx.dr-moagi-permeation.v1"
+
+
+class PermeationIntegrityError(ValueError):
+    """Raised when a received frame cannot be reconstructed with integrity."""
+
+
+@dataclass(frozen=True, slots=True)
+class PermeationConfig:
+    """Bounded software-channel parameters for one permeation transaction."""
+
+    carrier_hz: float = 333_330_000.0
+    propagation_speed_m_s: float = 299_792_458.0
+    source_strength: float = 0.941
+    range_m: float = 1.0
+    coherence: float = 0.967
+    omni_weight: float = 0.6
+    quadrupole_weight: float = 0.4
+    axis: tuple[float, float, float] = (0.0, 1.0, 0.0)
+    receiver_direction: tuple[float, float, float] = (0.0, 1.0, 0.0)
+    noise_std: float = 0.0
+    noise_seed: int = 0
+    max_payload_bytes: int = 65_536
+
+    def __post_init__(self) -> None:
+        for name in (
+            "carrier_hz",
+            "propagation_speed_m_s",
+            "source_strength",
+            "range_m",
+            "coherence",
+            "omni_weight",
+            "quadrupole_weight",
+            "noise_std",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if self.carrier_hz <= 0 or self.propagation_speed_m_s <= 0 or self.range_m <= 0:
+            raise ValueError("carrier_hz, propagation_speed_m_s and range_m must be positive")
+        if self.source_strength <= 0:
+            raise ValueError("source_strength must be positive")
+        if not 0.0 < self.coherence <= 1.0:
+            raise ValueError("coherence must be in (0, 1]")
+        if self.omni_weight < 0 or self.quadrupole_weight < 0:
+            raise ValueError("angular weights must be non-negative")
+        if self.omni_weight + self.quadrupole_weight <= 0:
+            raise ValueError("at least one angular weight must be positive")
+        if self.noise_std < 0:
+            raise ValueError("noise_std must be non-negative")
+        if isinstance(self.noise_seed, bool) or not isinstance(self.noise_seed, int):
+            raise TypeError("noise_seed must be an integer")
+        if isinstance(self.max_payload_bytes, bool) or not isinstance(self.max_payload_bytes, int):
+            raise TypeError("max_payload_bytes must be an integer")
+        if self.max_payload_bytes <= 0:
+            raise ValueError("max_payload_bytes must be positive")
+        _unit_vector(self.axis, "axis")
+        _unit_vector(self.receiver_direction, "receiver_direction")
+        if abs(self.angular_gain) < 1e-12:
+            raise ValueError("configured angular pattern has a channel null at the receiver")
+
+    @property
+    def wavelength_m(self) -> float:
+        return self.propagation_speed_m_s / self.carrier_hz
+
+    @property
+    def wave_number_rad_m(self) -> float:
+        return 2.0 * math.pi / self.wavelength_m
+
+    @property
+    def propagation_delay_ns(self) -> float:
+        return self.range_m / self.propagation_speed_m_s * 1e9
+
+    @property
+    def angular_gain(self) -> float:
+        """Return an axis-rotated l=0 plus l=2 Legendre-pattern gain.
+
+        This is a scalar quadrupole abstraction, not an antenna solver. A pure
+        l=2 pattern is symmetric about +/-axis; one-sided beamforming requires
+        a different phased-array model.
+        """
+
+        axis = _unit_vector(self.axis, "axis")
+        receiver = _unit_vector(self.receiver_direction, "receiver_direction")
+        cosine = sum(a * b for a, b in zip(axis, receiver))
+        p2 = 0.5 * (3.0 * cosine * cosine - 1.0)
+        return self.omni_weight + self.quadrupole_weight * p2
+
+    @property
+    def channel_coefficient(self) -> complex:
+        amplitude = self.source_strength * self.angular_gain / (4.0 * math.pi * self.range_m)
+        phase = self.wave_number_rad_m * self.range_m
+        return amplitude * cmath.exp(1j * phase)
+
+    def focused(self, axis: Sequence[float]) -> "PermeationConfig":
+        """Implement FOCUS Phi by rotating the quadrupole axis in the simulation."""
+
+        return replace(self, axis=_unit_vector(axis, "axis"))
+
+
+@dataclass(frozen=True, slots=True)
+class ModulatedFrame:
+    payload_digest: str
+    payload_length: int
+    symbols: tuple[float, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ReceivedFrame:
+    payload_digest: str
+    payload_length: int
+    samples: tuple[complex, ...]
+    channel_coefficient: complex
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def modulate(payload: Mapping[str, Any], config: PermeationConfig) -> ModulatedFrame:
+    """Implement MODULATE Phi using deterministic BPSK over canonical JSON."""
+
+    encoded = canonical_json_bytes(payload)
+    if len(encoded) > config.max_payload_bytes:
+        raise ValueError("payload exceeds max_payload_bytes")
+    digest = hashlib.sha256(encoded).hexdigest()
+    symbols: list[float] = []
+    for byte in encoded:
+        for shift in range(7, -1, -1):
+            bit = (byte >> shift) & 1
+            symbols.append(1.0 if bit else -1.0)
+    return ModulatedFrame(digest, len(encoded), tuple(symbols))
+
+
+def propagate(frame: ModulatedFrame, config: PermeationConfig) -> ReceivedFrame:
+    """Apply scalar 1/r propagation, carrier phase and deterministic optional noise."""
+
+    coefficient = config.channel_coefficient
+    rng = random.Random(config.noise_seed)
+    samples: list[complex] = []
+    for symbol in frame.symbols:
+        noise = 0j
+        if config.noise_std:
+            noise = complex(
+                rng.gauss(0.0, config.noise_std),
+                rng.gauss(0.0, config.noise_std),
+            )
+        samples.append(coefficient * symbol + noise)
+    return ReceivedFrame(frame.payload_digest, frame.payload_length, tuple(samples), coefficient)
+
+
+def absorb(frame: ReceivedFrame) -> dict[str, Any]:
+    """Implement ABSORB Phi by equalizing, demodulating and verifying the frame."""
+
+    coefficient = frame.channel_coefficient
+    if abs(coefficient) < 1e-15:
+        raise PermeationIntegrityError("channel coefficient is too small to equalize")
+    bits: list[int] = []
+    for sample in frame.samples:
+        equalized = sample / coefficient
+        bits.append(1 if equalized.real >= 0.0 else 0)
+    if len(bits) % 8:
+        raise PermeationIntegrityError("symbol count is not byte aligned")
+
+    decoded = bytearray()
+    for offset in range(0, len(bits), 8):
+        value = 0
+        for bit in bits[offset : offset + 8]:
+            value = (value << 1) | bit
+        decoded.append(value)
+    if len(decoded) != frame.payload_length:
+        raise PermeationIntegrityError("payload length mismatch")
+    digest = hashlib.sha256(bytes(decoded)).hexdigest()
+    if digest != frame.payload_digest:
+        raise PermeationIntegrityError("payload digest mismatch")
+    try:
+        value = json.loads(bytes(decoded).decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise PermeationIntegrityError("reconstructed payload is not valid JSON") from error
+    if not isinstance(value, dict):
+        raise PermeationIntegrityError("reconstructed payload must be a JSON object")
+    return value
+
+
+def simulate_round_trip(payload: Mapping[str, Any], config: PermeationConfig) -> dict[str, Any]:
+    """Run the full software permeation path and emit auditable telemetry."""
+
+    frame = modulate(payload, config)
+    received = propagate(frame, config)
+    reconstructed = absorb(received)
+    return {
+        "protocol": PROTOCOL,
+        "physical_rf": False,
+        "model": "deterministic-bpsk-scalar-free-space-simulation",
+        "carrier_hz": config.carrier_hz,
+        "wavelength_m": config.wavelength_m,
+        "wave_number_rad_m": config.wave_number_rad_m,
+        "range_m": config.range_m,
+        "propagation_delay_ns": config.propagation_delay_ns,
+        "source_strength": config.source_strength,
+        "coherence": config.coherence,
+        "angular_gain": config.angular_gain,
+        "amplitude_at_receiver": abs(config.channel_coefficient),
+        "payload_bytes": frame.payload_length,
+        "symbol_count": len(frame.symbols),
+        "payload_digest": frame.payload_digest,
+        "verified": reconstructed == dict(payload),
+        "reconstructed": reconstructed,
+    }
+
+
+def _unit_vector(values: Sequence[float], name: str) -> tuple[float, float, float]:
+    if len(values) != 3:
+        raise ValueError(f"{name} must contain exactly three components")
+    converted: list[float] = []
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} components must be numeric")
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            raise ValueError(f"{name} components must be finite")
+        converted.append(numeric)
+    norm = math.sqrt(sum(value * value for value in converted))
+    if norm <= 0.0:
+        raise ValueError(f"{name} must be non-zero")
+    return (
+        converted[0] / norm,
+        converted[1] / norm,
+        converted[2] / norm,
+    )

--- a/src/jarvisx/dr_moagi_permeation.py
+++ b/src/jarvisx/dr_moagi_permeation.py
@@ -13,7 +13,7 @@ import json
 import math
 import random
 from dataclasses import dataclass, replace
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, cast
 
 PROTOCOL = "jarvisx.dr-moagi-permeation.v1"
 
@@ -204,7 +204,7 @@ def absorb(frame: ReceivedFrame) -> dict[str, Any]:
         raise PermeationIntegrityError("reconstructed payload is not valid JSON") from error
     if not isinstance(value, dict):
         raise PermeationIntegrityError("reconstructed payload must be a JSON object")
-    return value
+    return cast(dict[str, Any], value)
 
 
 def simulate_round_trip(payload: Mapping[str, Any], config: PermeationConfig) -> dict[str, Any]:

--- a/src/jarvisx/dr_moagi_permeation_operation.py
+++ b/src/jarvisx/dr_moagi_permeation_operation.py
@@ -1,0 +1,63 @@
+"""Cloud-operation adapter for the Dr Moagi permeation transport."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+from .dr_moagi_cloud_runtime import ResourceLimits
+from .dr_moagi_permeation import PermeationConfig, simulate_round_trip
+
+
+class DrMoagiPermeationExecutor:
+    """Execute one bounded software permeation round trip."""
+
+    _CONFIG_FIELDS = frozenset(
+        {
+            "carrier_hz",
+            "propagation_speed_m_s",
+            "source_strength",
+            "range_m",
+            "coherence",
+            "omni_weight",
+            "quadrupole_weight",
+            "axis",
+            "receiver_direction",
+            "noise_std",
+            "noise_seed",
+            "max_payload_bytes",
+        }
+    )
+
+    def execute(self, payload: Mapping[str, Any], limits: ResourceLimits) -> Mapping[str, Any]:
+        raw_state = payload.get("state")
+        if not isinstance(raw_state, dict):
+            raise ValueError("state must be a JSON object")
+        raw_config = payload.get("config", {})
+        if not isinstance(raw_config, dict):
+            raise ValueError("config must be a JSON object")
+        unknown = set(raw_config).difference(self._CONFIG_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown permeation config keys: {sorted(unknown)}")
+
+        config_payload = dict(raw_config)
+        for vector_name in ("axis", "receiver_direction"):
+            if vector_name in config_payload:
+                value = config_payload[vector_name]
+                if not isinstance(value, list) or len(value) != 3:
+                    raise ValueError(f"{vector_name} must be a three-element list")
+                config_payload[vector_name] = tuple(value)
+
+        configured_max = config_payload.get("max_payload_bytes")
+        if configured_max is None:
+            config_payload["max_payload_bytes"] = min(65_536, limits.max_input_bytes)
+        elif isinstance(configured_max, bool) or not isinstance(configured_max, int):
+            raise ValueError("max_payload_bytes must be an integer")
+        elif configured_max > limits.max_input_bytes:
+            raise ValueError("max_payload_bytes exceeds cloud input budget")
+
+        config = PermeationConfig(**config_payload)
+        result = simulate_round_trip(raw_state, config)
+        return {
+            "operation": "permeate-roundtrip.v1",
+            **result,
+        }

--- a/tests/test_dr_moagi_permeation.py
+++ b/tests/test_dr_moagi_permeation.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.dr_moagi_permeation import (
+    PermeationConfig,
+    PermeationIntegrityError,
+    ReceivedFrame,
+    absorb,
+    modulate,
+    propagate,
+    simulate_round_trip,
+)
+
+
+def _state() -> dict[str, object]:
+    return {
+        "latent": [index / 10.0 for index in range(16)],
+        "geometry": {"vpx_density": 0.72, "vpx_velocity": [0.1, -0.2, 0.3]},
+        "intent": "fixed-point-description",
+    }
+
+
+def test_declared_default_field_numbers_are_reproducible():
+    config = PermeationConfig()
+
+    assert config.wavelength_m == pytest.approx(0.8993863678636786)
+    assert config.wave_number_rad_m == pytest.approx(6.986080211671541)
+    assert config.propagation_delay_ns == pytest.approx(3.3356409519815204)
+    assert abs(config.channel_coefficient) == pytest.approx(0.941 / (4.0 * math.pi))
+
+
+def test_round_trip_reconstructs_16d_state_exactly():
+    result = simulate_round_trip(_state(), PermeationConfig())
+
+    assert result["physical_rf"] is False
+    assert result["verified"] is True
+    assert result["reconstructed"] == _state()
+    assert result["symbol_count"] == result["payload_bytes"] * 8
+
+
+def test_focus_rotates_the_quadrupole_axis_without_claiming_one_sided_beamforming():
+    aligned = PermeationConfig(axis=(0.0, 1.0, 0.0), receiver_direction=(0.0, 1.0, 0.0))
+    perpendicular = aligned.focused((1.0, 0.0, 0.0))
+    opposite = PermeationConfig(
+        axis=(0.0, -1.0, 0.0), receiver_direction=(0.0, 1.0, 0.0)
+    )
+
+    assert aligned.angular_gain == pytest.approx(1.0)
+    assert perpendicular.angular_gain == pytest.approx(0.4)
+    assert opposite.angular_gain == pytest.approx(1.0)
+
+
+def test_absorb_rejects_symbol_corruption():
+    config = PermeationConfig()
+    received = propagate(modulate(_state(), config), config)
+    samples = list(received.samples)
+    samples[0] = -samples[0]
+    corrupted = ReceivedFrame(
+        payload_digest=received.payload_digest,
+        payload_length=received.payload_length,
+        samples=tuple(samples),
+        channel_coefficient=received.channel_coefficient,
+    )
+
+    with pytest.raises(PermeationIntegrityError, match="digest mismatch"):
+        absorb(corrupted)
+
+
+def test_payload_budget_is_enforced_before_symbol_expansion():
+    with pytest.raises(ValueError, match="max_payload_bytes"):
+        modulate({"payload": "x" * 100}, PermeationConfig(max_payload_bytes=16))
+
+
+def test_channel_null_is_rejected():
+    with pytest.raises(ValueError, match="channel null"):
+        PermeationConfig(
+            omni_weight=0.2,
+            quadrupole_weight=0.4,
+            axis=(0.0, 1.0, 0.0),
+            receiver_direction=(1.0, 0.0, 0.0),
+        )

--- a/tests/test_dr_moagi_permeation.py
+++ b/tests/test_dr_moagi_permeation.py
@@ -44,9 +44,7 @@ def test_round_trip_reconstructs_16d_state_exactly():
 def test_focus_rotates_the_quadrupole_axis_without_claiming_one_sided_beamforming():
     aligned = PermeationConfig(axis=(0.0, 1.0, 0.0), receiver_direction=(0.0, 1.0, 0.0))
     perpendicular = aligned.focused((1.0, 0.0, 0.0))
-    opposite = PermeationConfig(
-        axis=(0.0, -1.0, 0.0), receiver_direction=(0.0, 1.0, 0.0)
-    )
+    opposite = PermeationConfig(axis=(0.0, -1.0, 0.0), receiver_direction=(0.0, 1.0, 0.0))
 
     assert aligned.angular_gain == pytest.approx(1.0)
     assert perpendicular.angular_gain == pytest.approx(0.4)

--- a/tests/test_dr_moagi_permeation_cloud.py
+++ b/tests/test_dr_moagi_permeation_cloud.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from jarvisx.dr_moagi_cloud_service import CloudServiceSettings, create_app
+
+
+def _state() -> dict[str, object]:
+    return {
+        "latent": [index / 10.0 for index in range(16)],
+        "geometry": {"vpx_density": 0.72},
+        "intent": "externalize-and-reconstruct",
+    }
+
+
+def test_permeation_job_commits_and_replays_through_cloud_gate(tmp_path):
+    settings = CloudServiceSettings(
+        data_dir=tmp_path,
+        api_key="test-secret",
+        require_api_key=True,
+    )
+    client = TestClient(create_app(settings=settings))
+    headers = {
+        "X-Dr-Moagi-Key": "test-secret",
+        "X-Dr-Moagi-Principal": "permeation-test",
+    }
+
+    response = client.post(
+        "/api/v1/jobs",
+        headers=headers,
+        json={
+            "operation": "permeate-roundtrip.v1",
+            "request_id": "permeation-001",
+            "input": {
+                "state": _state(),
+                "config": {
+                    "carrier_hz": 333_330_000.0,
+                    "range_m": 1.0,
+                    "axis": [0.0, 1.0, 0.0],
+                    "receiver_direction": [0.0, 1.0, 0.0],
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    job = response.json()
+    assert job["state"] == "COMMITTED"
+    assert job["principal"] == "permeation-test"
+    result = job["result"]
+    assert result["operation"] == "permeate-roundtrip.v1"
+    assert result["physical_rf"] is False
+    assert result["verified"] is True
+    assert result["reconstructed"] == _state()
+
+    job_id = job["job_id"]
+    verify_response = client.post(f"/api/v1/jobs/{job_id}/verify", headers=headers)
+    assert verify_response.status_code == 200
+    assert verify_response.json()["verified"] is True
+
+    events_response = client.get(f"/api/v1/jobs/{job_id}/events", headers=headers)
+    assert events_response.status_code == 200
+    assert events_response.json()["events"][-1]["state"] == "COMMITTED"
+
+
+def test_permeation_rejects_unknown_transport_configuration(tmp_path):
+    settings = CloudServiceSettings(data_dir=tmp_path)
+    client = TestClient(create_app(settings=settings))
+
+    response = client.post(
+        "/api/v1/jobs",
+        json={
+            "operation": "permeate-roundtrip.v1",
+            "input": {
+                "state": _state(),
+                "config": {"physical_transmitter_gain": 1000},
+            },
+        },
+    )
+
+    assert response.status_code == 422
+    assert "unknown permeation config keys" in response.json()["detail"]


### PR DESCRIPTION
## What changed

Adds the first executable Dr Moagi **permeation transport** as a bounded software-channel layer on top of PR #115:

- deterministic canonical-JSON framing with SHA-256 payload identity;
- BPSK modulation (`0 -> -1`, `1 -> +1`);
- scalar `1/r` Green-function channel with carrier phase `exp(i k r)`;
- default 333.33 MHz carrier metadata, `Q = 0.941`, `c = 299,792,458 m/s`, and `0.6 + 0.4 P2(cos(theta))` angular model;
- `FOCUS Phi` semantics as quadrupole-axis rotation;
- `MODULATE Phi` semantics as canonical JSON -> BPSK;
- `ABSORB Phi` semantics as equalize -> demodulate -> SHA-256 verify -> reconstruct;
- deterministic optional seeded complex Gaussian channel noise;
- explicit payload ceilings before symbol expansion;
- cloud operation `permeate-roundtrip.v1` registered inside the PR #115 transaction/policy/verification/commit spine;
- ADR-011, normative operations documentation, pure transport tests, cloud vertical-slice tests, and a dedicated validation workflow.

## Interpretation boundary

Every result reports:

```text
physical_rf = false
```

This PR does **not** drive SDR/RF hardware, antennas, transmitter power, spectrum selection, or physical beamforming. Carrier frequency, range, wavelength, phase and propagation delay are parameters of the software channel model. A future physical-RF adapter requires a separate architecture decision and hardware/compliance boundary.

The v1 quadrupole uses `P2(cos(theta))`, so `FOCUS` rotates a symmetric +/-axis pattern; it is not described as one-sided beamforming.

## Reference numerical contract

At the defaults and 1 m aligned range:

```text
wavelength ~= 0.8993863679 m
wave number ~= 6.9860802117 rad/m
propagation delay ~= 3.335640952 ns
scalar amplitude ~= 0.0748824007
```

## Validation — green on current head

Current head: `6ab503a6011e90d0e285a8a513090634a178c50a`.

The dedicated **Dr Moagi Permeation Transport** workflow passes:

- Python 3.10 permeation/cloud conformance;
- Python 3.11 permeation/cloud conformance;
- Python 3.12 permeation/cloud conformance;
- Python 3.13 permeation/cloud conformance;
- compile checks for the transport, adapter, Cloud service and new tests;
- flake8 syntax/undefined-name checks;
- Black canonical formatting;
- isort import-order validation;
- full-package `mypy` type checking.

The inherited **Dr Moagi Cloud Runtime** conformance workflow also passes on the same head, proving the new operation did not regress the PR #115 transaction spine.

CI caught one formatting-only defect during this PR; the exact Black diff was applied and the full strengthened gate now passes.

Because this is intentionally stacked on a non-default base branch, the repository-wide `Jarvis-X CI` and CodeQL workflows that are configured for `main`/`develop` PR bases do not attach yet. PR #115 already carries the green dependency/package/security evidence for the unchanged base. After #115 is accepted and this PR is retargeted to `main`, the normal repository-wide gates should run again against the combined change.

## Stack

- base prerequisite: PR #115 — Dr Moagi Cloud transactional runtime v1;
- this PR adds only the permeation layer and Cloud operation registration;
- merge/retarget this PR after #115 is accepted.

## Deliberate v1 limits

- software-channel simulation only (`physical_rf=false`);
- scalar channel rather than full Maxwell vector fields;
- BPSK rather than adaptive QPSK/QAM/OFDM;
- known-channel equalization rather than receiver synchronization/channel estimation;
- SHA-256 integrity detection, not forward-error correction;
- `l=2` axis rotation, not physical phased-array beamforming.