### PR TITLE
Add bounded Dr Moagi state-space C++ core

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-dr-moagi-state-space
+    src/dr_moagi_state_space_main.cpp
+)
+jarvisx_include_runtime(jarvisx-dr-moagi-state-space)
+jarvisx_harden(jarvisx-dr-moagi-state-space)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -109,6 +115,12 @@ add_test(
 )
 set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME dr-moagi-state-space-smoke
+    COMMAND jarvisx-dr-moagi-state-space
+)
+set_tests_properties(dr-moagi-state-space-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -135,3 +147,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-dr-moagi-state-space-tests
+    tests/dr_moagi_state_space_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-dr-moagi-state-space-tests)
+jarvisx_harden(jarvisx-dr-moagi-state-space-tests)
+
+add_test(NAME dr-moagi-state-space-regressions COMMAND jarvisx-dr-moagi-state-space-tests)
+set_tests_properties(dr-moagi-state-space-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/dr_moagi_state_space.hpp
+++ b/cpp_runtime/include/jarvisx/dr_moagi_state_space.hpp
@@ -1,0 +1,330 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <limits>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+struct MultimodalIngress {
+    std::uint64_t timestamp_ns{};
+    std::vector<double> spatial_3d_mesh;
+    std::vector<double> spatial_audio;
+    std::vector<double> contextual_text;
+};
+
+struct OledTile {
+    std::uint32_t tile_id{};
+    std::uint32_t x_offset{};
+    std::uint32_t y_offset{};
+    std::uint32_t width{};
+    std::uint32_t height{};
+    std::vector<double> latent_slice;
+    std::array<std::uint8_t, 3> preview_rgb{0U, 0U, 0U};
+    double active_power_mw{};
+};
+
+// Single-producer/single-consumer ring buffer. The memory-ordering contract is
+// intentionally narrow; this type must not be used as an MPMC queue.
+template <typename T, std::size_t Capacity>
+class SpscIngressRingBuffer {
+    static_assert(Capacity >= 2U, "ring capacity must be at least two");
+
+public:
+    bool push(const T& item) {
+        const std::size_t current_tail = tail_.load(std::memory_order_relaxed);
+        const std::size_t next_tail = (current_tail + 1U) % Capacity;
+        if (next_tail == head_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        buffer_[current_tail] = item;
+        tail_.store(next_tail, std::memory_order_release);
+        return true;
+    }
+
+    bool pop(T& item) {
+        const std::size_t current_head = head_.load(std::memory_order_relaxed);
+        if (current_head == tail_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        item = buffer_[current_head];
+        head_.store((current_head + 1U) % Capacity, std::memory_order_release);
+        return true;
+    }
+
+private:
+    std::array<T, Capacity> buffer_{};
+    std::atomic<std::size_t> head_{0U};
+    std::atomic<std::size_t> tail_{0U};
+};
+
+class LinearStateGovernor {
+public:
+    static double infinity_norm(const std::vector<double>& matrix, std::size_t dim) {
+        validate_square(matrix, dim);
+        double max_row_sum = 0.0;
+        for (std::size_t i = 0; i < dim; ++i) {
+            double row_sum = 0.0;
+            for (std::size_t j = 0; j < dim; ++j) {
+                row_sum += std::abs(matrix[i * dim + j]);
+            }
+            max_row_sum = std::max(max_row_sum, row_sum);
+        }
+        return max_row_sum;
+    }
+
+    // Power-iteration estimate of the dominant linear growth factor. This is
+    // telemetry, not a proof of the full nonlinear closed-loop Jacobian radius.
+    static double dominant_growth_estimate(const std::vector<double>& matrix,
+                                           std::size_t dim,
+                                           std::size_t max_iter = 30U) {
+        validate_square(matrix, dim);
+        if (dim == 0U) {
+            return 0.0;
+        }
+
+        std::vector<double> v(dim, 1.0 / std::sqrt(static_cast<double>(dim)));
+        double estimate = 0.0;
+        for (std::size_t iter = 0; iter < max_iter; ++iter) {
+            std::vector<double> w(dim, 0.0);
+            for (std::size_t i = 0; i < dim; ++i) {
+                for (std::size_t j = 0; j < dim; ++j) {
+                    w[i] += matrix[i * dim + j] * v[j];
+                }
+            }
+
+            double norm_sq = 0.0;
+            for (const double value : w) {
+                norm_sq += value * value;
+            }
+            const double norm = std::sqrt(norm_sq);
+            if (norm < 1.0e-14) {
+                return 0.0;
+            }
+            estimate = norm;
+            for (std::size_t i = 0; i < dim; ++i) {
+                v[i] = w[i] / norm;
+            }
+        }
+        return estimate;
+    }
+
+    // Enforces ||Phi||_inf <= target. Since rho(Phi) <= ||Phi||_inf, this is
+    // a conservative sufficient bound for the linear transition operator.
+    static double enforce_contractive_bound(std::vector<double>& matrix,
+                                            std::size_t dim,
+                                            double target = 0.94) {
+        if (!(target > 0.0 && target < 1.0)) {
+            throw std::invalid_argument("target contraction bound must lie in (0, 1)");
+        }
+        const double current = infinity_norm(matrix, dim);
+        if (current <= target || current == 0.0) {
+            return 1.0;
+        }
+        const double scale = target / current;
+        for (double& value : matrix) {
+            value *= scale;
+        }
+        return scale;
+    }
+
+private:
+    static void validate_square(const std::vector<double>& matrix, std::size_t dim) {
+        if (dim == 0U || matrix.size() != dim * dim) {
+            throw std::invalid_argument("matrix dimensions do not match latent dimension");
+        }
+    }
+};
+
+struct DrMoagiStateSpaceConfig {
+    std::size_t latent_dim{256U};
+    std::size_t ingress_dim{32U};
+    std::size_t tiles_x{8U};
+    std::size_t tiles_y{8U};
+    std::uint32_t logical_width{1'000'000U};
+    std::uint32_t logical_height{1'000'000U};
+    double transition_bound{0.94};
+    double state_abs_limit{1.0e6};
+
+    void validate() const {
+        if (latent_dim == 0U || ingress_dim == 0U || tiles_x == 0U || tiles_y == 0U) {
+            throw std::invalid_argument("state-space dimensions must be non-zero");
+        }
+        if (logical_width == 0U || logical_height == 0U) {
+            throw std::invalid_argument("logical display dimensions must be non-zero");
+        }
+        if (!(transition_bound > 0.0 && transition_bound < 1.0)) {
+            throw std::invalid_argument("transition bound must lie in (0, 1)");
+        }
+        if (!(state_abs_limit > 0.0) || !std::isfinite(state_abs_limit)) {
+            throw std::invalid_argument("state absolute limit must be finite and positive");
+        }
+    }
+
+    std::size_t total_tiles() const noexcept { return tiles_x * tiles_y; }
+};
+
+class DrMoagiStateSpaceEngine {
+public:
+    explicit DrMoagiStateSpaceEngine(DrMoagiStateSpaceConfig config)
+        : config_(std::move(config)),
+          z_state_(config_.latent_dim, 0.05),
+          phi_(config_.latent_dim * config_.latent_dim, 0.0),
+          psi_(config_.latent_dim * config_.ingress_dim, 0.02) {
+        config_.validate();
+        for (std::size_t i = 0; i < config_.latent_dim; ++i) {
+            phi_[i * config_.latent_dim + i] = 0.85;
+        }
+    }
+
+    std::vector<double> encode_ingress(const MultimodalIngress& ingress) const {
+        std::vector<double> u(config_.ingress_dim, 0.0);
+        accumulate_weighted(u, ingress.spatial_3d_mesh, 0.5);
+        accumulate_weighted(u, ingress.spatial_audio, 0.3);
+        accumulate_weighted(u, ingress.contextual_text, 0.2);
+        return u;
+    }
+
+    void step_state_space(const std::vector<double>& u,
+                          const std::vector<double>& delta_context) {
+        if (u.size() != config_.ingress_dim) {
+            throw std::invalid_argument("ingress vector dimension mismatch");
+        }
+        if (delta_context.size() != config_.latent_dim) {
+            throw std::invalid_argument("context vector dimension mismatch");
+        }
+
+        LinearStateGovernor::enforce_contractive_bound(
+            phi_, config_.latent_dim, config_.transition_bound);
+
+        std::vector<double> next(config_.latent_dim, 0.0);
+        for (std::size_t i = 0; i < config_.latent_dim; ++i) {
+            double state_sum = 0.0;
+            for (std::size_t j = 0; j < config_.latent_dim; ++j) {
+                state_sum += phi_[i * config_.latent_dim + j] * z_state_[j];
+            }
+
+            double input_sum = 0.0;
+            for (std::size_t j = 0; j < config_.ingress_dim; ++j) {
+                input_sum += psi_[i * config_.ingress_dim + j] * u[j];
+            }
+
+            const double candidate = state_sum + input_sum + delta_context[i];
+            if (!std::isfinite(candidate)) {
+                throw std::runtime_error("non-finite latent state rejected by admissibility gate");
+            }
+            next[i] = std::clamp(candidate, -config_.state_abs_limit, config_.state_abs_limit);
+        }
+        z_state_.swap(next);
+    }
+
+    std::vector<OledTile> decode_and_dispatch_tiles() const {
+        const std::size_t total = config_.total_tiles();
+        std::vector<OledTile> tiles(total);
+        const unsigned int hw = std::thread::hardware_concurrency();
+        const std::size_t available = hw == 0U ? 1U : static_cast<std::size_t>(hw);
+        const std::size_t worker_count = std::max<std::size_t>(1U, std::min(available, total));
+        const std::size_t batch = (total + worker_count - 1U) / worker_count;
+
+        auto decode_work = [this, total, &tiles](std::size_t begin_tile, std::size_t end_tile) {
+            for (std::size_t tile_index = begin_tile; tile_index < end_tile; ++tile_index) {
+                const std::size_t latent_begin = tile_index * config_.latent_dim / total;
+                const std::size_t latent_end = (tile_index + 1U) * config_.latent_dim / total;
+
+                OledTile tile;
+                tile.tile_id = static_cast<std::uint32_t>(tile_index);
+                const std::size_t tx = tile_index % config_.tiles_x;
+                const std::size_t ty = tile_index / config_.tiles_x;
+                tile.x_offset = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_width) * tx) / config_.tiles_x);
+                tile.y_offset = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_height) * ty) / config_.tiles_y);
+                const std::uint32_t x_end = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_width) * (tx + 1U)) / config_.tiles_x);
+                const std::uint32_t y_end = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_height) * (ty + 1U)) / config_.tiles_y);
+                tile.width = x_end - tile.x_offset;
+                tile.height = y_end - tile.y_offset;
+                tile.latent_slice.assign(z_state_.begin() + static_cast<std::ptrdiff_t>(latent_begin),
+                                         z_state_.begin() + static_cast<std::ptrdiff_t>(latent_end));
+
+                double energy = 0.0;
+                for (const double value : tile.latent_slice) {
+                    energy += std::abs(value);
+                }
+                if (energy >= 0.001) {
+                    tile.preview_rgb = {
+                        saturating_byte(energy * 100.0),
+                        saturating_byte(energy * 150.0),
+                        saturating_byte(energy * 200.0)};
+                    tile.active_power_mw = energy * 12.5;
+                }
+                tiles[tile_index] = std::move(tile);
+            }
+        };
+
+        std::vector<std::future<void>> futures;
+        futures.reserve(worker_count);
+        for (std::size_t worker = 0; worker < worker_count; ++worker) {
+            const std::size_t begin_tile = worker * batch;
+            const std::size_t end_tile = std::min(begin_tile + batch, total);
+            if (begin_tile < end_tile) {
+                futures.emplace_back(std::async(std::launch::async, decode_work, begin_tile, end_tile));
+            }
+        }
+        for (auto& future : futures) {
+            future.get();
+        }
+        return tiles;
+    }
+
+    double transition_infinity_norm() const {
+        return LinearStateGovernor::infinity_norm(phi_, config_.latent_dim);
+    }
+
+    double transition_growth_estimate() const {
+        return LinearStateGovernor::dominant_growth_estimate(phi_, config_.latent_dim);
+    }
+
+    double latent_norm() const noexcept {
+        double norm_sq = 0.0;
+        for (const double value : z_state_) {
+            norm_sq += value * value;
+        }
+        return std::sqrt(norm_sq);
+    }
+
+    const std::vector<double>& state() const noexcept { return z_state_; }
+    const DrMoagiStateSpaceConfig& config() const noexcept { return config_; }
+
+private:
+    static void accumulate_weighted(std::vector<double>& target,
+                                    const std::vector<double>& source,
+                                    double weight) {
+        const std::size_t count = std::min(target.size(), source.size());
+        for (std::size_t i = 0; i < count; ++i) {
+            target[i] += source[i] * weight;
+        }
+    }
+
+    static std::uint8_t saturating_byte(double value) noexcept {
+        const double bounded = std::clamp(value, 0.0, 255.0);
+        return static_cast<std::uint8_t>(bounded);
+    }
+
+    DrMoagiStateSpaceConfig config_;
+    std::vector<double> z_state_;
+    std::vector<double> phi_;
+    std::vector<double> psi_;
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/src/dr_moagi_state_space_main.cpp
+++ b/cpp_runtime/src/dr_moagi_state_space_main.cpp
@@ -1,0 +1,64 @@
+#include "jarvisx/dr_moagi_state_space.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+int main() {
+    using namespace jarvisx;
+
+    DrMoagiStateSpaceConfig config;
+    SpscIngressRingBuffer<MultimodalIngress, 16U> ingress_ring;
+    DrMoagiStateSpaceEngine engine(config);
+
+    MultimodalIngress payload;
+    payload.timestamp_ns = static_cast<std::uint64_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    payload.spatial_3d_mesh = {0.8, 0.4, -0.2, 0.9, 0.1};
+    payload.spatial_audio = {0.1, 0.85, 0.44};
+    payload.contextual_text = {1.0, 0.0, 0.5, 0.25};
+
+    if (!ingress_ring.push(payload)) {
+        std::cerr << "failed to enqueue synthetic ingress\n";
+        return 1;
+    }
+
+    std::cout << "=========================================================\n"
+              << "  DR MOAGI STATE-SPACE C++ REFERENCE CORE               \n"
+              << "=========================================================\n\n"
+              << std::fixed << std::setprecision(4);
+
+    for (int frame = 1; frame <= 5; ++frame) {
+        const auto start = std::chrono::high_resolution_clock::now();
+
+        MultimodalIngress active_ingress;
+        std::vector<double> u(config.ingress_dim, 0.05);
+        if (ingress_ring.pop(active_ingress)) {
+            u = engine.encode_ingress(active_ingress);
+        }
+
+        std::vector<double> delta_context(config.latent_dim, 0.005);
+        engine.step_state_space(u, delta_context);
+        const auto tiles = engine.decode_and_dispatch_tiles();
+
+        double total_power_mw = 0.0;
+        for (const auto& tile : tiles) {
+            total_power_mw += tile.active_power_mw;
+        }
+
+        const auto end = std::chrono::high_resolution_clock::now();
+        const double frame_ms = std::chrono::duration<double, std::milli>(end - start).count();
+
+        std::cout << "[FRAME " << frame << "]"
+                  << " LatentNorm=" << engine.latent_norm()
+                  << " | ||Phi||_inf=" << engine.transition_infinity_norm()
+                  << " | growth_est(Phi)=" << engine.transition_growth_estimate()
+                  << " | tile_power_model=" << total_power_mw << " mW"
+                  << " | latency=" << frame_ms << " ms\n";
+    }
+
+    std::cout << "\n[STATE] Linear transition bound enforced. "
+              << "Full nonlinear closed-loop Jacobian stability is not asserted by this harness.\n";
+    return 0;
+}

--- a/cpp_runtime/tests/dr_moagi_state_space_tests.cpp
+++ b/cpp_runtime/tests/dr_moagi_state_space_tests.cpp
@@ -1,0 +1,85 @@
+#include "jarvisx/dr_moagi_state_space.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void test_spsc_ring() {
+    jarvisx::SpscIngressRingBuffer<int, 4U> ring;
+    assert(ring.push(1));
+    assert(ring.push(2));
+    assert(ring.push(3));
+    assert(!ring.push(4));
+    int value = 0;
+    assert(ring.pop(value) && value == 1);
+    assert(ring.pop(value) && value == 2);
+    assert(ring.pop(value) && value == 3);
+    assert(!ring.pop(value));
+}
+
+void test_linear_bound() {
+    std::vector<double> matrix{
+        1.2, 0.2,
+        0.1, 1.1};
+    const double scale = jarvisx::LinearStateGovernor::enforce_contractive_bound(matrix, 2U, 0.94);
+    assert(scale < 1.0);
+    const double norm = jarvisx::LinearStateGovernor::infinity_norm(matrix, 2U);
+    assert(norm <= 0.9400000001);
+}
+
+void test_engine_dimensions_and_tiles() {
+    jarvisx::DrMoagiStateSpaceConfig config;
+    config.latent_dim = 10U;
+    config.ingress_dim = 4U;
+    config.tiles_x = 3U;
+    config.tiles_y = 2U;
+    config.logical_width = 10U;
+    config.logical_height = 8U;
+
+    jarvisx::DrMoagiStateSpaceEngine engine(config);
+    jarvisx::MultimodalIngress ingress;
+    ingress.spatial_3d_mesh = {1.0, 2.0, 3.0, 4.0};
+    const auto u = engine.encode_ingress(ingress);
+    std::vector<double> context(config.latent_dim, 0.0);
+    engine.step_state_space(u, context);
+
+    const auto tiles = engine.decode_and_dispatch_tiles();
+    assert(tiles.size() == 6U);
+    std::size_t latent_count = 0U;
+    for (const auto& tile : tiles) {
+        latent_count += tile.latent_slice.size();
+    }
+    assert(latent_count == config.latent_dim);
+    assert(engine.transition_infinity_norm() < 1.0);
+    assert(std::isfinite(engine.latent_norm()));
+}
+
+void test_dimension_rejection() {
+    jarvisx::DrMoagiStateSpaceConfig config;
+    config.latent_dim = 8U;
+    config.ingress_dim = 4U;
+    jarvisx::DrMoagiStateSpaceEngine engine(config);
+    bool threw = false;
+    try {
+        engine.step_state_space(std::vector<double>(3U, 0.0),
+                                std::vector<double>(8U, 0.0));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+} // namespace
+
+int main() {
+    test_spsc_ring();
+    test_linear_bound();
+    test_engine_dimensions_and_tiles();
+    test_dimension_rejection();
+    std::cout << "dr_moagi_state_space_tests: PASS\n";
+    return 0;
+}


### PR DESCRIPTION
## What changed

- add a C++17 `DrMoagiStateSpaceEngine` for multimodal ingress, bounded latent transition, logical OLED tile dispatch, and telemetry
- replace the supplied generic lock-free claim with an explicit SPSC ring-buffer contract
- enforce a conservative `||Phi||_inf <= 0.94` bound, which is sufficient for the linear transition because `rho(Phi) <= ||Phi||_inf`
- report power-iteration growth telemetry without mislabeling it as the full nonlinear closed-loop Jacobian spectral radius
- model the `1,000,000 x 1,000,000` OLED plane as logical tile geometry rather than materializing `10^12` pixels
- add regression coverage for queue behavior, contraction enforcement, non-divisible latent/tile partitioning, and dimension rejection
- wire the executable and tests into the existing `cpp_runtime` CMake/CTest surface

## Why

This operationalizes the submitted state-space prototype inside the repository boundary already established by ADR-002, while preserving Jarvis-X invariants around bounded resources, honest virtual scale, and measured-vs-asserted stability.

## Important mathematical boundary

This PR does **not** claim that bounding `Phi` proves `rho(J_F) < 1` for the complete nonlinear `Encode -> Decode -> memory/context -> state` loop. It only enforces and reports a conservative bound for the implemented linear state-transition operator. Full closed-loop Jacobian/Lyapunov validation remains a separate extension.

## Validation

Local validation completed with:

```text
g++ -std=c++17 -Wall -Wextra -Wpedantic -Wconversion -Wshadow
```

The standalone regression binary passed, and a minimal CMake/CTest integration build passed. Repository CI will additionally exercise GCC, Clang+ASan/UBSan, and MSVC through the existing C++ runtime workflow.