### PR TITLE
Permeate unified candidate control plane across Jarvis-X

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -156,3 +156,12 @@ jarvisx_harden(jarvisx-dr-moagi-state-space-tests)
 
 add_test(NAME dr-moagi-state-space-regressions COMMAND jarvisx-dr-moagi-state-space-tests)
 set_tests_properties(dr-moagi-state-space-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-electromagnetic-flow-tests
+    tests/electromagnetic_flow_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-electromagnetic-flow-tests)
+jarvisx_harden(jarvisx-electromagnetic-flow-tests)
+
+add_test(NAME electromagnetic-flow-regressions COMMAND jarvisx-electromagnetic-flow-tests)
+set_tests_properties(electromagnetic-flow-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-dr-moagi-state-space
+    src/dr_moagi_state_space_main.cpp
+)
+jarvisx_include_runtime(jarvisx-dr-moagi-state-space)
+jarvisx_harden(jarvisx-dr-moagi-state-space)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -109,6 +115,12 @@ add_test(
 )
 set_tests_properties(multimedia4d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME dr-moagi-state-space-smoke
+    COMMAND jarvisx-dr-moagi-state-space
+)
+set_tests_properties(dr-moagi-state-space-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -135,3 +147,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-dr-moagi-state-space-tests
+    tests/dr_moagi_state_space_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-dr-moagi-state-space-tests)
+jarvisx_harden(jarvisx-dr-moagi-state-space-tests)
+
+add_test(NAME dr-moagi-state-space-regressions COMMAND jarvisx-dr-moagi-state-space-tests)
+set_tests_properties(dr-moagi-state-space-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/dr_moagi_state_space.hpp
+++ b/cpp_runtime/include/jarvisx/dr_moagi_state_space.hpp
@@ -1,0 +1,330 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <limits>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+struct MultimodalIngress {
+    std::uint64_t timestamp_ns{};
+    std::vector<double> spatial_3d_mesh;
+    std::vector<double> spatial_audio;
+    std::vector<double> contextual_text;
+};
+
+struct OledTile {
+    std::uint32_t tile_id{};
+    std::uint32_t x_offset{};
+    std::uint32_t y_offset{};
+    std::uint32_t width{};
+    std::uint32_t height{};
+    std::vector<double> latent_slice;
+    std::array<std::uint8_t, 3> preview_rgb{0U, 0U, 0U};
+    double active_power_mw{};
+};
+
+// Single-producer/single-consumer ring buffer. The memory-ordering contract is
+// intentionally narrow; this type must not be used as an MPMC queue.
+template <typename T, std::size_t Capacity>
+class SpscIngressRingBuffer {
+    static_assert(Capacity >= 2U, "ring capacity must be at least two");
+
+public:
+    bool push(const T& item) {
+        const std::size_t current_tail = tail_.load(std::memory_order_relaxed);
+        const std::size_t next_tail = (current_tail + 1U) % Capacity;
+        if (next_tail == head_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        buffer_[current_tail] = item;
+        tail_.store(next_tail, std::memory_order_release);
+        return true;
+    }
+
+    bool pop(T& item) {
+        const std::size_t current_head = head_.load(std::memory_order_relaxed);
+        if (current_head == tail_.load(std::memory_order_acquire)) {
+            return false;
+        }
+        item = buffer_[current_head];
+        head_.store((current_head + 1U) % Capacity, std::memory_order_release);
+        return true;
+    }
+
+private:
+    std::array<T, Capacity> buffer_{};
+    std::atomic<std::size_t> head_{0U};
+    std::atomic<std::size_t> tail_{0U};
+};
+
+class LinearStateGovernor {
+public:
+    static double infinity_norm(const std::vector<double>& matrix, std::size_t dim) {
+        validate_square(matrix, dim);
+        double max_row_sum = 0.0;
+        for (std::size_t i = 0; i < dim; ++i) {
+            double row_sum = 0.0;
+            for (std::size_t j = 0; j < dim; ++j) {
+                row_sum += std::abs(matrix[i * dim + j]);
+            }
+            max_row_sum = std::max(max_row_sum, row_sum);
+        }
+        return max_row_sum;
+    }
+
+    // Power-iteration estimate of the dominant linear growth factor. This is
+    // telemetry, not a proof of the full nonlinear closed-loop Jacobian radius.
+    static double dominant_growth_estimate(const std::vector<double>& matrix,
+                                           std::size_t dim,
+                                           std::size_t max_iter = 30U) {
+        validate_square(matrix, dim);
+        if (dim == 0U) {
+            return 0.0;
+        }
+
+        std::vector<double> v(dim, 1.0 / std::sqrt(static_cast<double>(dim)));
+        double estimate = 0.0;
+        for (std::size_t iter = 0; iter < max_iter; ++iter) {
+            std::vector<double> w(dim, 0.0);
+            for (std::size_t i = 0; i < dim; ++i) {
+                for (std::size_t j = 0; j < dim; ++j) {
+                    w[i] += matrix[i * dim + j] * v[j];
+                }
+            }
+
+            double norm_sq = 0.0;
+            for (const double value : w) {
+                norm_sq += value * value;
+            }
+            const double norm = std::sqrt(norm_sq);
+            if (norm < 1.0e-14) {
+                return 0.0;
+            }
+            estimate = norm;
+            for (std::size_t i = 0; i < dim; ++i) {
+                v[i] = w[i] / norm;
+            }
+        }
+        return estimate;
+    }
+
+    // Enforces ||Phi||_inf <= target. Since rho(Phi) <= ||Phi||_inf, this is
+    // a conservative sufficient bound for the linear transition operator.
+    static double enforce_contractive_bound(std::vector<double>& matrix,
+                                            std::size_t dim,
+                                            double target = 0.94) {
+        if (!(target > 0.0 && target < 1.0)) {
+            throw std::invalid_argument("target contraction bound must lie in (0, 1)");
+        }
+        const double current = infinity_norm(matrix, dim);
+        if (current <= target || current == 0.0) {
+            return 1.0;
+        }
+        const double scale = target / current;
+        for (double& value : matrix) {
+            value *= scale;
+        }
+        return scale;
+    }
+
+private:
+    static void validate_square(const std::vector<double>& matrix, std::size_t dim) {
+        if (dim == 0U || matrix.size() != dim * dim) {
+            throw std::invalid_argument("matrix dimensions do not match latent dimension");
+        }
+    }
+};
+
+struct DrMoagiStateSpaceConfig {
+    std::size_t latent_dim{256U};
+    std::size_t ingress_dim{32U};
+    std::size_t tiles_x{8U};
+    std::size_t tiles_y{8U};
+    std::uint32_t logical_width{1'000'000U};
+    std::uint32_t logical_height{1'000'000U};
+    double transition_bound{0.94};
+    double state_abs_limit{1.0e6};
+
+    void validate() const {
+        if (latent_dim == 0U || ingress_dim == 0U || tiles_x == 0U || tiles_y == 0U) {
+            throw std::invalid_argument("state-space dimensions must be non-zero");
+        }
+        if (logical_width == 0U || logical_height == 0U) {
+            throw std::invalid_argument("logical display dimensions must be non-zero");
+        }
+        if (!(transition_bound > 0.0 && transition_bound < 1.0)) {
+            throw std::invalid_argument("transition bound must lie in (0, 1)");
+        }
+        if (!(state_abs_limit > 0.0) || !std::isfinite(state_abs_limit)) {
+            throw std::invalid_argument("state absolute limit must be finite and positive");
+        }
+    }
+
+    std::size_t total_tiles() const noexcept { return tiles_x * tiles_y; }
+};
+
+class DrMoagiStateSpaceEngine {
+public:
+    explicit DrMoagiStateSpaceEngine(DrMoagiStateSpaceConfig config)
+        : config_(std::move(config)),
+          z_state_(config_.latent_dim, 0.05),
+          phi_(config_.latent_dim * config_.latent_dim, 0.0),
+          psi_(config_.latent_dim * config_.ingress_dim, 0.02) {
+        config_.validate();
+        for (std::size_t i = 0; i < config_.latent_dim; ++i) {
+            phi_[i * config_.latent_dim + i] = 0.85;
+        }
+    }
+
+    std::vector<double> encode_ingress(const MultimodalIngress& ingress) const {
+        std::vector<double> u(config_.ingress_dim, 0.0);
+        accumulate_weighted(u, ingress.spatial_3d_mesh, 0.5);
+        accumulate_weighted(u, ingress.spatial_audio, 0.3);
+        accumulate_weighted(u, ingress.contextual_text, 0.2);
+        return u;
+    }
+
+    void step_state_space(const std::vector<double>& u,
+                          const std::vector<double>& delta_context) {
+        if (u.size() != config_.ingress_dim) {
+            throw std::invalid_argument("ingress vector dimension mismatch");
+        }
+        if (delta_context.size() != config_.latent_dim) {
+            throw std::invalid_argument("context vector dimension mismatch");
+        }
+
+        LinearStateGovernor::enforce_contractive_bound(
+            phi_, config_.latent_dim, config_.transition_bound);
+
+        std::vector<double> next(config_.latent_dim, 0.0);
+        for (std::size_t i = 0; i < config_.latent_dim; ++i) {
+            double state_sum = 0.0;
+            for (std::size_t j = 0; j < config_.latent_dim; ++j) {
+                state_sum += phi_[i * config_.latent_dim + j] * z_state_[j];
+            }
+
+            double input_sum = 0.0;
+            for (std::size_t j = 0; j < config_.ingress_dim; ++j) {
+                input_sum += psi_[i * config_.ingress_dim + j] * u[j];
+            }
+
+            const double candidate = state_sum + input_sum + delta_context[i];
+            if (!std::isfinite(candidate)) {
+                throw std::runtime_error("non-finite latent state rejected by admissibility gate");
+            }
+            next[i] = std::clamp(candidate, -config_.state_abs_limit, config_.state_abs_limit);
+        }
+        z_state_.swap(next);
+    }
+
+    std::vector<OledTile> decode_and_dispatch_tiles() const {
+        const std::size_t total = config_.total_tiles();
+        std::vector<OledTile> tiles(total);
+        const unsigned int hw = std::thread::hardware_concurrency();
+        const std::size_t available = hw == 0U ? 1U : static_cast<std::size_t>(hw);
+        const std::size_t worker_count = std::max<std::size_t>(1U, std::min(available, total));
+        const std::size_t batch = (total + worker_count - 1U) / worker_count;
+
+        auto decode_work = [this, total, &tiles](std::size_t begin_tile, std::size_t end_tile) {
+            for (std::size_t tile_index = begin_tile; tile_index < end_tile; ++tile_index) {
+                const std::size_t latent_begin = tile_index * config_.latent_dim / total;
+                const std::size_t latent_end = (tile_index + 1U) * config_.latent_dim / total;
+
+                OledTile tile;
+                tile.tile_id = static_cast<std::uint32_t>(tile_index);
+                const std::size_t tx = tile_index % config_.tiles_x;
+                const std::size_t ty = tile_index / config_.tiles_x;
+                tile.x_offset = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_width) * tx) / config_.tiles_x);
+                tile.y_offset = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_height) * ty) / config_.tiles_y);
+                const std::uint32_t x_end = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_width) * (tx + 1U)) / config_.tiles_x);
+                const std::uint32_t y_end = static_cast<std::uint32_t>(
+                    (static_cast<std::uint64_t>(config_.logical_height) * (ty + 1U)) / config_.tiles_y);
+                tile.width = x_end - tile.x_offset;
+                tile.height = y_end - tile.y_offset;
+                tile.latent_slice.assign(z_state_.begin() + static_cast<std::ptrdiff_t>(latent_begin),
+                                         z_state_.begin() + static_cast<std::ptrdiff_t>(latent_end));
+
+                double energy = 0.0;
+                for (const double value : tile.latent_slice) {
+                    energy += std::abs(value);
+                }
+                if (energy >= 0.001) {
+                    tile.preview_rgb = {
+                        saturating_byte(energy * 100.0),
+                        saturating_byte(energy * 150.0),
+                        saturating_byte(energy * 200.0)};
+                    tile.active_power_mw = energy * 12.5;
+                }
+                tiles[tile_index] = std::move(tile);
+            }
+        };
+
+        std::vector<std::future<void>> futures;
+        futures.reserve(worker_count);
+        for (std::size_t worker = 0; worker < worker_count; ++worker) {
+            const std::size_t begin_tile = worker * batch;
+            const std::size_t end_tile = std::min(begin_tile + batch, total);
+            if (begin_tile < end_tile) {
+                futures.emplace_back(std::async(std::launch::async, decode_work, begin_tile, end_tile));
+            }
+        }
+        for (auto& future : futures) {
+            future.get();
+        }
+        return tiles;
+    }
+
+    double transition_infinity_norm() const {
+        return LinearStateGovernor::infinity_norm(phi_, config_.latent_dim);
+    }
+
+    double transition_growth_estimate() const {
+        return LinearStateGovernor::dominant_growth_estimate(phi_, config_.latent_dim);
+    }
+
+    double latent_norm() const noexcept {
+        double norm_sq = 0.0;
+        for (const double value : z_state_) {
+            norm_sq += value * value;
+        }
+        return std::sqrt(norm_sq);
+    }
+
+    const std::vector<double>& state() const noexcept { return z_state_; }
+    const DrMoagiStateSpaceConfig& config() const noexcept { return config_; }
+
+private:
+    static void accumulate_weighted(std::vector<double>& target,
+                                    const std::vector<double>& source,
+                                    double weight) {
+        const std::size_t count = std::min(target.size(), source.size());
+        for (std::size_t i = 0; i < count; ++i) {
+            target[i] += source[i] * weight;
+        }
+    }
+
+    static std::uint8_t saturating_byte(double value) noexcept {
+        const double bounded = std::clamp(value, 0.0, 255.0);
+        return static_cast<std::uint8_t>(bounded);
+    }
+
+    DrMoagiStateSpaceConfig config_;
+    std::vector<double> z_state_;
+    std::vector<double> phi_;
+    std::vector<double> psi_;
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/include/jarvisx/electromagnetic_flow.hpp
+++ b/cpp_runtime/include/jarvisx/electromagnetic_flow.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace jarvisx {
+
+// Deterministic Q16.16 projection used only to measure logical switching
+// activity. The authoritative state-space engine may retain a different
+// numerical representation; this adapter makes the bit-level observation
+// contract explicit instead of pretending floating-point object bytes are a
+// stable hardware-independent logic encoding.
+struct Q16_16SwitchWord {
+    std::int32_t raw{};
+
+    static Q16_16SwitchWord from_double(double value) {
+        if (!std::isfinite(value)) {
+            throw std::invalid_argument("switching telemetry requires finite state values");
+        }
+        constexpr double scale = 65536.0;
+        constexpr double minimum =
+            static_cast<double>(std::numeric_limits<std::int32_t>::min()) / scale;
+        constexpr double maximum =
+            static_cast<double>(std::numeric_limits<std::int32_t>::max()) / scale;
+        const double bounded = std::clamp(value, minimum, maximum);
+        const long long quantized = static_cast<long long>(std::llround(bounded * scale));
+        return {static_cast<std::int32_t>(quantized)};
+    }
+};
+
+struct SwitchingActivityTelemetry {
+    std::size_t words{};
+    std::uint64_t raw_bit_toggles{};
+    std::uint64_t dbi_bit_toggles{};
+    std::uint32_t max_raw_toggles_per_word{};
+    double raw_activity_factor{};
+    double dbi_activity_factor{};
+};
+
+struct ElectricalSwitchingEstimate {
+    double raw_dynamic_power_w{};
+    double dbi_dynamic_power_w{};
+    double raw_average_current_a{};
+    double dbi_average_current_a{};
+};
+
+struct PhysicalSwitchingModel {
+    // Aggregate effective switched capacitance for the modeled domain. This is
+    // intentionally supplied by a hardware model or measurement rather than
+    // inferred from software state.
+    double effective_capacitance_f{};
+    double supply_voltage_v{};
+    double cycle_frequency_hz{};
+
+    void validate() const {
+        if (!(effective_capacitance_f > 0.0) || !std::isfinite(effective_capacitance_f)) {
+            throw std::invalid_argument("effective capacitance must be finite and positive");
+        }
+        if (!(supply_voltage_v > 0.0) || !std::isfinite(supply_voltage_v)) {
+            throw std::invalid_argument("supply voltage must be finite and positive");
+        }
+        if (!(cycle_frequency_hz > 0.0) || !std::isfinite(cycle_frequency_hz)) {
+            throw std::invalid_argument("cycle frequency must be finite and positive");
+        }
+    }
+};
+
+class ElectromagneticFlowLogic {
+public:
+    // Counts state transitions in a canonical 32-bit Q16.16 logic image.
+    // DBI telemetry applies the ideal per-word transform min(H, 32-H), so its
+    // result is an upper-level switching bound, not a claim that the executing
+    // CPU/GPU interconnect actually implements Data Bus Inversion.
+    static SwitchingActivityTelemetry measure_transition(
+        const std::vector<double>& before,
+        const std::vector<double>& after) {
+        if (before.size() != after.size()) {
+            throw std::invalid_argument("switching telemetry state dimensions must match");
+        }
+
+        SwitchingActivityTelemetry telemetry;
+        telemetry.words = before.size();
+        for (std::size_t index = 0; index < before.size(); ++index) {
+            const auto lhs = Q16_16SwitchWord::from_double(before[index]);
+            const auto rhs = Q16_16SwitchWord::from_double(after[index]);
+            const std::uint32_t lhs_bits = static_cast<std::uint32_t>(lhs.raw);
+            const std::uint32_t rhs_bits = static_cast<std::uint32_t>(rhs.raw);
+            const std::uint32_t toggles = popcount32(lhs_bits ^ rhs_bits);
+            const std::uint32_t dbi_toggles = std::min<std::uint32_t>(toggles, 32U - toggles);
+
+            telemetry.raw_bit_toggles += static_cast<std::uint64_t>(toggles);
+            telemetry.dbi_bit_toggles += static_cast<std::uint64_t>(dbi_toggles);
+            telemetry.max_raw_toggles_per_word =
+                std::max(telemetry.max_raw_toggles_per_word, toggles);
+        }
+
+        if (telemetry.words > 0U) {
+            const double total_bits = static_cast<double>(telemetry.words) * 32.0;
+            telemetry.raw_activity_factor =
+                static_cast<double>(telemetry.raw_bit_toggles) / total_bits;
+            telemetry.dbi_activity_factor =
+                static_cast<double>(telemetry.dbi_bit_toggles) / total_bits;
+        }
+        return telemetry;
+    }
+
+    // Maps measured logical activity into the standard first-order digital
+    // switching model P_dyn = alpha * C_eff * V_dd^2 * f. This is an electrical
+    // estimate only. It does not solve package/interconnect Maxwell fields or
+    // establish electromagnetic emissions fidelity.
+    static ElectricalSwitchingEstimate estimate_electrical_switching(
+        const SwitchingActivityTelemetry& telemetry,
+        const PhysicalSwitchingModel& model) {
+        model.validate();
+        const double scale = model.effective_capacitance_f *
+                             model.supply_voltage_v *
+                             model.supply_voltage_v *
+                             model.cycle_frequency_hz;
+
+        ElectricalSwitchingEstimate estimate;
+        estimate.raw_dynamic_power_w = telemetry.raw_activity_factor * scale;
+        estimate.dbi_dynamic_power_w = telemetry.dbi_activity_factor * scale;
+        estimate.raw_average_current_a =
+            estimate.raw_dynamic_power_w / model.supply_voltage_v;
+        estimate.dbi_average_current_a =
+            estimate.dbi_dynamic_power_w / model.supply_voltage_v;
+        return estimate;
+    }
+
+    static double current_slew_proxy(double previous_current_a,
+                                     double current_a,
+                                     double delta_t_s) {
+        if (!std::isfinite(previous_current_a) || !std::isfinite(current_a)) {
+            throw std::invalid_argument("current slew proxy requires finite current values");
+        }
+        if (!(delta_t_s > 0.0) || !std::isfinite(delta_t_s)) {
+            throw std::invalid_argument("current slew proxy requires finite positive delta_t");
+        }
+        return std::abs(current_a - previous_current_a) / delta_t_s;
+    }
+
+private:
+    static std::uint32_t popcount32(std::uint32_t value) noexcept {
+        std::uint32_t count = 0U;
+        while (value != 0U) {
+            value &= value - 1U;
+            ++count;
+        }
+        return count;
+    }
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/src/dr_moagi_state_space_main.cpp
+++ b/cpp_runtime/src/dr_moagi_state_space_main.cpp
@@ -1,0 +1,64 @@
+#include "jarvisx/dr_moagi_state_space.hpp"
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <vector>
+
+int main() {
+    using namespace jarvisx;
+
+    DrMoagiStateSpaceConfig config;
+    SpscIngressRingBuffer<MultimodalIngress, 16U> ingress_ring;
+    DrMoagiStateSpaceEngine engine(config);
+
+    MultimodalIngress payload;
+    payload.timestamp_ns = static_cast<std::uint64_t>(
+        std::chrono::steady_clock::now().time_since_epoch().count());
+    payload.spatial_3d_mesh = {0.8, 0.4, -0.2, 0.9, 0.1};
+    payload.spatial_audio = {0.1, 0.85, 0.44};
+    payload.contextual_text = {1.0, 0.0, 0.5, 0.25};
+
+    if (!ingress_ring.push(payload)) {
+        std::cerr << "failed to enqueue synthetic ingress\n";
+        return 1;
+    }
+
+    std::cout << "=========================================================\n"
+              << "  DR MOAGI STATE-SPACE C++ REFERENCE CORE               \n"
+              << "=========================================================\n\n"
+              << std::fixed << std::setprecision(4);
+
+    for (int frame = 1; frame <= 5; ++frame) {
+        const auto start = std::chrono::high_resolution_clock::now();
+
+        MultimodalIngress active_ingress;
+        std::vector<double> u(config.ingress_dim, 0.05);
+        if (ingress_ring.pop(active_ingress)) {
+            u = engine.encode_ingress(active_ingress);
+        }
+
+        std::vector<double> delta_context(config.latent_dim, 0.005);
+        engine.step_state_space(u, delta_context);
+        const auto tiles = engine.decode_and_dispatch_tiles();
+
+        double total_power_mw = 0.0;
+        for (const auto& tile : tiles) {
+            total_power_mw += tile.active_power_mw;
+        }
+
+        const auto end = std::chrono::high_resolution_clock::now();
+        const double frame_ms = std::chrono::duration<double, std::milli>(end - start).count();
+
+        std::cout << "[FRAME " << frame << "]"
+                  << " LatentNorm=" << engine.latent_norm()
+                  << " | ||Phi||_inf=" << engine.transition_infinity_norm()
+                  << " | growth_est(Phi)=" << engine.transition_growth_estimate()
+                  << " | tile_power_model=" << total_power_mw << " mW"
+                  << " | latency=" << frame_ms << " ms\n";
+    }
+
+    std::cout << "\n[STATE] Linear transition bound enforced. "
+              << "Full nonlinear closed-loop Jacobian stability is not asserted by this harness.\n";
+    return 0;
+}

--- a/cpp_runtime/src/dr_moagi_state_space_main.cpp
+++ b/cpp_runtime/src/dr_moagi_state_space_main.cpp
@@ -1,4 +1,5 @@
 #include "jarvisx/dr_moagi_state_space.hpp"
+#include "jarvisx/electromagnetic_flow.hpp"
 
 #include <chrono>
 #include <iomanip>
@@ -38,8 +39,11 @@ int main() {
             u = engine.encode_ingress(active_ingress);
         }
 
+        const std::vector<double> before_state = engine.state();
         std::vector<double> delta_context(config.latent_dim, 0.005);
         engine.step_state_space(u, delta_context);
+        const auto switching = ElectromagneticFlowLogic::measure_transition(
+            before_state, engine.state());
         const auto tiles = engine.decode_and_dispatch_tiles();
 
         double total_power_mw = 0.0;
@@ -54,11 +58,16 @@ int main() {
                   << " LatentNorm=" << engine.latent_norm()
                   << " | ||Phi||_inf=" << engine.transition_infinity_norm()
                   << " | growth_est(Phi)=" << engine.transition_growth_estimate()
+                  << " | Q16.raw_alpha=" << switching.raw_activity_factor
+                  << " | Q16.DBI_alpha=" << switching.dbi_activity_factor
+                  << " | Q16.toggles=" << switching.raw_bit_toggles
                   << " | tile_power_model=" << total_power_mw << " mW"
                   << " | latency=" << frame_ms << " ms\n";
     }
 
     std::cout << "\n[STATE] Linear transition bound enforced. "
+              << "Q16.16 switching telemetry observes logical state transitions only; "
+              << "physical power/EM fields require an explicit hardware model. "
               << "Full nonlinear closed-loop Jacobian stability is not asserted by this harness.\n";
     return 0;
 }

--- a/cpp_runtime/tests/dr_moagi_state_space_tests.cpp
+++ b/cpp_runtime/tests/dr_moagi_state_space_tests.cpp
@@ -1,0 +1,85 @@
+#include "jarvisx/dr_moagi_state_space.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void test_spsc_ring() {
+    jarvisx::SpscIngressRingBuffer<int, 4U> ring;
+    assert(ring.push(1));
+    assert(ring.push(2));
+    assert(ring.push(3));
+    assert(!ring.push(4));
+    int value = 0;
+    assert(ring.pop(value) && value == 1);
+    assert(ring.pop(value) && value == 2);
+    assert(ring.pop(value) && value == 3);
+    assert(!ring.pop(value));
+}
+
+void test_linear_bound() {
+    std::vector<double> matrix{
+        1.2, 0.2,
+        0.1, 1.1};
+    const double scale = jarvisx::LinearStateGovernor::enforce_contractive_bound(matrix, 2U, 0.94);
+    assert(scale < 1.0);
+    const double norm = jarvisx::LinearStateGovernor::infinity_norm(matrix, 2U);
+    assert(norm <= 0.9400000001);
+}
+
+void test_engine_dimensions_and_tiles() {
+    jarvisx::DrMoagiStateSpaceConfig config;
+    config.latent_dim = 10U;
+    config.ingress_dim = 4U;
+    config.tiles_x = 3U;
+    config.tiles_y = 2U;
+    config.logical_width = 10U;
+    config.logical_height = 8U;
+
+    jarvisx::DrMoagiStateSpaceEngine engine(config);
+    jarvisx::MultimodalIngress ingress;
+    ingress.spatial_3d_mesh = {1.0, 2.0, 3.0, 4.0};
+    const auto u = engine.encode_ingress(ingress);
+    std::vector<double> context(config.latent_dim, 0.0);
+    engine.step_state_space(u, context);
+
+    const auto tiles = engine.decode_and_dispatch_tiles();
+    assert(tiles.size() == 6U);
+    std::size_t latent_count = 0U;
+    for (const auto& tile : tiles) {
+        latent_count += tile.latent_slice.size();
+    }
+    assert(latent_count == config.latent_dim);
+    assert(engine.transition_infinity_norm() < 1.0);
+    assert(std::isfinite(engine.latent_norm()));
+}
+
+void test_dimension_rejection() {
+    jarvisx::DrMoagiStateSpaceConfig config;
+    config.latent_dim = 8U;
+    config.ingress_dim = 4U;
+    jarvisx::DrMoagiStateSpaceEngine engine(config);
+    bool threw = false;
+    try {
+        engine.step_state_space(std::vector<double>(3U, 0.0),
+                                std::vector<double>(8U, 0.0));
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+} // namespace
+
+int main() {
+    test_spsc_ring();
+    test_linear_bound();
+    test_engine_dimensions_and_tiles();
+    test_dimension_rejection();
+    std::cout << "dr_moagi_state_space_tests: PASS\n";
+    return 0;
+}

--- a/cpp_runtime/tests/electromagnetic_flow_tests.cpp
+++ b/cpp_runtime/tests/electromagnetic_flow_tests.cpp
@@ -1,0 +1,99 @@
+#include "jarvisx/electromagnetic_flow.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+bool close(double lhs, double rhs, double tolerance = 1.0e-12) {
+    return std::abs(lhs - rhs) <= tolerance;
+}
+
+void test_single_q16_lsb_toggle() {
+    const std::vector<double> before{0.0};
+    const std::vector<double> after{1.0 / 65536.0};
+    const auto telemetry = jarvisx::ElectromagneticFlowLogic::measure_transition(before, after);
+
+    assert(telemetry.words == 1U);
+    assert(telemetry.raw_bit_toggles == 1U);
+    assert(telemetry.dbi_bit_toggles == 1U);
+    assert(telemetry.max_raw_toggles_per_word == 1U);
+    assert(close(telemetry.raw_activity_factor, 1.0 / 32.0));
+    assert(close(telemetry.dbi_activity_factor, 1.0 / 32.0));
+}
+
+void test_dbi_caps_payload_toggles() {
+    const std::vector<double> before{0.0};
+    const std::vector<double> after{-1.0 / 65536.0};
+    const auto telemetry = jarvisx::ElectromagneticFlowLogic::measure_transition(before, after);
+
+    // Q16.16 -1 LSB is the two's-complement word 0xffffffff. Relative to
+    // zero this flips all 32 payload bits; ideal payload DBI selects its
+    // complement, reducing the payload transition count to zero. The separate
+    // DBI control-line transition is deliberately outside this metric.
+    assert(telemetry.raw_bit_toggles == 32U);
+    assert(telemetry.dbi_bit_toggles == 0U);
+    assert(telemetry.max_raw_toggles_per_word == 32U);
+    assert(close(telemetry.raw_activity_factor, 1.0));
+    assert(close(telemetry.dbi_activity_factor, 0.0));
+}
+
+void test_physical_model_is_explicit() {
+    jarvisx::SwitchingActivityTelemetry telemetry;
+    telemetry.words = 1U;
+    telemetry.raw_activity_factor = 0.5;
+    telemetry.dbi_activity_factor = 0.25;
+
+    jarvisx::PhysicalSwitchingModel model;
+    model.effective_capacitance_f = 1.0e-12;
+    model.supply_voltage_v = 1.0;
+    model.cycle_frequency_hz = 1.0e9;
+
+    const auto estimate =
+        jarvisx::ElectromagneticFlowLogic::estimate_electrical_switching(telemetry, model);
+    assert(close(estimate.raw_dynamic_power_w, 5.0e-4));
+    assert(close(estimate.dbi_dynamic_power_w, 2.5e-4));
+    assert(close(estimate.raw_average_current_a, 5.0e-4));
+    assert(close(estimate.dbi_average_current_a, 2.5e-4));
+}
+
+void test_dimension_and_nonfinite_rejection() {
+    bool dimension_threw = false;
+    try {
+        (void)jarvisx::ElectromagneticFlowLogic::measure_transition(
+            std::vector<double>{0.0}, std::vector<double>{0.0, 1.0});
+    } catch (const std::invalid_argument&) {
+        dimension_threw = true;
+    }
+    assert(dimension_threw);
+
+    bool finite_threw = false;
+    try {
+        (void)jarvisx::ElectromagneticFlowLogic::measure_transition(
+            std::vector<double>{0.0}, std::vector<double>{std::nan("")});
+    } catch (const std::invalid_argument&) {
+        finite_threw = true;
+    }
+    assert(finite_threw);
+}
+
+void test_current_slew_proxy() {
+    const double slew = jarvisx::ElectromagneticFlowLogic::current_slew_proxy(
+        0.10, 0.13, 1.0e-9);
+    assert(close(slew, 3.0e7, 1.0e-5));
+}
+
+} // namespace
+
+int main() {
+    test_single_q16_lsb_toggle();
+    test_dbi_caps_payload_toggles();
+    test_physical_model_is_explicit();
+    test_dimension_and_nonfinite_rejection();
+    test_current_slew_proxy();
+    std::cout << "electromagnetic_flow_tests: PASS\n";
+    return 0;
+}

--- a/docs/adr/0010-unified-candidate-control-plane.md
+++ b/docs/adr/0010-unified-candidate-control-plane.md
@@ -1,0 +1,236 @@
+# ADR-010: Unify candidate admission and Omega evidence across Jarvis-X runtimes
+
+**Status:** Proposed  
+**Date:** 2026-08-19
+
+## Context
+
+Jarvis-X now contains several executable state-transition systems that share the same conceptual law but expose different local transaction semantics:
+
+- the canonical `CodexVM` checkpoints authoritative state, executes an instruction, writes ledger/trace receipts and rolls back on failure;
+- the Dr Moagi sparse field runtime freezes a field snapshot, computes a projected candidate, invokes an optional validator and commits or rejects the candidate;
+- the C++ inward processor evaluates bounded genome candidates and admits only a coherent, sufficiently improved champion;
+- the Dr Moagi state-space integration candidate computes bounded latent transitions and logical tile emissions;
+- Hyperion constructs deterministic evidence bundles and replay commitments over observations.
+
+Without one executable cross-subsystem transaction contract, the symbols `Lambda`, `Omega`, candidate, commit, rollback and state have compatible intent but different schemas. That fragmentation makes end-to-end replay, orchestration and cross-engine provenance unnecessarily difficult.
+
+## Decision
+
+Jarvis-X adopts a common candidate-first control-plane law:
+
+```text
+S_t --Transform--> C_t --Lambda--> decision
+                                  | commit
+                                  v
+                                S_t+1 = C_t
+                                  |
+                                  +-- Omega receipt
+
+                                  | rollback
+                                  v
+                                S_t+1 = S_t
+                                  |
+                                  +-- Omega receipt
+```
+
+The common transition is:
+
+```text
+C_t = T_Theta(S_t, U_t, Omega_t)
+
+d_t = V_Lambda(C_t)
+
+S_(t+1) = C_t  if d_t = commit
+S_(t+1) = S_t  if d_t = rollback
+```
+
+Every completed candidate decision emits a deterministic transaction receipt.
+
+### State envelope
+
+A `StateEnvelope` does not contain an unrestricted full state object. It binds:
+
+```text
+protocol
+state_type
+state_version
+dimensions
+payload_digest
+authoritative
+```
+
+`payload_digest` is SHA-256 over canonical JSON of the subsystem's declared bounded state representation. A subsystem may hash a compact manifest or a digest of large binary memory rather than materializing its entire logical address space.
+
+The authority flags are explicit:
+
+- `before.authoritative == true`
+- `candidate.authoritative == false`
+- `after.authoritative == true`
+
+### Transaction receipt
+
+A receipt binds:
+
+```text
+protocol
+sequence
+subsystem
+operation
+transaction_id
+decision
+reason
+before envelope
+candidate envelope
+after envelope
+metrics
+previous_hash
+receipt_hash
+```
+
+The receipt chain is deterministic and intentionally excludes wall-clock timestamps from the canonical hash. Environmental timestamps may be carried separately by subsystem telemetry when needed.
+
+### Commit invariant
+
+For an admitted candidate:
+
+```text
+decision = commit
+candidate.payload_digest == after.payload_digest
+```
+
+### Rollback invariant
+
+For a rejected candidate:
+
+```text
+decision = rollback
+before.payload_digest == after.payload_digest
+```
+
+A rejected transform therefore cannot claim rollback while silently changing authoritative state.
+
+### Omega evidence chain
+
+The first receipt uses a 64-zero genesis hash. Each later receipt binds the prior receipt hash:
+
+```text
+H_t = SHA256(receipt_body_t || previous_hash_t)
+previous_hash_(t+1) = H_t
+```
+
+The current implementation achieves the equivalent binding by including `previous_hash` in the canonical receipt body before SHA-256 hashing.
+
+The chain establishes deterministic transition integrity. It does not:
+
+- prove that an external sensor or user supplied truthful data;
+- encrypt state;
+- provide hostile-code isolation;
+- prove semantic correctness of an admitted candidate;
+- make an experimental subsystem authoritative merely because it emits a receipt.
+
+## Initial permeation
+
+This ADR is introduced with a substrate-neutral Python reference implementation in:
+
+```text
+src/jarvisx/control_plane.py
+```
+
+The first adapters are:
+
+1. **CodexVM** — every successfully completed instruction emits a common commit receipt. The control-plane checkpoint participates in VM rollback, so failed post-execution receipt work cannot leave evidence ahead of authoritative VM state.
+2. **Dr Moagi Field Runtime v2** — each completed field candidate emits either a commit receipt or a rollback receipt. A new field `load()` starts a new evidence chain for that run.
+
+The state-space C++ integration branch is the next adoption point. Its linear contraction telemetry remains distinct from a proof of full nonlinear closed-loop stability.
+
+## Required subsystem adapters
+
+A subsystem joining the control plane must provide:
+
+- a stable `state_type` and positive `state_version`;
+- deterministic dimensions;
+- a deterministic bounded payload representation;
+- an explicit candidate boundary;
+- an explicit admission decision;
+- authoritative before/after envelopes;
+- JSON-native deterministic metrics;
+- failure behavior that does not advance authoritative state after a failed receipt operation.
+
+## Relationship to Lambda
+
+`Lambda` remains the subsystem-specific admissibility mechanism. The common control plane does not force every subsystem to use the same validator mathematics.
+
+Instead it standardizes the decision boundary:
+
+```text
+subsystem-specific V_Lambda
+          |
+          v
+  commit / rollback
+          |
+          v
+common receipt semantics
+```
+
+This preserves local numerical and domain expertise while making global orchestration auditable.
+
+## Relationship to Omega
+
+`Omega` is separated into two meanings that must not be conflated:
+
+1. **working correction memory** used inside a model or runtime, such as residual memory in the C++ processor;
+2. **provenance evidence** describing authoritative state transitions.
+
+Both may be called Omega in research notation, but the control-plane evidence chain is specifically the second role. Working correction memory must be included in a state digest when it is authoritative for replay.
+
+## Consequences
+
+### Positive
+
+- VM instructions and sparse field steps now share one transaction vocabulary;
+- rollback becomes machine-checkable across subsystem boundaries;
+- orchestration can consume one receipt schema without understanding every internal runtime;
+- evidence scales with active manifests/digests rather than logical virtual extent;
+- deterministic replay is not polluted by wall-clock latency or timestamps;
+- future state-space, C++, Hyperion and distributed adapters have a precise target contract.
+
+### Negative
+
+- subsystem state adapters must define canonical bounded representations;
+- two provenance systems temporarily coexist in the VM: the historical opcode ledger and the unified control-plane chain;
+- SHA-256/canonical-JSON parity must be implemented or delegated carefully in native runtimes before cross-language receipt hashes can be identical;
+- this contract proves transition integrity, not convergence, safety, intelligence or source truth.
+
+## Validation
+
+Promotion to Accepted requires:
+
+- deterministic unit tests for state envelopes and transaction IDs;
+- chain-integrity and tamper tests;
+- explicit commit and rollback invariant tests;
+- VM rollback tests covering the common evidence checkpoint;
+- field commit/rejection receipt tests;
+- CI across supported Python versions;
+- a documented native-runtime strategy for hash/serialization parity before claiming cross-language receipt equivalence.
+
+## Follow-up permeation
+
+After this contract is validated, the preferred sequence is:
+
+```text
+CodexVM + Field Runtime
+        -> C++ inward runtime
+        -> Dr Moagi state-space loop
+        -> Moagi-Helmholtz orchestration
+        -> Hyperion evidence envelope
+        -> distributed consensus receipts
+```
+
+The end state is one system law:
+
+```text
+Observe -> Candidate -> Lambda -> Commit/Rollback -> Omega -> Re-enter
+```
+
+with subsystem-specific mathematics behind a common authority boundary.

--- a/docs/adr/0011-electromagnetic-flow-logic-substrate.md
+++ b/docs/adr/0011-electromagnetic-flow-logic-substrate.md
@@ -1,0 +1,212 @@
+# ADR-011: Electromagnetic Flow Logic as the Physical Substrate Boundary
+
+- Status: Proposed integration
+- Date: 2026-08-19
+- Scope: Dr Moagi state-space runtime, fixed-point switching telemetry, hardware-facing research layers
+
+## Context
+
+Jarvis-X increasingly represents computation as bounded kinetic state evolution:
+
+```text
+Observe -> Encode -> Evolve -> Decode -> Compare -> Correct
+       -> Lambda -> Commit/Rollback -> Omega -> Re-enter
+```
+
+At the physical implementation layer, any electronic realization of those state transitions is ultimately carried by charge, current and electromagnetic fields. However, the repository must preserve a strict distinction between:
+
+1. abstract computational state,
+2. its canonical digital bit representation,
+3. an electrical switching model, and
+4. a physically validated electromagnetic field model.
+
+Collapsing those layers would create false claims. A software state equation is not itself a Maxwell field, and a logical toggle count does not determine radiated or conducted emissions without hardware geometry and electrical parameters.
+
+## Decision
+
+Jarvis-X will treat **electromagnetic flow logic** as a layered substrate model:
+
+```text
+kinetic state transition
+        |
+        v
+canonical fixed-point logic image
+        |
+        v
+bit-transition / Hamming activity
+        |
+        v
+explicit electrical switching model
+        |
+        v
+hardware current-density / geometry model
+        |
+        v
+Maxwell / EM field solution
+```
+
+The canonical logical-to-electrical bridge is observational and fail-closed. It does not acquire authority over the computational state merely because it can estimate switching cost.
+
+## Canonical mapping
+
+For a state transition
+
+```text
+Xi_t -> Xi_{t+1}
+```
+
+an observer first projects selected scalar state into an explicit Q16.16 logic image:
+
+```text
+B_t = Q16.16(Xi_t)
+B_{t+1} = Q16.16(Xi_{t+1})
+```
+
+The raw switching count is
+
+```text
+H_t = sum popcount(B_t XOR B_{t+1})
+```
+
+and the measured activity factor is
+
+```text
+alpha_t = H_t / N_bits.
+```
+
+The reference Data Bus Inversion (DBI) payload model reports
+
+```text
+H_DBI = sum min(H_word, 32 - H_word)
+```
+
+for each 32-bit Q16.16 word. This is an ideal payload transition bound only. It does not assert that the executing CPU, GPU, memory controller or physical bus implements DBI, and it excludes the separate inversion-control line.
+
+When and only when explicit hardware constants are supplied, the first-order electrical model may estimate
+
+```text
+P_dyn = alpha * C_eff * V_dd^2 * f
+I_avg = P_dyn / V_dd.
+```
+
+`C_eff`, `V_dd` and `f` must come from an identified hardware model, design specification or measurement. Jarvis-X must not infer them from logical state.
+
+A current-slew proxy may be reported as
+
+```text
+|dI/dt| ~= |I_t - I_{t-1}| / Delta_t
+```
+
+when the current estimates and timing interval are explicit.
+
+## Physical boundary
+
+The repository will not derive electric or magnetic field fidelity directly from logical telemetry.
+
+A physical EM claim requires, at minimum, an identified mapping for current density and geometry:
+
+```text
+J(r,t) = G_layout[I(t), placement, routing, package, return paths, materials]
+```
+
+followed by an appropriate electromagnetic solution such as Maxwell's equations:
+
+```text
+div E = rho / epsilon
+div B = 0
+curl E = -dB/dt
+curl B = mu J + mu epsilon dE/dt.
+```
+
+Without that layer, Jarvis-X may report **logical switching telemetry** or an **electrical first-order estimate**, but not electromagnetic field strength, radiation, emissions compliance, signal integrity or hardware power fidelity.
+
+## Architectural interpretation
+
+The physical-to-logical hierarchy is therefore:
+
+```text
+(E, B, rho, J)
+      -> electrical circuit state
+      -> transistor / interconnect switching
+      -> digital words
+      -> Q16.16 latent state
+      -> kinetic logic
+      -> 3D adaptive computation.
+```
+
+Conversely, an implemented kinetic transition can be traced downward only as far as evidence permits:
+
+```text
+Delta Xi
+  -> Delta Q16.16 words
+  -> measured bit toggles
+  -> alpha
+  -> P/I estimate when hardware constants exist
+  -> physical EM only when layout/current-density model exists.
+```
+
+## Relationship to the Psi-Phi-Lambda-Omega-Theta stack
+
+The symbols remain computational abstractions. A hardware implementation may map them onto physical structures, but the mapping must be explicit:
+
+- `Psi`: observation / ingress coupling
+- `Phi`: state propagation
+- `Lambda`: admissibility and authority constraints
+- `Omega`: persistent correction and evidence state
+- `Theta`: configurable transfer parameters
+
+No symbol is automatically identified with a Maxwell field quantity.
+
+## Implementation
+
+The C++ reference layer provides `jarvisx/electromagnetic_flow.hpp` with:
+
+- deterministic Q16.16 switching projection,
+- raw Hamming transition counts,
+- ideal DBI payload transition counts,
+- raw and DBI activity factors,
+- optional first-order electrical power/current estimates requiring explicit hardware parameters,
+- a current-slew proxy requiring an explicit time interval.
+
+The Dr Moagi state-space reference executable observes every state transition through this layer and reports raw and DBI activity without altering authoritative state.
+
+## Invariants
+
+1. **Observation does not grant authority.** EM/switching telemetry cannot mutate the state transition.
+2. **No implicit hardware model.** Physical constants must be supplied explicitly.
+3. **No field claim from toggle count.** Bit activity is not Maxwell-field fidelity.
+4. **Canonical representation before comparison.** State is projected to Q16.16 rather than hashing or comparing implementation-defined floating-point object bytes.
+5. **DBI claims are scoped.** Reported DBI values describe ideal payload transition reduction, not actual interconnect behavior unless hardware support is demonstrated.
+6. **Finite bounded inputs.** Non-finite state or invalid physical parameters fail closed.
+7. **Measured-vs-asserted separation.** Logical activity, electrical estimates and physical EM measurements remain distinct telemetry classes.
+
+## Consequences
+
+### Positive
+
+- Provides a concrete bridge from kinetic logic to switching activity.
+- Makes the earlier Q16.16 EM-leanness concept measurable.
+- Enables future optimization objectives that include both reconstruction loss and switching cost.
+- Preserves honest separation between software simulation and physical hardware evidence.
+- Supports future GALS, phase-staggering and placement studies without changing authority semantics.
+
+### Trade-offs
+
+- Q16.16 telemetry is a canonical observation image, not necessarily the representation used by the physical compiler or processor.
+- First-order dynamic power estimates omit leakage, short-circuit current, clock-tree effects, memory subsystem behavior, parasitics, voltage droop and thermal coupling.
+- Accurate EM prediction requires a separate hardware/layout solver and empirical calibration.
+
+## Future work
+
+1. Bind switching telemetry into unified transaction receipts as non-authoritative metrics.
+2. Add per-region / per-agent activity maps for the 3D swarm.
+3. Measure deterministic phase-staggering and GALS scheduling effects on peak activity.
+4. Add an explicit hardware-description contract for `C_eff`, voltage domains, frequency domains and interconnect topology.
+5. Integrate package/layout current-density data before introducing Maxwell-field simulation.
+6. Validate estimates against measured power/current traces on identified hardware.
+
+## Claim boundary
+
+This ADR establishes **electromagnetic flow logic as the physical substrate interpretation of electronic computation** while keeping the executable repository claim narrower:
+
+> Jarvis-X can measure canonical logical switching activity and, with explicit hardware parameters, compute a first-order electrical switching estimate. It does not yet simulate or validate the physical electromagnetic fields of a real implementation.

--- a/src/jarvisx/control_plane.py
+++ b/src/jarvisx/control_plane.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+CONTROL_PROTOCOL = "jarvisx.control-plane.v1"
+GENESIS_RECEIPT_HASH = "0" * 64
+Decision = Literal["commit", "rollback"]
+
+
+def _normalize_json(value: object) -> object:
+    """Normalize a value into deterministic JSON-native data.
+
+    The unified control plane deliberately refuses implicit stringification.
+    Subsystems must declare how domain-specific state is represented before it
+    can become part of authoritative evidence.
+    """
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError("control-plane evidence cannot contain non-finite floats")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("control-plane mapping keys must be strings")
+            normalized[key] = _normalize_json(item)
+        return normalized
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_json(item) for item in value]
+    raise TypeError(f"unsupported control-plane evidence type: {type(value).__name__}")
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(
+        _normalize_json(value),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def digest_json(value: object) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class StateEnvelope:
+    """Typed digest of one subsystem state at a transaction boundary."""
+
+    state_type: str
+    state_version: int
+    dimensions: tuple[int, ...]
+    payload_digest: str
+    authoritative: bool
+    protocol: str = CONTROL_PROTOCOL
+
+    def __post_init__(self) -> None:
+        if self.protocol != CONTROL_PROTOCOL:
+            raise ValueError("unsupported control-plane protocol")
+        if not self.state_type:
+            raise ValueError("state_type must be non-empty")
+        if self.state_version < 1:
+            raise ValueError("state_version must be positive")
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) or value < 0
+            for value in self.dimensions
+        ):
+            raise ValueError("state dimensions must be non-negative integers")
+        if len(self.payload_digest) != 64 or any(
+            character not in "0123456789abcdef" for character in self.payload_digest
+        ):
+            raise ValueError("payload_digest must be 64 lowercase hexadecimal characters")
+
+    @classmethod
+    def from_payload(
+        cls,
+        *,
+        state_type: str,
+        state_version: int,
+        dimensions: Sequence[int],
+        payload: object,
+        authoritative: bool,
+    ) -> "StateEnvelope":
+        return cls(
+            state_type=state_type,
+            state_version=state_version,
+            dimensions=tuple(dimensions),
+            payload_digest=digest_json(payload),
+            authoritative=bool(authoritative),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "protocol": self.protocol,
+            "state_type": self.state_type,
+            "state_version": self.state_version,
+            "dimensions": list(self.dimensions),
+            "payload_digest": self.payload_digest,
+            "authoritative": self.authoritative,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class TransactionReceipt:
+    """Deterministic evidence for one candidate-first state transition."""
+
+    sequence: int
+    subsystem: str
+    operation: str
+    transaction_id: str
+    decision: Decision
+    reason: str | None
+    before: StateEnvelope
+    candidate: StateEnvelope
+    after: StateEnvelope
+    metrics: Mapping[str, object]
+    previous_hash: str
+    receipt_hash: str
+    protocol: str = CONTROL_PROTOCOL
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        sequence: int,
+        subsystem: str,
+        operation: str,
+        decision: Decision,
+        reason: str | None,
+        before: StateEnvelope,
+        candidate: StateEnvelope,
+        after: StateEnvelope,
+        metrics: Mapping[str, object] | None,
+        previous_hash: str,
+    ) -> "TransactionReceipt":
+        if sequence < 0:
+            raise ValueError("receipt sequence must be non-negative")
+        if not subsystem or not operation:
+            raise ValueError("subsystem and operation must be non-empty")
+        if decision not in ("commit", "rollback"):
+            raise ValueError("decision must be commit or rollback")
+        if before.state_type != candidate.state_type or before.state_type != after.state_type:
+            raise ValueError("transaction state types must match")
+        if not before.authoritative or candidate.authoritative or not after.authoritative:
+            raise ValueError("transaction authority flags are inconsistent")
+        if decision == "commit" and candidate.payload_digest != after.payload_digest:
+            raise ValueError("committed after-state must equal the admitted candidate")
+        if decision == "rollback" and before.payload_digest != after.payload_digest:
+            raise ValueError("rollback must preserve the authoritative before-state")
+        if len(previous_hash) != 64 or any(
+            character not in "0123456789abcdef" for character in previous_hash
+        ):
+            raise ValueError("previous_hash must be 64 lowercase hexadecimal characters")
+
+        normalized_metrics = _normalize_json(dict(metrics or {}))
+        assert isinstance(normalized_metrics, dict)
+        transaction_id = digest_json(
+            {
+                "protocol": CONTROL_PROTOCOL,
+                "sequence": sequence,
+                "subsystem": subsystem,
+                "operation": operation,
+                "before": before.to_dict(),
+                "candidate": candidate.to_dict(),
+            }
+        )
+        body = {
+            "protocol": CONTROL_PROTOCOL,
+            "sequence": sequence,
+            "subsystem": subsystem,
+            "operation": operation,
+            "transaction_id": transaction_id,
+            "decision": decision,
+            "reason": reason,
+            "before": before.to_dict(),
+            "candidate": candidate.to_dict(),
+            "after": after.to_dict(),
+            "metrics": normalized_metrics,
+            "previous_hash": previous_hash,
+        }
+        return cls(
+            sequence=sequence,
+            subsystem=subsystem,
+            operation=operation,
+            transaction_id=transaction_id,
+            decision=decision,
+            reason=reason,
+            before=before,
+            candidate=candidate,
+            after=after,
+            metrics=normalized_metrics,
+            previous_hash=previous_hash,
+            receipt_hash=digest_json(body),
+        )
+
+    def body(self) -> dict[str, object]:
+        return {
+            "protocol": self.protocol,
+            "sequence": self.sequence,
+            "subsystem": self.subsystem,
+            "operation": self.operation,
+            "transaction_id": self.transaction_id,
+            "decision": self.decision,
+            "reason": self.reason,
+            "before": self.before.to_dict(),
+            "candidate": self.candidate.to_dict(),
+            "after": self.after.to_dict(),
+            "metrics": dict(self.metrics),
+            "previous_hash": self.previous_hash,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.body(), "receipt_hash": self.receipt_hash}
+
+    def verify(self) -> bool:
+        expected_transaction_id = digest_json(
+            {
+                "protocol": self.protocol,
+                "sequence": self.sequence,
+                "subsystem": self.subsystem,
+                "operation": self.operation,
+                "before": self.before.to_dict(),
+                "candidate": self.candidate.to_dict(),
+            }
+        )
+        if not hmac.compare_digest(self.transaction_id, expected_transaction_id):
+            return False
+        if self.decision == "commit":
+            if self.candidate.payload_digest != self.after.payload_digest:
+                return False
+        elif self.decision == "rollback":
+            if self.before.payload_digest != self.after.payload_digest:
+                return False
+        else:
+            return False
+        return hmac.compare_digest(self.receipt_hash, digest_json(self.body()))
+
+
+class OmegaEvidenceChain:
+    """Hash-chained subsystem-neutral transaction evidence.
+
+    This chain complements subsystem-specific telemetry. It does not attest
+    external truth and it does not replace OS/process isolation.
+    """
+
+    def __init__(self) -> None:
+        self.chain: list[TransactionReceipt] = []
+
+    def checkpoint(self) -> int:
+        return len(self.chain)
+
+    def restore(self, checkpoint: int) -> None:
+        if (
+            isinstance(checkpoint, bool)
+            or not isinstance(checkpoint, int)
+            or checkpoint < 0
+            or checkpoint > len(self.chain)
+        ):
+            raise ValueError("evidence checkpoint is invalid")
+        del self.chain[checkpoint:]
+
+    def reset(self) -> None:
+        self.chain.clear()
+
+    def append(
+        self,
+        *,
+        subsystem: str,
+        operation: str,
+        decision: Decision,
+        before: StateEnvelope,
+        candidate: StateEnvelope,
+        after: StateEnvelope,
+        metrics: Mapping[str, object] | None = None,
+        reason: str | None = None,
+    ) -> TransactionReceipt:
+        previous_hash = self.chain[-1].receipt_hash if self.chain else GENESIS_RECEIPT_HASH
+        receipt = TransactionReceipt.build(
+            sequence=len(self.chain),
+            subsystem=subsystem,
+            operation=operation,
+            decision=decision,
+            reason=reason,
+            before=before,
+            candidate=candidate,
+            after=after,
+            metrics=metrics,
+            previous_hash=previous_hash,
+        )
+        self.chain.append(receipt)
+        return receipt
+
+    def verify(self) -> bool:
+        previous_hash = GENESIS_RECEIPT_HASH
+        for sequence, receipt in enumerate(self.chain):
+            if receipt.sequence != sequence:
+                return False
+            if receipt.previous_hash != previous_hash:
+                return False
+            if not receipt.verify():
+                return False
+            previous_hash = receipt.receipt_hash
+        return True
+
+    def snapshot(self) -> list[dict[str, object]]:
+        return [receipt.to_dict() for receipt in self.chain]

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterable
 from dataclasses import dataclass
 from os import PathLike
 
+from .control_plane import OmegaEvidenceChain, StateEnvelope
 from .debugger import Debugger
 from .decoder import Decoder
 from .ethics import LambdaShield
@@ -25,15 +27,17 @@ class _VMCheckpoint:
     running: bool
     ledger_length: int
     trace_length: int
+    control_length: int
 
 
 class CodexVM:
     """Deterministic transactional Jarvis-X bytecode virtual machine.
 
     Each instruction executes against a complete authoritative-state checkpoint.
-    A failed execution, validation, journal write, or trace write restores the
-    checkpoint and stops the VM. Reflex stabilization is opt-in and occurs
-    before the canonical post-instruction snapshot is journalled and traced.
+    A failed execution, validation, journal write, trace write, or unified
+    control-plane receipt restores the checkpoint and stops the VM. Reflex
+    stabilization is opt-in and occurs before the canonical post-instruction
+    snapshot is journalled, traced and admitted into the common evidence plane.
     """
 
     def __init__(
@@ -57,6 +61,7 @@ class CodexVM:
         self.sandbox = Sandbox(max_cycles=max_cycles)
         self.debugger = Debugger(self)
         self.tracer = Tracer()
+        self.control_plane = OmegaEvidenceChain()
         self.program: list[int] = []
         self.cycles = 0
         self.running = False
@@ -69,6 +74,7 @@ class CodexVM:
             running=self.running,
             ledger_length=self.ledger.checkpoint(),
             trace_length=self.tracer.checkpoint(),
+            control_length=self.control_plane.checkpoint(),
         )
 
     def _restore(self, checkpoint: _VMCheckpoint) -> None:
@@ -78,6 +84,29 @@ class CodexVM:
         self.running = checkpoint.running
         self.ledger.restore(checkpoint.ledger_length)
         self.tracer.restore(checkpoint.trace_length)
+        self.control_plane.restore(checkpoint.control_length)
+
+    def _control_payload(self) -> dict[str, object]:
+        memory = self.mem.snapshot()
+        return {
+            "registers": self.regs.snapshot(),
+            "memory_sha256": hashlib.sha256(memory).hexdigest(),
+            "memory_bytes": len(memory),
+            "cycles": self.cycles,
+            "running": self.running,
+        }
+
+    def _control_envelope(self, *, authoritative: bool) -> StateEnvelope:
+        payload = self._control_payload()
+        registers = payload["registers"]
+        assert isinstance(registers, dict)
+        return StateEnvelope.from_payload(
+            state_type="jarvisx.vm-state",
+            state_version=1,
+            dimensions=(len(registers), int(payload["memory_bytes"])),
+            payload=payload,
+            authoritative=authoritative,
+        )
 
     def load(self, bytecode: Iterable[int]) -> None:
         program = list(bytecode)
@@ -109,6 +138,7 @@ class CodexVM:
             raise RuntimeError("Lambda policy blocked instruction")
 
         checkpoint = self._checkpoint()
+        before = self._control_envelope(authoritative=True)
         try:
             next_cycles = self.cycles + 1
             self.sandbox.enforce(next_cycles)
@@ -124,6 +154,18 @@ class CodexVM:
             snapshot = self.regs.snapshot()
             self.ledger.log(snapshot, instruction.opcode)
             self.tracer.record(instruction, snapshot)
+
+            candidate = self._control_envelope(authoritative=False)
+            after = self._control_envelope(authoritative=True)
+            self.control_plane.append(
+                subsystem="codex-vm",
+                operation=f"opcode:{int(instruction.opcode)}",
+                decision="commit",
+                before=before,
+                candidate=candidate,
+                after=after,
+                metrics={"cycles": self.cycles},
+            )
         except Exception:
             try:
                 self._restore(checkpoint)

--- a/src/jarvisx/core.py
+++ b/src/jarvisx/core.py
@@ -99,11 +99,13 @@ class CodexVM:
     def _control_envelope(self, *, authoritative: bool) -> StateEnvelope:
         payload = self._control_payload()
         registers = payload["registers"]
+        memory_bytes = payload["memory_bytes"]
         assert isinstance(registers, dict)
+        assert isinstance(memory_bytes, int)
         return StateEnvelope.from_payload(
             state_type="jarvisx.vm-state",
             state_version=1,
-            dimensions=(len(registers), int(payload["memory_bytes"])),
+            dimensions=(len(registers), memory_bytes),
             payload=payload,
             authoritative=authoritative,
         )

--- a/src/jarvisx/dr_moagi_field_runtime.py
+++ b/src/jarvisx/dr_moagi_field_runtime.py
@@ -10,13 +10,17 @@ This module operationalizes the same-space field law
 on a sparse logical 3D lattice. It is intentionally independent of the
 canonical 64-bit VM: candidate field transitions are computed in a research
 layer and become authoritative only after projection and optional validation.
+Every completed candidate decision also emits the same deterministic
+control-plane receipt used by the canonical VM.
 """
 
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, replace
+from dataclasses import asdict, dataclass, replace
 from typing import Any, Callable, Mapping, Protocol, Sequence
+
+from .control_plane import OmegaEvidenceChain, StateEnvelope
 
 Coordinate = tuple[int, int, int]
 SparseField = dict[Coordinate, float]
@@ -162,6 +166,7 @@ class DrMoagiFieldRuntime:
         self._state: SparseField = {}
         self._anchor: SparseField = {}
         self._cycle = 0
+        self.control_plane = OmegaEvidenceChain()
 
     @property
     def cycle(self) -> int:
@@ -190,18 +195,20 @@ class DrMoagiFieldRuntime:
         self._state = projected
         self._anchor = dict(projected)
         self._cycle = 0
+        self.control_plane.reset()
 
     def step(self, validator: Validator | None = None) -> FieldStepMetrics:
         """Attempt one atomic field transition.
 
         All terms are evaluated from one frozen snapshot. Candidate state is
         projected first and becomes authoritative only if the optional
-        validator accepts it.
+        validator accepts it. Commit and rollback decisions are emitted into
+        the shared Omega evidence chain before authoritative state is changed.
         """
 
         snapshot = dict(self._state)
+        before = self._state_envelope(snapshot, authoritative=True)
         support = self._support(snapshot)
-        active_before = len(snapshot)
         cycle = self._cycle + 1
 
         latent = self.codec.encode(snapshot)
@@ -229,10 +236,10 @@ class DrMoagiFieldRuntime:
                 for coordinate in support
             }
         )
+        candidate_envelope = self._state_envelope(candidate, authoritative=False)
 
         if len(candidate) > self.config.max_active_cells:
-            self._cycle = cycle
-            return self._metrics(
+            metrics = self._metrics(
                 cycle,
                 support,
                 snapshot,
@@ -243,6 +250,14 @@ class DrMoagiFieldRuntime:
                 committed=False,
                 rejection_reason="active-cell budget exceeded",
             )
+            self._record_decision(
+                before=before,
+                candidate=candidate_envelope,
+                after=self._state_envelope(snapshot, authoritative=True),
+                metrics=metrics,
+            )
+            self._cycle = cycle
+            return metrics
 
         provisional = self._metrics(
             cycle,
@@ -255,12 +270,17 @@ class DrMoagiFieldRuntime:
             committed=False,
         )
         if validator is not None and not bool(validator(candidate, provisional)):
+            metrics = replace(provisional, rejection_reason="validator rejected candidate")
+            self._record_decision(
+                before=before,
+                candidate=candidate_envelope,
+                after=self._state_envelope(snapshot, authoritative=True),
+                metrics=metrics,
+            )
             self._cycle = cycle
-            return replace(provisional, rejection_reason="validator rejected candidate")
+            return metrics
 
-        self._state = candidate
-        self._cycle = cycle
-        return self._metrics(
+        metrics = self._metrics(
             cycle,
             support,
             snapshot,
@@ -269,6 +289,56 @@ class DrMoagiFieldRuntime:
             residual,
             rhs,
             committed=True,
+        )
+        self._record_decision(
+            before=before,
+            candidate=candidate_envelope,
+            after=self._state_envelope(candidate, authoritative=True),
+            metrics=metrics,
+        )
+        self._state = candidate
+        self._cycle = cycle
+        return metrics
+
+    def _state_payload(self, field: Mapping[Coordinate, float]) -> dict[str, object]:
+        cells = [
+            [coordinate[0], coordinate[1], coordinate[2], float(value)]
+            for coordinate, value in sorted(field.items(), key=lambda item: self._linear_address(item[0]))
+        ]
+        return {
+            "logical_side": self.config.side,
+            "active_cells": len(cells),
+            "cells": cells,
+        }
+
+    def _state_envelope(
+        self, field: Mapping[Coordinate, float], *, authoritative: bool
+    ) -> StateEnvelope:
+        return StateEnvelope.from_payload(
+            state_type="jarvisx.dr-moagi-field",
+            state_version=1,
+            dimensions=(self.config.side, self.config.side, self.config.side),
+            payload=self._state_payload(field),
+            authoritative=authoritative,
+        )
+
+    def _record_decision(
+        self,
+        *,
+        before: StateEnvelope,
+        candidate: StateEnvelope,
+        after: StateEnvelope,
+        metrics: FieldStepMetrics,
+    ) -> None:
+        self.control_plane.append(
+            subsystem="dr-moagi-field-runtime",
+            operation="field-step",
+            decision="commit" if metrics.committed else "rollback",
+            reason=metrics.rejection_reason,
+            before=before,
+            candidate=candidate,
+            after=after,
+            metrics=asdict(metrics),
         )
 
     def _support(self, field: Mapping[Coordinate, float]) -> tuple[Coordinate, ...]:

--- a/tests/test_control_plane.py
+++ b/tests/test_control_plane.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.assembler import Assembler
+from jarvisx.control_plane import OmegaEvidenceChain, StateEnvelope, TransactionReceipt
+from jarvisx.core import CodexVM
+from jarvisx.dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
+from jarvisx.parser import Parser
+
+
+def envelope(value: int, *, authoritative: bool) -> StateEnvelope:
+    return StateEnvelope.from_payload(
+        state_type="test-state",
+        state_version=1,
+        dimensions=(1,),
+        payload={"value": value},
+        authoritative=authoritative,
+    )
+
+
+def test_commit_receipt_is_hash_chained_and_deterministic() -> None:
+    chain = OmegaEvidenceChain()
+    before = envelope(1, authoritative=True)
+    candidate = envelope(2, authoritative=False)
+    after = envelope(2, authoritative=True)
+
+    first = chain.append(
+        subsystem="test",
+        operation="advance",
+        decision="commit",
+        before=before,
+        candidate=candidate,
+        after=after,
+        metrics={"error": 0.25},
+    )
+    second = chain.append(
+        subsystem="test",
+        operation="advance",
+        decision="commit",
+        before=after,
+        candidate=envelope(3, authoritative=False),
+        after=envelope(3, authoritative=True),
+        metrics={"error": 0.125},
+    )
+
+    assert first.verify()
+    assert second.previous_hash == first.receipt_hash
+    assert chain.verify()
+
+
+def test_rollback_receipt_requires_authoritative_state_preservation() -> None:
+    chain = OmegaEvidenceChain()
+    before = envelope(1, authoritative=True)
+    candidate = envelope(2, authoritative=False)
+
+    with pytest.raises(ValueError, match="rollback"):
+        chain.append(
+            subsystem="test",
+            operation="advance",
+            decision="rollback",
+            before=before,
+            candidate=candidate,
+            after=envelope(3, authoritative=True),
+        )
+
+    receipt = chain.append(
+        subsystem="test",
+        operation="advance",
+        decision="rollback",
+        reason="validator rejected candidate",
+        before=before,
+        candidate=candidate,
+        after=envelope(1, authoritative=True),
+    )
+
+    assert receipt.decision == "rollback"
+    assert chain.verify()
+
+
+def test_tampered_receipt_breaks_chain_verification() -> None:
+    chain = OmegaEvidenceChain()
+    receipt = chain.append(
+        subsystem="test",
+        operation="advance",
+        decision="commit",
+        before=envelope(1, authoritative=True),
+        candidate=envelope(2, authoritative=False),
+        after=envelope(2, authoritative=True),
+    )
+    chain.chain[0] = replace(receipt, receipt_hash="f" * 64)
+
+    assert not chain.verify()
+
+
+def test_transaction_receipt_rejects_mismatched_state_types() -> None:
+    before = envelope(1, authoritative=True)
+    candidate = StateEnvelope.from_payload(
+        state_type="other-state",
+        state_version=1,
+        dimensions=(1,),
+        payload={"value": 2},
+        authoritative=False,
+    )
+
+    with pytest.raises(ValueError, match="state types"):
+        TransactionReceipt.build(
+            sequence=0,
+            subsystem="test",
+            operation="advance",
+            decision="commit",
+            reason=None,
+            before=before,
+            candidate=candidate,
+            after=envelope(2, authoritative=True),
+            metrics={},
+            previous_hash="0" * 64,
+        )
+
+
+def test_codex_vm_emits_common_control_receipts() -> None:
+    program = Assembler().assemble(Parser().parse("SET A 7\nHALT"))
+    vm = CodexVM()
+    vm.load(program)
+
+    vm.run()
+
+    assert len(vm.control_plane.chain) == 2
+    assert vm.control_plane.verify()
+    assert all(receipt.subsystem == "codex-vm" for receipt in vm.control_plane.chain)
+    assert vm.control_plane.chain[-1].after.authoritative
+
+
+def test_vm_control_receipt_is_rolled_back_with_failed_instruction_receipt(monkeypatch) -> None:
+    program = Assembler().assemble(Parser().parse("SET A 7\nHALT"))
+    vm = CodexVM()
+    vm.load(program)
+
+    def fail_log(state: object, opcode: int) -> None:
+        raise OSError("receipt unavailable")
+
+    monkeypatch.setattr(vm.ledger, "log", fail_log)
+
+    with pytest.raises(OSError, match="receipt unavailable"):
+        vm.step()
+
+    assert not vm.control_plane.chain
+
+
+def test_field_runtime_emits_commit_and_rollback_receipts() -> None:
+    class ZeroCodec:
+        def encode(self, field):
+            return None
+
+        def decode(self, latent, support):
+            return {coordinate: 0.0 for coordinate in support}
+
+    runtime = DrMoagiFieldRuntime(
+        ZeroCodec(),
+        DrMoagiFieldConfig(
+            side=5,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    runtime.load({(2, 2, 2): 1.0})
+
+    committed = runtime.step()
+    rejected = runtime.step(validator=lambda candidate, metrics: False)
+
+    assert committed.committed
+    assert not rejected.committed
+    assert [receipt.decision for receipt in runtime.control_plane.chain] == [
+        "commit",
+        "rollback",
+    ]
+    assert runtime.control_plane.verify()
+    assert (
+        runtime.control_plane.chain[-1].before.payload_digest
+        == runtime.control_plane.chain[-1].after.payload_digest
+    )


### PR DESCRIPTION
## Permeation objective

Turn the repeated Jarvis-X systems law

```text
Observe -> Candidate -> Lambda -> Commit/Rollback -> Omega -> Re-enter
```

into one executable cross-subsystem contract instead of parallel local semantics, then extend that loop downward into a measured physical-substrate boundary:

```text
kinetic state -> canonical Q16.16 words -> bit transitions -> electrical estimate -> physical EM only with hardware evidence
```

This combined integration PR targets `main` directly so the exact permeated stack receives the repository's real CI matrix. It includes the bounded Dr Moagi state-space core originally isolated in #118 plus the unified control-plane and electromagnetic-flow changes below.

## What changed

### Dr Moagi state-space layer
- C++17 bounded latent state-space core
- multimodal ingress and SPSC ring contract
- conservative `||Phi||_inf <= 0.94` transition bound
- logical `1,000,000 x 1,000,000` OLED tile geometry without dense `10^12` pixel allocation
- regression tests and CMake/CTest wiring

### Unified control plane
- add `src/jarvisx/control_plane.py` with:
  - typed `StateEnvelope`
  - deterministic `TransactionReceipt`
  - hash-chained `OmegaEvidenceChain`
  - SHA-256 over canonical JSON
  - machine-checkable commit/rollback invariants
- permeate the contract through `CodexVM`
  - unified evidence chain participates in VM checkpoint/rollback
  - each successfully completed instruction emits a common commit receipt
  - large VM memory is represented by a SHA-256 digest rather than duplicated into every receipt
- permeate the contract through `DrMoagiFieldRuntime`
  - field load starts a run-scoped evidence chain
  - committed field candidates emit commit receipts
  - validator/resource rejections emit rollback receipts whose after-state must equal the before-state
  - sparse state manifests are deterministically ordered before hashing
- add focused conformance tests for deterministic chaining, tamper detection, rollback invariants, VM integration, VM receipt rollback, and field commit/rejection evidence
- add ADR-010 defining the language/subsystem-neutral authority boundary

### Electromagnetic-flow logic substrate
- add `cpp_runtime/include/jarvisx/electromagnetic_flow.hpp`
  - deterministic Q16.16 projection for switching observation
  - raw per-transition Hamming toggle counts
  - ideal payload-DBI toggle counts via `min(H, 32-H)`
  - raw and DBI switching activity factors `alpha`
  - optional `P_dyn = alpha * C_eff * V_dd^2 * f` and average-current estimates only when explicit hardware constants are supplied
  - explicit current-slew proxy requiring a real time interval
- instrument the Dr Moagi state-space executable as a **non-authoritative observer** of its own latent state transitions
- add cross-platform C++ regression coverage for Q16.16 bit toggles, DBI payload bounds, physical-model validation, non-finite rejection and current-slew calculation
- add ADR-011 defining electromagnetic flow logic as the physical substrate interpretation while preserving the software/electrical/Maxwell claim boundary

## Systems boundary

The common control plane standardizes **authority semantics**, not subsystem mathematics. `Lambda` remains domain-specific: VM policy, numerical projection, candidate fitness, stability gates, etc. all retain their own validators.

The electromagnetic observer likewise does not own authority. It measures the canonical digital image of a transition but cannot mutate the state because it can estimate switching cost.

The evidence chain proves deterministic transition integrity. It does not prove external source truth, convergence, intelligence, hostile-code isolation, production safety, physical power fidelity, electromagnetic field strength or emissions compliance.

## Why this matters

Before this change, `Omega`, `Lambda`, candidate, commit and rollback meant compatible things across the repository but had different executable schemas. This PR gives orchestration a single receipt shape:

```text
before authoritative state
candidate non-authoritative state
Lambda decision
after authoritative state
metrics
previous receipt hash
receipt hash
```

A commit requires `candidate.digest == after.digest`; a rollback requires `before.digest == after.digest`.

The new substrate observer extends the same measured-vs-asserted discipline downward:

```text
Delta Xi
  -> Delta Q16.16 words
  -> measured bit toggles
  -> alpha
  -> electrical P/I estimate only with explicit C_eff, V_dd and f
  -> physical EM only with current-density + geometry model
```

## Mathematical boundary

The C++ state-space layer only bounds the implemented linear transition operator. It does **not** claim that bounding `Phi` proves `rho(J_F) < 1` for the complete nonlinear `Encode -> Decode -> memory/context -> state` loop. Full closed-loop Jacobian, Reality Gap and Lyapunov validation remain explicit next steps.

Likewise, Q16.16 Hamming activity is a deterministic logical metric, not a Maxwell-field solution. Accurate EM prediction requires physical placement/routing, package/material properties, return paths and current-density mapping.

## Next permeation targets

1. native/C++ receipt serialization and SHA-256/canonical-JSON parity
2. bind switching telemetry into C++ transaction receipts as non-authoritative metrics
3. state-space `Decode -> Re-encode -> Reality Gap` feedback closure
4. event-driven / phase-staggered / GALS swarm scheduling with measured peak switching activity
5. explicit hardware-description contract for voltage, capacitance, frequency domains and interconnect topology
6. C++ inward genome-selection receipts
7. Hyperion wrapping of control-plane receipts into the evidence plane
8. distributed consensus/replication receipts
9. physical current-density/layout integration before any Maxwell-field simulation claim

## Validation

The previous combined head passed Jarvis-X CI, the Python matrix, package smoke tests, empirical validation, GCC, Clang+sanitizers, MSVC and CodeQL. The electromagnetic-flow additions are now on the same draft PR and will be validated by those repository workflows before merge.