### PR TITLE
Add QSOL 3D auto-encoding bytecode profile

### DIFF
--- a/.github/workflows/qsol-3d-codec.yml
+++ b/.github/workflows/qsol-3d-codec.yml
@@ -1,0 +1,47 @@
+name: QSOL 3D Codec Bytecode
+
+on:
+  push:
+    paths:
+      - "reference/qsol_3d_codec/**"
+      - "docs/adr/0010-qsol-3d-autoencoding-bytecode-profile.md"
+      - ".github/workflows/qsol-3d-codec.yml"
+  pull_request:
+    paths:
+      - "reference/qsol_3d_codec/**"
+      - "docs/adr/0010-qsol-3d-autoencoding-bytecode-profile.md"
+      - ".github/workflows/qsol-3d-codec.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.13"]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Compile reference VM
+        run: python -m compileall -q reference/qsol_3d_codec
+
+      - name: Run bytecode conformance tests
+        working-directory: reference/qsol_3d_codec
+        run: python -m unittest -v test_reference_vm.py
+
+      - name: Verify canonical fixed-point receipt
+        run: |
+          python reference/qsol_3d_codec/reference_vm.py > /tmp/qsol-3d-codec.txt
+          grep -F "[CYCLE 010] PC 0x0024 HALT_LOOP" /tmp/qsol-3d-codec.txt
+          grep -F "max_commit_drift_q16=0" /tmp/qsol-3d-codec.txt
+          grep -F "fixed_point=True" /tmp/qsol-3d-codec.txt

--- a/docs/adr/0010-qsol-3d-autoencoding-bytecode-profile.md
+++ b/docs/adr/0010-qsol-3d-autoencoding-bytecode-profile.md
@@ -1,0 +1,208 @@
+# ADR-010: QSOL 3D Auto-Encoding/Decoding Bytecode Profile
+
+- **Status:** Proposed
+- **Date:** 2026-08-20
+- **Decision scope:** bounded Q16.16 research interpreter for the DM–vΩΞ⁺ engine
+
+## Context
+
+ADR-008 established QSOL as a bounded, non-authoritative research surface. ADR-009 established a separate 32-bit DM–vΩΞ⁺ swarm ISA with a 16-register encoding. This decision defines a new QSOL codec profile for a 256-register namespace and a four-byte instruction word:
+
+```text
+[ opcode:8 ][ dest:8 ][ src/coord:8 ][ modifier:8 ]
+```
+
+The profile expresses a deterministic 3D toroidal stencil, local Q16.16 transform encoding/decoding, a bounded Hamiltonian/error proxy, an internal actuation register, and an atomic residual commit.
+
+This profile is **not** binary-compatible with ADR-009. It is a sibling research ISA profile.
+
+## Decision
+
+### 1. Fixed-width instruction word
+
+Every instruction is exactly four bytes, big-endian by field position:
+
+```text
+byte 0: opcode
+byte 1: destination register ID, 0..255
+byte 2: source or coordinate-register ID, 0..255
+byte 3: opcode-specific modifier
+```
+
+The fourth byte is deliberately opcode-specific. It is not claimed to directly contain an arbitrary Q16.16 immediate.
+
+### 2. Q16.16 constant-selector table
+
+The supplied program needs constants wider than eight bits. The modifier therefore selects a profile-local constant table for opcodes that require scalar coefficients:
+
+```text
+selector  Q16.16 value  decimal
+0x10      0x00010000    1.0
+0x33      0x00003333    0.1999969482421875
+0x40      0x00004000    0.25
+0x9A      0x0000D99A    0.850006103515625
+```
+
+This resolves the width contradiction between an 8-bit modifier and values such as `0x00010000`, `0x4000`, and `0xD99A`.
+
+### 3. Opcode table
+
+| Opcode | Mnemonic | v1 reference semantics |
+|---|---|---|
+| `0x00` | `HALT_LOOP` | End-of-epoch fence. The host may start another epoch explicitly. |
+| `0x01` | `LDF_PSI` | Load a Q16.16 scalar selected by byte 3 into the destination register across the current lattice. Byte 2 is a source tag (`0x00=MEM_NULL`, `0x01=MEM_OFF`). |
+| `0x02` | `FETCH_NB` | Fetch six orthogonal toroidal neighbors of source register byte 2 into a typed six-value vector at destination. Byte 3 must be `0x06`. |
+| `0x03` | `LAPLACE_3D` | Compute normalized six-point Laplacian `mean(neighbors) - center`. Byte 2 names the neighbor-vector register and byte 3 names the center scalar register. |
+| `0x04` | `ENCODE_3D` | Q16.16 local transform `dest = src * K_encode`, with `K_encode` selected by byte 3. |
+| `0x05` | `DECODE_3D` | Q16.16 local reconstruction transform `dest = src * K_decode`, with `K_decode` selected by byte 3. |
+| `0x06` | `ACTUATE_E` | Copy the decoded value into an **internal simulated actuation register**. No device, electron, power, RF, or other external hardware I/O is authorized by this opcode. |
+| `0x07` | `HAMILTON_CHK` | Evaluate the bounded reference energy proxy `H_eff = 0.5 * Xi^2` and store it in destination. Byte 3 selects the reference profile; `0x00` is v1. |
+| `0x08` | `SYNC_COMMIT` | Atomic lattice commit. Modifier `0x01` means residual-add: `dest <- sat_Q16(dest + src)` using one pre-commit snapshot. Modifier `0x00` is replace mode. |
+
+The discrete operator implemented by `LAPLACE_3D` is
+
+```text
+L_norm(Psi)[i,j,k] =
+    (Psi[i+1,j,k] + Psi[i-1,j,k]
+   + Psi[i,j+1,k] + Psi[i,j-1,k]
+   + Psi[i,j,k+1] + Psi[i,j,k-1]) / 6
+   - Psi[i,j,k]
+```
+
+with all indices wrapped modulo lattice extent. This is a normalized form of the standard unit-spacing six-point Laplacian; the factor of six is absorbed into the transform scale.
+
+### 4. Canonical corrected byte stream
+
+The submitted draft described registers by decimal labels such as `R48`, `R64`, and `R96`, but several source bytes encoded those decimal digits as hexadecimal values. The canonical stream uses the actual byte IDs:
+
+```text
+01 10 00 10  # LDF_PSI      R16,  MEM_NULL, CONST[0x10] = 1.0
+01 11 01 33  # LDF_PSI      R17,  MEM_OFF,  CONST[0x33] = 0x00003333
+02 20 10 06  # FETCH_NB     R32,  R16,      six orthogonal neighbors
+03 30 20 10  # LAPLACE_3D   R48,  R32,      center=R16
+04 40 30 40  # ENCODE_3D    R64,  R48,      gain=0.25
+07 50 40 00  # HAMILTON_CHK R80,  R64,      profile=0
+05 60 40 9A  # DECODE_3D    R96,  R64,      gain=0.8500061035
+06 70 60 00  # ACTUATE_E    R112, R96,      internal sink
+08 10 70 01  # SYNC_COMMIT  R16,  R112,     residual-add
+00 00 00 00  # HALT_LOOP                         epoch fence
+```
+
+Raw hexadecimal stream:
+
+```text
+01100010 01110133 02201006 03302010 04403040
+07504000 0560409A 06706000 08107001 00000000
+```
+
+### 5. Corrections relative to the submitted draft
+
+The profile makes the following arithmetic/encoding corrections explicit:
+
+1. An 8-bit modifier cannot directly hold a 16-bit or 32-bit Q16.16 constant. The v1 constant-selector table supplies those values deterministically.
+2. `LAPLACE_3D` uses byte 3 as a second register ID (`R16`) rather than as a scalar modifier.
+3. `R48` is register ID `48 decimal = 0x30`; therefore `ENCODE_3D` must read source byte `0x30`, not `0x48`.
+4. `R64` is `0x40`; therefore `HAMILTON_CHK` and `DECODE_3D` read `0x40`, not `0x64`.
+5. `R96` is `0x60`; therefore `ACTUATE_E` reads `0x60`, not `0x96`.
+6. `0x9A` is a selector for Q16.16 `0x0000D99A`; it is not itself the value `0.85`.
+7. The two initial `LDF_PSI` words are separate instructions. `R16=0x00010000` and `R17=0x00003333`; they do not arithmetically combine into `R16=0x00013333` without an explicit add instruction.
+8. The supplied `R17` offset is initialized but not consumed by the v1 dataflow. It is retained for compatibility and exposed as a dead-value diagnostic rather than given a hidden side effect.
+
+### 6. Correct execution trace
+
+The single-issue reference trace is ten four-byte instructions:
+
+```text
+[CYCLE 001] PC 0x0000 LDF_PSI      -> R16 = 0x00010000
+[CYCLE 002] PC 0x0004 LDF_PSI      -> R17 = 0x00003333
+[CYCLE 003] PC 0x0008 FETCH_NB     -> R32 = six wrapped R16 neighbors
+[CYCLE 004] PC 0x000C LAPLACE_3D   -> R48 = mean(R32) - R16
+[CYCLE 005] PC 0x0010 ENCODE_3D    -> R64 = R48 * 0.25
+[CYCLE 006] PC 0x0014 HAMILTON_CHK -> R80 = 0.5 * R64^2
+[CYCLE 007] PC 0x0018 DECODE_3D    -> R96 = R64 * 0.8500061035
+[CYCLE 008] PC 0x001C ACTUATE_E    -> R112/internal actuation register updated
+[CYCLE 009] PC 0x0020 SYNC_COMMIT  -> R16 += R112 atomically over the lattice
+[CYCLE 010] PC 0x0024 HALT_LOOP    -> end-of-epoch fence
+```
+
+For the supplied uniform fixture, `R16=1.0` at every toroidal coordinate. Therefore
+
+```text
+L_norm(Psi) = 0
+R48 = R64 = R80 = R96 = R112 = 0
+SYNC_COMMIT residual = 0
+max commit drift = 0
+```
+
+so the fixture is a valid discrete fixed point. This is an arithmetic property of the reference lattice; it is not evidence of zero physical latency, zero thermal dissipation, zero inductive ringing, or literal electron-level actuation.
+
+### 7. Auto-encoding interpretation
+
+The v1 reference instruction `ENCODE_3D` is a deterministic local transform over a toroidal field. By itself, multiplication by `0.25` does **not** reduce tensor cardinality or establish a compression ratio. A future profile may add explicit latent subsampling, quantization, entropy coding, learned transform tables, or sparse index selection.
+
+Likewise, `DECODE_3D` in v1 is a deterministic reconstruction transform, not a claim of trained autoencoder fidelity.
+
+### 8. Fixed-point semantics
+
+`SYNC_COMMIT ... 0x01` is a residual update:
+
+```text
+Psi_(t+1) = sat_Q16(Psi_t + DeltaPsi_t)
+```
+
+A fixed point is detected by measured residual/drift criteria, for example
+
+```text
+max_abs(DeltaPsi_t) <= epsilon_commit
+```
+
+The phrase `I AM = I DESCRIBE` remains a mnemonic for this self-consistent state and does not alter the numerical acceptance test.
+
+## Trust boundary
+
+This profile inherits ADR-008 and ADR-009 boundaries:
+
+- QSOL research state is not authoritative Jarvis-X task state.
+- `ACTUATE_E` writes only an internal interpreter register in the reference implementation.
+- `SYNC_COMMIT` commits only the simulated lattice/register state owned by this VM.
+- No network, device, RF, power-electronics, filesystem, shell, market, medical, infrastructure, or privileged external adapter is implied by these opcodes.
+- Physical latency, energy, thermal behavior, ringing, and electron transport require independent hardware measurement and are not inferred from bytecode semantics.
+
+## Validation requirements
+
+The reference implementation must test:
+
+1. exact four-byte instruction decoding;
+2. constant-selector expansion;
+3. corrected register IDs through the full dataflow;
+4. six-neighbor toroidal wraparound;
+5. normalized Laplacian arithmetic;
+6. saturating Q16.16 multiplication and commit;
+7. deterministic Hamiltonian proxy;
+8. internal-only actuation semantics;
+9. atomic residual-add commit;
+10. zero-drift behavior of the uniform fixed-point fixture;
+11. exact program-counter trace `0x0000..0x0024`;
+12. preservation of the submitted draft stream as a non-canonical compatibility fixture so encoding corrections remain auditable.
+
+## Consequences
+
+### Positive
+
+- the proposed four-byte bytecode becomes arithmetically representable;
+- register addressing is unambiguous across the 256-register namespace;
+- the toroidal stencil has executable boundary semantics;
+- the fixed-point claim is reduced to a measurable residual invariant;
+- hardware/thermal claims remain outside the simulator trust boundary;
+- the original draft can be preserved while a corrected executable stream becomes canonical for this profile.
+
+### Trade-offs
+
+- byte 3 is opcode-specific rather than a uniform immediate field;
+- the v1 encoder/decoder are transform primitives, not yet a rate-distortion codec;
+- `R17` is currently an unused compatibility value;
+- this profile intentionally differs from the 16-register encoding accepted in ADR-009.
+
+## Status
+
+**Proposed.** Promotion to Accepted requires a reviewable reference implementation, passing conformance tests, and repository CI.

--- a/reference/qsol_3d_codec/README.md
+++ b/reference/qsol_3d_codec/README.md
@@ -1,0 +1,113 @@
+# QSOL 3D Auto-Encoding/Decoding Bytecode Reference
+
+This directory contains the executable research reference for ADR-010.
+
+## Scope
+
+The VM implements a deterministic four-byte instruction profile:
+
+```text
+[ opcode:8 ][ dest:8 ][ src/coord:8 ][ modifier:8 ]
+```
+
+It models a 256-register SIMD-style toroidal lattice using signed saturating Q16.16 arithmetic. It is a bounded software reference only.
+
+`ACTUATE_E` writes to an in-memory simulated actuation register. It does not perform device, RF, power-electronics, electron-transport, or other external hardware control.
+
+## Canonical program
+
+```text
+01 10 00 10
+01 11 01 33
+02 20 10 06
+03 30 20 10
+04 40 30 40
+07 50 40 00
+05 60 40 9A
+06 70 60 00
+08 10 70 01
+00 00 00 00
+```
+
+Compact form:
+
+```text
+01100010 01110133 02201006 03302010 04403040
+07504000 0560409A 06706000 08107001 00000000
+```
+
+## Constant selectors
+
+The fourth byte selects a Q16.16 constant for coefficient-bearing opcodes:
+
+| Selector | Q16.16 | Decimal |
+|---|---:|---:|
+| `0x10` | `0x00010000` | `1.0` |
+| `0x33` | `0x00003333` | `0.1999969482421875` |
+| `0x40` | `0x00004000` | `0.25` |
+| `0x9A` | `0x0000D99A` | `0.850006103515625` |
+
+This expansion is required because a single 8-bit modifier cannot directly encode the wider Q16.16 values.
+
+## Register-byte correction
+
+The submitted draft is retained exactly in `PROGRAM_SUBMITTED_DRAFT`, but the executable canonical stream corrects four source bytes:
+
+```text
+R48  decimal 48  = 0x30, not 0x48
+R64  decimal 64  = 0x40, not 0x64
+R96  decimal 96  = 0x60, not 0x96
+R112 decimal 112 = 0x70
+```
+
+Accordingly:
+
+```text
+ENCODE_3D    source 0x48 -> 0x30
+HAMILTON_CHK source 0x64 -> 0x40
+DECODE_3D    source 0x64 -> 0x40
+ACTUATE_E    source 0x96 -> 0x60
+```
+
+## Fixed-point fixture
+
+The canonical initialization sets `R16 = 1.0` uniformly over the torus. The normalized six-neighbor Laplacian is therefore zero:
+
+```text
+mean(neighbors(R16)) - R16 = 0
+```
+
+The encode/decode residual path remains zero. `SYNC_COMMIT` modifier `0x01` is defined as atomic residual-add:
+
+```text
+R16 <- sat_Q16(R16 + R112)
+```
+
+so the uniform fixture produces `max_commit_drift_q16=0`.
+
+This verifies a discrete software fixed point only; it does not establish zero physical latency, zero energy dissipation, zero ringing, or literal electron-level actuation.
+
+## Run
+
+```bash
+python reference/qsol_3d_codec/reference_vm.py
+```
+
+Expected tail:
+
+```text
+[CYCLE 010] PC 0x0024 HALT_LOOP     -> end-of-epoch fence
+
+commit_generation=1
+max_commit_drift_q16=0
+fixed_point=True
+```
+
+## Test
+
+```bash
+cd reference/qsol_3d_codec
+python -m unittest -v test_reference_vm.py
+```
+
+The dedicated GitHub Actions workflow runs the reference on Python 3.10 and 3.13 and verifies the fixed-point receipt.

--- a/reference/qsol_3d_codec/reference_vm.py
+++ b/reference/qsol_3d_codec/reference_vm.py
@@ -1,0 +1,439 @@
+"""Deterministic QSOL 3D auto-encoding/decoding bytecode reference VM.
+
+This module implements the bounded research semantics from ADR-010.  It has no
+external device I/O: ACTUATE_E writes only an in-memory register bank.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Dict, Iterable, List, Mapping, Sequence, Tuple, Union
+
+Q16_ONE = 1 << 16
+INT32_MIN = -(1 << 31)
+INT32_MAX = (1 << 31) - 1
+
+Coord3 = Tuple[int, int, int]
+NeighborVector = Tuple[int, int, int, int, int, int]
+RegisterValue = Union[int, NeighborVector]
+
+
+class Opcode(IntEnum):
+    HALT_LOOP = 0x00
+    LDF_PSI = 0x01
+    FETCH_NB = 0x02
+    LAPLACE_3D = 0x03
+    ENCODE_3D = 0x04
+    DECODE_3D = 0x05
+    ACTUATE_E = 0x06
+    HAMILTON_CHK = 0x07
+    SYNC_COMMIT = 0x08
+
+
+# Byte 3 is a selector for these Q16.16 constants when an opcode requires a
+# scalar coefficient.  This is deliberately not described as an 8-bit
+# immediate, because the represented constants are wider than one byte.
+CONST_POOL: Mapping[int, int] = {
+    0x10: 0x00010000,  # 1.0
+    0x33: 0x00003333,  # ~0.2
+    0x40: 0x00004000,  # 0.25
+    0x9A: 0x0000D99A,  # ~0.85
+}
+
+MEM_NULL = 0x00
+MEM_OFF = 0x01
+
+
+# Preserved exactly as submitted.  It is intentionally non-canonical because
+# several source-register bytes encode decimal register labels as hexadecimal
+# values (for example R48 as 0x48 rather than decimal 48 == 0x30).
+PROGRAM_SUBMITTED_DRAFT = bytes(
+    [
+        0x01,
+        0x10,
+        0x00,
+        0x10,
+        0x01,
+        0x11,
+        0x01,
+        0x33,
+        0x02,
+        0x20,
+        0x10,
+        0x06,
+        0x03,
+        0x30,
+        0x20,
+        0x10,
+        0x04,
+        0x40,
+        0x48,
+        0x40,
+        0x07,
+        0x50,
+        0x64,
+        0x00,
+        0x05,
+        0x60,
+        0x64,
+        0x9A,
+        0x06,
+        0x70,
+        0x96,
+        0x00,
+        0x08,
+        0x10,
+        0x70,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    ]
+)
+
+
+# Corrected executable stream for the 256-register four-byte profile.
+PROGRAM_CANONICAL_V1 = bytes(
+    [
+        0x01,
+        0x10,
+        0x00,
+        0x10,  # LDF_PSI R16, MEM_NULL, CONST[0x10]
+        0x01,
+        0x11,
+        0x01,
+        0x33,  # LDF_PSI R17, MEM_OFF, CONST[0x33]
+        0x02,
+        0x20,
+        0x10,
+        0x06,  # FETCH_NB R32, R16, 6
+        0x03,
+        0x30,
+        0x20,
+        0x10,  # LAPLACE_3D R48, R32, center R16
+        0x04,
+        0x40,
+        0x30,
+        0x40,  # ENCODE_3D R64, R48, gain 0.25
+        0x07,
+        0x50,
+        0x40,
+        0x00,  # HAMILTON_CHK R80, R64, profile 0
+        0x05,
+        0x60,
+        0x40,
+        0x9A,  # DECODE_3D R96, R64, gain ~0.85
+        0x06,
+        0x70,
+        0x60,
+        0x00,  # ACTUATE_E R112, R96, internal sink
+        0x08,
+        0x10,
+        0x70,
+        0x01,  # SYNC_COMMIT R16, R112, residual-add
+        0x00,
+        0x00,
+        0x00,
+        0x00,  # HALT_LOOP epoch fence
+    ]
+)
+
+
+REGISTER_CORRECTIONS: Mapping[int, Tuple[int, int]] = {
+    # word_index: (submitted_source_byte, canonical_source_byte)
+    4: (0x48, 0x30),  # R48 decimal == 0x30
+    5: (0x64, 0x40),  # R64 decimal == 0x40
+    6: (0x64, 0x40),  # R64 decimal == 0x40
+    7: (0x96, 0x60),  # R96 decimal == 0x60
+}
+
+
+def sat_i32(value: int) -> int:
+    """Saturate an integer to signed 32-bit range."""
+
+    return max(INT32_MIN, min(INT32_MAX, int(value)))
+
+
+def trunc_div(numerator: int, denominator: int) -> int:
+    """Integer division truncated toward zero, independent of Python // sign rules."""
+
+    if denominator == 0:
+        raise ZeroDivisionError("division by zero")
+    quotient = abs(numerator) // abs(denominator)
+    return -quotient if (numerator < 0) ^ (denominator < 0) else quotient
+
+
+def q16_mul(lhs: int, rhs: int) -> int:
+    """Saturating signed Q16.16 multiply with a wide intermediate."""
+
+    product = int(lhs) * int(rhs)
+    return sat_i32(trunc_div(product, Q16_ONE))
+
+
+def q16_to_float(value: int) -> float:
+    return int(value) / Q16_ONE
+
+
+@dataclass(frozen=True)
+class Instruction:
+    opcode: int
+    dest: int
+    src: int
+    modifier: int
+
+    @classmethod
+    def decode(cls, word: bytes) -> "Instruction":
+        if len(word) != 4:
+            raise ValueError("instruction must be exactly four bytes")
+        return cls(*word)
+
+    def encode(self) -> bytes:
+        return bytes((self.opcode, self.dest, self.src, self.modifier))
+
+
+@dataclass(frozen=True)
+class TraceRecord:
+    cycle: int
+    pc: int
+    opcode: Opcode
+    note: str
+
+
+class QSOL3DVM:
+    """Small SIMD-style toroidal reference interpreter.
+
+    Each lattice coordinate owns a 256-entry register bank.  Instructions are
+    applied over the complete lattice from a consistent source snapshot where
+    neighborhood or atomic-commit semantics require it.
+    """
+
+    def __init__(self, shape: Tuple[int, int, int] = (3, 3, 3)) -> None:
+        if len(shape) != 3 or any(axis <= 0 for axis in shape):
+            raise ValueError("shape must contain three positive extents")
+
+        self.shape = shape
+        self.coords: List[Coord3] = [
+            (x, y, z)
+            for z in range(shape[2])
+            for y in range(shape[1])
+            for x in range(shape[0])
+        ]
+        self.registers: Dict[Coord3, List[RegisterValue]] = {
+            coord: [0] * 256 for coord in self.coords
+        }
+        self.actuation_register: Dict[Coord3, int] = {coord: 0 for coord in self.coords}
+        self.trace: List[TraceRecord] = []
+        self.halted = False
+        self.commit_generation = 0
+        self.last_commit_drift = 0
+
+    def neighbor_coords(self, coord: Coord3) -> NeighborVector:  # type: ignore[override]
+        """Return six wrapped coordinate tuples.
+
+        The return annotation is intentionally replaced below at runtime by the
+        actual tuple-of-coordinate shape; keeping the implementation explicit
+        avoids any hidden addressing rules.
+        """
+
+        x, y, z = coord
+        sx, sy, sz = self.shape
+        return (  # type: ignore[return-value]
+            ((x + 1) % sx, y, z),
+            ((x - 1) % sx, y, z),
+            (x, (y + 1) % sy, z),
+            (x, (y - 1) % sy, z),
+            (x, y, (z + 1) % sz),
+            (x, y, (z - 1) % sz),
+        )
+
+    def _scalar_snapshot(self, register_id: int) -> Dict[Coord3, int]:
+        snapshot: Dict[Coord3, int] = {}
+        for coord in self.coords:
+            value = self.registers[coord][register_id]
+            if not isinstance(value, int):
+                raise TypeError(f"R{register_id} does not contain scalar Q16.16 data")
+            snapshot[coord] = value
+        return snapshot
+
+    @staticmethod
+    def _constant(selector: int) -> int:
+        try:
+            return CONST_POOL[selector]
+        except KeyError as exc:
+            raise ValueError(f"unknown Q16.16 constant selector 0x{selector:02X}") from exc
+
+    def execute(self, instruction: Instruction, *, cycle: int, pc: int) -> None:
+        try:
+            opcode = Opcode(instruction.opcode)
+        except ValueError as exc:
+            raise ValueError(f"unknown opcode 0x{instruction.opcode:02X}") from exc
+
+        note = ""
+
+        if opcode == Opcode.HALT_LOOP:
+            self.halted = True
+            note = "end-of-epoch fence"
+
+        elif opcode == Opcode.LDF_PSI:
+            if instruction.src not in (MEM_NULL, MEM_OFF):
+                raise ValueError("LDF_PSI source tag must be MEM_NULL or MEM_OFF in v1")
+            value = self._constant(instruction.modifier)
+            for coord in self.coords:
+                self.registers[coord][instruction.dest] = value
+            note = f"R{instruction.dest}=0x{value & 0xFFFFFFFF:08X}"
+
+        elif opcode == Opcode.FETCH_NB:
+            if instruction.modifier != 0x06:
+                raise ValueError("FETCH_NB v1 requires exactly six orthogonal neighbors")
+            source = self._scalar_snapshot(instruction.src)
+            for coord in self.coords:
+                neighbors = tuple(source[n] for n in self.neighbor_coords(coord))
+                self.registers[coord][instruction.dest] = neighbors  # type: ignore[assignment]
+            note = f"six-neighbor toroidal stencil from R{instruction.src}"
+
+        elif opcode == Opcode.LAPLACE_3D:
+            center = self._scalar_snapshot(instruction.modifier)
+            for coord in self.coords:
+                value = self.registers[coord][instruction.src]
+                if not (isinstance(value, tuple) and len(value) == 6):
+                    raise TypeError("LAPLACE_3D source must contain a six-value neighbor vector")
+                neighbor_mean = trunc_div(sum(value), 6)
+                self.registers[coord][instruction.dest] = sat_i32(neighbor_mean - center[coord])
+            note = (
+                f"normalized Laplacian mean(R{instruction.src})-R{instruction.modifier}"
+            )
+
+        elif opcode == Opcode.ENCODE_3D:
+            gain = self._constant(instruction.modifier)
+            source = self._scalar_snapshot(instruction.src)
+            for coord in self.coords:
+                self.registers[coord][instruction.dest] = q16_mul(source[coord], gain)
+            note = f"Q16 encode gain={q16_to_float(gain):.9f}"
+
+        elif opcode == Opcode.DECODE_3D:
+            gain = self._constant(instruction.modifier)
+            source = self._scalar_snapshot(instruction.src)
+            for coord in self.coords:
+                self.registers[coord][instruction.dest] = q16_mul(source[coord], gain)
+            note = f"Q16 decode gain={q16_to_float(gain):.9f}"
+
+        elif opcode == Opcode.ACTUATE_E:
+            if instruction.modifier != 0x00:
+                raise ValueError("ACTUATE_E v1 supports only internal-sink profile 0")
+            source = self._scalar_snapshot(instruction.src)
+            for coord in self.coords:
+                value = source[coord]
+                self.registers[coord][instruction.dest] = value
+                self.actuation_register[coord] = value
+            note = "internal simulated actuation register only"
+
+        elif opcode == Opcode.HAMILTON_CHK:
+            if instruction.modifier != 0x00:
+                raise ValueError("HAMILTON_CHK v1 supports only profile 0")
+            source = self._scalar_snapshot(instruction.src)
+            max_energy = 0
+            for coord in self.coords:
+                squared = q16_mul(source[coord], source[coord])
+                energy = trunc_div(squared, 2)
+                self.registers[coord][instruction.dest] = energy
+                max_energy = max(max_energy, abs(energy))
+            note = f"H_eff proxy max={q16_to_float(max_energy):.9f}"
+
+        elif opcode == Opcode.SYNC_COMMIT:
+            source = self._scalar_snapshot(instruction.src)
+            previous = self._scalar_snapshot(instruction.dest)
+            staged: Dict[Coord3, int] = {}
+
+            if instruction.modifier == 0x01:
+                mode = "residual-add"
+                for coord in self.coords:
+                    staged[coord] = sat_i32(previous[coord] + source[coord])
+            elif instruction.modifier == 0x00:
+                mode = "replace"
+                staged = dict(source)
+            else:
+                raise ValueError("SYNC_COMMIT modifier must be 0x00 or 0x01")
+
+            self.last_commit_drift = max(
+                abs(staged[coord] - previous[coord]) for coord in self.coords
+            )
+            for coord, value in staged.items():
+                self.registers[coord][instruction.dest] = value
+            self.commit_generation += 1
+            note = (
+                f"atomic {mode}; max drift={q16_to_float(self.last_commit_drift):.9f}"
+            )
+
+        self.trace.append(TraceRecord(cycle=cycle, pc=pc, opcode=opcode, note=note))
+
+    def run_once(self, program: bytes = PROGRAM_CANONICAL_V1) -> Sequence[TraceRecord]:
+        if len(program) % 4 != 0:
+            raise ValueError("program length must be a multiple of four bytes")
+
+        self.halted = False
+        self.trace = []
+
+        for pc in range(0, len(program), 4):
+            cycle = (pc // 4) + 1
+            instruction = Instruction.decode(program[pc : pc + 4])
+            self.execute(instruction, cycle=cycle, pc=pc)
+            if self.halted:
+                break
+
+        return tuple(self.trace)
+
+
+def iter_instructions(program: bytes) -> Iterable[Instruction]:
+    if len(program) % 4 != 0:
+        raise ValueError("program length must be a multiple of four bytes")
+    for pc in range(0, len(program), 4):
+        yield Instruction.decode(program[pc : pc + 4])
+
+
+def audit_submitted_register_bytes() -> List[str]:
+    """Return the known source-register corrections in human-readable form."""
+
+    draft = list(iter_instructions(PROGRAM_SUBMITTED_DRAFT))
+    canonical = list(iter_instructions(PROGRAM_CANONICAL_V1))
+    findings: List[str] = []
+
+    for word_index, (submitted, corrected) in REGISTER_CORRECTIONS.items():
+        if draft[word_index].src != submitted:
+            raise AssertionError("submitted compatibility fixture changed unexpectedly")
+        if canonical[word_index].src != corrected:
+            raise AssertionError("canonical register correction changed unexpectedly")
+        findings.append(
+            f"word {word_index}: source 0x{submitted:02X} -> 0x{corrected:02X}"
+        )
+
+    return findings
+
+
+def format_program_hex(program: bytes = PROGRAM_CANONICAL_V1) -> str:
+    return " ".join(program[i : i + 4].hex().upper() for i in range(0, len(program), 4))
+
+
+def main() -> int:
+    vm = QSOL3DVM()
+    trace = vm.run_once()
+
+    print("QSOL 3D codec bytecode v1")
+    print(format_program_hex())
+    print()
+    for record in trace:
+        print(
+            f"[CYCLE {record.cycle:03d}] PC 0x{record.pc:04X} "
+            f"{record.opcode.name:<13} -> {record.note}"
+        )
+
+    print()
+    print(f"commit_generation={vm.commit_generation}")
+    print(f"max_commit_drift_q16={vm.last_commit_drift}")
+    print(f"fixed_point={vm.last_commit_drift == 0}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reference/qsol_3d_codec/test_reference_vm.py
+++ b/reference/qsol_3d_codec/test_reference_vm.py
@@ -1,0 +1,129 @@
+"""Conformance tests for the QSOL 3D codec reference VM.
+
+Run directly from the repository root:
+
+    python reference/qsol_3d_codec/test_reference_vm.py
+"""
+
+import unittest
+
+from reference_vm import (
+    CONST_POOL,
+    INT32_MAX,
+    PROGRAM_CANONICAL_V1,
+    PROGRAM_SUBMITTED_DRAFT,
+    Q16_ONE,
+    Instruction,
+    Opcode,
+    QSOL3DVM,
+    audit_submitted_register_bytes,
+    iter_instructions,
+    q16_mul,
+)
+
+
+class QSOL3DCodecTests(unittest.TestCase):
+    def test_instruction_is_exactly_four_bytes(self) -> None:
+        instruction = Instruction(0x04, 0x40, 0x30, 0x40)
+        self.assertEqual(instruction.encode(), bytes.fromhex("04 40 30 40"))
+        self.assertEqual(Instruction.decode(instruction.encode()), instruction)
+        with self.assertRaises(ValueError):
+            Instruction.decode(b"\x00\x00\x00")
+
+    def test_constant_selectors_expand_to_q16_values(self) -> None:
+        self.assertEqual(CONST_POOL[0x10], 0x00010000)
+        self.assertEqual(CONST_POOL[0x33], 0x00003333)
+        self.assertEqual(CONST_POOL[0x40], 0x00004000)
+        self.assertEqual(CONST_POOL[0x9A], 0x0000D99A)
+
+    def test_submitted_stream_is_preserved_but_not_canonical(self) -> None:
+        self.assertNotEqual(PROGRAM_SUBMITTED_DRAFT, PROGRAM_CANONICAL_V1)
+        self.assertEqual(
+            audit_submitted_register_bytes(),
+            [
+                "word 4: source 0x48 -> 0x30",
+                "word 5: source 0x64 -> 0x40",
+                "word 6: source 0x64 -> 0x40",
+                "word 7: source 0x96 -> 0x60",
+            ],
+        )
+
+    def test_canonical_register_chain_uses_actual_byte_ids(self) -> None:
+        instructions = list(iter_instructions(PROGRAM_CANONICAL_V1))
+        self.assertEqual((instructions[3].dest, instructions[3].src), (0x30, 0x20))
+        self.assertEqual((instructions[4].dest, instructions[4].src), (0x40, 0x30))
+        self.assertEqual((instructions[5].dest, instructions[5].src), (0x50, 0x40))
+        self.assertEqual((instructions[6].dest, instructions[6].src), (0x60, 0x40))
+        self.assertEqual((instructions[7].dest, instructions[7].src), (0x70, 0x60))
+        self.assertEqual((instructions[8].dest, instructions[8].src), (0x10, 0x70))
+
+    def test_toroidal_fetch_wraps_all_six_axes(self) -> None:
+        vm = QSOL3DVM((3, 3, 3))
+        for x, y, z in vm.coords:
+            vm.registers[(x, y, z)][0x10] = x + 10 * y + 100 * z
+
+        vm.execute(Instruction(Opcode.FETCH_NB, 0x20, 0x10, 0x06), cycle=1, pc=0)
+        self.assertEqual(vm.registers[(0, 0, 0)][0x20], (1, 2, 10, 20, 100, 200))
+
+    def test_normalized_laplacian_is_neighbor_mean_minus_center(self) -> None:
+        vm = QSOL3DVM((1, 1, 1))
+        vm.registers[(0, 0, 0)][0x10] = Q16_ONE
+        vm.registers[(0, 0, 0)][0x20] = (2 * Q16_ONE,) * 6
+        vm.execute(Instruction(Opcode.LAPLACE_3D, 0x30, 0x20, 0x10), cycle=1, pc=0)
+        self.assertEqual(vm.registers[(0, 0, 0)][0x30], Q16_ONE)
+
+    def test_q16_multiply_and_saturation(self) -> None:
+        self.assertEqual(q16_mul(Q16_ONE, CONST_POOL[0x40]), 0x00004000)
+        self.assertEqual(q16_mul(INT32_MAX, 2 * Q16_ONE), INT32_MAX)
+
+    def test_hamilton_proxy_is_half_x_squared(self) -> None:
+        vm = QSOL3DVM((1, 1, 1))
+        vm.registers[(0, 0, 0)][0x40] = Q16_ONE
+        vm.execute(Instruction(Opcode.HAMILTON_CHK, 0x50, 0x40, 0x00), cycle=1, pc=0)
+        self.assertEqual(vm.registers[(0, 0, 0)][0x50], Q16_ONE // 2)
+
+    def test_sync_commit_residual_add_is_atomic_state_update(self) -> None:
+        vm = QSOL3DVM((1, 1, 1))
+        vm.registers[(0, 0, 0)][0x10] = Q16_ONE
+        vm.registers[(0, 0, 0)][0x70] = Q16_ONE // 4
+        vm.execute(Instruction(Opcode.SYNC_COMMIT, 0x10, 0x70, 0x01), cycle=1, pc=0)
+        self.assertEqual(vm.registers[(0, 0, 0)][0x10], Q16_ONE + Q16_ONE // 4)
+        self.assertEqual(vm.last_commit_drift, Q16_ONE // 4)
+        self.assertEqual(vm.commit_generation, 1)
+
+    def test_actuate_e_is_internal_only_register_copy(self) -> None:
+        vm = QSOL3DVM((1, 1, 1))
+        vm.registers[(0, 0, 0)][0x60] = 0x00001234
+        vm.execute(Instruction(Opcode.ACTUATE_E, 0x70, 0x60, 0x00), cycle=1, pc=0)
+        self.assertEqual(vm.registers[(0, 0, 0)][0x70], 0x00001234)
+        self.assertEqual(vm.actuation_register[(0, 0, 0)], 0x00001234)
+
+    def test_uniform_canonical_program_is_zero_drift_fixed_point(self) -> None:
+        vm = QSOL3DVM((3, 3, 3))
+        trace = vm.run_once()
+
+        self.assertEqual(len(trace), 10)
+        self.assertEqual([record.pc for record in trace], list(range(0x00, 0x28, 0x04)))
+        self.assertEqual(trace[-1].opcode, Opcode.HALT_LOOP)
+        self.assertTrue(vm.halted)
+        self.assertEqual(vm.commit_generation, 1)
+        self.assertEqual(vm.last_commit_drift, 0)
+
+        for coord in vm.coords:
+            self.assertEqual(vm.registers[coord][0x10], 0x00010000)
+            self.assertEqual(vm.registers[coord][0x11], 0x00003333)
+            self.assertEqual(vm.registers[coord][0x30], 0)
+            self.assertEqual(vm.registers[coord][0x40], 0)
+            self.assertEqual(vm.registers[coord][0x50], 0)
+            self.assertEqual(vm.registers[coord][0x60], 0)
+            self.assertEqual(vm.registers[coord][0x70], 0)
+            self.assertEqual(vm.actuation_register[coord], 0)
+
+    def test_invalid_fetch_neighbor_count_fails_closed(self) -> None:
+        vm = QSOL3DVM((1, 1, 1))
+        with self.assertRaises(ValueError):
+            vm.execute(Instruction(Opcode.FETCH_NB, 0x20, 0x10, 0x05), cycle=1, pc=0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds a bounded, executable QSOL 3D auto-encoding/decoding bytecode profile for the DM–vΩΞ⁺ research engine.

### What this adds
- ADR-010 defining the four-byte `[opcode][dest][src/coord][modifier]` profile.
- A 256-register SIMD-style toroidal Q16.16 reference VM.
- Exact preservation of the submitted draft stream plus a corrected canonical stream.
- A constant-selector table for Q16.16 values that cannot fit directly in the 8-bit modifier.
- Six-neighbor toroidal stencil and normalized Laplacian semantics.
- Deterministic encode/decode transform primitives.
- Bounded `HAMILTON_CHK` energy proxy.
- Internal-only `ACTUATE_E` register semantics with no external device authority.
- Atomic residual-add `SYNC_COMMIT` fixed-point semantics.
- Conformance tests and a dedicated Python 3.10/3.13 GitHub Actions workflow.

## Arithmetic/encoding corrections

The submitted draft mixes decimal register labels with hexadecimal bytes in four source positions. The canonical stream corrects:

- `R48`: `0x48 -> 0x30`
- `R64`: `0x64 -> 0x40` for `HAMILTON_CHK`
- `R64`: `0x64 -> 0x40` for `DECODE_3D`
- `R96`: `0x96 -> 0x60`

It also defines modifier `0x9A` as a selector for Q16.16 `0x0000D99A ≈ 0.8500061`, rather than claiming the one-byte value itself contains the full coefficient.

## Fixed-point result

For the canonical uniform `Psi=1.0` fixture:

`normalized_laplacian = 0 -> encoded residual = 0 -> decoded residual = 0 -> atomic residual commit drift = 0`.

This is a discrete software invariant. The profile does not infer zero physical latency, thermal dissipation, inductive ringing, or literal electron-level actuation from bytecode execution.

## Compatibility

This is a sibling research ISA profile. It does not replace ADR-008 or the accepted 16-register encoding in ADR-009.