### PR TITLE
operationalize bounded 3D auto-codec system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM python:3.10-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
+COPY pyproject.toml setup.py README.md ./
 COPY src/ ./src/
-COPY setup.py .
-RUN pip install .
 
+RUN pip install --no-cache-dir .
+
+ENV PORT=10000
 EXPOSE 10000
 
-CMD ["sh", "-c", "uvicorn src.main:app --host 0.0.0.0 --port $PORT"]
+CMD ["sh", "-c", "uvicorn jarvisx.api:app --host 0.0.0.0 --port ${PORT:-10000}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ WORKDIR /app
 COPY pyproject.toml setup.py README.md ./
 COPY src/ ./src/
 
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir . && mkdir -p /data/runs
 
 ENV PORT=10000
+ENV JARVISX_RUN_STORE=/data/runs
+VOLUME ["/data"]
+
 EXPOSE 10000
 
 CMD ["sh", "-c", "uvicorn jarvisx.api:app --host 0.0.0.0 --port ${PORT:-10000}"]

--- a/docs/OPERATIONAL_3D_AUTO_CODEC.md
+++ b/docs/OPERATIONAL_3D_AUTO_CODEC.md
@@ -1,0 +1,172 @@
+# Operational 3D Auto-Encoding / Decoding System
+
+## Status
+
+Integration candidate on `agent/operational-auto-codec-loop` / PR #120.
+
+This subsystem makes 3D space part of the executable data contract rather than a presentation-only metaphor. The authoritative state remains a bounded sparse scalar field on integer `(x, y, z)` coordinates. Each cycle encodes those coordinates into a reversible 63-bit Morton address, quantizes the scalar value, decodes the requested support, computes the existing Dr Moagi residual-field update, validates the candidate transaction, commits or rolls it back, records the state in the Omega hash chain, and emits a 3D runtime frame from the resulting authoritative state.
+
+## End-to-end kinetic path
+
+```text
+3D INPUT FIELD
+    ↓
+VALIDATE (x,y,z,value)
+    ↓
+MORTON 3D ADDRESS ENCODE
+    ↓
+QUANTIZE VALUE
+    ↓
+SPARSE 3D LATENT
+    ↓
+DECODE REQUESTED 3D SUPPORT
+    ↓
+RECONSTRUCTION
+    ↓
+RESIDUAL R = Psi - D(E(Psi))
+    ↓
+3D SIX-FACE LAPLACIAN + GLYPH COUPLING
+    ↓
+PROJECT INTO NUMERICAL / RESOURCE BOUNDS
+    ↓
+VERIFY
+   ↙  ↘
+ROLLBACK  COMMIT
+            ↓
+        OMEGA JOURNAL
+            ↓
+     SPATIAL METRICS
+            ↓
+        3D FRAME
+            ↓
+   CONVERGENCE / FIXED POINT / BUDGET
+            ↓
+           LOOP
+```
+
+## Spatial latent
+
+`MortonQuantizedFieldCodec3D` maps a coordinate
+
+`(x, y, z)`
+
+to a Morton/Z-order key by bit-interleaving 21 bits from each axis:
+
+`m = interleave_3(x, y, z)`.
+
+The resulting key is reversible for coordinates in `[0, 2^21 - 1]` on each axis. Values are independently quantized as
+
+`q = round(value / step)`
+
+and reconstructed as
+
+`value_hat = q * step`.
+
+The reference latent therefore consists of sparse records
+
+`(morton_63, signed_quantized_value)`.
+
+For a portable packed representation the runtime reports an estimate based on an unsigned 64-bit Morton key plus a signed 32-bit value code, i.e. 12 bytes per active latent entry. This is a wire-format estimate, not Python heap usage.
+
+## 3D field mechanics
+
+The existing field runtime evaluates the same-space equation
+
+```text
+dPsi/dt =
+  -alpha (I - D o E)[Psi]
+  + lambda * Laplacian((I - D o E)[Psi])
+  + eta * G_moagi(Psi)
+```
+
+on the sparse logical 3D lattice.
+
+The Laplacian uses six face-neighbours (`±x`, `±y`, `±z`). Candidate state is projected into configured value and active-cell bounds before publication. A validator may reject the candidate without mutating authoritative state.
+
+## 3D telemetry
+
+Every captured frame is derived from `runtime.snapshot()` after a completed cycle. Frames therefore represent execution state, not a separately simulated animation.
+
+The runtime reports:
+
+- active sparse cell count;
+- axis-aligned 3D bounds;
+- geometric centroid;
+- absolute-value-weighted centroid;
+- RMS spatial radius;
+- L1 and L2 field energy;
+- number of occupied six-face neighbour links;
+- sparse occupancy ratio;
+- state SHA-256 digest;
+- bounded point-cloud sample for visualization.
+
+Point samples are deterministically ordered by Morton key and downsampled when the render budget is exceeded.
+
+## Execution surfaces
+
+### Python library
+
+Use `MortonQuantizedFieldCodec3D`, `DrMoagiFieldRuntime`, `AutoCodecLoop`, and `SpatialAutoCodec3DSystem` directly.
+
+### CLI
+
+```bash
+jarvisx codec3d examples/auto_codec_3d_run.json
+```
+
+The command returns a JSON receipt with the loop result, 3D frames, spatial metrics, latent digest, state digest, and Omega journal verification.
+
+### Cloud API
+
+```text
+POST /codec/3d/run
+```
+
+accepts sparse 3D cells and bounded runtime parameters.
+
+`GET /health` advertises the active 3D codec endpoint and spatial codec mode.
+
+### Browser
+
+`GET /` serves a dependency-free WebGL control surface. The viewer consumes only frame data returned by `/codec/3d/run`.
+
+Controls:
+
+- drag: orbit;
+- wheel/pinch: zoom;
+- frame slider: inspect a specific runtime cycle;
+- Play/Pause: traverse captured execution frames.
+
+Positive and negative scalar values are rendered differently, while point size scales with absolute field magnitude.
+
+## Verification and termination
+
+The system is bounded by:
+
+- field-side and coordinate validation;
+- maximum active cells;
+- conservative explicit-step guard;
+- value projection;
+- decoder support confinement;
+- optional external transaction validator;
+- maximum cycles;
+- reconstruction MSE target;
+- fixed-point state digest detection;
+- rejection circuit breaker;
+- frame count and render-point budgets;
+- hash-chained Omega journal verification.
+
+## Operational boundary
+
+This is a fully executable 3D **reference runtime**: the spatial codec, field operators, transaction gates, receipts, CLI, API, container entry point, and WebGL viewer are implemented as software paths.
+
+It is not a claim that:
+
+- the Morton codec is a trained or optimal neural latent representation;
+- arbitrary 3D assets are losslessly compressed;
+- the sparse scalar field is a general mesh, CAD, physics, or volumetric rendering engine;
+- the runtime provides hostile-code isolation;
+- visualization proves physical hardware, electromagnetic, or AGI properties;
+- the current reference performance is production-scale.
+
+Those require separate adapters, benchmarks, security controls, and empirical evidence.

--- a/docs/OPERATIONAL_AUTO_CODEC_LOOP.md
+++ b/docs/OPERATIONAL_AUTO_CODEC_LOOP.md
@@ -1,0 +1,117 @@
+# Operational Auto-Encoding / Decoding Loop
+
+## Status
+
+Integration candidate on `agent/operational-auto-codec-loop`.
+
+This implementation turns the existing bounded Dr Moagi sparse-field codec step into an executable closed control loop. It is intentionally a deterministic reference runtime, not a claim of a trained neural autoencoder, unrestricted autonomy, or production-scale compression.
+
+## Closed-loop execution
+
+For field state `Psi_t`, codec encoder `E`, decoder `D`, and reconstruction residual
+
+`R_t = Psi_t - D(E(Psi_t))`,
+
+the existing field runtime evaluates
+
+`dPsi/dt = -alpha R_t + lambda * Laplacian(R_t) + eta * G_moagi(Psi_t)`
+
+and commits a projected candidate only after the runtime's validation and resource guards accept it.
+
+The new controller repeatedly executes:
+
+1. ingest a sparse 3D field;
+2. encode it into a bounded latent representation;
+3. decode exactly the requested sparse support;
+4. calculate reconstruction error;
+5. evaluate the Dr Moagi field update;
+6. project and validate the candidate transaction;
+7. commit or roll back;
+8. hash the resulting state into the Omega journal;
+9. test explicit stop criteria;
+10. repeat until convergence, fixed point, rejection limit, or cycle budget.
+
+Operationally:
+
+`INPUT -> ENCODE -> LATENT -> DECODE -> RECONSTRUCT -> RESIDUAL -> UPDATE -> VERIFY -> COMMIT -> JOURNAL -> LOOP`
+
+## Reference codec
+
+`UniformQuantizedFieldCodec` provides a real deterministic encode/decode transform for the reference loop. Each active scalar value is quantized with an explicit step size and reconstructed from its integer code. Zero codes may be pruned from the latent map.
+
+It is deliberately simple so reconstruction error and loop behavior remain inspectable. Learned codec backends can implement the existing `FieldCodec` protocol without changing the controller.
+
+## Stop conditions
+
+`AutoCodecLoopConfig` bounds every run with:
+
+- `max_cycles` — hard upper execution bound;
+- `min_cycles` — minimum work before convergence is accepted;
+- `reconstruction_mse_target` — explicit reconstruction threshold;
+- `max_consecutive_rejections` — circuit breaker for rejected candidates;
+- `stop_on_fixed_point` — optional digest-based fixed-point termination.
+
+Every run returns a machine-readable receipt containing cycle counts, convergence state, final reconstruction MSE, final sparse-state digest, journal verification status, journal head hash, and final sparse field.
+
+## Cloud API
+
+The FastAPI service exposes:
+
+- `GET /` — executable browser dashboard;
+- `GET /health` — health probe;
+- `POST /run` — deterministic Jarvis-X VM execution;
+- `POST /codec/run` — bounded auto-encoding/decoding loop.
+
+Example request:
+
+```json
+{
+  "cells": [
+    {"x": 2, "y": 2, "z": 2, "value": 0.26},
+    {"x": 3, "y": 2, "z": 2, "value": -0.37}
+  ],
+  "side": 64,
+  "quantization_step": 0.1,
+  "alpha": 1.0,
+  "lambda_residual": 0.0,
+  "eta": 0.0,
+  "dt": 0.1,
+  "expand_halo": false,
+  "max_cycles": 64,
+  "reconstruction_mse_target": 0.001
+}
+```
+
+## CLI
+
+Run the reference loop from a JSON file:
+
+```bash
+jarvisx codec examples/auto_codec_run.json
+```
+
+Start the browser/API service:
+
+```bash
+jarvisx api
+```
+
+or:
+
+```bash
+jarvisx web
+```
+
+## Container deployment
+
+The container now starts the actual package application:
+
+```bash
+uvicorn jarvisx.api:app --host 0.0.0.0 --port "$PORT"
+```
+
+This replaces the previous invalid `src.main:app` entry point.
+
+## Verification boundary
+
+The runtime verifies software invariants only: bounded support, numeric projection, candidate commit/rollback, deterministic sparse serialization, cycle limits, reconstruction telemetry, and the hash-chained Omega journal. A passing run does not establish model quality, security isolation, physical-computation claims, or superiority to learned autoencoder baselines.

--- a/examples/auto_codec_3d_run.json
+++ b/examples/auto_codec_3d_run.json
@@ -1,0 +1,32 @@
+{
+  "cells": [
+    {"x": 20, "y": 20, "z": 20, "value": 0.86},
+    {"x": 21, "y": 20, "z": 20, "value": 0.62},
+    {"x": 20, "y": 21, "z": 20, "value": -0.55},
+    {"x": 20, "y": 20, "z": 21, "value": 0.44},
+    {"x": 21, "y": 21, "z": 21, "value": -0.31}
+  ],
+  "quantization_step": 0.1,
+  "field_config": {
+    "side": 64,
+    "alpha": 1.0,
+    "lambda_residual": 0.05,
+    "eta": 0.02,
+    "dt": 0.02,
+    "max_active_cells": 100000,
+    "expand_halo": true,
+    "prune_epsilon": 0.000001
+  },
+  "loop_config": {
+    "max_cycles": 32,
+    "min_cycles": 1,
+    "reconstruction_mse_target": 0.001,
+    "max_consecutive_rejections": 3,
+    "stop_on_fixed_point": true
+  },
+  "spatial_config": {
+    "frame_stride": 1,
+    "max_render_points": 4096,
+    "max_frames": 64
+  }
+}

--- a/examples/auto_codec_run.json
+++ b/examples/auto_codec_run.json
@@ -1,0 +1,24 @@
+{
+  "cells": [
+    {"x": 2, "y": 2, "z": 2, "value": 0.26},
+    {"x": 3, "y": 2, "z": 2, "value": -0.37}
+  ],
+  "quantization_step": 0.1,
+  "field_config": {
+    "side": 64,
+    "alpha": 1.0,
+    "lambda_residual": 0.0,
+    "eta": 0.0,
+    "dt": 0.1,
+    "max_active_cells": 100000,
+    "expand_halo": false,
+    "prune_epsilon": 0.0
+  },
+  "loop_config": {
+    "max_cycles": 64,
+    "min_cycles": 1,
+    "reconstruction_mse_target": 0.001,
+    "max_consecutive_rejections": 3,
+    "stop_on_fixed_point": true
+  }
+}

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, cast
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
@@ -96,7 +96,7 @@ def _loop_config(payload: AutoCodecRequest) -> AutoCodecLoopConfig:
 
 @app.get("/", response_class=HTMLResponse)
 def dashboard() -> str:
-    return DASHBOARD_HTML
+    return cast(str, DASHBOARD_HTML)
 
 
 @app.get("/health")
@@ -139,7 +139,8 @@ def run_auto_codec(payload: AutoCodecRequest) -> dict[str, Any]:
         runtime = DrMoagiFieldRuntime(codec, _field_config(payload))
         loop = AutoCodecLoop(runtime, _loop_config(payload))
         loop.load(field)
-        return loop.run().to_dict()
+        result = cast(dict[str, Any], loop.run().to_dict())
+        return result
     except (TypeError, ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
@@ -167,7 +168,7 @@ def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
             max_render_points=payload.max_render_points,
             max_frames=payload.max_frames,
         )
-        result = system.run(field).to_dict()
+        result = cast(dict[str, Any], system.run(field).to_dict())
         result["run_id"] = run_id
         result["persisted"] = run_id is not None
         if run_id is not None:
@@ -182,7 +183,8 @@ def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
 @app.get("/codec/3d/runs/{run_id}")
 def get_auto_codec_3d_run(run_id: str) -> dict[str, Any]:
     try:
-        return RUN_STORE.read_summary(run_id)
+        summary = cast(dict[str, Any], RUN_STORE.read_summary(run_id))
+        return summary
     except FileNotFoundError as exc:
         raise HTTPException(status_code=404, detail="run not found") from exc
     except ValueError as exc:
@@ -194,7 +196,7 @@ def get_auto_codec_3d_run(run_id: str) -> dict[str, Any]:
 @app.get("/codec/3d/runs/{run_id}/verify")
 def verify_auto_codec_3d_run(run_id: str) -> dict[str, Any]:
     try:
-        verification = RUN_STORE.verify(run_id)
+        verification = cast(dict[str, Any], RUN_STORE.verify(run_id))
         if not verification["verified"]:
             raise HTTPException(status_code=409, detail=verification)
         return verification

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -9,230 +9,20 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 from .assembler import Assembler
-from .auto_codec_loop import (
-    AutoCodecLoop,
-    AutoCodecLoopConfig,
-    UniformQuantizedFieldCodec,
-)
+from .auto_codec_loop import AutoCodecLoop, AutoCodecLoopConfig, UniformQuantizedFieldCodec
 from .core import CodexVM
+from .dashboard_3d import DASHBOARD_HTML
 from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
 from .parser import Parser
+from .run_store import RunArtifactStore
 from .spatial_codec_3d import MortonQuantizedFieldCodec3D, SpatialAutoCodec3DSystem
 
 app = FastAPI(
     title="Jarvis-X / Dr Moagi 3D Runtime API",
     version="0.1.0",
-    description="Deterministic VM and bounded operational 3D auto-codec runtime.",
+    description="Deterministic VM and bounded persistent operational 3D auto-codec runtime.",
 )
-
-DASHBOARD_HTML = r"""<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Dr Moagi 3D Auto-Codec Runtime</title>
-<style>
-:root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-* { box-sizing:border-box; }
-body { margin:0; background:#070a11; color:#e8eefc; }
-main { max-width:1320px; margin:auto; padding:24px; }
-.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; }
-.layout { display:grid; grid-template-columns:minmax(0,1.7fr) minmax(300px,.8fr); gap:12px; margin-top:12px; }
-.card { background:#101623; border:1px solid #27344f; border-radius:12px; padding:14px; overflow:hidden; }
-label { display:block; font-size:11px; color:#91a0bc; margin-bottom:5px; }
-input, textarea, button { width:100%; border-radius:8px; border:1px solid #344362; background:#09101f; color:#eef4ff; padding:9px; }
-textarea { min-height:145px; resize:vertical; }
-button { cursor:pointer; background:#162e58; font-weight:700; }
-button:hover { background:#1d3d74; }
-button:disabled { opacity:.55; cursor:default; }
-.metric { font-size:20px; font-weight:700; overflow-wrap:anywhere; }
-.muted { color:#91a0bc; font-size:11px; line-height:1.5; }
-.status { display:inline-block; padding:4px 8px; border-radius:999px; border:1px solid #344362; }
-canvas { display:block; width:100%; height:520px; border-radius:9px; background:#050811; touch-action:none; }
-pre { white-space:pre-wrap; overflow-wrap:anywhere; max-height:330px; overflow:auto; font-size:11px; }
-.controls { display:grid; grid-template-columns:100px 1fr 80px; gap:8px; align-items:center; margin-top:8px; }
-#frame { width:100%; }
-@media(max-width:900px){ .layout{grid-template-columns:1fr;} canvas{height:420px;} }
-</style>
-</head>
-<body>
-<main>
-  <h1>Dr Moagi 3D Auto-Encoding / Decoding Runtime</h1>
-  <p class="muted">Authoritative path: 3D sparse field → Morton spatial latent → decode → residual → 3D field operator → verify → commit/rollback → Omega journal → next frame.</p>
-
-  <div class="grid">
-    <div class="card"><label>Quantization step</label><input id="step" type="number" step="0.01" value="0.10"></div>
-    <div class="card"><label>Alpha · reconstruction closure</label><input id="alpha" type="number" step="0.1" value="1.0"></div>
-    <div class="card"><label>Lambda · residual Laplacian</label><input id="lambda" type="number" step="0.05" value="0.0"></div>
-    <div class="card"><label>Eta · 3D glyph coupling</label><input id="eta" type="number" step="0.05" value="0.0"></div>
-    <div class="card"><label>dt</label><input id="dt" type="number" step="0.01" value="0.10"></div>
-    <div class="card"><label>Max cycles</label><input id="cycles" type="number" value="64"></div>
-    <div class="card"><label>MSE target</label><input id="target" type="number" step="0.0001" value="0.001"></div>
-  </div>
-
-  <div class="layout">
-    <section>
-      <div class="card">
-        <canvas id="view" width="1000" height="620"></canvas>
-        <div class="controls">
-          <button id="play">Play</button>
-          <input id="frame" type="range" min="0" max="0" value="0" />
-          <span id="frameLabel" class="muted">0 / 0</span>
-        </div>
-        <p class="muted">Drag to orbit · wheel/pinch to zoom · Play traverses authoritative runtime frames.</p>
-      </div>
-      <div class="grid" style="margin-top:10px">
-        <div class="card"><div class="muted">Stop reason</div><div id="stop" class="metric">—</div></div>
-        <div class="card"><div class="muted">Cycles</div><div id="cycleCount" class="metric">0</div></div>
-        <div class="card"><div class="muted">Final MSE</div><div id="mse" class="metric">—</div></div>
-        <div class="card"><div class="muted">Active 3D cells</div><div id="active" class="metric">0</div></div>
-        <div class="card"><div class="muted">Six-face links</div><div id="links" class="metric">0</div></div>
-        <div class="card"><div class="muted">Spatial RMS radius</div><div id="radius" class="metric">—</div></div>
-        <div class="card"><div class="muted">Latent entries</div><div id="latent" class="metric">0</div></div>
-        <div class="card"><div class="muted">Omega journal</div><div id="journal" class="status">not run</div></div>
-      </div>
-    </section>
-
-    <aside>
-      <div class="card">
-        <label>Sparse 3D input cells</label>
-        <textarea id="cells">[
-  {"x": 20, "y": 20, "z": 20, "value": 0.86},
-  {"x": 21, "y": 20, "z": 20, "value": 0.62},
-  {"x": 20, "y": 21, "z": 20, "value": -0.55},
-  {"x": 20, "y": 20, "z": 21, "value": 0.44},
-  {"x": 21, "y": 21, "z": 21, "value": -0.31}
-]</textarea>
-        <button id="run" style="margin-top:9px">Execute 3D closed loop</button>
-      </div>
-      <div class="card" style="margin-top:10px">
-        <div class="muted">3D geometry</div>
-        <pre id="geometry">Ready.</pre>
-      </div>
-      <div class="card" style="margin-top:10px">
-        <div class="muted">Runtime receipt</div>
-        <pre id="result">Ready.</pre>
-      </div>
-    </aside>
-  </div>
-</main>
-<script>
-const $ = (id) => document.getElementById(id);
-let runtimeFrames = [];
-let frameIndex = 0;
-let playing = false;
-let lastPlayback = 0;
-let yaw = -0.7, pitch = 0.45, zoom = 1.0;
-let dragging = false, lastX = 0, lastY = 0;
-
-const canvas = $('view');
-const gl = canvas.getContext('webgl', {antialias:true, alpha:false});
-if (!gl) $('result').textContent = 'WebGL unavailable; API execution remains usable.';
-
-let program, positionBuffer, valueBuffer, aPosition, aValue, uYaw, uPitch, uZoom, uCenter, uScale;
-function shader(type, source) {
-  const item = gl.createShader(type); gl.shaderSource(item, source); gl.compileShader(item);
-  if (!gl.getShaderParameter(item, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(item));
-  return item;
-}
-function initGL() {
-  if (!gl) return;
-  const vs = shader(gl.VERTEX_SHADER, `
-    attribute vec3 a_position; attribute float a_value;
-    uniform float u_yaw, u_pitch, u_zoom, u_scale; uniform vec3 u_center;
-    varying float v_value;
-    void main(){
-      vec3 p=(a_position-u_center)*u_scale;
-      float cy=cos(u_yaw), sy=sin(u_yaw), cp=cos(u_pitch), sp=sin(u_pitch);
-      p=vec3(cy*p.x+sy*p.z,p.y,-sy*p.x+cy*p.z);
-      p=vec3(p.x,cp*p.y-sp*p.z,sp*p.y+cp*p.z);
-      float depth=max(1.0,4.0+p.z);
-      gl_Position=vec4(p.x*u_zoom*1.8,p.y*u_zoom*1.8,depth-2.0,depth);
-      gl_PointSize=min(18.0, max(4.0, 7.0 + abs(a_value)*7.0));
-      v_value=a_value;
-    }`);
-  const fs = shader(gl.FRAGMENT_SHADER, `
-    precision mediump float; varying float v_value;
-    void main(){
-      vec2 d=gl_PointCoord-vec2(.5); if(dot(d,d)>.25) discard;
-      float a=min(1.0,abs(v_value));
-      vec3 positive=vec3(.20,.78,1.0), negative=vec3(1.0,.30,.68);
-      vec3 c=mix(vec3(.72,.78,.90), v_value>=0.0?positive:negative, .45+.55*a);
-      gl_FragColor=vec4(c,1.0);
-    }`);
-  program=gl.createProgram(); gl.attachShader(program,vs); gl.attachShader(program,fs); gl.linkProgram(program);
-  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(program));
-  aPosition=gl.getAttribLocation(program,'a_position'); aValue=gl.getAttribLocation(program,'a_value');
-  uYaw=gl.getUniformLocation(program,'u_yaw'); uPitch=gl.getUniformLocation(program,'u_pitch');
-  uZoom=gl.getUniformLocation(program,'u_zoom'); uCenter=gl.getUniformLocation(program,'u_center'); uScale=gl.getUniformLocation(program,'u_scale');
-  positionBuffer=gl.createBuffer(); valueBuffer=gl.createBuffer();
-  gl.enable(gl.DEPTH_TEST); gl.clearColor(.018,.026,.055,1);
-}
-function currentFrame(){ return runtimeFrames[frameIndex] || {points:[],metrics:{}}; }
-function draw(){
-  if (!gl || !program) return;
-  const frame=currentFrame(), pts=frame.points||[];
-  const positions=new Float32Array(pts.length*3), values=new Float32Array(pts.length);
-  for(let i=0;i<pts.length;i++){ positions[i*3]=pts[i].x; positions[i*3+1]=pts[i].y; positions[i*3+2]=pts[i].z; values[i]=pts[i].value; }
-  const m=frame.metrics||{}, lo=m.bounds_min||[0,0,0], hi=m.bounds_max||[1,1,1];
-  const center=[(lo[0]+hi[0])/2,(lo[1]+hi[1])/2,(lo[2]+hi[2])/2];
-  const span=Math.max(1,hi[0]-lo[0],hi[1]-lo[1],hi[2]-lo[2]);
-  gl.viewport(0,0,canvas.width,canvas.height); gl.clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT); gl.useProgram(program);
-  gl.bindBuffer(gl.ARRAY_BUFFER,positionBuffer); gl.bufferData(gl.ARRAY_BUFFER,positions,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aPosition); gl.vertexAttribPointer(aPosition,3,gl.FLOAT,false,0,0);
-  gl.bindBuffer(gl.ARRAY_BUFFER,valueBuffer); gl.bufferData(gl.ARRAY_BUFFER,values,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aValue); gl.vertexAttribPointer(aValue,1,gl.FLOAT,false,0,0);
-  gl.uniform1f(uYaw,yaw); gl.uniform1f(uPitch,pitch); gl.uniform1f(uZoom,zoom); gl.uniform3fv(uCenter,new Float32Array(center)); gl.uniform1f(uScale,1.6/span);
-  gl.drawArrays(gl.POINTS,0,pts.length);
-}
-function selectFrame(index){
-  frameIndex=Math.max(0,Math.min(index,runtimeFrames.length-1)); $('frame').value=String(frameIndex);
-  $('frameLabel').textContent=`${frameIndex} / ${Math.max(0,runtimeFrames.length-1)}`;
-  const f=currentFrame(), m=f.metrics||{};
-  $('active').textContent=m.active_cells ?? 0; $('links').textContent=m.six_face_links ?? 0;
-  $('radius').textContent=m.rms_radius == null ? '—' : Number(m.rms_radius).toFixed(4);
-  $('geometry').textContent=JSON.stringify({cycle:f.cycle,state_digest:f.state_digest,metrics:m},null,2);
-  draw();
-}
-function animate(t){
-  if(playing && runtimeFrames.length>1 && t-lastPlayback>220){ frameIndex=(frameIndex+1)%runtimeFrames.length; selectFrame(frameIndex); lastPlayback=t; }
-  draw(); requestAnimationFrame(animate);
-}
-canvas.addEventListener('pointerdown',e=>{dragging=true;lastX=e.clientX;lastY=e.clientY;canvas.setPointerCapture(e.pointerId);});
-canvas.addEventListener('pointermove',e=>{if(!dragging)return; yaw+=(e.clientX-lastX)*.01; pitch+=(e.clientY-lastY)*.01; pitch=Math.max(-1.45,Math.min(1.45,pitch)); lastX=e.clientX;lastY=e.clientY;});
-canvas.addEventListener('pointerup',()=>dragging=false); canvas.addEventListener('pointercancel',()=>dragging=false);
-canvas.addEventListener('wheel',e=>{e.preventDefault();zoom*=Math.exp(-e.deltaY*.001);zoom=Math.max(.25,Math.min(4,zoom));},{passive:false});
-$('play').addEventListener('click',()=>{playing=!playing;$('play').textContent=playing?'Pause':'Play';});
-$('frame').addEventListener('input',()=>{playing=false;$('play').textContent='Play';selectFrame(Number($('frame').value));});
-
-$('run').addEventListener('click', async () => {
-  $('run').disabled=true; $('result').textContent='Executing 3D loop…'; playing=false; $('play').textContent='Play';
-  try {
-    const body={
-      cells:JSON.parse($('cells').value), side:64, quantization_step:Number($('step').value),
-      alpha:Number($('alpha').value), lambda_residual:Number($('lambda').value), eta:Number($('eta').value), dt:Number($('dt').value),
-      expand_halo:true, max_cycles:Number($('cycles').value), reconstruction_mse_target:Number($('target').value),
-      stop_on_fixed_point:true, frame_stride:1, max_render_points:4096, max_frames:128
-    };
-    const response=await fetch('/codec/3d/run',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
-    const data=await response.json(); if(!response.ok) throw new Error(data.detail||JSON.stringify(data));
-    runtimeFrames=data.frames||[]; frameIndex=Math.max(0,runtimeFrames.length-1); $('frame').max=String(Math.max(0,runtimeFrames.length-1));
-    $('stop').textContent=data.stop_reason; $('cycleCount').textContent=data.cycles_executed;
-    $('mse').textContent=data.final_reconstruction_mse==null?'—':Number(data.final_reconstruction_mse).toExponential(3);
-    $('latent').textContent=data.latent_entries; $('journal').textContent=data.journal_verified?`verified · ${data.journal_entries} receipts`:'verification failed';
-    $('result').textContent=JSON.stringify({
-      spatial_mode:data.spatial_mode, codec:data.codec, stop_reason:data.stop_reason, cycles_executed:data.cycles_executed,
-      converged:data.converged, final_reconstruction_mse:data.final_reconstruction_mse, latent_entries:data.latent_entries,
-      packed_latent_bytes_estimate:data.packed_latent_bytes_estimate, latent_digest:data.latent_digest,
-      final_state_digest:data.final_state_digest, journal_verified:data.journal_verified, journal_head_hash:data.journal_head_hash
-    },null,2);
-    selectFrame(frameIndex);
-  } catch(error){ $('result').textContent=String(error); }
-  finally { $('run').disabled=false; }
-});
-
-try { initGL(); requestAnimationFrame(animate); } catch(error) { $('result').textContent=String(error); }
-</script>
-</body>
-</html>"""
+RUN_STORE = RunArtifactStore(os.environ.get("JARVISX_RUN_STORE", "data/runs"))
 
 
 class VMRunRequest(BaseModel):
@@ -268,6 +58,7 @@ class AutoCodec3DRequest(AutoCodecRequest):
     frame_stride: int = Field(default=1, gt=0, le=512)
     max_render_points: int = Field(default=4096, gt=0, le=10_000)
     max_frames: int = Field(default=128, gt=0, le=256)
+    persist: bool = True
 
 
 def _field_from_cells(cells: list[SparseCell]) -> dict[tuple[int, int, int], float]:
@@ -313,8 +104,15 @@ def health() -> dict[str, Any]:
     return {
         "status": "ok",
         "runtime": "jarvisx-auto-codec-3d",
-        "spatial_codec": "morton-63bit",
-        "endpoints": ["/run", "/codec/run", "/codec/3d/run"],
+        "spatial_codec": "morton-63bit-int32",
+        "persistence": "enabled",
+        "endpoints": [
+            "/run",
+            "/codec/run",
+            "/codec/3d/run",
+            "/codec/3d/runs/{run_id}",
+            "/codec/3d/runs/{run_id}/verify",
+        ],
     }
 
 
@@ -326,10 +124,7 @@ def run_code(payload: VMRunRequest) -> dict[str, Any]:
         vm = CodexVM()
         vm.load(bytecode)
         vm.run()
-        return {
-            "registers": vm.regs.snapshot(),
-            "ledger_entries": len(vm.ledger.chain),
-        }
+        return {"registers": vm.regs.snapshot(), "ledger_entries": len(vm.ledger.chain)}
     except Exception as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -338,7 +133,6 @@ def run_code(payload: VMRunRequest) -> dict[str, Any]:
 def run_auto_codec(payload: AutoCodecRequest) -> dict[str, Any]:
     if payload.min_cycles > payload.max_cycles:
         raise HTTPException(status_code=422, detail="min_cycles cannot exceed max_cycles")
-
     try:
         field = _field_from_cells(payload.cells)
         codec = UniformQuantizedFieldCodec(step=payload.quantization_step)
@@ -354,7 +148,6 @@ def run_auto_codec(payload: AutoCodecRequest) -> dict[str, Any]:
 def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
     if payload.min_cycles > payload.max_cycles:
         raise HTTPException(status_code=422, detail="min_cycles cannot exceed max_cycles")
-
     try:
         field = _field_from_cells(payload.cells)
         codec = MortonQuantizedFieldCodec3D(
@@ -362,7 +155,14 @@ def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
             side=payload.side,
         )
         runtime = DrMoagiFieldRuntime(codec, _field_config(payload))
-        loop = AutoCodecLoop(runtime, _loop_config(payload))
+
+        run_id: str | None = None
+        ledger = None
+        if payload.persist:
+            run_id = RUN_STORE.new_run_id()
+            ledger = RUN_STORE.ledger(run_id)
+
+        loop = AutoCodecLoop(runtime, _loop_config(payload), ledger=ledger)
         system = SpatialAutoCodec3DSystem(
             loop,
             codec,
@@ -371,9 +171,45 @@ def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
             max_render_points=payload.max_render_points,
             max_frames=payload.max_frames,
         )
-        return system.run(field).to_dict()
+        result = system.run(field).to_dict()
+        result["run_id"] = run_id
+        result["persisted"] = run_id is not None
+        if run_id is not None:
+            RUN_STORE.write_summary(run_id, result)
+        return result
     except (TypeError, ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"run persistence failed: {exc}") from exc
+
+
+@app.get("/codec/3d/runs/{run_id}")
+def get_auto_codec_3d_run(run_id: str) -> dict[str, Any]:
+    try:
+        return RUN_STORE.read_summary(run_id)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="run not found") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"run retrieval failed: {exc}") from exc
+
+
+@app.get("/codec/3d/runs/{run_id}/verify")
+def verify_auto_codec_3d_run(run_id: str) -> dict[str, Any]:
+    try:
+        verification = RUN_STORE.verify(run_id)
+        if not verification["verified"]:
+            raise HTTPException(status_code=409, detail=verification)
+        return verification
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="run not found") from exc
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=f"run verification failed: {exc}") from exc
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"run verification failed: {exc}") from exc
 
 
 def start_api() -> None:

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -156,12 +156,8 @@ def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
         )
         runtime = DrMoagiFieldRuntime(codec, _field_config(payload))
 
-        run_id: str | None = None
-        ledger = None
-        if payload.persist:
-            run_id = RUN_STORE.new_run_id()
-            ledger = RUN_STORE.ledger(run_id)
-
+        run_id = RUN_STORE.new_run_id() if payload.persist else None
+        ledger = RUN_STORE.ledger(run_id) if run_id is not None else None
         loop = AutoCodecLoop(runtime, _loop_config(payload), ledger=ledger)
         system = SpatialAutoCodec3DSystem(
             loop,

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,22 +1,218 @@
-from flask import Flask, request, jsonify
-from .core import CodexVM
-from .parser import Parser
+from __future__ import annotations
+
+from typing import Any
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel, Field
+
 from .assembler import Assembler
+from .auto_codec_loop import (
+    AutoCodecLoop,
+    AutoCodecLoopConfig,
+    UniformQuantizedFieldCodec,
+)
+from .core import CodexVM
+from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
+from .parser import Parser
 
-app = Flask(__name__)
-vm = CodexVM()
+app = FastAPI(
+    title="Jarvis-X / Dr Moagi Runtime API",
+    version="0.1.0",
+    description="Deterministic VM and bounded sparse auto-codec runtime.",
+)
 
-@app.route("/run", methods=["POST"])
-def run_code():
-    source = request.json.get("source", "")
-    ast = Parser().parse(source)
-    bytecode = Assembler().assemble(ast)
-    vm.load(bytecode)
-    vm.run()
-    return jsonify({
-        "registers": vm.regs.snapshot(),
-        "ledger_entries": len(vm.ledger.chain)
-    })
+DASHBOARD_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dr Moagi Auto-Codec Runtime</title>
+<style>
+:root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+body { margin:0; background:#080b12; color:#e8eefc; }
+main { max-width:1100px; margin:auto; padding:28px; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:12px; }
+.card { background:#111725; border:1px solid #26324a; border-radius:12px; padding:16px; }
+label { display:block; font-size:12px; color:#91a0bc; margin-bottom:6px; }
+input, textarea, button { width:100%; box-sizing:border-box; border-radius:8px; border:1px solid #33415f; background:#0a1020; color:#eef4ff; padding:10px; }
+textarea { min-height:180px; resize:vertical; }
+button { cursor:pointer; background:#162b52; font-weight:700; }
+button:hover { background:#1c386b; }
+.metric { font-size:22px; font-weight:700; }
+.muted { color:#91a0bc; font-size:12px; }
+pre { white-space:pre-wrap; overflow-wrap:anywhere; max-height:420px; overflow:auto; }
+.status { display:inline-block; padding:4px 8px; border-radius:999px; border:1px solid #33415f; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Dr Moagi Auto-Encoding / Decoding Runtime</h1>
+  <p class="muted">Executable loop: ingest → encode → decode → residual → field update → verify → journal → repeat.</p>
+  <div class="grid">
+    <div class="card"><label>Quantization step</label><input id="step" type="number" step="0.01" value="0.10"></div>
+    <div class="card"><label>Alpha (closure)</label><input id="alpha" type="number" step="0.1" value="1.0"></div>
+    <div class="card"><label>dt</label><input id="dt" type="number" step="0.01" value="0.10"></div>
+    <div class="card"><label>Max cycles</label><input id="cycles" type="number" value="64"></div>
+    <div class="card"><label>MSE target</label><input id="target" type="number" step="0.0001" value="0.001"></div>
+  </div>
+  <div class="card" style="margin-top:12px">
+    <label>Sparse input cells (JSON array)</label>
+    <textarea id="cells">[
+  {"x": 2, "y": 2, "z": 2, "value": 0.26},
+  {"x": 3, "y": 2, "z": 2, "value": -0.37}
+]</textarea>
+    <button id="run" style="margin-top:10px">Run closed loop</button>
+  </div>
+  <div class="grid" style="margin-top:12px">
+    <div class="card"><div class="muted">Stop reason</div><div id="stop" class="metric">—</div></div>
+    <div class="card"><div class="muted">Cycles</div><div id="cycleCount" class="metric">0</div></div>
+    <div class="card"><div class="muted">Final MSE</div><div id="mse" class="metric">—</div></div>
+    <div class="card"><div class="muted">Journal</div><div id="journal" class="status">not run</div></div>
+  </div>
+  <div class="card" style="margin-top:12px"><div class="muted">Runtime receipt</div><pre id="result">Ready.</pre></div>
+</main>
+<script>
+const $ = (id) => document.getElementById(id);
+$('run').addEventListener('click', async () => {
+  $('run').disabled = true;
+  $('result').textContent = 'Executing…';
+  try {
+    const body = {
+      cells: JSON.parse($('cells').value),
+      side: 64,
+      quantization_step: Number($('step').value),
+      alpha: Number($('alpha').value),
+      lambda_residual: 0,
+      eta: 0,
+      dt: Number($('dt').value),
+      expand_halo: false,
+      max_cycles: Number($('cycles').value),
+      reconstruction_mse_target: Number($('target').value),
+      stop_on_fixed_point: true
+    };
+    const response = await fetch('/codec/run', {
+      method: 'POST', headers: {'content-type':'application/json'}, body: JSON.stringify(body)
+    });
+    const data = await response.json();
+    if (!response.ok) throw new Error(data.detail || JSON.stringify(data));
+    $('stop').textContent = data.stop_reason;
+    $('cycleCount').textContent = data.cycles_executed;
+    $('mse').textContent = data.final_reconstruction_mse === null ? '—' : Number(data.final_reconstruction_mse).toExponential(3);
+    $('journal').textContent = data.journal_verified ? `verified · ${data.journal_entries} receipts` : 'verification failed';
+    $('result').textContent = JSON.stringify(data, null, 2);
+  } catch (error) {
+    $('result').textContent = String(error);
+  } finally {
+    $('run').disabled = false;
+  }
+});
+</script>
+</body>
+</html>"""
 
-def start_api():
-    app.run(host="0.0.0.0", port=8080)
+
+class VMRunRequest(BaseModel):
+    source: str = ""
+
+
+class SparseCell(BaseModel):
+    x: int
+    y: int
+    z: int
+    value: float
+
+
+class AutoCodecRequest(BaseModel):
+    cells: list[SparseCell] = Field(default_factory=list)
+    side: int = Field(default=64, gt=0, le=1000)
+    quantization_step: float = Field(default=0.05, gt=0.0)
+    alpha: float = Field(default=1.0, ge=0.0)
+    lambda_residual: float = Field(default=0.0, ge=0.0)
+    eta: float = 0.0
+    dt: float = Field(default=0.05, gt=0.0)
+    max_active_cells: int = Field(default=100_000, gt=0, le=100_000)
+    expand_halo: bool = False
+    prune_epsilon: float = Field(default=0.0, ge=0.0)
+    max_cycles: int = Field(default=64, gt=0, le=512)
+    min_cycles: int = Field(default=1, gt=0, le=512)
+    reconstruction_mse_target: float = Field(default=1e-8, ge=0.0)
+    max_consecutive_rejections: int = Field(default=3, gt=0, le=100)
+    stop_on_fixed_point: bool = True
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard() -> str:
+    return DASHBOARD_HTML
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok", "runtime": "jarvisx-auto-codec"}
+
+
+@app.post("/run")
+def run_code(payload: VMRunRequest) -> dict[str, Any]:
+    try:
+        ast = Parser().parse(payload.source)
+        bytecode = Assembler().assemble(ast)
+        vm = CodexVM()
+        vm.load(bytecode)
+        vm.run()
+        return {
+            "registers": vm.regs.snapshot(),
+            "ledger_entries": len(vm.ledger.chain),
+        }
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/codec/run")
+def run_auto_codec(payload: AutoCodecRequest) -> dict[str, Any]:
+    if payload.min_cycles > payload.max_cycles:
+        raise HTTPException(status_code=422, detail="min_cycles cannot exceed max_cycles")
+
+    field = {}
+    for cell in payload.cells:
+        coordinate = (cell.x, cell.y, cell.z)
+        if coordinate in field:
+            raise HTTPException(
+                status_code=422,
+                detail=f"duplicate sparse coordinate: {coordinate}",
+            )
+        field[coordinate] = cell.value
+
+    try:
+        codec = UniformQuantizedFieldCodec(step=payload.quantization_step)
+        runtime = DrMoagiFieldRuntime(
+            codec,
+            DrMoagiFieldConfig(
+                side=payload.side,
+                alpha=payload.alpha,
+                lambda_residual=payload.lambda_residual,
+                eta=payload.eta,
+                dt=payload.dt,
+                max_active_cells=payload.max_active_cells,
+                expand_halo=payload.expand_halo,
+                prune_epsilon=payload.prune_epsilon,
+            ),
+        )
+        loop = AutoCodecLoop(
+            runtime,
+            AutoCodecLoopConfig(
+                max_cycles=payload.max_cycles,
+                min_cycles=payload.min_cycles,
+                reconstruction_mse_target=payload.reconstruction_mse_target,
+                max_consecutive_rejections=payload.max_consecutive_rejections,
+                stop_on_fixed_point=payload.stop_on_fixed_point,
+            ),
+        )
+        loop.load(field)
+        return loop.run().to_dict()
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+def start_api() -> None:
+    uvicorn.run("jarvisx.api:app", host="0.0.0.0", port=8080)

--- a/src/jarvisx/api.py
+++ b/src/jarvisx/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import uvicorn
@@ -16,11 +17,12 @@ from .auto_codec_loop import (
 from .core import CodexVM
 from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
 from .parser import Parser
+from .spatial_codec_3d import MortonQuantizedFieldCodec3D, SpatialAutoCodec3DSystem
 
 app = FastAPI(
-    title="Jarvis-X / Dr Moagi Runtime API",
+    title="Jarvis-X / Dr Moagi 3D Runtime API",
     version="0.1.0",
-    description="Deterministic VM and bounded sparse auto-codec runtime.",
+    description="Deterministic VM and bounded operational 3D auto-codec runtime.",
 )
 
 DASHBOARD_HTML = r"""<!doctype html>
@@ -28,86 +30,206 @@ DASHBOARD_HTML = r"""<!doctype html>
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Dr Moagi Auto-Codec Runtime</title>
+<title>Dr Moagi 3D Auto-Codec Runtime</title>
 <style>
 :root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-body { margin:0; background:#080b12; color:#e8eefc; }
-main { max-width:1100px; margin:auto; padding:28px; }
-.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(210px,1fr)); gap:12px; }
-.card { background:#111725; border:1px solid #26324a; border-radius:12px; padding:16px; }
-label { display:block; font-size:12px; color:#91a0bc; margin-bottom:6px; }
-input, textarea, button { width:100%; box-sizing:border-box; border-radius:8px; border:1px solid #33415f; background:#0a1020; color:#eef4ff; padding:10px; }
-textarea { min-height:180px; resize:vertical; }
-button { cursor:pointer; background:#162b52; font-weight:700; }
-button:hover { background:#1c386b; }
-.metric { font-size:22px; font-weight:700; }
-.muted { color:#91a0bc; font-size:12px; }
-pre { white-space:pre-wrap; overflow-wrap:anywhere; max-height:420px; overflow:auto; }
-.status { display:inline-block; padding:4px 8px; border-radius:999px; border:1px solid #33415f; }
+* { box-sizing:border-box; }
+body { margin:0; background:#070a11; color:#e8eefc; }
+main { max-width:1320px; margin:auto; padding:24px; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; }
+.layout { display:grid; grid-template-columns:minmax(0,1.7fr) minmax(300px,.8fr); gap:12px; margin-top:12px; }
+.card { background:#101623; border:1px solid #27344f; border-radius:12px; padding:14px; overflow:hidden; }
+label { display:block; font-size:11px; color:#91a0bc; margin-bottom:5px; }
+input, textarea, button { width:100%; border-radius:8px; border:1px solid #344362; background:#09101f; color:#eef4ff; padding:9px; }
+textarea { min-height:145px; resize:vertical; }
+button { cursor:pointer; background:#162e58; font-weight:700; }
+button:hover { background:#1d3d74; }
+button:disabled { opacity:.55; cursor:default; }
+.metric { font-size:20px; font-weight:700; overflow-wrap:anywhere; }
+.muted { color:#91a0bc; font-size:11px; line-height:1.5; }
+.status { display:inline-block; padding:4px 8px; border-radius:999px; border:1px solid #344362; }
+canvas { display:block; width:100%; height:520px; border-radius:9px; background:#050811; touch-action:none; }
+pre { white-space:pre-wrap; overflow-wrap:anywhere; max-height:330px; overflow:auto; font-size:11px; }
+.controls { display:grid; grid-template-columns:100px 1fr 80px; gap:8px; align-items:center; margin-top:8px; }
+#frame { width:100%; }
+@media(max-width:900px){ .layout{grid-template-columns:1fr;} canvas{height:420px;} }
 </style>
 </head>
 <body>
 <main>
-  <h1>Dr Moagi Auto-Encoding / Decoding Runtime</h1>
-  <p class="muted">Executable loop: ingest → encode → decode → residual → field update → verify → journal → repeat.</p>
+  <h1>Dr Moagi 3D Auto-Encoding / Decoding Runtime</h1>
+  <p class="muted">Authoritative path: 3D sparse field → Morton spatial latent → decode → residual → 3D field operator → verify → commit/rollback → Omega journal → next frame.</p>
+
   <div class="grid">
     <div class="card"><label>Quantization step</label><input id="step" type="number" step="0.01" value="0.10"></div>
-    <div class="card"><label>Alpha (closure)</label><input id="alpha" type="number" step="0.1" value="1.0"></div>
+    <div class="card"><label>Alpha · reconstruction closure</label><input id="alpha" type="number" step="0.1" value="1.0"></div>
+    <div class="card"><label>Lambda · residual Laplacian</label><input id="lambda" type="number" step="0.05" value="0.0"></div>
+    <div class="card"><label>Eta · 3D glyph coupling</label><input id="eta" type="number" step="0.05" value="0.0"></div>
     <div class="card"><label>dt</label><input id="dt" type="number" step="0.01" value="0.10"></div>
     <div class="card"><label>Max cycles</label><input id="cycles" type="number" value="64"></div>
     <div class="card"><label>MSE target</label><input id="target" type="number" step="0.0001" value="0.001"></div>
   </div>
-  <div class="card" style="margin-top:12px">
-    <label>Sparse input cells (JSON array)</label>
-    <textarea id="cells">[
-  {"x": 2, "y": 2, "z": 2, "value": 0.26},
-  {"x": 3, "y": 2, "z": 2, "value": -0.37}
+
+  <div class="layout">
+    <section>
+      <div class="card">
+        <canvas id="view" width="1000" height="620"></canvas>
+        <div class="controls">
+          <button id="play">Play</button>
+          <input id="frame" type="range" min="0" max="0" value="0" />
+          <span id="frameLabel" class="muted">0 / 0</span>
+        </div>
+        <p class="muted">Drag to orbit · wheel/pinch to zoom · Play traverses authoritative runtime frames.</p>
+      </div>
+      <div class="grid" style="margin-top:10px">
+        <div class="card"><div class="muted">Stop reason</div><div id="stop" class="metric">—</div></div>
+        <div class="card"><div class="muted">Cycles</div><div id="cycleCount" class="metric">0</div></div>
+        <div class="card"><div class="muted">Final MSE</div><div id="mse" class="metric">—</div></div>
+        <div class="card"><div class="muted">Active 3D cells</div><div id="active" class="metric">0</div></div>
+        <div class="card"><div class="muted">Six-face links</div><div id="links" class="metric">0</div></div>
+        <div class="card"><div class="muted">Spatial RMS radius</div><div id="radius" class="metric">—</div></div>
+        <div class="card"><div class="muted">Latent entries</div><div id="latent" class="metric">0</div></div>
+        <div class="card"><div class="muted">Omega journal</div><div id="journal" class="status">not run</div></div>
+      </div>
+    </section>
+
+    <aside>
+      <div class="card">
+        <label>Sparse 3D input cells</label>
+        <textarea id="cells">[
+  {"x": 20, "y": 20, "z": 20, "value": 0.86},
+  {"x": 21, "y": 20, "z": 20, "value": 0.62},
+  {"x": 20, "y": 21, "z": 20, "value": -0.55},
+  {"x": 20, "y": 20, "z": 21, "value": 0.44},
+  {"x": 21, "y": 21, "z": 21, "value": -0.31}
 ]</textarea>
-    <button id="run" style="margin-top:10px">Run closed loop</button>
+        <button id="run" style="margin-top:9px">Execute 3D closed loop</button>
+      </div>
+      <div class="card" style="margin-top:10px">
+        <div class="muted">3D geometry</div>
+        <pre id="geometry">Ready.</pre>
+      </div>
+      <div class="card" style="margin-top:10px">
+        <div class="muted">Runtime receipt</div>
+        <pre id="result">Ready.</pre>
+      </div>
+    </aside>
   </div>
-  <div class="grid" style="margin-top:12px">
-    <div class="card"><div class="muted">Stop reason</div><div id="stop" class="metric">—</div></div>
-    <div class="card"><div class="muted">Cycles</div><div id="cycleCount" class="metric">0</div></div>
-    <div class="card"><div class="muted">Final MSE</div><div id="mse" class="metric">—</div></div>
-    <div class="card"><div class="muted">Journal</div><div id="journal" class="status">not run</div></div>
-  </div>
-  <div class="card" style="margin-top:12px"><div class="muted">Runtime receipt</div><pre id="result">Ready.</pre></div>
 </main>
 <script>
 const $ = (id) => document.getElementById(id);
+let runtimeFrames = [];
+let frameIndex = 0;
+let playing = false;
+let lastPlayback = 0;
+let yaw = -0.7, pitch = 0.45, zoom = 1.0;
+let dragging = false, lastX = 0, lastY = 0;
+
+const canvas = $('view');
+const gl = canvas.getContext('webgl', {antialias:true, alpha:false});
+if (!gl) $('result').textContent = 'WebGL unavailable; API execution remains usable.';
+
+let program, positionBuffer, valueBuffer, aPosition, aValue, uYaw, uPitch, uZoom, uCenter, uScale;
+function shader(type, source) {
+  const item = gl.createShader(type); gl.shaderSource(item, source); gl.compileShader(item);
+  if (!gl.getShaderParameter(item, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(item));
+  return item;
+}
+function initGL() {
+  if (!gl) return;
+  const vs = shader(gl.VERTEX_SHADER, `
+    attribute vec3 a_position; attribute float a_value;
+    uniform float u_yaw, u_pitch, u_zoom, u_scale; uniform vec3 u_center;
+    varying float v_value;
+    void main(){
+      vec3 p=(a_position-u_center)*u_scale;
+      float cy=cos(u_yaw), sy=sin(u_yaw), cp=cos(u_pitch), sp=sin(u_pitch);
+      p=vec3(cy*p.x+sy*p.z,p.y,-sy*p.x+cy*p.z);
+      p=vec3(p.x,cp*p.y-sp*p.z,sp*p.y+cp*p.z);
+      float depth=max(1.0,4.0+p.z);
+      gl_Position=vec4(p.x*u_zoom*1.8,p.y*u_zoom*1.8,depth-2.0,depth);
+      gl_PointSize=min(18.0, max(4.0, 7.0 + abs(a_value)*7.0));
+      v_value=a_value;
+    }`);
+  const fs = shader(gl.FRAGMENT_SHADER, `
+    precision mediump float; varying float v_value;
+    void main(){
+      vec2 d=gl_PointCoord-vec2(.5); if(dot(d,d)>.25) discard;
+      float a=min(1.0,abs(v_value));
+      vec3 positive=vec3(.20,.78,1.0), negative=vec3(1.0,.30,.68);
+      vec3 c=mix(vec3(.72,.78,.90), v_value>=0.0?positive:negative, .45+.55*a);
+      gl_FragColor=vec4(c,1.0);
+    }`);
+  program=gl.createProgram(); gl.attachShader(program,vs); gl.attachShader(program,fs); gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(program));
+  aPosition=gl.getAttribLocation(program,'a_position'); aValue=gl.getAttribLocation(program,'a_value');
+  uYaw=gl.getUniformLocation(program,'u_yaw'); uPitch=gl.getUniformLocation(program,'u_pitch');
+  uZoom=gl.getUniformLocation(program,'u_zoom'); uCenter=gl.getUniformLocation(program,'u_center'); uScale=gl.getUniformLocation(program,'u_scale');
+  positionBuffer=gl.createBuffer(); valueBuffer=gl.createBuffer();
+  gl.enable(gl.DEPTH_TEST); gl.clearColor(.018,.026,.055,1);
+}
+function currentFrame(){ return runtimeFrames[frameIndex] || {points:[],metrics:{}}; }
+function draw(){
+  if (!gl || !program) return;
+  const frame=currentFrame(), pts=frame.points||[];
+  const positions=new Float32Array(pts.length*3), values=new Float32Array(pts.length);
+  for(let i=0;i<pts.length;i++){ positions[i*3]=pts[i].x; positions[i*3+1]=pts[i].y; positions[i*3+2]=pts[i].z; values[i]=pts[i].value; }
+  const m=frame.metrics||{}, lo=m.bounds_min||[0,0,0], hi=m.bounds_max||[1,1,1];
+  const center=[(lo[0]+hi[0])/2,(lo[1]+hi[1])/2,(lo[2]+hi[2])/2];
+  const span=Math.max(1,hi[0]-lo[0],hi[1]-lo[1],hi[2]-lo[2]);
+  gl.viewport(0,0,canvas.width,canvas.height); gl.clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT); gl.useProgram(program);
+  gl.bindBuffer(gl.ARRAY_BUFFER,positionBuffer); gl.bufferData(gl.ARRAY_BUFFER,positions,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aPosition); gl.vertexAttribPointer(aPosition,3,gl.FLOAT,false,0,0);
+  gl.bindBuffer(gl.ARRAY_BUFFER,valueBuffer); gl.bufferData(gl.ARRAY_BUFFER,values,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aValue); gl.vertexAttribPointer(aValue,1,gl.FLOAT,false,0,0);
+  gl.uniform1f(uYaw,yaw); gl.uniform1f(uPitch,pitch); gl.uniform1f(uZoom,zoom); gl.uniform3fv(uCenter,new Float32Array(center)); gl.uniform1f(uScale,1.6/span);
+  gl.drawArrays(gl.POINTS,0,pts.length);
+}
+function selectFrame(index){
+  frameIndex=Math.max(0,Math.min(index,runtimeFrames.length-1)); $('frame').value=String(frameIndex);
+  $('frameLabel').textContent=`${frameIndex} / ${Math.max(0,runtimeFrames.length-1)}`;
+  const f=currentFrame(), m=f.metrics||{};
+  $('active').textContent=m.active_cells ?? 0; $('links').textContent=m.six_face_links ?? 0;
+  $('radius').textContent=m.rms_radius == null ? '—' : Number(m.rms_radius).toFixed(4);
+  $('geometry').textContent=JSON.stringify({cycle:f.cycle,state_digest:f.state_digest,metrics:m},null,2);
+  draw();
+}
+function animate(t){
+  if(playing && runtimeFrames.length>1 && t-lastPlayback>220){ frameIndex=(frameIndex+1)%runtimeFrames.length; selectFrame(frameIndex); lastPlayback=t; }
+  draw(); requestAnimationFrame(animate);
+}
+canvas.addEventListener('pointerdown',e=>{dragging=true;lastX=e.clientX;lastY=e.clientY;canvas.setPointerCapture(e.pointerId);});
+canvas.addEventListener('pointermove',e=>{if(!dragging)return; yaw+=(e.clientX-lastX)*.01; pitch+=(e.clientY-lastY)*.01; pitch=Math.max(-1.45,Math.min(1.45,pitch)); lastX=e.clientX;lastY=e.clientY;});
+canvas.addEventListener('pointerup',()=>dragging=false); canvas.addEventListener('pointercancel',()=>dragging=false);
+canvas.addEventListener('wheel',e=>{e.preventDefault();zoom*=Math.exp(-e.deltaY*.001);zoom=Math.max(.25,Math.min(4,zoom));},{passive:false});
+$('play').addEventListener('click',()=>{playing=!playing;$('play').textContent=playing?'Pause':'Play';});
+$('frame').addEventListener('input',()=>{playing=false;$('play').textContent='Play';selectFrame(Number($('frame').value));});
+
 $('run').addEventListener('click', async () => {
-  $('run').disabled = true;
-  $('result').textContent = 'Executing…';
+  $('run').disabled=true; $('result').textContent='Executing 3D loop…'; playing=false; $('play').textContent='Play';
   try {
-    const body = {
-      cells: JSON.parse($('cells').value),
-      side: 64,
-      quantization_step: Number($('step').value),
-      alpha: Number($('alpha').value),
-      lambda_residual: 0,
-      eta: 0,
-      dt: Number($('dt').value),
-      expand_halo: false,
-      max_cycles: Number($('cycles').value),
-      reconstruction_mse_target: Number($('target').value),
-      stop_on_fixed_point: true
+    const body={
+      cells:JSON.parse($('cells').value), side:64, quantization_step:Number($('step').value),
+      alpha:Number($('alpha').value), lambda_residual:Number($('lambda').value), eta:Number($('eta').value), dt:Number($('dt').value),
+      expand_halo:true, max_cycles:Number($('cycles').value), reconstruction_mse_target:Number($('target').value),
+      stop_on_fixed_point:true, frame_stride:1, max_render_points:4096, max_frames:128
     };
-    const response = await fetch('/codec/run', {
-      method: 'POST', headers: {'content-type':'application/json'}, body: JSON.stringify(body)
-    });
-    const data = await response.json();
-    if (!response.ok) throw new Error(data.detail || JSON.stringify(data));
-    $('stop').textContent = data.stop_reason;
-    $('cycleCount').textContent = data.cycles_executed;
-    $('mse').textContent = data.final_reconstruction_mse === null ? '—' : Number(data.final_reconstruction_mse).toExponential(3);
-    $('journal').textContent = data.journal_verified ? `verified · ${data.journal_entries} receipts` : 'verification failed';
-    $('result').textContent = JSON.stringify(data, null, 2);
-  } catch (error) {
-    $('result').textContent = String(error);
-  } finally {
-    $('run').disabled = false;
-  }
+    const response=await fetch('/codec/3d/run',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+    const data=await response.json(); if(!response.ok) throw new Error(data.detail||JSON.stringify(data));
+    runtimeFrames=data.frames||[]; frameIndex=Math.max(0,runtimeFrames.length-1); $('frame').max=String(Math.max(0,runtimeFrames.length-1));
+    $('stop').textContent=data.stop_reason; $('cycleCount').textContent=data.cycles_executed;
+    $('mse').textContent=data.final_reconstruction_mse==null?'—':Number(data.final_reconstruction_mse).toExponential(3);
+    $('latent').textContent=data.latent_entries; $('journal').textContent=data.journal_verified?`verified · ${data.journal_entries} receipts`:'verification failed';
+    $('result').textContent=JSON.stringify({
+      spatial_mode:data.spatial_mode, codec:data.codec, stop_reason:data.stop_reason, cycles_executed:data.cycles_executed,
+      converged:data.converged, final_reconstruction_mse:data.final_reconstruction_mse, latent_entries:data.latent_entries,
+      packed_latent_bytes_estimate:data.packed_latent_bytes_estimate, latent_digest:data.latent_digest,
+      final_state_digest:data.final_state_digest, journal_verified:data.journal_verified, journal_head_hash:data.journal_head_hash
+    },null,2);
+    selectFrame(frameIndex);
+  } catch(error){ $('result').textContent=String(error); }
+  finally { $('run').disabled=false; }
 });
+
+try { initGL(); requestAnimationFrame(animate); } catch(error) { $('result').textContent=String(error); }
 </script>
 </body>
 </html>"""
@@ -142,14 +264,58 @@ class AutoCodecRequest(BaseModel):
     stop_on_fixed_point: bool = True
 
 
+class AutoCodec3DRequest(AutoCodecRequest):
+    frame_stride: int = Field(default=1, gt=0, le=512)
+    max_render_points: int = Field(default=4096, gt=0, le=10_000)
+    max_frames: int = Field(default=128, gt=0, le=256)
+
+
+def _field_from_cells(cells: list[SparseCell]) -> dict[tuple[int, int, int], float]:
+    field: dict[tuple[int, int, int], float] = {}
+    for cell in cells:
+        coordinate = (cell.x, cell.y, cell.z)
+        if coordinate in field:
+            raise ValueError(f"duplicate sparse coordinate: {coordinate}")
+        field[coordinate] = cell.value
+    return field
+
+
+def _field_config(payload: AutoCodecRequest) -> DrMoagiFieldConfig:
+    return DrMoagiFieldConfig(
+        side=payload.side,
+        alpha=payload.alpha,
+        lambda_residual=payload.lambda_residual,
+        eta=payload.eta,
+        dt=payload.dt,
+        max_active_cells=payload.max_active_cells,
+        expand_halo=payload.expand_halo,
+        prune_epsilon=payload.prune_epsilon,
+    )
+
+
+def _loop_config(payload: AutoCodecRequest) -> AutoCodecLoopConfig:
+    return AutoCodecLoopConfig(
+        max_cycles=payload.max_cycles,
+        min_cycles=payload.min_cycles,
+        reconstruction_mse_target=payload.reconstruction_mse_target,
+        max_consecutive_rejections=payload.max_consecutive_rejections,
+        stop_on_fixed_point=payload.stop_on_fixed_point,
+    )
+
+
 @app.get("/", response_class=HTMLResponse)
 def dashboard() -> str:
     return DASHBOARD_HTML
 
 
 @app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok", "runtime": "jarvisx-auto-codec"}
+def health() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "runtime": "jarvisx-auto-codec-3d",
+        "spatial_codec": "morton-63bit",
+        "endpoints": ["/run", "/codec/run", "/codec/3d/run"],
+    }
 
 
 @app.post("/run")
@@ -173,46 +339,43 @@ def run_auto_codec(payload: AutoCodecRequest) -> dict[str, Any]:
     if payload.min_cycles > payload.max_cycles:
         raise HTTPException(status_code=422, detail="min_cycles cannot exceed max_cycles")
 
-    field = {}
-    for cell in payload.cells:
-        coordinate = (cell.x, cell.y, cell.z)
-        if coordinate in field:
-            raise HTTPException(
-                status_code=422,
-                detail=f"duplicate sparse coordinate: {coordinate}",
-            )
-        field[coordinate] = cell.value
-
     try:
+        field = _field_from_cells(payload.cells)
         codec = UniformQuantizedFieldCodec(step=payload.quantization_step)
-        runtime = DrMoagiFieldRuntime(
-            codec,
-            DrMoagiFieldConfig(
-                side=payload.side,
-                alpha=payload.alpha,
-                lambda_residual=payload.lambda_residual,
-                eta=payload.eta,
-                dt=payload.dt,
-                max_active_cells=payload.max_active_cells,
-                expand_halo=payload.expand_halo,
-                prune_epsilon=payload.prune_epsilon,
-            ),
-        )
-        loop = AutoCodecLoop(
-            runtime,
-            AutoCodecLoopConfig(
-                max_cycles=payload.max_cycles,
-                min_cycles=payload.min_cycles,
-                reconstruction_mse_target=payload.reconstruction_mse_target,
-                max_consecutive_rejections=payload.max_consecutive_rejections,
-                stop_on_fixed_point=payload.stop_on_fixed_point,
-            ),
-        )
+        runtime = DrMoagiFieldRuntime(codec, _field_config(payload))
+        loop = AutoCodecLoop(runtime, _loop_config(payload))
         loop.load(field)
         return loop.run().to_dict()
     except (TypeError, ValueError, RuntimeError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
+@app.post("/codec/3d/run")
+def run_auto_codec_3d(payload: AutoCodec3DRequest) -> dict[str, Any]:
+    if payload.min_cycles > payload.max_cycles:
+        raise HTTPException(status_code=422, detail="min_cycles cannot exceed max_cycles")
+
+    try:
+        field = _field_from_cells(payload.cells)
+        codec = MortonQuantizedFieldCodec3D(
+            step=payload.quantization_step,
+            side=payload.side,
+        )
+        runtime = DrMoagiFieldRuntime(codec, _field_config(payload))
+        loop = AutoCodecLoop(runtime, _loop_config(payload))
+        system = SpatialAutoCodec3DSystem(
+            loop,
+            codec,
+            side=payload.side,
+            frame_stride=payload.frame_stride,
+            max_render_points=payload.max_render_points,
+            max_frames=payload.max_frames,
+        )
+        return system.run(field).to_dict()
+    except (TypeError, ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
 def start_api() -> None:
-    uvicorn.run("jarvisx.api:app", host="0.0.0.0", port=8080)
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run("jarvisx.api:app", host="0.0.0.0", port=port)

--- a/src/jarvisx/auto_codec_loop.py
+++ b/src/jarvisx/auto_codec_loop.py
@@ -1,0 +1,309 @@
+"""Operational auto-encoding/decoding control loop for the Dr Moagi field runtime.
+
+The loop is deliberately bounded: it repeatedly executes the existing
+transactional encode -> decode -> residual -> projected-field step, records a
+hash-chained Omega journal receipt, and stops only on an explicit convergence,
+fixed-point, rejection-budget, or cycle-budget condition.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, replace
+from typing import Any
+
+from .dr_moagi_field_runtime import (
+    Coordinate,
+    DrMoagiFieldRuntime,
+    FieldStepMetrics,
+    SparseField,
+    Validator,
+)
+from .ledger import OmegaLedger
+
+OPCODE_AUTO_CODEC_LOAD = 0xA0
+OPCODE_AUTO_CODEC_CYCLE = 0xA1
+OPCODE_AUTO_CODEC_STOP = 0xA2
+
+
+@dataclass(frozen=True)
+class UniformQuantizedLatent:
+    """Sparse quantized latent representation used by the reference codec."""
+
+    step: float
+    codes: dict[Coordinate, int]
+
+
+class UniformQuantizedFieldCodec:
+    """Deterministic sparse scalar codec with explicit quantization error.
+
+    This is a reference codec, not a learned neural compressor. It exists so
+    the operational loop has a real, bounded encode/decode transform whose
+    reconstruction error can be measured and driven toward a fixed point.
+    """
+
+    def __init__(self, step: float = 0.05, *, prune_zero_codes: bool = True) -> None:
+        if isinstance(step, bool) or not isinstance(step, (int, float)):
+            raise TypeError("step must be numeric")
+        step = float(step)
+        if not math.isfinite(step) or step <= 0.0:
+            raise ValueError("step must be finite and positive")
+        self.step = step
+        self.prune_zero_codes = bool(prune_zero_codes)
+
+    def encode(self, field: Mapping[Coordinate, float]) -> UniformQuantizedLatent:
+        codes: dict[Coordinate, int] = {}
+        for coordinate, raw_value in field.items():
+            if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+                raise TypeError("field values must be numeric")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError("field values must be finite")
+            code = int(round(value / self.step))
+            if code != 0 or not self.prune_zero_codes:
+                codes[coordinate] = code
+        return UniformQuantizedLatent(step=self.step, codes=codes)
+
+    def decode(
+        self,
+        latent: UniformQuantizedLatent,
+        support: Sequence[Coordinate],
+    ) -> Mapping[Coordinate, float]:
+        if not isinstance(latent, UniformQuantizedLatent):
+            raise TypeError("latent must be a UniformQuantizedLatent")
+        if latent.step != self.step:
+            raise ValueError("latent quantization step does not match codec")
+        return {
+            coordinate: float(latent.codes.get(coordinate, 0)) * self.step
+            for coordinate in support
+        }
+
+
+@dataclass(frozen=True)
+class AutoCodecLoopConfig:
+    """Termination and verification contract for one auto-codec run."""
+
+    max_cycles: int = 64
+    min_cycles: int = 1
+    reconstruction_mse_target: float = 1e-8
+    max_consecutive_rejections: int = 3
+    stop_on_fixed_point: bool = True
+
+    def __post_init__(self) -> None:
+        for name in ("max_cycles", "min_cycles", "max_consecutive_rejections"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.min_cycles > self.max_cycles:
+            raise ValueError("min_cycles cannot exceed max_cycles")
+        target = self.reconstruction_mse_target
+        if isinstance(target, bool) or not isinstance(target, (int, float)):
+            raise TypeError("reconstruction_mse_target must be numeric")
+        if not math.isfinite(float(target)) or float(target) < 0.0:
+            raise ValueError("reconstruction_mse_target must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class AutoCodecCycleReceipt:
+    cycle: int
+    committed: bool
+    reconstruction_mse: float
+    anchor_mse: float
+    active_cells: int
+    state_digest: str
+    rejection_reason: str | None
+
+
+@dataclass(frozen=True)
+class AutoCodecRunSummary:
+    stop_reason: str
+    cycles_executed: int
+    committed_cycles: int
+    rejected_cycles: int
+    converged: bool
+    final_cycle: int
+    final_state_digest: str
+    final_reconstruction_mse: float | None
+    journal_verified: bool
+    journal_entries: int
+    journal_head_hash: str | None
+    final_state: SparseField
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "stop_reason": self.stop_reason,
+            "cycles_executed": self.cycles_executed,
+            "committed_cycles": self.committed_cycles,
+            "rejected_cycles": self.rejected_cycles,
+            "converged": self.converged,
+            "final_cycle": self.final_cycle,
+            "final_state_digest": self.final_state_digest,
+            "final_reconstruction_mse": self.final_reconstruction_mse,
+            "journal_verified": self.journal_verified,
+            "journal_entries": self.journal_entries,
+            "journal_head_hash": self.journal_head_hash,
+            "final_state": field_to_cells(self.final_state),
+        }
+
+
+class AutoCodecLoop:
+    """Bounded closed-loop controller around :class:`DrMoagiFieldRuntime`."""
+
+    def __init__(
+        self,
+        runtime: DrMoagiFieldRuntime,
+        config: AutoCodecLoopConfig | None = None,
+        *,
+        ledger: OmegaLedger | None = None,
+    ) -> None:
+        self.runtime = runtime
+        self.config = config or AutoCodecLoopConfig()
+        self.ledger = ledger or OmegaLedger()
+        self._loaded = False
+
+    def load(self, field: Mapping[Coordinate, float]) -> None:
+        self.runtime.load(field)
+        self._loaded = True
+        snapshot = self.runtime.snapshot()
+        self.ledger.log(
+            {
+                "event": "auto_codec_load",
+                "cycle": self.runtime.cycle,
+                "active_cells": len(snapshot),
+                "state_digest": digest_field(snapshot),
+            },
+            OPCODE_AUTO_CODEC_LOAD,
+        )
+
+    def step(self, validator: Validator | None = None) -> AutoCodecCycleReceipt:
+        if not self._loaded:
+            raise RuntimeError("load a field before stepping the auto-codec loop")
+        metrics = self.runtime.step(validator=validator)
+        snapshot = self.runtime.snapshot()
+        receipt = self._receipt(metrics, snapshot)
+        self.ledger.log(
+            {
+                "event": "auto_codec_cycle",
+                **asdict(receipt),
+            },
+            OPCODE_AUTO_CODEC_CYCLE,
+        )
+        return receipt
+
+    def run(self, validator: Validator | None = None) -> AutoCodecRunSummary:
+        if not self._loaded:
+            raise RuntimeError("load a field before running the auto-codec loop")
+
+        start_cycle = self.runtime.cycle
+        committed = 0
+        rejected = 0
+        consecutive_rejections = 0
+        last_receipt: AutoCodecCycleReceipt | None = None
+        previous_committed_digest: str | None = None
+        stop_reason = "cycle_limit"
+        converged = False
+
+        while self.runtime.cycle - start_cycle < self.config.max_cycles:
+            receipt = self.step(validator=validator)
+            last_receipt = receipt
+            executed = self.runtime.cycle - start_cycle
+
+            if receipt.committed:
+                committed += 1
+                consecutive_rejections = 0
+                if (
+                    executed >= self.config.min_cycles
+                    and receipt.reconstruction_mse <= self.config.reconstruction_mse_target
+                ):
+                    stop_reason = "reconstruction_target"
+                    converged = True
+                    break
+                if (
+                    self.config.stop_on_fixed_point
+                    and executed >= self.config.min_cycles
+                    and previous_committed_digest == receipt.state_digest
+                ):
+                    stop_reason = "fixed_point"
+                    converged = True
+                    break
+                previous_committed_digest = receipt.state_digest
+            else:
+                rejected += 1
+                consecutive_rejections += 1
+                if consecutive_rejections >= self.config.max_consecutive_rejections:
+                    stop_reason = "rejection_limit"
+                    break
+
+        final_state = self.runtime.snapshot()
+        summary = AutoCodecRunSummary(
+            stop_reason=stop_reason,
+            cycles_executed=self.runtime.cycle - start_cycle,
+            committed_cycles=committed,
+            rejected_cycles=rejected,
+            converged=converged,
+            final_cycle=self.runtime.cycle,
+            final_state_digest=digest_field(final_state),
+            final_reconstruction_mse=(
+                None if last_receipt is None else last_receipt.reconstruction_mse
+            ),
+            journal_verified=self.ledger.verify(),
+            journal_entries=len(self.ledger.chain),
+            journal_head_hash=(self.ledger.chain[-1]["hash"] if self.ledger.chain else None),
+            final_state=final_state,
+        )
+        self.ledger.log(
+            {
+                "event": "auto_codec_stop",
+                "stop_reason": summary.stop_reason,
+                "cycles_executed": summary.cycles_executed,
+                "committed_cycles": summary.committed_cycles,
+                "rejected_cycles": summary.rejected_cycles,
+                "converged": summary.converged,
+                "final_cycle": summary.final_cycle,
+                "final_state_digest": summary.final_state_digest,
+            },
+            OPCODE_AUTO_CODEC_STOP,
+        )
+        return replace(
+            summary,
+            journal_verified=self.ledger.verify(),
+            journal_entries=len(self.ledger.chain),
+            journal_head_hash=(self.ledger.chain[-1]["hash"] if self.ledger.chain else None),
+        )
+
+    @staticmethod
+    def _receipt(
+        metrics: FieldStepMetrics, snapshot: Mapping[Coordinate, float]
+    ) -> AutoCodecCycleReceipt:
+        return AutoCodecCycleReceipt(
+            cycle=metrics.cycle,
+            committed=metrics.committed,
+            reconstruction_mse=metrics.reconstruction_mse,
+            anchor_mse=metrics.anchor_mse,
+            active_cells=len(snapshot),
+            state_digest=digest_field(snapshot),
+            rejection_reason=metrics.rejection_reason,
+        )
+
+
+def field_to_cells(field: Mapping[Coordinate, float]) -> list[dict[str, int | float]]:
+    """Return a deterministic JSON-native representation of a sparse field."""
+
+    return [
+        {"x": x, "y": y, "z": z, "value": float(value)}
+        for (x, y, z), value in sorted(field.items())
+    ]
+
+
+def digest_field(field: Mapping[Coordinate, float]) -> str:
+    payload = json.dumps(
+        field_to_cells(field),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()

--- a/src/jarvisx/auto_codec_loop.py
+++ b/src/jarvisx/auto_codec_loop.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import asdict, dataclass, replace
 from typing import Any
 
@@ -149,6 +149,9 @@ class AutoCodecRunSummary:
         }
 
 
+CycleObserver = Callable[[int, SparseField], None]
+
+
 class AutoCodecLoop:
     """Bounded closed-loop controller around :class:`DrMoagiFieldRuntime`."""
 
@@ -193,7 +196,12 @@ class AutoCodecLoop:
         )
         return receipt
 
-    def run(self, validator: Validator | None = None) -> AutoCodecRunSummary:
+    def run(
+        self,
+        validator: Validator | None = None,
+        *,
+        on_cycle: CycleObserver | None = None,
+    ) -> AutoCodecRunSummary:
         if not self._loaded:
             raise RuntimeError("load a field before running the auto-codec loop")
 
@@ -210,6 +218,8 @@ class AutoCodecLoop:
             receipt = self.step(validator=validator)
             last_receipt = receipt
             executed = self.runtime.cycle - start_cycle
+            if on_cycle is not None:
+                on_cycle(receipt.cycle, self.runtime.snapshot())
 
             if receipt.committed:
                 committed += 1

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+from typing import Any
 
 from .api import start_api
 from .assembler import Assembler
@@ -10,23 +11,27 @@ from .core import CodexVM
 from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
 from .node import CodexNode
 from .parser import Parser
+from .spatial_codec_3d import MortonQuantizedFieldCodec3D, SpatialAutoCodec3DSystem
 from .web import start_web
 
 
 def _usage() -> None:
-    print("Usage: jarvisx [run|codec|api|web|node] <file>")
+    print("Usage: jarvisx [run|codec|codec3d|api|web|node] <file>")
 
 
-def _run_codec_file(path: str) -> None:
+def _load_json_object(path: str) -> dict[str, Any]:
     with open(path, encoding="utf-8") as source:
         payload = json.load(source)
     if not isinstance(payload, dict):
-        raise ValueError("codec input must be a JSON object")
+        raise ValueError("input must be a JSON object")
+    return payload
 
+
+def _field_from_payload(payload: dict[str, Any]) -> dict[tuple[int, int, int], float]:
     cells = payload.get("cells", [])
     if not isinstance(cells, list):
         raise ValueError("cells must be a JSON array")
-    field = {}
+    field: dict[tuple[int, int, int], float] = {}
     for cell in cells:
         if not isinstance(cell, dict):
             raise ValueError("each cell must be an object")
@@ -34,17 +39,52 @@ def _run_codec_file(path: str) -> None:
         if coordinate in field:
             raise ValueError(f"duplicate sparse coordinate: {coordinate}")
         field[coordinate] = float(cell["value"])
+    return field
 
-    codec = UniformQuantizedFieldCodec(float(payload.get("quantization_step", 0.05)))
+
+def _configs(payload: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     field_config = payload.get("field_config", {})
     loop_config = payload.get("loop_config", {})
     if not isinstance(field_config, dict) or not isinstance(loop_config, dict):
         raise ValueError("field_config and loop_config must be JSON objects")
+    return field_config, loop_config
 
+
+def _run_codec_file(path: str) -> None:
+    payload = _load_json_object(path)
+    field = _field_from_payload(payload)
+    field_config, loop_config = _configs(payload)
+
+    codec = UniformQuantizedFieldCodec(float(payload.get("quantization_step", 0.05)))
     runtime = DrMoagiFieldRuntime(codec, DrMoagiFieldConfig(**field_config))
     loop = AutoCodecLoop(runtime, AutoCodecLoopConfig(**loop_config))
     loop.load(field)
     print(json.dumps(loop.run().to_dict(), indent=2, sort_keys=True, allow_nan=False))
+
+
+def _run_codec_3d_file(path: str) -> None:
+    payload = _load_json_object(path)
+    field = _field_from_payload(payload)
+    field_config, loop_config = _configs(payload)
+    spatial_config = payload.get("spatial_config", {})
+    if not isinstance(spatial_config, dict):
+        raise ValueError("spatial_config must be a JSON object")
+
+    configured_field = DrMoagiFieldConfig(**field_config)
+    codec = MortonQuantizedFieldCodec3D(
+        float(payload.get("quantization_step", 0.05)),
+        side=configured_field.side,
+    )
+    runtime = DrMoagiFieldRuntime(codec, configured_field)
+    loop = AutoCodecLoop(runtime, AutoCodecLoopConfig(**loop_config))
+    system = SpatialAutoCodec3DSystem(
+        loop,
+        codec,
+        side=configured_field.side,
+        **spatial_config,
+    )
+    summary = system.run(field)
+    print(json.dumps(summary.to_dict(), indent=2, sort_keys=True, allow_nan=False))
 
 
 def main() -> None:
@@ -71,6 +111,12 @@ def main() -> None:
             _usage()
             return
         _run_codec_file(sys.argv[2])
+
+    elif cmd == "codec3d":
+        if len(sys.argv) < 3:
+            _usage()
+            return
+        _run_codec_3d_file(sys.argv[2])
 
     elif cmd == "api":
         start_api()

--- a/src/jarvisx/cli.py
+++ b/src/jarvisx/cli.py
@@ -1,28 +1,76 @@
-import sys
-from .parser import Parser
-from .assembler import Assembler
-from .core import CodexVM
-from .api import start_api
-from .web import start_web
-from .node import CodexNode
+from __future__ import annotations
 
-def main():
+import json
+import sys
+
+from .api import start_api
+from .assembler import Assembler
+from .auto_codec_loop import AutoCodecLoop, AutoCodecLoopConfig, UniformQuantizedFieldCodec
+from .core import CodexVM
+from .dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
+from .node import CodexNode
+from .parser import Parser
+from .web import start_web
+
+
+def _usage() -> None:
+    print("Usage: jarvisx [run|codec|api|web|node] <file>")
+
+
+def _run_codec_file(path: str) -> None:
+    with open(path, encoding="utf-8") as source:
+        payload = json.load(source)
+    if not isinstance(payload, dict):
+        raise ValueError("codec input must be a JSON object")
+
+    cells = payload.get("cells", [])
+    if not isinstance(cells, list):
+        raise ValueError("cells must be a JSON array")
+    field = {}
+    for cell in cells:
+        if not isinstance(cell, dict):
+            raise ValueError("each cell must be an object")
+        coordinate = (int(cell["x"]), int(cell["y"]), int(cell["z"]))
+        if coordinate in field:
+            raise ValueError(f"duplicate sparse coordinate: {coordinate}")
+        field[coordinate] = float(cell["value"])
+
+    codec = UniformQuantizedFieldCodec(float(payload.get("quantization_step", 0.05)))
+    field_config = payload.get("field_config", {})
+    loop_config = payload.get("loop_config", {})
+    if not isinstance(field_config, dict) or not isinstance(loop_config, dict):
+        raise ValueError("field_config and loop_config must be JSON objects")
+
+    runtime = DrMoagiFieldRuntime(codec, DrMoagiFieldConfig(**field_config))
+    loop = AutoCodecLoop(runtime, AutoCodecLoopConfig(**loop_config))
+    loop.load(field)
+    print(json.dumps(loop.run().to_dict(), indent=2, sort_keys=True, allow_nan=False))
+
+
+def main() -> None:
     if len(sys.argv) < 2:
-        print("Usage: jarvisx [run|api|web|node] <file>")
+        _usage()
         return
 
     cmd = sys.argv[1]
 
     if cmd == "run":
-        file = sys.argv[2]
-        with open(file) as f:
-            source = f.read()
-        ast = Parser().parse(source)
+        if len(sys.argv) < 3:
+            _usage()
+            return
+        with open(sys.argv[2], encoding="utf-8") as source:
+            ast = Parser().parse(source.read())
         bytecode = Assembler().assemble(ast)
         vm = CodexVM()
         vm.load(bytecode)
         vm.run()
         print("Registers:", vm.regs.snapshot())
+
+    elif cmd == "codec":
+        if len(sys.argv) < 3:
+            _usage()
+            return
+        _run_codec_file(sys.argv[2])
 
     elif cmd == "api":
         start_api()
@@ -31,8 +79,11 @@ def main():
         start_web()
 
     elif cmd == "node":
-        node = CodexNode()
-        node.start()
+        CodexNode().start()
+
+    else:
+        _usage()
+
 
 if __name__ == "__main__":
     main()

--- a/src/jarvisx/dashboard_3d.py
+++ b/src/jarvisx/dashboard_3d.py
@@ -1,0 +1,179 @@
+"""Dependency-free WebGL dashboard for the operational 3D runtime."""
+
+DASHBOARD_HTML = r"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Dr Moagi 3D Auto-Codec Runtime</title>
+<style>
+:root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+* { box-sizing:border-box; }
+body { margin:0; background:#070a11; color:#e8eefc; }
+main { max-width:1320px; margin:auto; padding:24px; }
+.grid { display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:10px; }
+.layout { display:grid; grid-template-columns:minmax(0,1.7fr) minmax(300px,.8fr); gap:12px; margin-top:12px; }
+.card { background:#101623; border:1px solid #27344f; border-radius:12px; padding:14px; overflow:hidden; }
+label { display:block; font-size:11px; color:#91a0bc; margin-bottom:5px; }
+input, textarea, button { width:100%; border-radius:8px; border:1px solid #344362; background:#09101f; color:#eef4ff; padding:9px; }
+textarea { min-height:145px; resize:vertical; }
+button { cursor:pointer; background:#162e58; font-weight:700; }
+button:hover { background:#1d3d74; }
+button:disabled { opacity:.55; cursor:default; }
+.metric { font-size:20px; font-weight:700; overflow-wrap:anywhere; }
+.muted { color:#91a0bc; font-size:11px; line-height:1.5; }
+.status { display:inline-block; padding:4px 8px; border-radius:999px; border:1px solid #344362; }
+canvas { display:block; width:100%; height:520px; border-radius:9px; background:#050811; touch-action:none; }
+pre { white-space:pre-wrap; overflow-wrap:anywhere; max-height:330px; overflow:auto; font-size:11px; }
+.controls { display:grid; grid-template-columns:100px 1fr 80px; gap:8px; align-items:center; margin-top:8px; }
+#frame { width:100%; }
+@media(max-width:900px){ .layout{grid-template-columns:1fr;} canvas{height:420px;} }
+</style>
+</head>
+<body>
+<main>
+  <h1>Dr Moagi 3D Auto-Encoding / Decoding Runtime</h1>
+  <p class="muted">Authoritative path: 3D sparse field → Morton spatial latent → decode → residual → 3D field operator → verify → commit/rollback → Omega journal → persisted run → next frame.</p>
+
+  <div class="grid">
+    <div class="card"><label>Quantization step</label><input id="step" type="number" step="0.01" value="0.10"></div>
+    <div class="card"><label>Alpha · reconstruction closure</label><input id="alpha" type="number" step="0.1" value="1.0"></div>
+    <div class="card"><label>Lambda · residual Laplacian</label><input id="lambda" type="number" step="0.05" value="0.0"></div>
+    <div class="card"><label>Eta · 3D glyph coupling</label><input id="eta" type="number" step="0.05" value="0.0"></div>
+    <div class="card"><label>dt</label><input id="dt" type="number" step="0.01" value="0.10"></div>
+    <div class="card"><label>Max cycles</label><input id="cycles" type="number" value="64"></div>
+    <div class="card"><label>MSE target</label><input id="target" type="number" step="0.0001" value="0.001"></div>
+  </div>
+
+  <div class="layout">
+    <section>
+      <div class="card">
+        <canvas id="view" width="1000" height="620"></canvas>
+        <div class="controls">
+          <button id="play">Play</button>
+          <input id="frame" type="range" min="0" max="0" value="0" />
+          <span id="frameLabel" class="muted">0 / 0</span>
+        </div>
+        <p class="muted">Drag to orbit · wheel/pinch to zoom · Play traverses authoritative runtime frames.</p>
+      </div>
+      <div class="grid" style="margin-top:10px">
+        <div class="card"><div class="muted">Stop reason</div><div id="stop" class="metric">—</div></div>
+        <div class="card"><div class="muted">Cycles</div><div id="cycleCount" class="metric">0</div></div>
+        <div class="card"><div class="muted">Final MSE</div><div id="mse" class="metric">—</div></div>
+        <div class="card"><div class="muted">Active 3D cells</div><div id="active" class="metric">0</div></div>
+        <div class="card"><div class="muted">Six-face links</div><div id="links" class="metric">0</div></div>
+        <div class="card"><div class="muted">Spatial RMS radius</div><div id="radius" class="metric">—</div></div>
+        <div class="card"><div class="muted">Latent entries</div><div id="latent" class="metric">0</div></div>
+        <div class="card"><div class="muted">Omega journal</div><div id="journal" class="status">not run</div></div>
+      </div>
+    </section>
+
+    <aside>
+      <div class="card">
+        <label>Sparse 3D input cells</label>
+        <textarea id="cells">[
+  {"x": 20, "y": 20, "z": 20, "value": 0.86},
+  {"x": 21, "y": 20, "z": 20, "value": 0.62},
+  {"x": 20, "y": 21, "z": 20, "value": -0.55},
+  {"x": 20, "y": 20, "z": 21, "value": 0.44},
+  {"x": 21, "y": 21, "z": 21, "value": -0.31}
+]</textarea>
+        <button id="run" style="margin-top:9px">Execute 3D closed loop</button>
+      </div>
+      <div class="card" style="margin-top:10px">
+        <div class="muted">Persisted run ID</div>
+        <div id="runId" class="metric">—</div>
+        <button id="verify" style="margin-top:9px" disabled>Verify persisted run</button>
+      </div>
+      <div class="card" style="margin-top:10px">
+        <div class="muted">3D geometry</div>
+        <pre id="geometry">Ready.</pre>
+      </div>
+      <div class="card" style="margin-top:10px">
+        <div class="muted">Runtime receipt</div>
+        <pre id="result">Ready.</pre>
+      </div>
+    </aside>
+  </div>
+</main>
+<script>
+const $ = (id) => document.getElementById(id);
+let runtimeFrames = [], frameIndex = 0, playing = false, lastPlayback = 0;
+let yaw = -0.7, pitch = 0.45, zoom = 1.0, dragging = false, lastX = 0, lastY = 0;
+let currentRunId = null;
+const canvas = $('view');
+const gl = canvas.getContext('webgl', {antialias:true, alpha:false});
+if (!gl) $('result').textContent = 'WebGL unavailable; API execution remains usable.';
+let program, positionBuffer, valueBuffer, aPosition, aValue, uYaw, uPitch, uZoom, uCenter, uScale;
+function shader(type, source) {
+  const item = gl.createShader(type); gl.shaderSource(item, source); gl.compileShader(item);
+  if (!gl.getShaderParameter(item, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(item));
+  return item;
+}
+function initGL() {
+  if (!gl) return;
+  const vs = shader(gl.VERTEX_SHADER, `
+    attribute vec3 a_position; attribute float a_value;
+    uniform float u_yaw, u_pitch, u_zoom, u_scale; uniform vec3 u_center;
+    varying float v_value;
+    void main(){
+      vec3 p=(a_position-u_center)*u_scale;
+      float cy=cos(u_yaw), sy=sin(u_yaw), cp=cos(u_pitch), sp=sin(u_pitch);
+      p=vec3(cy*p.x+sy*p.z,p.y,-sy*p.x+cy*p.z);
+      p=vec3(p.x,cp*p.y-sp*p.z,sp*p.y+cp*p.z);
+      float depth=max(1.0,4.0+p.z);
+      gl_Position=vec4(p.x*u_zoom*1.8,p.y*u_zoom*1.8,depth-2.0,depth);
+      gl_PointSize=min(18.0,max(4.0,7.0+abs(a_value)*7.0)); v_value=a_value;
+    }`);
+  const fs = shader(gl.FRAGMENT_SHADER, `
+    precision mediump float; varying float v_value;
+    void main(){ vec2 d=gl_PointCoord-vec2(.5); if(dot(d,d)>.25) discard;
+      float a=min(1.0,abs(v_value)); vec3 p=vec3(.20,.78,1.0), n=vec3(1.0,.30,.68);
+      vec3 c=mix(vec3(.72,.78,.90),v_value>=0.0?p:n,.45+.55*a); gl_FragColor=vec4(c,1.0); }`);
+  program=gl.createProgram(); gl.attachShader(program,vs); gl.attachShader(program,fs); gl.linkProgram(program);
+  if (!gl.getProgramParameter(program, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(program));
+  aPosition=gl.getAttribLocation(program,'a_position'); aValue=gl.getAttribLocation(program,'a_value');
+  uYaw=gl.getUniformLocation(program,'u_yaw'); uPitch=gl.getUniformLocation(program,'u_pitch'); uZoom=gl.getUniformLocation(program,'u_zoom');
+  uCenter=gl.getUniformLocation(program,'u_center'); uScale=gl.getUniformLocation(program,'u_scale');
+  positionBuffer=gl.createBuffer(); valueBuffer=gl.createBuffer(); gl.enable(gl.DEPTH_TEST); gl.clearColor(.018,.026,.055,1);
+}
+function resizeCanvas(){ const dpr=Math.min(2,window.devicePixelRatio||1), w=Math.max(1,Math.floor(canvas.clientWidth*dpr)), h=Math.max(1,Math.floor(canvas.clientHeight*dpr)); if(canvas.width!==w||canvas.height!==h){canvas.width=w;canvas.height=h;} }
+function currentFrame(){ return runtimeFrames[frameIndex] || {points:[],metrics:{}}; }
+function draw(){
+  if (!gl || !program) return; resizeCanvas();
+  const frame=currentFrame(), pts=frame.points||[], positions=new Float32Array(pts.length*3), values=new Float32Array(pts.length);
+  for(let i=0;i<pts.length;i++){ positions[i*3]=pts[i].x; positions[i*3+1]=pts[i].y; positions[i*3+2]=pts[i].z; values[i]=pts[i].value; }
+  const m=frame.metrics||{}, lo=m.bounds_min||[0,0,0], hi=m.bounds_max||[1,1,1], center=[(lo[0]+hi[0])/2,(lo[1]+hi[1])/2,(lo[2]+hi[2])/2];
+  const span=Math.max(1,hi[0]-lo[0],hi[1]-lo[1],hi[2]-lo[2]);
+  gl.viewport(0,0,canvas.width,canvas.height); gl.clear(gl.COLOR_BUFFER_BIT|gl.DEPTH_BUFFER_BIT); gl.useProgram(program);
+  gl.bindBuffer(gl.ARRAY_BUFFER,positionBuffer); gl.bufferData(gl.ARRAY_BUFFER,positions,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aPosition); gl.vertexAttribPointer(aPosition,3,gl.FLOAT,false,0,0);
+  gl.bindBuffer(gl.ARRAY_BUFFER,valueBuffer); gl.bufferData(gl.ARRAY_BUFFER,values,gl.DYNAMIC_DRAW); gl.enableVertexAttribArray(aValue); gl.vertexAttribPointer(aValue,1,gl.FLOAT,false,0,0);
+  gl.uniform1f(uYaw,yaw); gl.uniform1f(uPitch,pitch); gl.uniform1f(uZoom,zoom); gl.uniform3fv(uCenter,new Float32Array(center)); gl.uniform1f(uScale,1.6/span); gl.drawArrays(gl.POINTS,0,pts.length);
+}
+function selectFrame(index){
+  frameIndex=Math.max(0,Math.min(index,Math.max(0,runtimeFrames.length-1))); $('frame').value=String(frameIndex); $('frameLabel').textContent=`${frameIndex} / ${Math.max(0,runtimeFrames.length-1)}`;
+  const f=currentFrame(), m=f.metrics||{}; $('active').textContent=m.active_cells ?? 0; $('links').textContent=m.six_face_links ?? 0; $('radius').textContent=m.rms_radius==null?'—':Number(m.rms_radius).toFixed(4);
+  $('geometry').textContent=JSON.stringify({cycle:f.cycle,state_digest:f.state_digest,metrics:m},null,2); draw();
+}
+function animate(t){ if(playing&&runtimeFrames.length>1&&t-lastPlayback>220){frameIndex=(frameIndex+1)%runtimeFrames.length;selectFrame(frameIndex);lastPlayback=t;} draw(); requestAnimationFrame(animate); }
+canvas.addEventListener('pointerdown',e=>{dragging=true;lastX=e.clientX;lastY=e.clientY;canvas.setPointerCapture(e.pointerId);});
+canvas.addEventListener('pointermove',e=>{if(!dragging)return;yaw+=(e.clientX-lastX)*.01;pitch+=(e.clientY-lastY)*.01;pitch=Math.max(-1.45,Math.min(1.45,pitch));lastX=e.clientX;lastY=e.clientY;});
+canvas.addEventListener('pointerup',()=>dragging=false); canvas.addEventListener('pointercancel',()=>dragging=false);
+canvas.addEventListener('wheel',e=>{e.preventDefault();zoom*=Math.exp(-e.deltaY*.001);zoom=Math.max(.25,Math.min(4,zoom));},{passive:false});
+$('play').addEventListener('click',()=>{playing=!playing;$('play').textContent=playing?'Pause':'Play';});
+$('frame').addEventListener('input',()=>{playing=false;$('play').textContent='Play';selectFrame(Number($('frame').value));});
+$('verify').addEventListener('click',async()=>{ if(!currentRunId)return; try{ const r=await fetch(`/codec/3d/runs/${currentRunId}/verify`), d=await r.json(); if(!r.ok)throw new Error(d.detail||JSON.stringify(d)); $('result').textContent=JSON.stringify(d,null,2); }catch(e){$('result').textContent=String(e);} });
+$('run').addEventListener('click',async()=>{
+  $('run').disabled=true; $('result').textContent='Executing and persisting 3D loop…'; playing=false; $('play').textContent='Play';
+  try{
+    const body={cells:JSON.parse($('cells').value),side:64,quantization_step:Number($('step').value),alpha:Number($('alpha').value),lambda_residual:Number($('lambda').value),eta:Number($('eta').value),dt:Number($('dt').value),expand_halo:true,max_cycles:Number($('cycles').value),reconstruction_mse_target:Number($('target').value),stop_on_fixed_point:true,frame_stride:1,max_render_points:4096,max_frames:128,persist:true};
+    const response=await fetch('/codec/3d/run',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)}), data=await response.json(); if(!response.ok)throw new Error(data.detail||JSON.stringify(data));
+    runtimeFrames=data.frames||[]; frameIndex=Math.max(0,runtimeFrames.length-1); $('frame').max=String(Math.max(0,runtimeFrames.length-1)); $('stop').textContent=data.stop_reason; $('cycleCount').textContent=data.cycles_executed; $('mse').textContent=data.final_reconstruction_mse==null?'—':Number(data.final_reconstruction_mse).toExponential(3); $('latent').textContent=data.latent_entries; $('journal').textContent=data.journal_verified?`verified · ${data.journal_entries} receipts`:'verification failed';
+    currentRunId=data.run_id||null; $('runId').textContent=currentRunId||'not persisted'; $('verify').disabled=!currentRunId;
+    $('result').textContent=JSON.stringify({run_id:data.run_id,persisted:data.persisted,spatial_mode:data.spatial_mode,codec:data.codec,stop_reason:data.stop_reason,cycles_executed:data.cycles_executed,converged:data.converged,final_reconstruction_mse:data.final_reconstruction_mse,latent_entries:data.latent_entries,packed_latent_bytes_estimate:data.packed_latent_bytes_estimate,latent_digest:data.latent_digest,final_state_digest:data.final_state_digest,journal_verified:data.journal_verified,journal_head_hash:data.journal_head_hash},null,2); selectFrame(frameIndex);
+  }catch(error){$('result').textContent=String(error);}finally{$('run').disabled=false;}
+});
+try{initGL();requestAnimationFrame(animate);}catch(error){$('result').textContent=String(error);}
+</script>
+</body>
+</html>"""

--- a/src/jarvisx/run_store.py
+++ b/src/jarvisx/run_store.py
@@ -1,0 +1,78 @@
+"""Durable run-artifact storage for bounded Jarvis-X executions."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from .ledger_store import PersistentLedger
+
+_RUN_ID = re.compile(r"^[0-9a-f]{32}$")
+
+
+class RunArtifactStore:
+    """Persist run summaries and Omega journals under opaque validated IDs.
+
+    The store uses atomic file replacement for summaries. Journal durability and
+    integrity checking are delegated to :class:`PersistentLedger`.
+    """
+
+    def __init__(self, root: str | os.PathLike[str] = "data/runs") -> None:
+        self.root = Path(root)
+
+    def new_run_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def ledger(self, run_id: str) -> PersistentLedger:
+        directory = self._directory(run_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        return PersistentLedger(directory / "omega.json")
+
+    def write_summary(self, run_id: str, summary: Mapping[str, Any]) -> Path:
+        directory = self._directory(run_id)
+        directory.mkdir(parents=True, exist_ok=True)
+        target = directory / "summary.json"
+        temporary = directory / ".summary.json.tmp"
+        with temporary.open("w", encoding="utf-8", newline="\n") as output:
+            json.dump(dict(summary), output, ensure_ascii=False, indent=2, sort_keys=True, allow_nan=False)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, target)
+        return target
+
+    def read_summary(self, run_id: str) -> dict[str, Any]:
+        target = self._directory(run_id) / "summary.json"
+        with target.open(encoding="utf-8") as source:
+            value: Any = json.load(source)
+        if not isinstance(value, dict):
+            raise ValueError("stored run summary must be a JSON object")
+        return value
+
+    def verify(self, run_id: str) -> dict[str, Any]:
+        summary = self.read_summary(run_id)
+        ledger = PersistentLedger(self._directory(run_id) / "omega.json")
+        head = ledger.chain[-1]["hash"] if ledger.chain else None
+        expected_head = summary.get("journal_head_hash")
+        journal_verified = ledger.verify()
+        head_matches_summary = head == expected_head
+        return {
+            "run_id": run_id,
+            "verified": journal_verified and head_matches_summary,
+            "journal_verified": journal_verified,
+            "head_matches_summary": head_matches_summary,
+            "journal_entries": len(ledger.chain),
+            "journal_head_hash": head,
+            "final_state_digest": summary.get("final_state_digest"),
+            "latent_digest": summary.get("latent_digest"),
+        }
+
+    def _directory(self, run_id: str) -> Path:
+        if not isinstance(run_id, str) or _RUN_ID.fullmatch(run_id) is None:
+            raise ValueError("run_id must be a 32-character lowercase hexadecimal identifier")
+        return self.root / run_id

--- a/src/jarvisx/spatial_codec_3d.py
+++ b/src/jarvisx/spatial_codec_3d.py
@@ -13,7 +13,7 @@ import json
 import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from .auto_codec_loop import AutoCodecLoop, AutoCodecRunSummary, digest_field
 from .dr_moagi_field_runtime import Coordinate, SparseField, Validator
@@ -133,7 +133,7 @@ class MortonQuantizedFieldCodec3D:
             raise TypeError("latent must be a MortonQuantizedLatent3D")
         if latent.step != self.step:
             raise ValueError("latent quantization step does not match codec")
-        result: SparseField = {}
+        result: dict[Coordinate, float] = {}
         for coordinate in support:
             coordinate = _field_coordinate(coordinate, self.side)
             value_code = latent.entries.get(morton_encode_3d(*coordinate), 0)
@@ -306,7 +306,7 @@ class SpatialAutoCodec3DSummary:
     loop: AutoCodecRunSummary
 
     def to_dict(self) -> dict[str, Any]:
-        result = self.loop.to_dict()
+        result = cast(dict[str, Any], self.loop.to_dict())
         result.update(
             {
                 "spatial_mode": "3d-morton-quantized",
@@ -397,7 +397,6 @@ class SpatialAutoCodec3DSystem:
                 frames[-1] = final_frame
 
         latent = self.codec.encode(final_state)
-        # Guaranteed by codec range checks: uint64 Morton key + int32 value code.
         packed_bytes = len(latent.entries) * 12
         return SpatialAutoCodec3DSummary(
             codec="MortonQuantizedFieldCodec3D",

--- a/src/jarvisx/spatial_codec_3d.py
+++ b/src/jarvisx/spatial_codec_3d.py
@@ -1,0 +1,430 @@
+"""Operational 3D spatial codec and telemetry for the Dr Moagi field runtime.
+
+The module keeps spatial execution explicit. Integer ``(x, y, z)`` lattice
+coordinates are encoded into reversible Morton (Z-order) addresses and scalar
+field values are quantized independently. The resulting latent representation
+therefore retains a deterministic spatial address instead of treating the 3D
+coordinates as UI-only metadata.
+
+This is a bounded reference implementation. It does not claim that Morton
+ordering is an optimal learned latent geometry or that the reported packed-byte
+estimate is Python object memory usage.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from .auto_codec_loop import AutoCodecLoop, AutoCodecRunSummary, digest_field
+from .dr_moagi_field_runtime import Coordinate, SparseField, Validator
+
+MORTON_BITS_PER_AXIS = 21
+MORTON_MAX_COORDINATE = (1 << MORTON_BITS_PER_AXIS) - 1
+
+
+def _coordinate_component(value: int, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    if value < 0 or value > MORTON_MAX_COORDINATE:
+        raise ValueError(
+            f"{name} must be within [0, {MORTON_MAX_COORDINATE}] for the 63-bit Morton key"
+        )
+    return value
+
+
+def morton_encode_3d(x: int, y: int, z: int) -> int:
+    """Interleave 21 bits from each axis into one reversible 63-bit key."""
+
+    x = _coordinate_component(x, "x")
+    y = _coordinate_component(y, "y")
+    z = _coordinate_component(z, "z")
+    code = 0
+    for bit in range(MORTON_BITS_PER_AXIS):
+        code |= ((x >> bit) & 1) << (3 * bit)
+        code |= ((y >> bit) & 1) << (3 * bit + 1)
+        code |= ((z >> bit) & 1) << (3 * bit + 2)
+    return code
+
+
+def morton_decode_3d(code: int) -> Coordinate:
+    """Recover ``(x, y, z)`` from a 63-bit Morton key."""
+
+    if isinstance(code, bool) or not isinstance(code, int):
+        raise TypeError("Morton code must be an integer")
+    if code < 0 or code >= 1 << (3 * MORTON_BITS_PER_AXIS):
+        raise ValueError("Morton code is outside the supported 63-bit range")
+    x = y = z = 0
+    for bit in range(MORTON_BITS_PER_AXIS):
+        x |= ((code >> (3 * bit)) & 1) << bit
+        y |= ((code >> (3 * bit + 1)) & 1) << bit
+        z |= ((code >> (3 * bit + 2)) & 1) << bit
+    return x, y, z
+
+
+@dataclass(frozen=True)
+class MortonQuantizedLatent3D:
+    """Sparse 3D latent: reversible Morton address -> signed quantized code."""
+
+    step: float
+    entries: dict[int, int]
+
+
+class MortonQuantizedFieldCodec3D:
+    """Deterministic spatial codec implementing the field-runtime codec contract."""
+
+    def __init__(
+        self,
+        step: float = 0.05,
+        *,
+        side: int = 1000,
+        prune_zero_codes: bool = True,
+    ) -> None:
+        if isinstance(step, bool) or not isinstance(step, (int, float)):
+            raise TypeError("step must be numeric")
+        step = float(step)
+        if not math.isfinite(step) or step <= 0.0:
+            raise ValueError("step must be finite and positive")
+        if isinstance(side, bool) or not isinstance(side, int) or side <= 0:
+            raise ValueError("side must be a positive integer")
+        if side - 1 > MORTON_MAX_COORDINATE:
+            raise ValueError("side exceeds the supported Morton coordinate range")
+        self.step = step
+        self.side = side
+        self.prune_zero_codes = bool(prune_zero_codes)
+
+    def encode(self, field: Mapping[Coordinate, float]) -> MortonQuantizedLatent3D:
+        entries: dict[int, int] = {}
+        for coordinate, raw_value in field.items():
+            self._validate_coordinate(coordinate)
+            if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
+                raise TypeError("field values must be numeric")
+            value = float(raw_value)
+            if not math.isfinite(value):
+                raise ValueError("field values must be finite")
+            code = int(round(value / self.step))
+            if code != 0 or not self.prune_zero_codes:
+                key = morton_encode_3d(*coordinate)
+                if key in entries:
+                    raise RuntimeError("Morton address collision detected")
+                entries[key] = code
+        return MortonQuantizedLatent3D(step=self.step, entries=entries)
+
+    def decode(
+        self,
+        latent: MortonQuantizedLatent3D,
+        support: Sequence[Coordinate],
+    ) -> Mapping[Coordinate, float]:
+        if not isinstance(latent, MortonQuantizedLatent3D):
+            raise TypeError("latent must be a MortonQuantizedLatent3D")
+        if latent.step != self.step:
+            raise ValueError("latent quantization step does not match codec")
+        result: SparseField = {}
+        for coordinate in support:
+            self._validate_coordinate(coordinate)
+            key = morton_encode_3d(*coordinate)
+            result[coordinate] = float(latent.entries.get(key, 0)) * self.step
+        return result
+
+    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
+        if (
+            not isinstance(coordinate, tuple)
+            or len(coordinate) != 3
+            or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
+        ):
+            raise TypeError("coordinates must be integer (x, y, z) tuples")
+        if any(value < 0 or value >= self.side for value in coordinate):
+            raise ValueError("coordinate is outside the configured 3D side length")
+        return coordinate
+
+
+@dataclass(frozen=True)
+class SpatialMetrics3D:
+    active_cells: int
+    bounds_min: Coordinate | None
+    bounds_max: Coordinate | None
+    centroid: tuple[float, float, float] | None
+    weighted_centroid: tuple[float, float, float] | None
+    rms_radius: float
+    l1_energy: float
+    l2_energy: float
+    six_face_links: int
+    occupancy_ratio: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "active_cells": self.active_cells,
+            "bounds_min": list(self.bounds_min) if self.bounds_min is not None else None,
+            "bounds_max": list(self.bounds_max) if self.bounds_max is not None else None,
+            "centroid": list(self.centroid) if self.centroid is not None else None,
+            "weighted_centroid": (
+                list(self.weighted_centroid) if self.weighted_centroid is not None else None
+            ),
+            "rms_radius": self.rms_radius,
+            "l1_energy": self.l1_energy,
+            "l2_energy": self.l2_energy,
+            "six_face_links": self.six_face_links,
+            "occupancy_ratio": self.occupancy_ratio,
+        }
+
+
+def measure_spatial_field(field: Mapping[Coordinate, float], *, side: int) -> SpatialMetrics3D:
+    """Measure geometry directly from the active sparse 3D state."""
+
+    if isinstance(side, bool) or not isinstance(side, int) or side <= 0:
+        raise ValueError("side must be a positive integer")
+    if not field:
+        return SpatialMetrics3D(0, None, None, None, None, 0.0, 0.0, 0.0, 0, 0.0)
+
+    coordinates = tuple(field)
+    for coordinate in coordinates:
+        if (
+            not isinstance(coordinate, tuple)
+            or len(coordinate) != 3
+            or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
+        ):
+            raise TypeError("coordinates must be integer (x, y, z) tuples")
+        if any(value < 0 or value >= side for value in coordinate):
+            raise ValueError("coordinate is outside the configured 3D side length")
+
+    xs = tuple(coordinate[0] for coordinate in coordinates)
+    ys = tuple(coordinate[1] for coordinate in coordinates)
+    zs = tuple(coordinate[2] for coordinate in coordinates)
+    count = len(coordinates)
+    centroid = (sum(xs) / count, sum(ys) / count, sum(zs) / count)
+
+    weights = tuple(abs(float(field[coordinate])) for coordinate in coordinates)
+    if not all(math.isfinite(weight) for weight in weights):
+        raise ValueError("field values must be finite")
+    weight_sum = sum(weights)
+    weighted_centroid = (
+        (
+            sum(coordinate[0] * weight for coordinate, weight in zip(coordinates, weights))
+            / weight_sum,
+            sum(coordinate[1] * weight for coordinate, weight in zip(coordinates, weights))
+            / weight_sum,
+            sum(coordinate[2] * weight for coordinate, weight in zip(coordinates, weights))
+            / weight_sum,
+        )
+        if weight_sum > 0.0
+        else centroid
+    )
+
+    rms_radius = math.sqrt(
+        sum(
+            (coordinate[0] - centroid[0]) ** 2
+            + (coordinate[1] - centroid[1]) ** 2
+            + (coordinate[2] - centroid[2]) ** 2
+            for coordinate in coordinates
+        )
+        / count
+    )
+    values = tuple(float(field[coordinate]) for coordinate in coordinates)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("field values must be finite")
+    l1_energy = sum(abs(value) for value in values)
+    l2_energy = sum(value * value for value in values)
+
+    support = set(coordinates)
+    links = 0
+    for x, y, z in coordinates:
+        for neighbor in ((x + 1, y, z), (x, y + 1, z), (x, y, z + 1)):
+            if neighbor in support:
+                links += 1
+
+    return SpatialMetrics3D(
+        active_cells=count,
+        bounds_min=(min(xs), min(ys), min(zs)),
+        bounds_max=(max(xs), max(ys), max(zs)),
+        centroid=centroid,
+        weighted_centroid=weighted_centroid,
+        rms_radius=rms_radius,
+        l1_energy=l1_energy,
+        l2_energy=l2_energy,
+        six_face_links=links,
+        occupancy_ratio=count / float(side**3),
+    )
+
+
+@dataclass(frozen=True)
+class SpatialFrame3D:
+    cycle: int
+    state_digest: str
+    metrics: SpatialMetrics3D
+    points: tuple[dict[str, int | float], ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cycle": self.cycle,
+            "state_digest": self.state_digest,
+            "metrics": self.metrics.to_dict(),
+            "points": list(self.points),
+        }
+
+
+def spatial_frame(
+    field: Mapping[Coordinate, float],
+    *,
+    side: int,
+    cycle: int,
+    max_render_points: int = 4096,
+) -> SpatialFrame3D:
+    """Create a deterministic bounded point-cloud frame from authoritative state."""
+
+    if isinstance(max_render_points, bool) or not isinstance(max_render_points, int):
+        raise TypeError("max_render_points must be an integer")
+    if max_render_points <= 0:
+        raise ValueError("max_render_points must be positive")
+
+    ordered = sorted(field.items(), key=lambda item: morton_encode_3d(*item[0]))
+    if len(ordered) > max_render_points:
+        stride = math.ceil(len(ordered) / max_render_points)
+        ordered = ordered[::stride][:max_render_points]
+    points = tuple(
+        {"x": x, "y": y, "z": z, "value": float(value)}
+        for (x, y, z), value in ordered
+    )
+    return SpatialFrame3D(
+        cycle=cycle,
+        state_digest=digest_field(field),
+        metrics=measure_spatial_field(field, side=side),
+        points=points,
+    )
+
+
+def digest_latent(latent: MortonQuantizedLatent3D) -> str:
+    payload = {
+        "step": latent.step,
+        "entries": [[key, value] for key, value in sorted(latent.entries.items())],
+    }
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class SpatialAutoCodec3DSummary:
+    """Machine-readable result for one bounded spatial auto-codec execution."""
+
+    codec: str
+    latent_entries: int
+    latent_digest: str
+    packed_latent_bytes_estimate: int
+    input_frame: SpatialFrame3D
+    final_frame: SpatialFrame3D
+    frames: tuple[SpatialFrame3D, ...]
+    loop: AutoCodecRunSummary
+
+    def to_dict(self) -> dict[str, Any]:
+        result = self.loop.to_dict()
+        result.update(
+            {
+                "spatial_mode": "3d-morton-quantized",
+                "codec": self.codec,
+                "latent_entries": self.latent_entries,
+                "latent_digest": self.latent_digest,
+                "packed_latent_bytes_estimate": self.packed_latent_bytes_estimate,
+                "input_frame": self.input_frame.to_dict(),
+                "final_frame": self.final_frame.to_dict(),
+                "frames": [frame.to_dict() for frame in self.frames],
+            }
+        )
+        return result
+
+
+class SpatialAutoCodec3DSystem:
+    """Coordinate-aware 3D wrapper around the bounded auto-codec loop."""
+
+    def __init__(
+        self,
+        loop: AutoCodecLoop,
+        codec: MortonQuantizedFieldCodec3D,
+        *,
+        side: int,
+        frame_stride: int = 1,
+        max_render_points: int = 4096,
+        max_frames: int = 128,
+    ) -> None:
+        if loop.runtime.codec is not codec:
+            raise ValueError("loop runtime must use the same spatial codec instance")
+        for name, value in (
+            ("frame_stride", frame_stride),
+            ("max_render_points", max_render_points),
+            ("max_frames", max_frames),
+        ):
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if side != codec.side:
+            raise ValueError("system side must match codec side")
+        self.loop = loop
+        self.codec = codec
+        self.side = side
+        self.frame_stride = frame_stride
+        self.max_render_points = max_render_points
+        self.max_frames = max_frames
+
+    def run(
+        self,
+        field: Mapping[Coordinate, float],
+        *,
+        validator: Validator | None = None,
+    ) -> SpatialAutoCodec3DSummary:
+        self.loop.load(field)
+        input_frame = spatial_frame(
+            self.loop.runtime.snapshot(),
+            side=self.side,
+            cycle=self.loop.runtime.cycle,
+            max_render_points=self.max_render_points,
+        )
+        frames: list[SpatialFrame3D] = [input_frame]
+
+        def capture(cycle: int, state: SparseField) -> None:
+            if cycle % self.frame_stride != 0:
+                return
+            frame = spatial_frame(
+                state,
+                side=self.side,
+                cycle=cycle,
+                max_render_points=self.max_render_points,
+            )
+            if len(frames) < self.max_frames:
+                frames.append(frame)
+            elif frames:
+                frames[-1] = frame
+
+        summary = self.loop.run(validator=validator, on_cycle=capture)
+        final_state = self.loop.runtime.snapshot()
+        final_frame = spatial_frame(
+            final_state,
+            side=self.side,
+            cycle=self.loop.runtime.cycle,
+            max_render_points=self.max_render_points,
+        )
+        if frames[-1].state_digest != final_frame.state_digest:
+            if len(frames) < self.max_frames:
+                frames.append(final_frame)
+            else:
+                frames[-1] = final_frame
+
+        latent = self.codec.encode(final_state)
+        # A portable packed record would use uint64 Morton key + int32 value code.
+        packed_bytes = len(latent.entries) * 12
+        return SpatialAutoCodec3DSummary(
+            codec="MortonQuantizedFieldCodec3D",
+            latent_entries=len(latent.entries),
+            latent_digest=digest_latent(latent),
+            packed_latent_bytes_estimate=packed_bytes,
+            input_frame=input_frame,
+            final_frame=final_frame,
+            frames=tuple(frames),
+            loop=summary,
+        )

--- a/src/jarvisx/spatial_codec_3d.py
+++ b/src/jarvisx/spatial_codec_3d.py
@@ -1,14 +1,9 @@
-"""Operational 3D spatial codec and telemetry for the Dr Moagi field runtime.
+"""Operational 3D spatial codec and authoritative frame telemetry.
 
-The module keeps spatial execution explicit. Integer ``(x, y, z)`` lattice
-coordinates are encoded into reversible Morton (Z-order) addresses and scalar
-field values are quantized independently. The resulting latent representation
-therefore retains a deterministic spatial address instead of treating the 3D
-coordinates as UI-only metadata.
-
-This is a bounded reference implementation. It does not claim that Morton
-ordering is an optimal learned latent geometry or that the reported packed-byte
-estimate is Python object memory usage.
+Integer lattice coordinates are encoded as reversible 63-bit Morton/Z-order
+keys and scalar values are quantized into signed 32-bit codes. The module is a
+bounded deterministic reference implementation: 3D coordinates are part of the
+codec contract and emitted frames are derived from authoritative runtime state.
 """
 
 from __future__ import annotations
@@ -25,9 +20,11 @@ from .dr_moagi_field_runtime import Coordinate, SparseField, Validator
 
 MORTON_BITS_PER_AXIS = 21
 MORTON_MAX_COORDINATE = (1 << MORTON_BITS_PER_AXIS) - 1
+SIGNED_INT32_MIN = -(1 << 31)
+SIGNED_INT32_MAX = (1 << 31) - 1
 
 
-def _coordinate_component(value: int, name: str) -> int:
+def _axis(value: int, name: str) -> int:
     if isinstance(value, bool) or not isinstance(value, int):
         raise TypeError(f"{name} must be an integer")
     if value < 0 or value > MORTON_MAX_COORDINATE:
@@ -37,12 +34,22 @@ def _coordinate_component(value: int, name: str) -> int:
     return value
 
 
+def _field_coordinate(coordinate: Coordinate, side: int) -> Coordinate:
+    if (
+        not isinstance(coordinate, tuple)
+        or len(coordinate) != 3
+        or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
+    ):
+        raise TypeError("coordinates must be integer (x, y, z) tuples")
+    if any(value < 0 or value >= side for value in coordinate):
+        raise ValueError("coordinate is outside the configured 3D side length")
+    return coordinate
+
+
 def morton_encode_3d(x: int, y: int, z: int) -> int:
     """Interleave 21 bits from each axis into one reversible 63-bit key."""
 
-    x = _coordinate_component(x, "x")
-    y = _coordinate_component(y, "y")
-    z = _coordinate_component(z, "z")
+    x, y, z = _axis(x, "x"), _axis(y, "y"), _axis(z, "z")
     code = 0
     for bit in range(MORTON_BITS_PER_AXIS):
         code |= ((x >> bit) & 1) << (3 * bit)
@@ -52,7 +59,7 @@ def morton_encode_3d(x: int, y: int, z: int) -> int:
 
 
 def morton_decode_3d(code: int) -> Coordinate:
-    """Recover ``(x, y, z)`` from a 63-bit Morton key."""
+    """Recover ``(x, y, z)`` from a supported Morton key."""
 
     if isinstance(code, bool) or not isinstance(code, int):
         raise TypeError("Morton code must be an integer")
@@ -68,14 +75,14 @@ def morton_decode_3d(code: int) -> Coordinate:
 
 @dataclass(frozen=True)
 class MortonQuantizedLatent3D:
-    """Sparse 3D latent: reversible Morton address -> signed quantized code."""
+    """Sparse 3D latent: Morton address -> signed 32-bit quantized value."""
 
     step: float
     entries: dict[int, int]
 
 
 class MortonQuantizedFieldCodec3D:
-    """Deterministic spatial codec implementing the field-runtime codec contract."""
+    """Deterministic 3D field codec with an explicit packed-record contract."""
 
     def __init__(
         self,
@@ -100,19 +107,22 @@ class MortonQuantizedFieldCodec3D:
     def encode(self, field: Mapping[Coordinate, float]) -> MortonQuantizedLatent3D:
         entries: dict[int, int] = {}
         for coordinate, raw_value in field.items():
-            self._validate_coordinate(coordinate)
+            coordinate = _field_coordinate(coordinate, self.side)
             if isinstance(raw_value, bool) or not isinstance(raw_value, (int, float)):
                 raise TypeError("field values must be numeric")
             value = float(raw_value)
             if not math.isfinite(value):
                 raise ValueError("field values must be finite")
-            code = int(round(value / self.step))
-            if code != 0 or not self.prune_zero_codes:
-                key = morton_encode_3d(*coordinate)
-                if key in entries:
-                    raise RuntimeError("Morton address collision detected")
-                entries[key] = code
-        return MortonQuantizedLatent3D(step=self.step, entries=entries)
+            value_code = int(round(value / self.step))
+            if value_code < SIGNED_INT32_MIN or value_code > SIGNED_INT32_MAX:
+                raise ValueError("quantized value exceeds signed 32-bit latent range")
+            if value_code == 0 and self.prune_zero_codes:
+                continue
+            key = morton_encode_3d(*coordinate)
+            if key in entries:
+                raise RuntimeError("Morton address collision detected")
+            entries[key] = value_code
+        return MortonQuantizedLatent3D(self.step, entries)
 
     def decode(
         self,
@@ -125,21 +135,12 @@ class MortonQuantizedFieldCodec3D:
             raise ValueError("latent quantization step does not match codec")
         result: SparseField = {}
         for coordinate in support:
-            self._validate_coordinate(coordinate)
-            key = morton_encode_3d(*coordinate)
-            result[coordinate] = float(latent.entries.get(key, 0)) * self.step
+            coordinate = _field_coordinate(coordinate, self.side)
+            value_code = latent.entries.get(morton_encode_3d(*coordinate), 0)
+            if value_code < SIGNED_INT32_MIN or value_code > SIGNED_INT32_MAX:
+                raise ValueError("latent contains a value outside signed 32-bit range")
+            result[coordinate] = float(value_code) * self.step
         return result
-
-    def _validate_coordinate(self, coordinate: Coordinate) -> Coordinate:
-        if (
-            not isinstance(coordinate, tuple)
-            or len(coordinate) != 3
-            or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
-        ):
-            raise TypeError("coordinates must be integer (x, y, z) tuples")
-        if any(value < 0 or value >= self.side for value in coordinate):
-            raise ValueError("coordinate is outside the configured 3D side length")
-        return coordinate
 
 
 @dataclass(frozen=True)
@@ -173,69 +174,52 @@ class SpatialMetrics3D:
 
 
 def measure_spatial_field(field: Mapping[Coordinate, float], *, side: int) -> SpatialMetrics3D:
-    """Measure geometry directly from the active sparse 3D state."""
+    """Measure spatial geometry directly from active authoritative cells."""
 
     if isinstance(side, bool) or not isinstance(side, int) or side <= 0:
         raise ValueError("side must be a positive integer")
     if not field:
         return SpatialMetrics3D(0, None, None, None, None, 0.0, 0.0, 0.0, 0, 0.0)
 
-    coordinates = tuple(field)
-    for coordinate in coordinates:
-        if (
-            not isinstance(coordinate, tuple)
-            or len(coordinate) != 3
-            or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
-        ):
-            raise TypeError("coordinates must be integer (x, y, z) tuples")
-        if any(value < 0 or value >= side for value in coordinate):
-            raise ValueError("coordinate is outside the configured 3D side length")
+    coordinates = tuple(_field_coordinate(coordinate, side) for coordinate in field)
+    values = tuple(float(field[coordinate]) for coordinate in coordinates)
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("field values must be finite")
 
-    xs = tuple(coordinate[0] for coordinate in coordinates)
-    ys = tuple(coordinate[1] for coordinate in coordinates)
-    zs = tuple(coordinate[2] for coordinate in coordinates)
     count = len(coordinates)
+    xs = tuple(item[0] for item in coordinates)
+    ys = tuple(item[1] for item in coordinates)
+    zs = tuple(item[2] for item in coordinates)
     centroid = (sum(xs) / count, sum(ys) / count, sum(zs) / count)
 
-    weights = tuple(abs(float(field[coordinate])) for coordinate in coordinates)
-    if not all(math.isfinite(weight) for weight in weights):
-        raise ValueError("field values must be finite")
-    weight_sum = sum(weights)
+    weights = tuple(abs(value) for value in values)
+    total_weight = sum(weights)
     weighted_centroid = (
         (
-            sum(coordinate[0] * weight for coordinate, weight in zip(coordinates, weights))
-            / weight_sum,
-            sum(coordinate[1] * weight for coordinate, weight in zip(coordinates, weights))
-            / weight_sum,
-            sum(coordinate[2] * weight for coordinate, weight in zip(coordinates, weights))
-            / weight_sum,
+            sum(c[0] * w for c, w in zip(coordinates, weights)) / total_weight,
+            sum(c[1] * w for c, w in zip(coordinates, weights)) / total_weight,
+            sum(c[2] * w for c, w in zip(coordinates, weights)) / total_weight,
         )
-        if weight_sum > 0.0
+        if total_weight > 0.0
         else centroid
     )
 
     rms_radius = math.sqrt(
         sum(
-            (coordinate[0] - centroid[0]) ** 2
-            + (coordinate[1] - centroid[1]) ** 2
-            + (coordinate[2] - centroid[2]) ** 2
-            for coordinate in coordinates
+            (c[0] - centroid[0]) ** 2
+            + (c[1] - centroid[1]) ** 2
+            + (c[2] - centroid[2]) ** 2
+            for c in coordinates
         )
         / count
     )
-    values = tuple(float(field[coordinate]) for coordinate in coordinates)
-    if not all(math.isfinite(value) for value in values):
-        raise ValueError("field values must be finite")
-    l1_energy = sum(abs(value) for value in values)
-    l2_energy = sum(value * value for value in values)
-
     support = set(coordinates)
-    links = 0
-    for x, y, z in coordinates:
-        for neighbor in ((x + 1, y, z), (x, y + 1, z), (x, y, z + 1)):
-            if neighbor in support:
-                links += 1
-
+    links = sum(
+        1
+        for x, y, z in coordinates
+        for neighbor in ((x + 1, y, z), (x, y + 1, z), (x, y, z + 1))
+        if neighbor in support
+    )
     return SpatialMetrics3D(
         active_cells=count,
         bounds_min=(min(xs), min(ys), min(zs)),
@@ -243,8 +227,8 @@ def measure_spatial_field(field: Mapping[Coordinate, float], *, side: int) -> Sp
         centroid=centroid,
         weighted_centroid=weighted_centroid,
         rms_radius=rms_radius,
-        l1_energy=l1_energy,
-        l2_energy=l2_energy,
+        l1_energy=sum(abs(value) for value in values),
+        l2_energy=sum(value * value for value in values),
         six_face_links=links,
         occupancy_ratio=count / float(side**3),
     )
@@ -273,13 +257,12 @@ def spatial_frame(
     cycle: int,
     max_render_points: int = 4096,
 ) -> SpatialFrame3D:
-    """Create a deterministic bounded point-cloud frame from authoritative state."""
+    """Create a deterministic bounded Morton-ordered point-cloud frame."""
 
     if isinstance(max_render_points, bool) or not isinstance(max_render_points, int):
         raise TypeError("max_render_points must be an integer")
     if max_render_points <= 0:
         raise ValueError("max_render_points must be positive")
-
     ordered = sorted(field.items(), key=lambda item: morton_encode_3d(*item[0]))
     if len(ordered) > max_render_points:
         stride = math.ceil(len(ordered) / max_render_points)
@@ -313,8 +296,6 @@ def digest_latent(latent: MortonQuantizedLatent3D) -> str:
 
 @dataclass(frozen=True)
 class SpatialAutoCodec3DSummary:
-    """Machine-readable result for one bounded spatial auto-codec execution."""
-
     codec: str
     latent_entries: int
     latent_digest: str
@@ -342,7 +323,7 @@ class SpatialAutoCodec3DSummary:
 
 
 class SpatialAutoCodec3DSystem:
-    """Coordinate-aware 3D wrapper around the bounded auto-codec loop."""
+    """Coordinate-aware 3D execution wrapper around ``AutoCodecLoop``."""
 
     def __init__(
         self,
@@ -398,10 +379,10 @@ class SpatialAutoCodec3DSystem:
             )
             if len(frames) < self.max_frames:
                 frames.append(frame)
-            elif frames:
+            else:
                 frames[-1] = frame
 
-        summary = self.loop.run(validator=validator, on_cycle=capture)
+        loop_summary = self.loop.run(validator=validator, on_cycle=capture)
         final_state = self.loop.runtime.snapshot()
         final_frame = spatial_frame(
             final_state,
@@ -416,7 +397,7 @@ class SpatialAutoCodec3DSystem:
                 frames[-1] = final_frame
 
         latent = self.codec.encode(final_state)
-        # A portable packed record would use uint64 Morton key + int32 value code.
+        # Guaranteed by codec range checks: uint64 Morton key + int32 value code.
         packed_bytes = len(latent.entries) * 12
         return SpatialAutoCodec3DSummary(
             codec="MortonQuantizedFieldCodec3D",
@@ -426,5 +407,5 @@ class SpatialAutoCodec3DSystem:
             input_frame=input_frame,
             final_frame=final_frame,
             frames=tuple(frames),
-            loop=summary,
+            loop=loop_summary,
         )

--- a/src/jarvisx/web.py
+++ b/src/jarvisx/web.py
@@ -1,42 +1,10 @@
-from flask import Flask, render_template_string, request
-from .core import CodexVM
-from .parser import Parser
-from .assembler import Assembler
+from __future__ import annotations
 
-app = Flask(__name__)
-vm = CodexVM()
+import uvicorn
 
-HTML = """
-<!DOCTYPE html>
-<html>
-<head>
-  <title>Jarvis-X Dashboard</title>
-</head>
-<body>
-  <h1>Jarvis-X Control Panel</h1>
-  <form method="post">
-    <textarea name="code" rows="10" cols="60"></textarea><br>
-    <button type="submit">Run</button>
-  </form>
-  {% if result %}
-    <h3>Registers</h3>
-    <pre>{{ result }}</pre>
-  {% endif %}
-</body>
-</html>
-"""
 
-@app.route("/", methods=["GET","POST"])
-def home():
-    result = None
-    if request.method == "POST":
-        source = request.form["code"]
-        ast = Parser().parse(source)
-        bytecode = Assembler().assemble(ast)
-        vm.load(bytecode)
-        vm.run()
-        result = vm.regs.snapshot()
-    return render_template_string(HTML, result=result)
-
-def start_web():
-    app.run(host="0.0.0.0", port=5000)
+def start_web() -> None:
+    # The FastAPI application serves both the operational dashboard at `/`
+    # and the JSON runtime endpoints. Keep a separate port for the legacy
+    # `jarvisx web` command while sharing one implementation.
+    uvicorn.run("jarvisx.api:app", host="0.0.0.0", port=5000)

--- a/tests/test_3d_operational_hardening.py
+++ b/tests/test_3d_operational_hardening.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.run_store import RunArtifactStore
+from jarvisx.spatial_codec_3d import MortonQuantizedFieldCodec3D, SIGNED_INT32_MAX
+
+
+def test_spatial_codec_rejects_values_that_cannot_fit_packed_int32():
+    codec = MortonQuantizedFieldCodec3D(step=1e-12, side=8)
+
+    with pytest.raises(ValueError, match="signed 32-bit"):
+        codec.encode({(1, 1, 1): 1.0})
+
+
+def test_spatial_codec_accepts_signed_int32_boundary():
+    codec = MortonQuantizedFieldCodec3D(step=1.0 / SIGNED_INT32_MAX, side=8)
+
+    latent = codec.encode({(1, 1, 1): 1.0})
+
+    assert next(iter(latent.entries.values())) == SIGNED_INT32_MAX
+
+
+def test_run_store_persists_summary_and_verifies_omega_head(tmp_path):
+    store = RunArtifactStore(tmp_path)
+    run_id = store.new_run_id()
+    ledger = store.ledger(run_id)
+    ledger.log({"event": "test", "state_digest": "abc"}, 0xA1)
+    head = ledger.chain[-1]["hash"]
+    summary = {
+        "journal_head_hash": head,
+        "final_state_digest": "state-digest",
+        "latent_digest": "latent-digest",
+    }
+
+    store.write_summary(run_id, summary)
+
+    assert store.read_summary(run_id) == summary
+    verification = store.verify(run_id)
+    assert verification["verified"] is True
+    assert verification["journal_head_hash"] == head
+    assert verification["final_state_digest"] == "state-digest"
+
+
+def test_run_store_detects_summary_to_journal_head_mismatch(tmp_path):
+    store = RunArtifactStore(tmp_path)
+    run_id = store.new_run_id()
+    ledger = store.ledger(run_id)
+    ledger.log({"event": "test"}, 0xA1)
+    store.write_summary(run_id, {"journal_head_hash": "0" * 64})
+
+    verification = store.verify(run_id)
+
+    assert verification["journal_verified"] is True
+    assert verification["head_matches_summary"] is False
+    assert verification["verified"] is False
+
+
+def test_run_store_rejects_path_like_run_identifier(tmp_path):
+    store = RunArtifactStore(tmp_path)
+
+    with pytest.raises(ValueError, match="32-character"):
+        store.read_summary("../escape")

--- a/tests/test_auto_codec_loop.py
+++ b/tests/test_auto_codec_loop.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.auto_codec_loop import (
+    AutoCodecLoop,
+    AutoCodecLoopConfig,
+    UniformQuantizedFieldCodec,
+    digest_field,
+    field_to_cells,
+)
+from jarvisx.dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
+
+
+def _runtime(*, step=0.1, dt=0.1):
+    return DrMoagiFieldRuntime(
+        UniformQuantizedFieldCodec(step),
+        DrMoagiFieldConfig(
+            side=8,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=dt,
+            expand_halo=False,
+        ),
+    )
+
+
+def test_uniform_quantized_codec_round_trip_is_sparse_and_deterministic():
+    codec = UniformQuantizedFieldCodec(0.1)
+    latent = codec.encode({(1, 2, 3): 0.26, (0, 0, 0): 0.01})
+
+    assert latent.codes == {(1, 2, 3): 3}
+    assert codec.decode(latent, [(1, 2, 3), (0, 0, 0)]) == {
+        (1, 2, 3): pytest.approx(0.3),
+        (0, 0, 0): pytest.approx(0.0),
+    }
+
+
+def test_auto_codec_loop_reduces_reconstruction_error_to_target():
+    runtime = _runtime(step=0.1, dt=0.1)
+    loop = AutoCodecLoop(
+        runtime,
+        AutoCodecLoopConfig(
+            max_cycles=16,
+            reconstruction_mse_target=1e-3,
+            stop_on_fixed_point=False,
+        ),
+    )
+    loop.load({(2, 2, 2): 0.26})
+
+    summary = loop.run()
+
+    assert summary.converged
+    assert summary.stop_reason == "reconstruction_target"
+    assert 1 <= summary.cycles_executed <= 16
+    assert summary.final_reconstruction_mse is not None
+    assert summary.final_reconstruction_mse <= 1e-3
+    assert summary.final_state[(2, 2, 2)] > 0.26
+    assert summary.journal_verified
+    assert summary.journal_entries == summary.cycles_executed + 2
+    assert summary.journal_head_hash is not None
+
+
+def test_rejection_budget_stops_without_committing_candidate():
+    runtime = _runtime()
+    initial = {(2, 2, 2): 0.26}
+    loop = AutoCodecLoop(
+        runtime,
+        AutoCodecLoopConfig(max_cycles=8, max_consecutive_rejections=2),
+    )
+    loop.load(initial)
+
+    summary = loop.run(validator=lambda candidate, metrics: False)
+
+    assert summary.stop_reason == "rejection_limit"
+    assert not summary.converged
+    assert summary.cycles_executed == 2
+    assert summary.committed_cycles == 0
+    assert summary.rejected_cycles == 2
+    assert summary.final_state == initial
+    assert summary.journal_verified
+
+
+def test_cycle_budget_is_a_hard_upper_bound():
+    runtime = _runtime(step=0.1, dt=0.01)
+    loop = AutoCodecLoop(
+        runtime,
+        AutoCodecLoopConfig(
+            max_cycles=2,
+            reconstruction_mse_target=0.0,
+            stop_on_fixed_point=False,
+        ),
+    )
+    loop.load({(2, 2, 2): 0.26})
+
+    summary = loop.run()
+
+    assert summary.stop_reason == "cycle_limit"
+    assert summary.cycles_executed == 2
+    assert summary.committed_cycles == 2
+    assert not summary.converged
+
+
+def test_loop_requires_explicit_load():
+    loop = AutoCodecLoop(_runtime())
+
+    with pytest.raises(RuntimeError, match="load a field"):
+        loop.run()
+
+
+def test_field_receipts_have_stable_order_and_digest():
+    a = {(2, 1, 0): -0.5, (0, 0, 0): 0.25}
+    b = {(0, 0, 0): 0.25, (2, 1, 0): -0.5}
+
+    assert field_to_cells(a) == field_to_cells(b)
+    assert digest_field(a) == digest_field(b)

--- a/tests/test_spatial_codec_3d.py
+++ b/tests/test_spatial_codec_3d.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.auto_codec_loop import AutoCodecLoop, AutoCodecLoopConfig
+from jarvisx.dr_moagi_field_runtime import DrMoagiFieldConfig, DrMoagiFieldRuntime
+from jarvisx.spatial_codec_3d import (
+    MORTON_MAX_COORDINATE,
+    MortonQuantizedFieldCodec3D,
+    SpatialAutoCodec3DSystem,
+    measure_spatial_field,
+    morton_decode_3d,
+    morton_encode_3d,
+    spatial_frame,
+)
+
+
+def test_morton_round_trip_uses_all_three_axes():
+    coordinates = [
+        (0, 0, 0),
+        (1, 2, 3),
+        (17, 31, 63),
+        (511, 255, 127),
+        (MORTON_MAX_COORDINATE, MORTON_MAX_COORDINATE, MORTON_MAX_COORDINATE),
+    ]
+    for coordinate in coordinates:
+        assert morton_decode_3d(morton_encode_3d(*coordinate)) == coordinate
+
+
+def test_morton_codec_quantizes_values_and_preserves_spatial_addresses():
+    codec = MortonQuantizedFieldCodec3D(step=0.1, side=16)
+    source = {(1, 2, 3): 0.26, (4, 5, 6): -0.37}
+
+    latent = codec.encode(source)
+    reconstructed = codec.decode(latent, tuple(source))
+
+    assert set(latent.entries) == {
+        morton_encode_3d(1, 2, 3),
+        morton_encode_3d(4, 5, 6),
+    }
+    assert reconstructed[(1, 2, 3)] == pytest.approx(0.3)
+    assert reconstructed[(4, 5, 6)] == pytest.approx(-0.4)
+
+
+def test_spatial_metrics_measure_bounds_centroid_links_and_energy():
+    field = {
+        (1, 1, 1): 1.0,
+        (2, 1, 1): -2.0,
+        (2, 2, 1): 3.0,
+    }
+
+    metrics = measure_spatial_field(field, side=8)
+
+    assert metrics.active_cells == 3
+    assert metrics.bounds_min == (1, 1, 1)
+    assert metrics.bounds_max == (2, 2, 1)
+    assert metrics.centroid == pytest.approx((5 / 3, 4 / 3, 1.0))
+    assert metrics.l1_energy == pytest.approx(6.0)
+    assert metrics.l2_energy == pytest.approx(14.0)
+    assert metrics.six_face_links == 2
+    assert metrics.occupancy_ratio == pytest.approx(3 / 512)
+
+
+def test_spatial_frame_is_deterministically_bounded_in_morton_order():
+    field = {(index, 0, 0): float(index) for index in range(10)}
+
+    first = spatial_frame(field, side=16, cycle=3, max_render_points=4)
+    second = spatial_frame(field, side=16, cycle=3, max_render_points=4)
+
+    assert first == second
+    assert len(first.points) <= 4
+    assert first.cycle == 3
+
+
+def test_3d_system_executes_closed_loop_and_emits_authoritative_frames():
+    codec = MortonQuantizedFieldCodec3D(step=0.1, side=16)
+    runtime = DrMoagiFieldRuntime(
+        codec,
+        DrMoagiFieldConfig(
+            side=16,
+            alpha=1.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    loop = AutoCodecLoop(
+        runtime,
+        AutoCodecLoopConfig(
+            max_cycles=8,
+            min_cycles=1,
+            reconstruction_mse_target=0.0,
+            stop_on_fixed_point=True,
+        ),
+    )
+    system = SpatialAutoCodec3DSystem(
+        loop,
+        codec,
+        side=16,
+        frame_stride=1,
+        max_render_points=64,
+        max_frames=16,
+    )
+
+    summary = system.run({(2, 2, 2): 0.26, (3, 2, 2): -0.37})
+    payload = summary.to_dict()
+
+    assert payload["spatial_mode"] == "3d-morton-quantized"
+    assert payload["cycles_executed"] >= 1
+    assert payload["journal_verified"] is True
+    assert payload["latent_entries"] >= 1
+    assert payload["latent_digest"]
+    assert payload["final_frame"]["state_digest"] == payload["final_state_digest"]
+    assert payload["frames"][0]["cycle"] == 0
+    assert payload["frames"][-1]["state_digest"] == payload["final_state_digest"]
+
+
+def test_3d_system_requires_runtime_and_codec_identity():
+    runtime_codec = MortonQuantizedFieldCodec3D(step=0.1, side=8)
+    other_codec = MortonQuantizedFieldCodec3D(step=0.1, side=8)
+    runtime = DrMoagiFieldRuntime(
+        runtime_codec,
+        DrMoagiFieldConfig(
+            side=8,
+            alpha=0.0,
+            lambda_residual=0.0,
+            eta=0.0,
+            dt=0.1,
+            expand_halo=False,
+        ),
+    )
+    loop = AutoCodecLoop(runtime)
+
+    with pytest.raises(ValueError, match="same spatial codec"):
+        SpatialAutoCodec3DSystem(loop, other_codec, side=8)


### PR DESCRIPTION
## What changed

- adds `AutoCodecLoop`, a bounded controller around the existing transactional `DrMoagiFieldRuntime`
- adds `MortonQuantizedFieldCodec3D`: reversible 63-bit Morton/Z-order spatial addresses plus explicitly bounded signed-32-bit quantized values
- records load/cycle/stop receipts in an Omega hash chain and exposes cycle observers for authoritative 3D frames
- adds `SpatialAutoCodec3DSystem` with 3D bounds, geometric and weighted centroids, RMS radius, field energy, six-face connectivity, sparse occupancy, state/latent digests, and bounded Morton-ordered render samples
- adds durable run IDs, atomic JSON summaries, disk-backed `PersistentLedger` journals, retrieval, and independent persisted-run verification
- exposes convergence, fixed-point, rejection, active-cell, render-point, frame-count, quantized-range, and hard cycle bounds
- exposes the system through `jarvisx codec3d <json>`, `POST /codec/3d/run`, `GET /codec/3d/runs/{run_id}`, and `GET /codec/3d/runs/{run_id}/verify`
- retains the scalar `jarvisx codec` / `POST /codec/run` execution path
- replaces Flask-only entry points with the declared FastAPI/Uvicorn stack
- serves a dependency-free WebGL 3D control surface whose orbit/zoom/frame playback consumes authoritative runtime frames; the UI can verify the persisted run it just executed
- fixes the Docker entry point and declares `/data` as the runtime-artifact volume with `JARVISX_RUN_STORE=/data/runs`
- adds focused 3D Morton/geometry/system/persistence hardening tests, reproducible JSON runs, and operational documentation

## Operational loop

`3D field -> Morton spatial encode -> int32 quantize -> latent -> decode -> reconstruction residual -> six-face 3D field update -> project -> verify -> commit/rollback -> persistent Omega journal -> spatial frame -> atomic run summary -> convergence test -> repeat`

## Why

The repository already had a bounded single-step sparse 3D field runtime and a separate geometric research runtime, but it lacked a canonical end-to-end controller in which 3D coordinates are part of the codec contract, browser frames come from authoritative execution state, and completed executions survive beyond the HTTP request. The previous container entry point also targeted a module that does not exist.

## Boundaries

This is a fully executable bounded 3D reference runtime, not a claim of a trained neural 3D compressor, arbitrary mesh/CAD support, hostile-code isolation, physical electromagnetic computation, AGI, or production-scale performance. Morton ordering is a deterministic spatial reference encoding, not an asserted optimal latent geometry. The 12-byte packed-record estimate is enforced by the `uint64 Morton + int32 value` range contract; it is not Python heap usage. Durable behavior across platform redeployments still depends on the hosting environment attaching persistent storage to `/data`.

## Validation — current head `e9d624676239dc0c957beb60c6f15abcd76dc670`

- **Jarvis-X CI: passed** — compilation, undefined-name checks, canonical quality checks, mypy, Python 3.10/3.11/3.12/3.13 tests, dependency audit, package build, metadata validation, and built-wheel smoke test are green
- **Empirical Validation: passed**
- **CodeQL: passed**
- focused tests cover 63-bit Morton round trips, spatial address preservation, signed-32-bit packed-latent bounds, quantized reconstruction, geometry metrics, deterministic bounded frames, 3D closed-loop execution, codec/runtime identity, convergence, rollback, cycle bounds, state digests, path-safe run IDs, persistent Omega verification, and summary-to-journal head mismatch detection

The PR remains draft only to avoid merging or deploying the validated integration without an explicit integration action.
