### PR TITLE
Add PY-MATRIX 3D 1M-LOC kinetic surface

### DIFF
--- a/apps/py-matrix-3d/README.md
+++ b/apps/py-matrix-3d/README.md
@@ -1,0 +1,31 @@
+# PY-MATRIX 3D — 1M LOC Mega-Code Engine
+
+This self-contained WebGL2 application is a bounded research surface for mapping a **logical 1,000,000-line Python code space** onto the DM-vΩΞ⁺ / Ψ-Φ-Λ-Ω-Θ visualization stack.
+
+It does not ingest, execute, or retain a literal million-line Python program. Instead it defines a deterministic address transform:
+
+```text
+line -> cluster -> local 20 x 20 x 10 cell -> procedural 3D position
+```
+
+The browser renders only 250 cluster instances with `drawArraysInstanced`. Line-level positions are derived on demand in O(1) arithmetic.
+
+## Stack mapping
+
+- **Ψ** — 1.0 Hz logical travelling pulse over cluster index space.
+- **Φ** — deterministic AST/LOC spatial index; 4,000 LOC per cluster.
+- **Λ** — explicit semantic-coherence target (`0.9998`) and measured frame-budget telemetry.
+- **Ω** — 250-cluster procedural spatial memory matrix; not a one-million-object VRAM allocation.
+- **Θ** — interactive line selection and camera/focus vector.
+
+## Performance semantics
+
+The renderer is designed to avoid per-frame cluster allocation and uses WebGL2 instanced drawing. `60 FPS` is a target that the HUD measures; it is **not** a browser real-time guarantee. The logical pulse remains exactly 1 Hz independent of observed frame cadence.
+
+## Run
+
+Open `index.html` in a WebGL2-capable browser. No CDN, package manager, or network connection is required.
+
+## Trust boundary
+
+This is a research/visualization surface. It has no network, shell, filesystem, market, medical, infrastructure, or device authority. It does not mutate authoritative Jarvis-X state and does not replace `jarvisx.system_runtime`.

--- a/apps/py-matrix-3d/index.html
+++ b/apps/py-matrix-3d/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>PY-MATRIX 3D :: 1M LOC Mega-Code Engine</title>
+<style>
+:root{--bg:#02050b;--panel:#07101bcc;--cyan:#31e7ff;--purple:#8b5cf6;--gold:#ffd166;--text:#e5edf6;--dim:#8192a6;--ok:#41f19a}
+*{box-sizing:border-box}html,body{width:100%;height:100%;margin:0;overflow:hidden;background:var(--bg);color:var(--text);font:13px ui-monospace,SFMono-Regular,Menlo,Consolas,monospace}
+#gl{position:fixed;inset:0;width:100%;height:100%;display:block}.hud{position:fixed;z-index:2;background:var(--panel);backdrop-filter:blur(12px);border:1px solid #31e7ff44;border-radius:12px;box-shadow:0 12px 50px #0008}.top{left:18px;right:18px;top:18px;padding:15px 18px;display:flex;align-items:center;justify-content:space-between;gap:16px}.brand b{display:block;color:var(--cyan);letter-spacing:.16em;font-size:15px}.brand span{display:block;color:var(--dim);margin-top:4px;font-size:11px}.controls{display:flex;gap:8px;flex-wrap:wrap}button,input{font:inherit;color:var(--text);background:#020812;border:1px solid #31e7ff55;border-radius:7px;padding:8px 10px;outline:none}button{cursor:pointer}button:hover{border-color:var(--cyan)}input{width:130px}.metrics{left:18px;right:18px;bottom:18px;padding:13px 16px;display:grid;grid-template-columns:repeat(7,minmax(90px,1fr));gap:12px}.m span{display:block;color:var(--dim);font-size:10px;text-transform:uppercase;letter-spacing:.09em}.m b{display:block;color:var(--cyan);margin-top:4px;font-size:12px}.side{right:18px;top:92px;width:300px;padding:14px 16px;line-height:1.5}.side h3{margin:0 0 8px;color:var(--gold);font-size:12px}.eq{color:#b8c7d9}.ok{color:var(--ok)!important}.warn{color:var(--gold)!important}@media(max-width:900px){.metrics{grid-template-columns:repeat(3,1fr)}.side{display:none}.top{align-items:flex-start;flex-direction:column}}
+</style>
+</head>
+<body>
+<canvas id="gl"></canvas>
+<div class="hud top">
+  <div class="brand"><b>PY-MATRIX 3D :: 1M LOC MEGA-CODE ENGINE</b><span>DM-vΩΞ⁺ baseline · Ψ-Φ-Λ-Ω-Θ cognitive stack · bounded research surface</span></div>
+  <div class="controls"><input id="line" type="number" min="1" max="1000000" value="48201" aria-label="line number"><button id="go">Fly to LOC</button><button id="toggle">Pause</button><button id="reset">Reset View</button></div>
+</div>
+<div class="hud side">
+  <h3>KINETIC EXECUTION TOPOLOGY</h3>
+  <div class="eq">AST → Φ spatial index → Ω instanced cluster matrix → Ψ 1 Hz wave → Λ coherence gate → Θ focus vector</div>
+  <p>Line lookup is arithmetic, not a scan: <b>cluster=(LOC−1)//4000</b>.</p>
+  <p>Each cluster is a <b>20×20×10</b> local lattice. Only 250 cluster instances are rendered; one million line objects are not allocated.</p>
+  <p>60 FPS is a measured target. Browser scheduling is not treated as a real-time guarantee.</p>
+</div>
+<div class="hud metrics">
+  <div class="m"><span>Virtual LOC</span><b>1,000,000</b></div>
+  <div class="m"><span>Ω Clusters</span><b id="cluster">250 / active 0</b></div>
+  <div class="m"><span>Ψ Pulse</span><b id="pulse">1.000 Hz</b></div>
+  <div class="m"><span>Λ Coherence</span><b id="coherence" class="ok">0.9998 target</b></div>
+  <div class="m"><span>Measured FPS</span><b id="fps">--</b></div>
+  <div class="m"><span>Selected LOC</span><b id="selected">48,201</b></div>
+  <div class="m"><span>Θ Cell</span><b id="cell">(0,10,0)</b></div>
+</div>
+<script>
+'use strict';
+const TOTAL_LOC=1000000, CLUSTER_COUNT=250, LOC_PER_CLUSTER=4000;
+const GRID_X=20, GRID_Y=20, GRID_Z=10, PULSE_HZ=1.0, COHERENCE_TARGET=0.9998;
+const GOLDEN_ANGLE=Math.PI*(3-Math.sqrt(5));
+const canvas=document.getElementById('gl');
+const gl=canvas.getContext('webgl2',{antialias:true,powerPreference:'high-performance'});
+if(!gl){document.body.innerHTML='<pre style="padding:24px">WebGL2 is required for the PY-MATRIX 3D research surface.</pre>';throw new Error('WebGL2 unavailable');}
+const vs=`#version 300 es
+precision highp float;
+uniform float uTime,uYaw,uPitch,uZoom,uAspect,uFocus;
+out float vPulse;out float vFocus;
+const float PI=3.141592653589793;
+void main(){
+ float i=float(gl_InstanceID); float theta=i*2.399963229728653; float r=3.2+i*0.020;
+ vec3 p=vec3(r*cos(theta),(i-124.5)*0.035,r*sin(theta));
+ float pulse=0.5+0.5*cos(2.0*PI*(uTime-i/32.0));
+ float cy=cos(uYaw),sy=sin(uYaw),cp=cos(uPitch),sp=sin(uPitch);
+ vec3 q=vec3(cy*p.x-sy*p.z,p.y,sy*p.x+cy*p.z);
+ q=vec3(q.x,cp*q.y-sp*q.z,sp*q.y+cp*q.z);
+ float depth=max(5.0,uZoom+q.z); float persp=uZoom/depth;
+ gl_Position=vec4((q.x*persp)/(6.8*uAspect),(q.y*persp)/6.8,clamp(q.z/30.0,-0.9,0.9),1.0);
+ vFocus=1.0-step(0.5,abs(i-uFocus)); vPulse=pulse;
+ gl_PointSize=mix(4.0+7.0*pulse,19.0,vFocus);
+}`;
+const fs=`#version 300 es
+precision highp float;in float vPulse;in float vFocus;out vec4 outColor;
+void main(){vec2 d=gl_PointCoord-0.5;if(dot(d,d)>0.25)discard;vec3 a=vec3(0.10,0.78,1.0),b=vec3(0.60,0.25,1.0),g=vec3(1.0,0.82,0.25);vec3 c=mix(mix(a,b,vPulse),g,vFocus);outColor=vec4(c,mix(0.58,1.0,vFocus));}`;
+function shader(type,src){const s=gl.createShader(type);gl.shaderSource(s,src);gl.compileShader(s);if(!gl.getShaderParameter(s,gl.COMPILE_STATUS))throw new Error(gl.getShaderInfoLog(s));return s}
+const program=gl.createProgram();gl.attachShader(program,shader(gl.VERTEX_SHADER,vs));gl.attachShader(program,shader(gl.FRAGMENT_SHADER,fs));gl.linkProgram(program);if(!gl.getProgramParameter(program,gl.LINK_STATUS))throw new Error(gl.getProgramInfoLog(program));gl.useProgram(program);
+const U={};for(const n of ['uTime','uYaw','uPitch','uZoom','uAspect','uFocus'])U[n]=gl.getUniformLocation(program,n);
+const vao=gl.createVertexArray();gl.bindVertexArray(vao);gl.enable(gl.BLEND);gl.blendFunc(gl.SRC_ALPHA,gl.ONE);gl.clearColor(0.008,0.02,0.045,1);
+let running=true,yaw=0.0,pitch=-0.16,zoom=14.0,focusCluster=12,selectedLine=48201,last=performance.now(),fpsEMA=60;
+function locate(line){line=Math.max(1,Math.min(TOTAL_LOC,Math.trunc(line)));const z=line-1,c=Math.floor(z/LOC_PER_CLUSTER),local=z%LOC_PER_CLUSTER;return{line,cluster:c,local,x:local%GRID_X,y:Math.floor(local/GRID_X)%GRID_Y,z:Math.floor(local/(GRID_X*GRID_Y))}}
+function selectLine(line){const a=locate(line);selectedLine=a.line;focusCluster=a.cluster;document.getElementById('line').value=a.line;document.getElementById('selected').textContent=a.line.toLocaleString();document.getElementById('cell').textContent=`(${a.x},${a.y},${a.z})`;document.getElementById('cluster').textContent=`250 / active ${a.cluster}`;}
+document.getElementById('go').onclick=()=>selectLine(Number(document.getElementById('line').value));
+document.getElementById('toggle').onclick=()=>{running=!running;document.getElementById('toggle').textContent=running?'Pause':'Resume'};
+document.getElementById('reset').onclick=()=>{yaw=0;pitch=-0.16;zoom=14;selectLine(48201)};
+let dragging=false,px=0,py=0;canvas.addEventListener('pointerdown',e=>{dragging=true;px=e.clientX;py=e.clientY;canvas.setPointerCapture(e.pointerId)});canvas.addEventListener('pointermove',e=>{if(!dragging)return;yaw+=(e.clientX-px)*0.006;pitch=Math.max(-1.2,Math.min(1.2,pitch+(e.clientY-py)*0.006));px=e.clientX;py=e.clientY});canvas.addEventListener('pointerup',()=>dragging=false);canvas.addEventListener('wheel',e=>{zoom=Math.max(7,Math.min(28,zoom+e.deltaY*0.01));e.preventDefault()},{passive:false});
+function resize(){const d=Math.min(devicePixelRatio||1,2),w=Math.floor(innerWidth*d),h=Math.floor(innerHeight*d);if(canvas.width!==w||canvas.height!==h){canvas.width=w;canvas.height=h;gl.viewport(0,0,w,h)}}
+function frame(now){resize();const dt=Math.max(0.0001,(now-last)/1000);last=now;const f=1/dt;fpsEMA=fpsEMA*0.92+f*0.08;if(running)yaw+=dt*0.08;gl.clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT);gl.useProgram(program);gl.bindVertexArray(vao);gl.uniform1f(U.uTime,now/1000*PULSE_HZ);gl.uniform1f(U.uYaw,yaw);gl.uniform1f(U.uPitch,pitch);gl.uniform1f(U.uZoom,zoom);gl.uniform1f(U.uAspect,canvas.width/canvas.height);gl.uniform1f(U.uFocus,focusCluster);gl.drawArraysInstanced(gl.POINTS,0,1,CLUSTER_COUNT);document.getElementById('fps').textContent=`${fpsEMA.toFixed(1)} ${fpsEMA>=60?'target':'measured'}`;document.getElementById('fps').className=fpsEMA>=60?'ok':'warn';requestAnimationFrame(frame)}
+selectLine(selectedLine);requestAnimationFrame(frame);
+</script>
+</body>
+</html>

--- a/docs/PY_MATRIX_3D_1M_LOC_MEGA_CODE_ENGINE.md
+++ b/docs/PY_MATRIX_3D_1M_LOC_MEGA_CODE_ENGINE.md
@@ -1,0 +1,140 @@
+# PY-MATRIX 3D 1M LOC Mega-Code Engine
+
+## Status
+
+Bounded research mapping across the DM-vΩΞ⁺ baseline and the Ψ-Φ-Λ-Ω-Θ cognitive visualization stack.
+
+## 1. Kinetic execution topology
+
+```text
+Raw Python LOC / AST address
+        |
+        v
+Phi: deterministic spatial index
+        |
+        v
+Omega: 250 procedural 3D cluster instances
+        |
+        v
+Psi: 1.0 Hz travelling execution pulse
+        |
+        v
+Lambda: coherence + frame-budget observation
+        |
+        v
+Theta: interactive focus / camera attention
+```
+
+The model describes **one million logical source-line addresses**, not one million resident browser objects.
+
+## 2. Φ — O(1) description and spatial indexing
+
+Let
+
+```text
+L = 1,000,000 LOC
+K = 250 clusters
+C = L / K = 4,000 LOC per cluster.
+```
+
+For one-based line `l`:
+
+```text
+c = floor((l - 1) / 4000)
+r = (l - 1) mod 4000
+```
+
+The local cluster lattice is `20 x 20 x 10 = 4,000`:
+
+```text
+x_local = r mod 20
+y_local = floor(r / 20) mod 20
+z_local = floor(r / 400)
+```
+
+Thus address resolution is constant-time arithmetic and does not scan the code space.
+
+Example:
+
+```text
+line 48,201 -> cluster 12 -> local index 200 -> cell (0, 10, 0)
+```
+
+Each cluster center follows a deterministic golden-angle spiral:
+
+```text
+theta_c = c * pi * (3 - sqrt(5))
+R_c     = 7 + 0.035 c
+Z_c     = 0.08 (c - 124.5)
+```
+
+The local cell offset is rotated with its parent cluster to preserve visual locality.
+
+## 3. Ψ — 1 Hz kinetic execution wave
+
+The logical pulse is
+
+```text
+Psi(t, c) = 1/2 + 1/2 cos(2 pi (f t - c/lambda_c))
+f = 1.0 Hz
+```
+
+with a default cluster wavelength `lambda_c = 32`.
+
+The pulse is defined against logical time, not render frames. Therefore a slow or variable browser frame cadence changes sampling density, not the declared 1 Hz period.
+
+## 4. Ω — sparse procedural spatial memory
+
+The browser materializes 250 cluster instances. It does **not** allocate one GPU object per line. The million-line layout remains implicit in the address transform and is reconstructed when a line is selected.
+
+This changes the memory model from
+
+```text
+O(1,000,000 visual objects)
+```
+
+to
+
+```text
+O(250 cluster instances + bounded UI/runtime state).
+```
+
+## 5. Λ — coherence and resource boundary
+
+The semantic-coherence target is explicitly represented as
+
+```text
+coherence >= 0.9998
+```
+
+but the target is not evidence of semantic correctness by itself; a production system must bind it to a declared metric and validator.
+
+Similarly, `60 FPS` is a measured rendering target. Browser scheduling and device load prevent a universal hard guarantee. The operational check is
+
+```text
+measured_frame_ms <= 1000 / target_fps.
+```
+
+## 6. Θ — attention / focus vector
+
+Selecting line `l` deterministically produces its cluster and local cell. The browser uses the cluster as the focus target and highlights it in the kinetic field. This is a visualization attention vector, not autonomous execution authority.
+
+## 7. DM-vΩΞ⁺ integration
+
+The stack can be summarized as
+
+```text
+Xi_LOC
+  -> Phi_address(Xi_LOC)
+  -> Omega_cluster_state
+  -> Psi_kinetic_pulse
+  -> Pi_Lambda(observed coherence/resources)
+  -> Theta_focus
+  -> rendered kinetic state.
+```
+
+This surface complements the accepted QSOL kinetic 3D research boundary and the accepted sparse DM-vΩΞ⁺ swarm ISA. It does not alter either authoritative contract.
+
+## 8. Trust boundary
+
+The PY-MATRIX surface is intentionally non-authoritative. It does not execute arbitrary Python source, mutate repository files, invoke tools, or bypass `jarvisx.system_runtime`. External actions remain behind the repository's existing prediction -> plan -> projection -> execution -> verification -> audit -> commit path.

--- a/src/jarvisx/py_matrix_3d.py
+++ b/src/jarvisx/py_matrix_3d.py
@@ -1,0 +1,173 @@
+"""Deterministic reference mathematics for the PY-MATRIX 3D 1M-LOC surface.
+
+The module maps one million logical source lines onto 250 procedural 3D clusters.
+It does not load or execute a million-line program and has no external side effects.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+TOTAL_LOC = 1_000_000
+CLUSTER_COUNT = 250
+LOC_PER_CLUSTER = TOTAL_LOC // CLUSTER_COUNT
+GRID_X = 20
+GRID_Y = 20
+GRID_Z = 10
+PULSE_HZ = 1.0
+PULSE_PERIOD_S = 1.0 / PULSE_HZ
+COHERENCE_TARGET = 0.9998
+TARGET_FPS = 60.0
+FRAME_BUDGET_MS = 1000.0 / TARGET_FPS
+GOLDEN_ANGLE = math.pi * (3.0 - math.sqrt(5.0))
+
+if GRID_X * GRID_Y * GRID_Z != LOC_PER_CLUSTER:
+    raise RuntimeError("local grid must exactly cover one cluster")
+
+
+@dataclass(frozen=True)
+class SpatialAddress:
+    """O(1) procedural address for one logical source line."""
+
+    line: int
+    cluster: int
+    local_index: int
+    cell_x: int
+    cell_y: int
+    cell_z: int
+    radius: float
+    theta: float
+    world_x: float
+    world_y: float
+    world_z: float
+
+
+@dataclass(frozen=True)
+class ClusterPose:
+    """Procedural cluster center used by the browser instancing surface."""
+
+    cluster: int
+    radius: float
+    theta: float
+    x: float
+    y: float
+    z: float
+
+
+def _line_number(line: int) -> int:
+    if isinstance(line, bool) or not isinstance(line, int):
+        raise TypeError("line must be an integer")
+    if not 1 <= line <= TOTAL_LOC:
+        raise ValueError(f"line must be within [1, {TOTAL_LOC}]")
+    return line
+
+
+def cluster_pose(cluster: int) -> ClusterPose:
+    """Return the deterministic center of one spiral cluster."""
+
+    if isinstance(cluster, bool) or not isinstance(cluster, int):
+        raise TypeError("cluster must be an integer")
+    if not 0 <= cluster < CLUSTER_COUNT:
+        raise ValueError(f"cluster must be within [0, {CLUSTER_COUNT - 1}]")
+
+    theta = cluster * GOLDEN_ANGLE
+    radius = 7.0 + 0.035 * cluster
+    z = (cluster - (CLUSTER_COUNT - 1) / 2.0) * 0.08
+    return ClusterPose(
+        cluster=cluster,
+        radius=radius,
+        theta=theta,
+        x=radius * math.cos(theta),
+        y=radius * math.sin(theta),
+        z=z,
+    )
+
+
+def locate_line(line: int) -> SpatialAddress:
+    """Map a 1-based LOC index to cluster, local cell and world position in O(1)."""
+
+    line = _line_number(line)
+    zero = line - 1
+    cluster = zero // LOC_PER_CLUSTER
+    local = zero % LOC_PER_CLUSTER
+    cell_x = local % GRID_X
+    cell_y = (local // GRID_X) % GRID_Y
+    cell_z = local // (GRID_X * GRID_Y)
+
+    pose = cluster_pose(cluster)
+    # Small deterministic local offsets encode the 20 x 20 x 10 cluster lattice.
+    ox = (cell_x - (GRID_X - 1) / 2.0) * 0.045
+    oy = (cell_y - (GRID_Y - 1) / 2.0) * 0.045
+    oz = (cell_z - (GRID_Z - 1) / 2.0) * 0.060
+
+    # Rotate the local XY lattice with the parent cluster to preserve spiral locality.
+    c = math.cos(pose.theta)
+    s = math.sin(pose.theta)
+    world_x = pose.x + ox * c - oy * s
+    world_y = pose.y + ox * s + oy * c
+    world_z = pose.z + oz
+
+    return SpatialAddress(
+        line=line,
+        cluster=cluster,
+        local_index=local,
+        cell_x=cell_x,
+        cell_y=cell_y,
+        cell_z=cell_z,
+        radius=pose.radius,
+        theta=pose.theta,
+        world_x=world_x,
+        world_y=world_y,
+        world_z=world_z,
+    )
+
+
+def pulse(time_s: float, *, phase_cycles: float = 0.0) -> float:
+    """Return the normalized logical execution pulse at exactly 1 Hz."""
+
+    time_s = float(time_s)
+    phase_cycles = float(phase_cycles)
+    if not math.isfinite(time_s) or not math.isfinite(phase_cycles):
+        raise ValueError("pulse inputs must be finite")
+    return 0.5 + 0.5 * math.cos(2.0 * math.pi * (PULSE_HZ * time_s - phase_cycles))
+
+
+def travelling_pulse(time_s: float, cluster: int, *, wavelength_clusters: float = 32.0) -> float:
+    """Propagate the 1-Hz wave across cluster index space."""
+
+    cluster_pose(cluster)  # validates cluster without allocating cluster state
+    wavelength_clusters = float(wavelength_clusters)
+    if not math.isfinite(wavelength_clusters) or wavelength_clusters <= 0.0:
+        raise ValueError("wavelength_clusters must be finite and positive")
+    return pulse(time_s, phase_cycles=cluster / wavelength_clusters)
+
+
+def coherence_pass(value: float, *, target: float = COHERENCE_TARGET) -> bool:
+    """Evaluate the declared semantic-coherence target as an explicit gate."""
+
+    value = float(value)
+    target = float(target)
+    if not math.isfinite(value) or not math.isfinite(target):
+        return False
+    if not 0.0 <= target <= 1.0:
+        raise ValueError("target must be within [0, 1]")
+    return value >= target
+
+
+def frame_budget_pass(frame_ms: float, *, target_fps: float = TARGET_FPS) -> bool:
+    """Check a measured frame time against a target; this is not a real-time guarantee."""
+
+    frame_ms = float(frame_ms)
+    target_fps = float(target_fps)
+    if not math.isfinite(frame_ms) or frame_ms < 0.0:
+        return False
+    if not math.isfinite(target_fps) or target_fps <= 0.0:
+        raise ValueError("target_fps must be finite and positive")
+    return frame_ms <= 1000.0 / target_fps
+
+
+def cluster_transforms() -> tuple[ClusterPose, ...]:
+    """Materialize only 250 cluster transforms, never one million line objects."""
+
+    return tuple(cluster_pose(index) for index in range(CLUSTER_COUNT))

--- a/tests/test_py_matrix_3d.py
+++ b/tests/test_py_matrix_3d.py
@@ -1,0 +1,75 @@
+import importlib.util
+import math
+import sys
+from pathlib import Path
+
+MODULE = Path(__file__).resolve().parents[1] / "src" / "jarvisx" / "py_matrix_3d.py"
+spec = importlib.util.spec_from_file_location("py_matrix_3d", MODULE)
+assert spec and spec.loader
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+
+
+def test_scale_and_cluster_factorization() -> None:
+    assert m.TOTAL_LOC == 1_000_000
+    assert m.CLUSTER_COUNT == 250
+    assert m.LOC_PER_CLUSTER == 4_000
+    assert m.GRID_X * m.GRID_Y * m.GRID_Z == 4_000
+    assert len(m.cluster_transforms()) == 250
+
+
+def test_line_mapping_is_arithmetic_and_exact() -> None:
+    first = m.locate_line(1)
+    assert (first.cluster, first.local_index, first.cell_x, first.cell_y, first.cell_z) == (0, 0, 0, 0, 0)
+
+    sample = m.locate_line(48_201)
+    assert (sample.cluster, sample.local_index) == (12, 200)
+    assert (sample.cell_x, sample.cell_y, sample.cell_z) == (0, 10, 0)
+
+    last = m.locate_line(1_000_000)
+    assert (last.cluster, last.local_index) == (249, 3999)
+    assert (last.cell_x, last.cell_y, last.cell_z) == (19, 19, 9)
+
+
+def test_pulse_is_one_hertz_and_travels() -> None:
+    for t in (0.0, 0.125, 0.37, 1.9):
+        assert math.isclose(m.pulse(t), m.pulse(t + 1.0), abs_tol=1e-12)
+    assert not math.isclose(m.travelling_pulse(0.0, 0), m.travelling_pulse(0.0, 8))
+
+
+def test_coherence_and_frame_budget_are_explicit_gates() -> None:
+    assert m.coherence_pass(0.9998)
+    assert not m.coherence_pass(0.99979)
+    assert m.frame_budget_pass(16.0)
+    assert not m.frame_budget_pass(17.0)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP = ROOT / "apps" / "py-matrix-3d" / "index.html"
+README = APP.parent / "README.md"
+
+
+def test_py_matrix_surface_is_self_contained_instanced_and_bounded() -> None:
+    html = APP.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    for marker in (
+        "PY-MATRIX 3D :: 1M LOC MEGA-CODE ENGINE",
+        "TOTAL_LOC=1000000",
+        "CLUSTER_COUNT=250",
+        "LOC_PER_CLUSTER=4000",
+        "PULSE_HZ=1.0",
+        "COHERENCE_TARGET=0.9998",
+        "getContext('webgl2'",
+        "drawArraysInstanced",
+        "20×20×10",
+        "cluster=(LOC−1)//4000",
+    ):
+        assert marker in html
+
+    assert "https://" not in html
+    assert "http://" not in html
+    assert "60 FPS" in readme and "not" in readme
+    assert "does not mutate authoritative Jarvis-X state" in readme
+    assert "jarvisx.system_runtime" in readme


### PR DESCRIPTION
## What changed

- add `src/jarvisx/py_matrix_3d.py` with deterministic O(1) line-to-cluster/cell mapping for a logical 1,000,000-LOC space
- factor the logical code surface into 250 clusters of 4,000 LOC, with each cluster represented by a 20×20×10 local lattice
- add an exact 1.0 Hz logical travelling pulse independent of browser frame cadence
- add explicit `0.9998` coherence and measured frame-budget gates
- add a self-contained WebGL2 kinetic surface using `drawArraysInstanced` for 250 procedural cluster instances
- add interactive LOC focus (including the line 48,201 → cluster 12 → local 200 → cell (0,10,0) fixture)
- document the DM-vΩΞ⁺ / Ψ-Φ-Λ-Ω-Θ mapping and trust boundary
- add focused conformance tests

## Performance semantics

The implementation deliberately does **not** allocate one million browser/GPU objects. The million-line space is procedural and line addresses are resolved arithmetically in O(1). The browser materializes only the bounded cluster surface and UI state.

`60 FPS` is treated as a measured target, not a real-time guarantee. The logical Ψ pulse is defined independently at exactly 1 Hz.

## Trust boundary

This remains a non-authoritative research/visualization surface. It does not execute arbitrary Python source, mutate authoritative Jarvis-X state, or bypass `jarvisx.system_runtime` and the existing prediction → plan → projection → execution → verification → audit → commit boundary.

## Validation

Focused local validation: **5 tests passed** covering scale factorization, line-address arithmetic, boundary addresses, 1 Hz periodicity, travelling pulse phase, coherence/frame gates, self-contained WebGL2 instancing, and trust-boundary markers.

Repository-wide CI remains the acceptance gate.