### PR TITLE
Permeate Jarvis-X into a leased 3D HyperCloud worker fabric

### DIFF
--- a/.env.hypercloud.example
+++ b/.env.hypercloud.example
@@ -1,7 +1,15 @@
-# Jarvis-X HyperCloud operational reference configuration
+# Jarvis-X HyperCloud operational permeation configuration
 JARVISX_PORT=8080
 JARVISX_LATTICE_SHAPE=16,16,16
 JARVISX_WORKER_POLL_SECONDS=0.25
+JARVISX_WORKER_TTL_SECONDS=30
+JARVISX_JOB_LEASE_SECONDS=300
+
+# Reference worker cells used by docker-compose.hypercloud.yml.
+JARVISX_WORKER_A_COORD=4,4,4
+JARVISX_WORKER_B_COORD=12,12,12
+JARVISX_WORKER_A_CAPABILITIES=chat,codec
+JARVISX_WORKER_B_CAPABILITIES=chat,codec
 
 # Optional API authentication. Set a long random value outside source control.
 JARVISX_API_KEY=

--- a/.env.hypercloud.example
+++ b/.env.hypercloud.example
@@ -1,0 +1,14 @@
+# Jarvis-X HyperCloud operational reference configuration
+JARVISX_PORT=8080
+JARVISX_LATTICE_SHAPE=16,16,16
+JARVISX_WORKER_POLL_SECONDS=0.25
+
+# Optional API authentication. Set a long random value outside source control.
+JARVISX_API_KEY=
+
+# Optional OpenAI-compatible neural model endpoint.
+# Leave BASE_URL empty to use the deterministic local reference backend.
+JARVISX_MODEL_BASE_URL=
+JARVISX_MODEL_NAME=
+JARVISX_MODEL_API_KEY=
+JARVISX_MODEL_TIMEOUT_SECONDS=120

--- a/.github/workflows/hypercloud-publish.yml
+++ b/.github/workflows/hypercloud-publish.yml
@@ -1,0 +1,48 @@
+name: Publish HyperCloud Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "src/jarvisx/cloud/**"
+      - "Dockerfile.cloud"
+      - "pyproject.toml"
+      - ".github/workflows/hypercloud-publish.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: hypercloud-publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and publish
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.cloud
+          push: true
+          tags: |
+            ghcr.io/lord-xido/jarvis-x:hypercloud
+            ghcr.io/lord-xido/jarvis-x:hypercloud-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/hypercloud.yml
+++ b/.github/workflows/hypercloud.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install package
         run: python -m pip install -e ".[test]"
       - name: Run HyperCloud tests
-        run: pytest tests/test_hypercloud_runtime.py tests/test_hypercloud_operational.py --no-cov
+        run: pytest tests/test_hypercloud*.py --no-cov
 
   full-stack:
     runs-on: ubuntu-latest

--- a/.github/workflows/hypercloud.yml
+++ b/.github/workflows/hypercloud.yml
@@ -4,8 +4,9 @@ on:
   pull_request:
     paths:
       - "src/jarvisx/cloud/**"
-      - "tests/test_hypercloud_runtime.py"
+      - "tests/test_hypercloud*.py"
       - "Dockerfile.cloud"
+      - "docker-compose.hypercloud.yml"
       - "deploy/k8s/hypercloud.yaml"
       - ".github/workflows/hypercloud.yml"
   push:
@@ -13,8 +14,9 @@ on:
       - main
     paths:
       - "src/jarvisx/cloud/**"
-      - "tests/test_hypercloud_runtime.py"
+      - "tests/test_hypercloud*.py"
       - "Dockerfile.cloud"
+      - "docker-compose.hypercloud.yml"
       - "deploy/k8s/hypercloud.yaml"
       - ".github/workflows/hypercloud.yml"
 
@@ -33,11 +35,53 @@ jobs:
       - name: Install package
         run: python -m pip install -e ".[test]"
       - name: Run HyperCloud tests
-        run: pytest tests/test_hypercloud_runtime.py --no-cov
+        run: pytest tests/test_hypercloud_runtime.py tests/test_hypercloud_operational.py --no-cov
 
-  container:
+  full-stack:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build reference image
-        run: docker build -f Dockerfile.cloud -t jarvisx-hypercloud:ci .
+      - name: Validate Compose configuration
+        run: docker compose -f docker-compose.hypercloud.yml config
+      - name: Boot API and worker
+        run: docker compose -f docker-compose.hypercloud.yml up -d --build
+      - name: Wait for API readiness
+        run: |
+          for i in $(seq 1 40); do
+            if curl -fsS http://127.0.0.1:8080/readyz; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker compose -f docker-compose.hypercloud.yml logs
+          exit 1
+      - name: Submit and complete durable chat job
+        run: |
+          response=$(curl -fsS \
+            -H 'Content-Type: application/json' \
+            -d '{"namespace":"ci","prompt":"hypercloud smoke test"}' \
+            http://127.0.0.1:8080/v1/chat)
+          job_id=$(python -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<< "$response")
+          for i in $(seq 1 40); do
+            state=$(curl -fsS "http://127.0.0.1:8080/v1/jobs/${job_id}")
+            status=$(python -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<< "$state")
+            if [ "$status" = "succeeded" ]; then
+              echo "$state"
+              exit 0
+            fi
+            if [ "$status" = "failed" ]; then
+              echo "$state"
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "job did not complete"
+          exit 1
+      - name: Verify metrics
+        run: curl -fsS http://127.0.0.1:8080/metrics | grep 'jarvisx_hypercloud_jobs{status="succeeded"} 1'
+      - name: Show logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.hypercloud.yml logs
+      - name: Shutdown stack
+        if: always()
+        run: docker compose -f docker-compose.hypercloud.yml down -v

--- a/.github/workflows/hypercloud.yml
+++ b/.github/workflows/hypercloud.yml
@@ -1,0 +1,43 @@
+name: HyperCloud Runtime
+
+on:
+  pull_request:
+    paths:
+      - "src/jarvisx/cloud/**"
+      - "tests/test_hypercloud_runtime.py"
+      - "Dockerfile.cloud"
+      - "deploy/k8s/hypercloud.yaml"
+      - ".github/workflows/hypercloud.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/jarvisx/cloud/**"
+      - "tests/test_hypercloud_runtime.py"
+      - "Dockerfile.cloud"
+      - "deploy/k8s/hypercloud.yaml"
+      - ".github/workflows/hypercloud.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install package
+        run: python -m pip install -e ".[test]"
+      - name: Run HyperCloud tests
+        run: pytest tests/test_hypercloud_runtime.py --no-cov
+
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build reference image
+        run: docker build -f Dockerfile.cloud -t jarvisx-hypercloud:ci .

--- a/.github/workflows/hypercloud.yml
+++ b/.github/workflows/hypercloud.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate Compose configuration
         run: docker compose -f docker-compose.hypercloud.yml config
-      - name: Boot API and worker
+      - name: Boot API and two-cell worker fabric
         run: docker compose -f docker-compose.hypercloud.yml up -d --build
       - name: Wait for API readiness
         run: |
@@ -55,13 +55,29 @@ jobs:
           done
           docker compose -f docker-compose.hypercloud.yml logs
           exit 1
+      - name: Verify worker fabric registration
+        run: |
+          for i in $(seq 1 40); do
+            workers=$(curl -fsS http://127.0.0.1:8080/v1/workers)
+            count=$(python -c 'import json,sys; print(json.load(sys.stdin)["count"])' <<< "$workers")
+            if [ "$count" -ge 2 ]; then
+              echo "$workers"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "two workers did not register"
+          docker compose -f docker-compose.hypercloud.yml logs
+          exit 1
       - name: Submit and complete durable chat job
         run: |
           response=$(curl -fsS \
             -H 'Content-Type: application/json' \
-            -d '{"namespace":"ci","prompt":"hypercloud smoke test"}' \
+            -d '{"namespace":"ci","prompt":"hypercloud permeation smoke test"}' \
             http://127.0.0.1:8080/v1/chat)
           job_id=$(python -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<< "$response")
+          target=$(python -c 'import json,sys; print(json.load(sys.stdin)["target"] is not None)' <<< "$response")
+          test "$target" = "True"
           for i in $(seq 1 40); do
             state=$(curl -fsS "http://127.0.0.1:8080/v1/jobs/${job_id}")
             status=$(python -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<< "$state")
@@ -77,8 +93,10 @@ jobs:
           done
           echo "job did not complete"
           exit 1
-      - name: Verify metrics
-        run: curl -fsS http://127.0.0.1:8080/metrics | grep 'jarvisx_hypercloud_jobs{status="succeeded"} 1'
+      - name: Verify topology and metrics
+        run: |
+          curl -fsS http://127.0.0.1:8080/metrics | grep 'jarvisx_hypercloud_active_workers 2'
+          curl -fsS http://127.0.0.1:8080/metrics | grep 'jarvisx_hypercloud_jobs{status="succeeded"} 1'
       - name: Show logs on failure
         if: failure()
         run: docker compose -f docker-compose.hypercloud.yml logs

--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -2,7 +2,10 @@ FROM python:3.12-slim AS runtime
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_NO_CACHE_DIR=1
+    PIP_NO_CACHE_DIR=1 \
+    JARVISX_STATE_DB=/var/lib/jarvisx/state.db \
+    JARVISX_OBJECT_ROOT=/var/lib/jarvisx/objects \
+    JARVISX_LATTICE_SHAPE=16,16,16
 
 WORKDIR /app
 
@@ -10,10 +13,18 @@ COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
 
 RUN python -m pip install --upgrade pip \
-    && python -m pip install .
+    && python -m pip install . \
+    && addgroup --system jarvisx \
+    && adduser --system --ingroup jarvisx --home /nonexistent --no-create-home jarvisx \
+    && mkdir -p /var/lib/jarvisx/objects \
+    && chown -R jarvisx:jarvisx /var/lib/jarvisx
 
 EXPOSE 8080
+VOLUME ["/var/lib/jarvisx"]
 
-USER nobody
+USER jarvisx
 
-CMD ["uvicorn", "jarvisx.cloud.api:app", "--host", "0.0.0.0", "--port", "8080"]
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/readyz', timeout=2).read()"
+
+CMD ["uvicorn", "jarvisx.cloud.api:app", "--host", "0.0.0.0", "--port", "8080", "--workers", "1"]

--- a/Dockerfile.cloud
+++ b/Dockerfile.cloud
@@ -1,0 +1,19 @@
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install .
+
+EXPOSE 8080
+
+USER nobody
+
+CMD ["uvicorn", "jarvisx.cloud.api:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/deploy/k8s/hypercloud.yaml
+++ b/deploy/k8s/hypercloud.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jarvisx-hypercloud
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: jarvisx-hypercloud
+  template:
+    metadata:
+      labels:
+        app: jarvisx-hypercloud
+    spec:
+      containers:
+        - name: api
+          image: ghcr.io/lord-xido/jarvis-x:hypercloud
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "1"
+              memory: "512Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jarvisx-hypercloud
+spec:
+  selector:
+    app: jarvisx-hypercloud
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/deploy/k8s/hypercloud.yaml
+++ b/deploy/k8s/hypercloud.yaml
@@ -1,9 +1,24 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jarvisx-hypercloud-state
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jarvisx-hypercloud
 spec:
-  replicas: 3
+  # SQLite/WAL is the operational single-pod reference state backend.
+  # Use a distributed state adapter before increasing replicas.
+  replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: jarvisx-hypercloud
@@ -12,15 +27,24 @@ spec:
       labels:
         app: jarvisx-hypercloud
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: api
           image: ghcr.io/lord-xido/jarvis-x:hypercloud
           imagePullPolicy: IfNotPresent
+          env:
+            - name: JARVISX_STATE_DB
+              value: /var/lib/jarvisx/state.db
+            - name: JARVISX_OBJECT_ROOT
+              value: /var/lib/jarvisx/objects
+            - name: JARVISX_LATTICE_SHAPE
+              value: "16,16,16"
           ports:
             - containerPort: 8080
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: 8080
             initialDelaySeconds: 2
             periodSeconds: 5
@@ -37,6 +61,33 @@ spec:
             limits:
               cpu: "1"
               memory: "512Mi"
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/jarvisx
+
+        - name: worker
+          image: ghcr.io/lord-xido/jarvis-x:hypercloud
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "jarvisx.cloud.worker"]
+          env:
+            - name: JARVISX_STATE_DB
+              value: /var/lib/jarvisx/state.db
+            - name: JARVISX_OBJECT_ROOT
+              value: /var/lib/jarvisx/objects
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/jarvisx
+      volumes:
+        - name: state
+          persistentVolumeClaim:
+            claimName: jarvisx-hypercloud-state
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s/hypercloud.yaml
+++ b/deploy/k8s/hypercloud.yaml
@@ -14,8 +14,9 @@ kind: Deployment
 metadata:
   name: jarvisx-hypercloud
 spec:
-  # SQLite/WAL is the operational single-pod reference state backend.
-  # Use a distributed state adapter before increasing replicas.
+  # SQLite/WAL is the operational single-pod reference state backend. Multiple
+  # worker sidecars share this one transactional volume. Replace the state
+  # adapter before increasing pod replicas across nodes.
   replicas: 1
   strategy:
     type: Recreate
@@ -40,6 +41,8 @@ spec:
               value: /var/lib/jarvisx/objects
             - name: JARVISX_LATTICE_SHAPE
               value: "16,16,16"
+            - name: JARVISX_WORKER_TTL_SECONDS
+              value: "30"
           ports:
             - containerPort: 8080
           readinessProbe:
@@ -65,7 +68,7 @@ spec:
             - name: state
               mountPath: /var/lib/jarvisx
 
-        - name: worker
+        - name: worker-a
           image: ghcr.io/lord-xido/jarvis-x:hypercloud
           imagePullPolicy: IfNotPresent
           command: ["python", "-m", "jarvisx.cloud.worker"]
@@ -74,6 +77,46 @@ spec:
               value: /var/lib/jarvisx/state.db
             - name: JARVISX_OBJECT_ROOT
               value: /var/lib/jarvisx/objects
+            - name: JARVISX_LATTICE_SHAPE
+              value: "16,16,16"
+            - name: JARVISX_WORKER_ID
+              value: hypercloud-worker-a
+            - name: JARVISX_WORKER_COORD
+              value: "4,4,4"
+            - name: JARVISX_WORKER_CAPABILITIES
+              value: "chat,codec"
+            - name: JARVISX_JOB_LEASE_SECONDS
+              value: "300"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "2"
+              memory: "2Gi"
+          volumeMounts:
+            - name: state
+              mountPath: /var/lib/jarvisx
+
+        - name: worker-b
+          image: ghcr.io/lord-xido/jarvis-x:hypercloud
+          imagePullPolicy: IfNotPresent
+          command: ["python", "-m", "jarvisx.cloud.worker"]
+          env:
+            - name: JARVISX_STATE_DB
+              value: /var/lib/jarvisx/state.db
+            - name: JARVISX_OBJECT_ROOT
+              value: /var/lib/jarvisx/objects
+            - name: JARVISX_LATTICE_SHAPE
+              value: "16,16,16"
+            - name: JARVISX_WORKER_ID
+              value: hypercloud-worker-b
+            - name: JARVISX_WORKER_COORD
+              value: "12,12,12"
+            - name: JARVISX_WORKER_CAPABILITIES
+              value: "chat,codec"
+            - name: JARVISX_JOB_LEASE_SECONDS
+              value: "300"
           resources:
             requests:
               cpu: "100m"

--- a/docker-compose.hypercloud.yml
+++ b/docker-compose.hypercloud.yml
@@ -9,6 +9,7 @@ services:
       JARVISX_STATE_DB: /var/lib/jarvisx/state.db
       JARVISX_OBJECT_ROOT: /var/lib/jarvisx/objects
       JARVISX_LATTICE_SHAPE: ${JARVISX_LATTICE_SHAPE:-16,16,16}
+      JARVISX_WORKER_TTL_SECONDS: ${JARVISX_WORKER_TTL_SECONDS:-30}
       JARVISX_API_KEY: ${JARVISX_API_KEY:-}
       JARVISX_MODEL_BASE_URL: ${JARVISX_MODEL_BASE_URL:-}
       JARVISX_MODEL_NAME: ${JARVISX_MODEL_NAME:-}
@@ -19,7 +20,7 @@ services:
     volumes:
       - hypercloud-state:/var/lib/jarvisx
 
-  worker:
+  worker-a:
     image: jarvisx-hypercloud:local
     restart: unless-stopped
     depends_on:
@@ -29,6 +30,34 @@ services:
     environment:
       JARVISX_STATE_DB: /var/lib/jarvisx/state.db
       JARVISX_OBJECT_ROOT: /var/lib/jarvisx/objects
+      JARVISX_LATTICE_SHAPE: ${JARVISX_LATTICE_SHAPE:-16,16,16}
+      JARVISX_WORKER_ID: hypercloud-worker-a
+      JARVISX_WORKER_COORD: ${JARVISX_WORKER_A_COORD:-4,4,4}
+      JARVISX_WORKER_CAPABILITIES: ${JARVISX_WORKER_A_CAPABILITIES:-chat,codec}
+      JARVISX_JOB_LEASE_SECONDS: ${JARVISX_JOB_LEASE_SECONDS:-300}
+      JARVISX_MODEL_BASE_URL: ${JARVISX_MODEL_BASE_URL:-}
+      JARVISX_MODEL_NAME: ${JARVISX_MODEL_NAME:-}
+      JARVISX_MODEL_API_KEY: ${JARVISX_MODEL_API_KEY:-}
+      JARVISX_MODEL_TIMEOUT_SECONDS: ${JARVISX_MODEL_TIMEOUT_SECONDS:-120}
+      JARVISX_WORKER_POLL_SECONDS: ${JARVISX_WORKER_POLL_SECONDS:-0.25}
+    volumes:
+      - hypercloud-state:/var/lib/jarvisx
+
+  worker-b:
+    image: jarvisx-hypercloud:local
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    command: ["python", "-m", "jarvisx.cloud.worker"]
+    environment:
+      JARVISX_STATE_DB: /var/lib/jarvisx/state.db
+      JARVISX_OBJECT_ROOT: /var/lib/jarvisx/objects
+      JARVISX_LATTICE_SHAPE: ${JARVISX_LATTICE_SHAPE:-16,16,16}
+      JARVISX_WORKER_ID: hypercloud-worker-b
+      JARVISX_WORKER_COORD: ${JARVISX_WORKER_B_COORD:-12,12,12}
+      JARVISX_WORKER_CAPABILITIES: ${JARVISX_WORKER_B_CAPABILITIES:-chat,codec}
+      JARVISX_JOB_LEASE_SECONDS: ${JARVISX_JOB_LEASE_SECONDS:-300}
       JARVISX_MODEL_BASE_URL: ${JARVISX_MODEL_BASE_URL:-}
       JARVISX_MODEL_NAME: ${JARVISX_MODEL_NAME:-}
       JARVISX_MODEL_API_KEY: ${JARVISX_MODEL_API_KEY:-}

--- a/docker-compose.hypercloud.yml
+++ b/docker-compose.hypercloud.yml
@@ -1,0 +1,41 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.cloud
+    image: jarvisx-hypercloud:local
+    restart: unless-stopped
+    environment:
+      JARVISX_STATE_DB: /var/lib/jarvisx/state.db
+      JARVISX_OBJECT_ROOT: /var/lib/jarvisx/objects
+      JARVISX_LATTICE_SHAPE: ${JARVISX_LATTICE_SHAPE:-16,16,16}
+      JARVISX_API_KEY: ${JARVISX_API_KEY:-}
+      JARVISX_MODEL_BASE_URL: ${JARVISX_MODEL_BASE_URL:-}
+      JARVISX_MODEL_NAME: ${JARVISX_MODEL_NAME:-}
+      JARVISX_MODEL_API_KEY: ${JARVISX_MODEL_API_KEY:-}
+      JARVISX_MODEL_TIMEOUT_SECONDS: ${JARVISX_MODEL_TIMEOUT_SECONDS:-120}
+    ports:
+      - "${JARVISX_PORT:-8080}:8080"
+    volumes:
+      - hypercloud-state:/var/lib/jarvisx
+
+  worker:
+    image: jarvisx-hypercloud:local
+    restart: unless-stopped
+    depends_on:
+      api:
+        condition: service_healthy
+    command: ["python", "-m", "jarvisx.cloud.worker"]
+    environment:
+      JARVISX_STATE_DB: /var/lib/jarvisx/state.db
+      JARVISX_OBJECT_ROOT: /var/lib/jarvisx/objects
+      JARVISX_MODEL_BASE_URL: ${JARVISX_MODEL_BASE_URL:-}
+      JARVISX_MODEL_NAME: ${JARVISX_MODEL_NAME:-}
+      JARVISX_MODEL_API_KEY: ${JARVISX_MODEL_API_KEY:-}
+      JARVISX_MODEL_TIMEOUT_SECONDS: ${JARVISX_MODEL_TIMEOUT_SECONDS:-120}
+      JARVISX_WORKER_POLL_SECONDS: ${JARVISX_WORKER_POLL_SECONDS:-0.25}
+    volumes:
+      - hypercloud-state:/var/lib/jarvisx
+
+volumes:
+  hypercloud-state:

--- a/docs/HYPERCLOUD_3D_RUNTIME.md
+++ b/docs/HYPERCLOUD_3D_RUNTIME.md
@@ -1,0 +1,215 @@
+# Jarvis-X 3D HyperCloud Runtime
+
+**Status:** Experimental integration track  
+**Capability boundary:** sparse symbolic control-plane reference; not a dense astronomical-parameter model
+
+## 1. Objective
+
+This track evolves Jarvis-X toward a multipurpose cloud runtime that can host multimodal model services over a logically enormous parameter namespace while preserving the repository's core engineering rule: **virtual extent is not physical allocation**.
+
+The requested logical parameter extent is represented symbolically as
+
+```text
+N_virtual = 1,000,000 ^ (1,000,000 ^ 1,000,000)
+```
+
+Jarvis-X does **not** attempt to construct `N_virtual` as a dense integer-sized array, enumerate every parameter, or imply that this many physical weights exist. Instead, clients address only finite hierarchical paths that are actually touched. Materialized state is therefore proportional to active work, not to the symbolic upper bound.
+
+## 2. Architecture
+
+```text
+                 ┌────────────────────────────────────┐
+ text/image/audio│ video/binary multimodal envelopes │
+        ────────►│ normalize → hash → validate       │
+                 └────────────────┬───────────────────┘
+                                  │
+                                  ▼
+                    ┌────────────────────────┐
+                    │ HyperCloud Control API │
+                    │ FastAPI / tenant scope │
+                    └────────────┬───────────┘
+                                 │
+                 ┌───────────────┴────────────────┐
+                 ▼                                ▼
+      symbolic parameter space           content-addressed media
+      hierarchical sparse paths          metadata / object boundary
+                 │
+                 ▼
+       deterministic 3D shard router
+          (x, y, z deployment cell)
+                 │
+          ┌──────┼────────┐
+          ▼      ▼        ▼
+       worker  worker   worker   ...
+        cell    cell     cell
+          │
+          ▼
+  model-specific encode / latent compute / decode
+  accelerator and object-store adapters (future track)
+```
+
+## 3. Parameter virtualization
+
+The runtime declares a `SymbolicParameterExtent` containing three finite terms:
+
+```text
+base              = 1,000,000
+exponent_base     = 1,000,000
+exponent_exponent = 1,000,000
+```
+
+Its expression is retained as metadata rather than evaluated. A touched parameter is addressed by a finite radix path such as
+
+```text
+(17, 42, 999999, 3, 88)
+```
+
+where every digit is in `[0, 1,000,000)`.
+
+This gives the system a practical sparse namespace with three important properties:
+
+1. no dense allocation follows from declaring the virtual extent;
+2. arbitrary active paths can be persisted or routed independently;
+3. physical resource consumption is measurable from the materialized subset.
+
+## 4. 3D execution lattice
+
+A finite deployment lattice, defaulting to `16 × 16 × 16`, represents actual executable shard locations. The router hashes
+
+```text
+(namespace, modality, hierarchical-address)
+```
+
+and maps the digest deterministically to
+
+```text
+(x, y, z)
+```
+
+inside the deployed lattice. The logical namespace and physical worker lattice remain separate. Scaling the deployment therefore does not alter the symbolic model definition.
+
+The first implementation optimizes for determinism. Production evolution should replace modulo routing with a consistent/rendezvous topology that minimizes data movement when shard counts change.
+
+## 5. Multimodal contract
+
+The control plane accepts typed immutable envelopes for:
+
+- text
+- image
+- audio
+- video
+- binary
+
+Each envelope carries bytes, MIME type, length and SHA-256 content identity. This layer intentionally does not pretend that all modalities share the same neural encoder. Model-specific adapters can attach behind the envelope boundary while the cloud control plane keeps routing, tenancy and audit semantics uniform.
+
+A future data plane can therefore implement:
+
+```text
+media bytes
+  → modality encoder
+  → latent tokens / patches / frames
+  → sparse parameter and expert activation
+  → 3D routed compute graph
+  → modality decoder
+  → generated text / image / audio / video / binary artifact
+```
+
+## 6. API surface
+
+The reference service exposes:
+
+```text
+GET  /healthz
+GET  /v1/runtime
+POST /v1/route
+PUT  /v1/parameters
+POST /v1/parameters/read
+POST /v1/media
+```
+
+The parameter endpoints are currently a bounded in-memory reference store. They establish addressing and routing semantics; they are not a production model-weight service.
+
+## 7. Deployment
+
+Build and run locally:
+
+```bash
+docker build -f Dockerfile.cloud -t jarvisx-hypercloud .
+docker run --rm -p 8080:8080 jarvisx-hypercloud
+```
+
+Then inspect the runtime:
+
+```bash
+curl http://localhost:8080/v1/runtime
+```
+
+A Kubernetes reference deployment exists at:
+
+```text
+deploy/k8s/hypercloud.yaml
+```
+
+The manifest deploys three stateless control-plane replicas. Persistent media, parameter shards and accelerator workers require separate production backends before horizontal stateful inference is claimed.
+
+## 8. Production evolution path
+
+The next engineering increments are deliberately separable:
+
+### Phase A — control-plane foundation
+
+- symbolic sparse parameter namespace
+- deterministic 3D routing
+- multimodal envelopes
+- REST control plane
+- tests and container image
+
+### Phase B — durable distributed state
+
+- S3-compatible object media store
+- metadata database
+- distributed sparse parameter KV service
+- tenant quotas and namespace authorization
+- WAL / replay integration with Jarvis-X Ω ledger semantics
+
+### Phase C — multimodal model execution
+
+- tokenizer and text model adapter
+- vision encoder / decoder adapter
+- audio codec / speech adapter
+- video frame/latent adapter
+- batching and KV-cache services
+- model registry and immutable weight manifests
+
+### Phase D — accelerator data plane
+
+- GPU/accelerator worker protocol
+- topology-aware placement
+- tensor/expert/pipeline parallel execution adapters
+- admission control and back-pressure
+- telemetry for latency, throughput, memory and power
+
+### Phase E — adaptive 3D orchestration
+
+- locality-aware routing over `(x, y, z)`
+- cache-aware expert placement
+- measured load balancing
+- failure-domain projection and rerouting
+- bounded auto-optimization subject to explicit Λ policy gates
+
+## 9. Invariants
+
+Every implementation on this track SHALL preserve the following:
+
+1. **No virtual-to-physical conflation.** A declared symbolic extent is not a statement of installed model weights, memory or hardware.
+2. **Sparse allocation.** Physical state is created only for touched addresses or explicitly loaded model shards.
+3. **Deterministic routing.** Identical routing inputs under an identical topology resolve to the same shard.
+4. **Typed multimodality.** Media kind, MIME type, digest and size are explicit before model-specific decoding.
+5. **Measurable claims.** Throughput, latency, scale, intelligence and accelerator claims require benchmarks or telemetry.
+6. **Bounded adaptation.** Any auto-evolution mechanism operates under explicit resource, safety, validation and rollback gates.
+
+## 10. What this increment proves
+
+This integration track proves that the existing Jarvis-X sparse/virtual design can be extended into a cloud service contract without requiring an impossible dense allocation. It establishes a clean seam between symbolic model extent, real deployed resources, multimodal data, and future distributed neural execution.
+
+It does **not** yet prove a functioning LLM of astronomical parameter count, distributed training, GPU inference, multimedia generation, or production persistence. Those capabilities must be implemented and measured incrementally behind the interfaces established here.

--- a/docs/HYPERCLOUD_OPERATIONS.md
+++ b/docs/HYPERCLOUD_OPERATIONS.md
@@ -1,0 +1,257 @@
+# Jarvis-X HyperCloud Operations
+
+**Status:** operational single-node/stateful reference deployment  
+**Scope:** durable sparse state, content-addressed multimedia, deterministic 3D routing, persistent jobs, codec execution, pluggable chat inference
+
+## 1. Start the complete stack
+
+```bash
+cp .env.hypercloud.example .env
+# edit .env if authentication or a model backend is required
+docker compose --env-file .env -f docker-compose.hypercloud.yml up -d --build
+```
+
+The stack contains:
+
+- `api`: FastAPI control plane on port 8080 by default;
+- `worker`: persistent job executor;
+- `hypercloud-state`: shared durable volume containing SQLite/WAL state and content-addressed objects.
+
+Verify:
+
+```bash
+curl http://127.0.0.1:8080/healthz
+curl http://127.0.0.1:8080/readyz
+curl http://127.0.0.1:8080/metrics
+```
+
+If `JARVISX_API_KEY` is set, add either:
+
+```text
+Authorization: Bearer <key>
+```
+
+or:
+
+```text
+X-API-Key: <key>
+```
+
+for `/v1/*` calls.
+
+## 2. Execute a chat job
+
+With the default configuration the worker uses the deterministic local reference backend. This validates the entire persistent execution path but is **not** represented as a neural LLM.
+
+```bash
+python examples/hypercloud_client.py "Explain the 3D sparse routing model"
+```
+
+Direct API sequence:
+
+```bash
+curl -sS \
+  -H 'Content-Type: application/json' \
+  -d '{"namespace":"demo","prompt":"Explain sparse virtual parameters"}' \
+  http://127.0.0.1:8080/v1/chat
+```
+
+The response contains a durable `id`. Poll:
+
+```bash
+curl http://127.0.0.1:8080/v1/jobs/<id>
+```
+
+until `status` becomes `succeeded` or `failed`.
+
+## 3. Attach a real model server
+
+HyperCloud can execute against an OpenAI-compatible chat-completions endpoint. This may be a self-hosted inference server or a managed provider.
+
+Configure:
+
+```bash
+export JARVISX_MODEL_BASE_URL=http://model-server:8000
+export JARVISX_MODEL_NAME=my-model
+export JARVISX_MODEL_API_KEY='optional-secret'
+docker compose -f docker-compose.hypercloud.yml up -d
+```
+
+The worker sends:
+
+```text
+POST ${JARVISX_MODEL_BASE_URL}/v1/chat/completions
+```
+
+using `JARVISX_MODEL_NAME`. API keys are read from the environment and are never persisted in the HyperCloud state database.
+
+A configured external model endpoint proves only that a model backend is attached. It does not by itself prove GPU acceleration, model size, throughput, or quality; those require backend telemetry and benchmarks.
+
+## 4. Persist sparse parameters
+
+Write an addressed value:
+
+```bash
+curl -sS -X PUT \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "namespace":"demo/model-a",
+        "modality":"text",
+        "digits":[17,42,999999],
+        "value":0.875
+      }' \
+  http://127.0.0.1:8080/v1/parameters
+```
+
+Read it:
+
+```bash
+curl -sS \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "namespace":"demo/model-a",
+        "modality":"text",
+        "digits":[17,42,999999]
+      }' \
+  http://127.0.0.1:8080/v1/parameters/read
+```
+
+Physical allocation remains proportional to touched addresses; the symbolic astronomical upper bound is never expanded densely.
+
+## 5. Ingest and auto-encode/decode multimedia
+
+Media ingestion accepts base64 bytes and an explicit modality:
+
+```json
+{
+  "namespace": "demo",
+  "kind": "image",
+  "content_type": "image/png",
+  "payload_base64": "..."
+}
+```
+
+POST this payload to:
+
+```text
+POST /v1/media
+```
+
+The returned SHA-256 digest is scoped by namespace. Submit an executable codec round-trip:
+
+```json
+{
+  "namespace": "demo",
+  "media_sha256": "<digest>"
+}
+```
+
+POST to:
+
+```text
+POST /v1/jobs/codec
+```
+
+The worker performs:
+
+```text
+media bytes
+  -> zlib-deflate latent packet
+  -> verified decode
+  -> byte-for-byte reconstruction check
+```
+
+This is a real deterministic auto-encoding/decoding transport primitive, but it is explicitly a lossless codec rather than a learned neural autoencoder. Learned image/audio/video codecs can replace or supplement this adapter later without changing the job/state contract.
+
+## 6. Data layout
+
+Default container paths:
+
+```text
+/var/lib/jarvisx/state.db
+/var/lib/jarvisx/state.db-wal
+/var/lib/jarvisx/state.db-shm
+/var/lib/jarvisx/objects/<sha-prefix>/<sha-prefix>/<sha256>
+```
+
+SQLite stores:
+
+- sparse parameter values;
+- namespace-scoped media metadata;
+- durable job inputs/results/errors.
+
+Object bytes are content-addressed and deduplicated globally by SHA-256 while metadata ownership remains namespace-scoped.
+
+## 7. Failure semantics
+
+Worker execution is transactional at the job-state boundary:
+
+```text
+queued -> running -> succeeded
+                  -> failed
+```
+
+An exception is stored in the job's `error` field. The API process and worker process are isolated so model/backend failures do not crash the control plane.
+
+The current worker intentionally does not auto-retry failed jobs. Retry policy should be added only with operation idempotency rules, attempt counters, backoff and dead-letter semantics.
+
+## 8. Observability
+
+Prometheus text metrics are available at:
+
+```text
+GET /metrics
+```
+
+Current gauges include:
+
+- materialized sparse parameters;
+- namespace-scoped media metadata objects;
+- queued/running/succeeded/failed job counts.
+
+Readiness checks SQLite availability at `/readyz`; liveness is exposed at `/healthz`.
+
+## 9. Kubernetes
+
+Apply:
+
+```bash
+kubectl apply -f deploy/k8s/hypercloud.yaml
+```
+
+The manifest intentionally runs **one pod** containing both API and worker with a `ReadWriteOnce` persistent volume. This is the correct topology for the SQLite/WAL reference backend.
+
+Do not increase replicas while using this manifest's local SQLite state plane. Horizontal production scale requires replacing the persistence adapter with distributed state/object services and then introducing topology-aware workers.
+
+## 10. Operational capability boundary
+
+Implemented and runnable:
+
+- symbolic astronomical virtual parameter namespace;
+- finite deterministic 3D shard mapping;
+- durable sparse parameters;
+- namespace-scoped multimedia metadata;
+- content-addressed object persistence;
+- lossless multimedia encode/decode execution;
+- durable asynchronous jobs;
+- worker isolation and persisted failures;
+- offline local response backend;
+- OpenAI-compatible neural model adapter;
+- optional API-key enforcement;
+- readiness/liveness/metrics;
+- Docker Compose deployment;
+- Kubernetes single-pod stateful deployment;
+- CI unit and full-stack execution tests.
+
+Not yet established by this reference deployment:
+
+- distributed database/object state;
+- multi-node worker leasing/heartbeats;
+- GPU-aware scheduler or verified accelerator execution;
+- tensor/expert/pipeline parallel training;
+- learned image/audio/video generation adapters;
+- autoscaling, ingress/TLS, network policy and secret-manager integration;
+- production tenant IAM, quotas and billing;
+- measured SLOs or astronomical physical model capacity.
+
+Those are infrastructure and model-data-plane increments, not properties that can be truthfully inferred from the symbolic virtual parameter extent.

--- a/docs/HYPERCLOUD_OPERATIONS.md
+++ b/docs/HYPERCLOUD_OPERATIONS.md
@@ -1,7 +1,7 @@
 # Jarvis-X HyperCloud Operations
 
 **Status:** operational permeated single-node/stateful reference deployment  
-**Scope:** durable sparse state, content-addressed multimedia, deterministic 3D routing, leased multiparallel workers, persistent jobs, codec execution, pluggable chat inference
+**Scope:** durable sparse state, content-addressed multimedia, deterministic 3D routing, renewable leased multiparallel workers, persistent jobs, codec execution, pluggable chat inference
 
 ## 1. Start the complete stack
 
@@ -49,24 +49,17 @@ live worker registry
 nearest capable worker
         |
         v
-expiring ownership lease
+renewable ownership lease
         |
         v
 execute -> verify -> commit
 ```
 
-The worker registry records:
-
-- worker identity;
-- 3D coordinate;
-- capability set (`chat`, `codec`, or future capabilities);
-- backend identity;
-- current load;
-- heartbeat timestamp.
+The worker registry records worker identity, 3D coordinate, capability set, backend identity, current load and heartbeat timestamp.
 
 Placement is intentionally transparent. The scheduler scores compatible workers using spatial distance plus a bounded load penalty. A queued worker claim independently prefers spatially nearest jobs, so geometry participates in execution rather than remaining decorative metadata.
 
-Inspect a queued job's target and current placement recommendation:
+Inspect a job's target and current placement recommendation:
 
 ```bash
 curl http://127.0.0.1:8080/v1/jobs/<id>/placement
@@ -89,13 +82,7 @@ curl -sS \
   http://127.0.0.1:8080/v1/chat
 ```
 
-The response contains a durable `id` and a non-null 3D `target`. Poll:
-
-```bash
-curl http://127.0.0.1:8080/v1/jobs/<id>
-```
-
-until `status` becomes `succeeded` or `failed`.
+The response contains a durable `id` and a non-null 3D `target`. Poll `/v1/jobs/<id>` until `status` becomes `succeeded` or `failed`.
 
 ## 4. Worker leases and failure recovery
 
@@ -107,6 +94,9 @@ queued
   | claim + lease
   v
 running ------------------> succeeded
+  |   ^
+  |   | active owner renews lease
+  |---+
   |
   +-----------------------> failed
   |
@@ -115,16 +105,11 @@ running ------------------> succeeded
 queued
 ```
 
-Each claim records:
+Each claim records `lease_owner`, `lease_expires_at`, `attempts`, and `max_attempts`. While execution is active, the worker periodically renews both its job lease and its registry heartbeat. Renewal succeeds only for the current `lease_owner`.
 
-- `lease_owner`;
-- `lease_expires_at`;
-- `attempts`;
-- `max_attempts`.
+If a worker disappears, renewal stops. Expired running work is automatically returned to `queued` while attempts remain. When the maximum attempt count is exhausted, the job becomes `failed` with an explicit lease-expiry error.
 
-If a worker disappears, expired running work is automatically returned to `queued` while attempts remain. When the maximum attempt count is exhausted, the job becomes `failed` with an explicit lease-expiry error.
-
-Completion and failure writes are fenced by `lease_owner`; a stale worker cannot overwrite a job after ownership has moved to another worker.
+Completion, failure, and renewal writes are fenced by `lease_owner`; a stale worker cannot overwrite or extend a job after ownership has moved to another worker.
 
 Reference settings:
 
@@ -134,7 +119,7 @@ JARVISX_WORKER_TTL_SECONDS=30
 JARVISX_WORKER_POLL_SECONDS=0.25
 ```
 
-The lease is deliberately much longer than the heartbeat TTL in the local reference deployment. Long-running production inference should evolve to renewable leases before reducing this safety margin.
+Workers renew an active lease at approximately one-third of the configured lease interval, capped to keep heartbeats responsive.
 
 ## 5. Attach a real model server
 
@@ -149,13 +134,7 @@ export JARVISX_MODEL_API_KEY='optional-secret'
 docker compose -f docker-compose.hypercloud.yml up -d
 ```
 
-Workers send:
-
-```text
-POST ${JARVISX_MODEL_BASE_URL}/v1/chat/completions
-```
-
-using `JARVISX_MODEL_NAME`. API keys are read from the environment and are never persisted in the HyperCloud state database.
+Workers send `POST ${JARVISX_MODEL_BASE_URL}/v1/chat/completions` using `JARVISX_MODEL_NAME`. API keys are read from the environment and are never persisted in the HyperCloud state database.
 
 A configured external model endpoint proves only that a model backend is attached. It does not by itself prove GPU acceleration, model size, throughput, or quality; those require backend telemetry and benchmarks.
 
@@ -175,46 +154,15 @@ curl -sS -X PUT \
   http://127.0.0.1:8080/v1/parameters
 ```
 
-Read it:
-
-```bash
-curl -sS \
-  -H 'Content-Type: application/json' \
-  -d '{
-        "namespace":"demo/model-a",
-        "modality":"text",
-        "digits":[17,42,999999]
-      }' \
-  http://127.0.0.1:8080/v1/parameters/read
-```
+Read it by POSTing the same namespace, modality and digits to `/v1/parameters/read`.
 
 Physical allocation remains proportional to touched addresses; the symbolic astronomical upper bound is never expanded densely.
 
 ## 7. Ingest and auto-encode/decode multimedia
 
-Media ingestion accepts base64 bytes and an explicit modality:
+Media ingestion accepts base64 bytes and an explicit modality at `POST /v1/media`. The returned SHA-256 digest is scoped by namespace. Submit an executable codec round-trip by POSTing the namespace and digest to `/v1/jobs/codec`.
 
-```json
-{
-  "namespace": "demo",
-  "kind": "image",
-  "content_type": "image/png",
-  "payload_base64": "..."
-}
-```
-
-POST to `/v1/media`. The returned SHA-256 digest is scoped by namespace. Submit an executable codec round-trip by POSTing:
-
-```json
-{
-  "namespace": "demo",
-  "media_sha256": "<digest>"
-}
-```
-
-to `/v1/jobs/codec`.
-
-A worker performs:
+A codec-capable worker performs:
 
 ```text
 media bytes
@@ -236,26 +184,13 @@ Default container paths:
 /var/lib/jarvisx/objects/<sha-prefix>/<sha-prefix>/<sha256>
 ```
 
-SQLite stores:
-
-- sparse parameter values;
-- namespace-scoped media metadata;
-- durable job inputs/results/errors;
-- 3D job targets and lease state;
-- worker coordinates, capabilities, load and heartbeats.
+SQLite stores sparse parameter values, namespace-scoped media metadata, durable job inputs/results/errors, 3D job targets and lease state, and worker coordinates/capabilities/load/heartbeats.
 
 Object bytes are content-addressed and deduplicated globally by SHA-256 while metadata ownership remains namespace-scoped.
 
 ## 9. Observability
 
-Prometheus text metrics are available at `GET /metrics`.
-
-Current gauges include:
-
-- materialized sparse parameters;
-- namespace-scoped media metadata objects;
-- active workers inside the heartbeat TTL;
-- queued/running/succeeded/failed job counts.
+Prometheus text metrics are available at `GET /metrics`. Current gauges include materialized sparse parameters, namespace-scoped media objects, active workers inside the heartbeat TTL, and queued/running/succeeded/failed job counts.
 
 Worker topology is available at `GET /v1/workers`. Readiness checks SQLite availability at `/readyz`; liveness is exposed at `/healthz`.
 
@@ -269,7 +204,7 @@ kubectl apply -f deploy/k8s/hypercloud.yaml
 
 The manifest intentionally runs **one pod** containing API plus two worker sidecars sharing a `ReadWriteOnce` persistent volume. This exercises concurrent leased workers while respecting SQLite/WAL's single-node state boundary.
 
-Do not increase pod replicas while using this manifest's SQLite state plane. Cross-node horizontal scale requires a distributed transactional job/metadata store and distributed object store first.
+Do not increase pod replicas while using this SQLite state plane. Cross-node horizontal scale requires a distributed transactional job/metadata store and distributed object store first.
 
 ## 11. Operational capability boundary
 
@@ -285,8 +220,9 @@ Implemented and runnable:
 - deterministic 3D job targets;
 - multiworker registration and heartbeat state;
 - capability-aware spatial placement;
-- expiring worker leases and abandoned-job recovery;
-- retry limits and lease-owner fencing;
+- expiring and renewable worker leases;
+- abandoned-job recovery and bounded retries;
+- lease-owner fencing for renewal/completion/failure;
 - offline local response backend;
 - OpenAI-compatible neural model adapter;
 - optional API-key enforcement;
@@ -298,7 +234,6 @@ Implemented and runnable:
 Not yet established by this reference deployment:
 
 - distributed database/object state across nodes;
-- renewable leases for arbitrarily long model calls;
 - GPU-aware scheduler or verified accelerator execution;
 - tensor/expert/pipeline parallel training;
 - learned image/audio/video generation adapters;

--- a/docs/HYPERCLOUD_OPERATIONS.md
+++ b/docs/HYPERCLOUD_OPERATIONS.md
@@ -1,7 +1,7 @@
 # Jarvis-X HyperCloud Operations
 
-**Status:** operational single-node/stateful reference deployment  
-**Scope:** durable sparse state, content-addressed multimedia, deterministic 3D routing, persistent jobs, codec execution, pluggable chat inference
+**Status:** operational permeated single-node/stateful reference deployment  
+**Scope:** durable sparse state, content-addressed multimedia, deterministic 3D routing, leased multiparallel workers, persistent jobs, codec execution, pluggable chat inference
 
 ## 1. Start the complete stack
 
@@ -14,7 +14,8 @@ docker compose --env-file .env -f docker-compose.hypercloud.yml up -d --build
 The stack contains:
 
 - `api`: FastAPI control plane on port 8080 by default;
-- `worker`: persistent job executor;
+- `worker-a`: leased execution cell at `(4,4,4)` by default;
+- `worker-b`: leased execution cell at `(12,12,12)` by default;
 - `hypercloud-state`: shared durable volume containing SQLite/WAL state and content-addressed objects.
 
 Verify:
@@ -23,25 +24,57 @@ Verify:
 curl http://127.0.0.1:8080/healthz
 curl http://127.0.0.1:8080/readyz
 curl http://127.0.0.1:8080/metrics
+curl http://127.0.0.1:8080/v1/workers
 ```
 
-If `JARVISX_API_KEY` is set, add either:
+If `JARVISX_API_KEY` is set, add either `Authorization: Bearer <key>` or `X-API-Key: <key>` to `/v1/*` calls.
+
+## 2. Permeated 3D execution loop
+
+Every executable job is assigned a deterministic target coordinate in the finite deployment lattice:
 
 ```text
-Authorization: Bearer <key>
+request / media digest
+        |
+        v
+hierarchical sparse address
+        |
+        v
+3D target (x,y,z)
+        |
+        v
+live worker registry
+        |
+        v
+nearest capable worker
+        |
+        v
+expiring ownership lease
+        |
+        v
+execute -> verify -> commit
 ```
 
-or:
+The worker registry records:
 
-```text
-X-API-Key: <key>
+- worker identity;
+- 3D coordinate;
+- capability set (`chat`, `codec`, or future capabilities);
+- backend identity;
+- current load;
+- heartbeat timestamp.
+
+Placement is intentionally transparent. The scheduler scores compatible workers using spatial distance plus a bounded load penalty. A queued worker claim independently prefers spatially nearest jobs, so geometry participates in execution rather than remaining decorative metadata.
+
+Inspect a queued job's target and current placement recommendation:
+
+```bash
+curl http://127.0.0.1:8080/v1/jobs/<id>/placement
 ```
 
-for `/v1/*` calls.
+## 3. Execute a chat job
 
-## 2. Execute a chat job
-
-With the default configuration the worker uses the deterministic local reference backend. This validates the entire persistent execution path but is **not** represented as a neural LLM.
+With the default configuration workers use the deterministic local reference backend. This validates the complete persistent execution path but is **not** represented as a neural LLM.
 
 ```bash
 python examples/hypercloud_client.py "Explain the 3D sparse routing model"
@@ -56,7 +89,7 @@ curl -sS \
   http://127.0.0.1:8080/v1/chat
 ```
 
-The response contains a durable `id`. Poll:
+The response contains a durable `id` and a non-null 3D `target`. Poll:
 
 ```bash
 curl http://127.0.0.1:8080/v1/jobs/<id>
@@ -64,7 +97,46 @@ curl http://127.0.0.1:8080/v1/jobs/<id>
 
 until `status` becomes `succeeded` or `failed`.
 
-## 3. Attach a real model server
+## 4. Worker leases and failure recovery
+
+The durable job state machine is:
+
+```text
+queued
+  |
+  | claim + lease
+  v
+running ------------------> succeeded
+  |
+  +-----------------------> failed
+  |
+  | lease expires, attempts remain
+  v
+queued
+```
+
+Each claim records:
+
+- `lease_owner`;
+- `lease_expires_at`;
+- `attempts`;
+- `max_attempts`.
+
+If a worker disappears, expired running work is automatically returned to `queued` while attempts remain. When the maximum attempt count is exhausted, the job becomes `failed` with an explicit lease-expiry error.
+
+Completion and failure writes are fenced by `lease_owner`; a stale worker cannot overwrite a job after ownership has moved to another worker.
+
+Reference settings:
+
+```text
+JARVISX_JOB_LEASE_SECONDS=300
+JARVISX_WORKER_TTL_SECONDS=30
+JARVISX_WORKER_POLL_SECONDS=0.25
+```
+
+The lease is deliberately much longer than the heartbeat TTL in the local reference deployment. Long-running production inference should evolve to renewable leases before reducing this safety margin.
+
+## 5. Attach a real model server
 
 HyperCloud can execute against an OpenAI-compatible chat-completions endpoint. This may be a self-hosted inference server or a managed provider.
 
@@ -77,7 +149,7 @@ export JARVISX_MODEL_API_KEY='optional-secret'
 docker compose -f docker-compose.hypercloud.yml up -d
 ```
 
-The worker sends:
+Workers send:
 
 ```text
 POST ${JARVISX_MODEL_BASE_URL}/v1/chat/completions
@@ -87,7 +159,7 @@ using `JARVISX_MODEL_NAME`. API keys are read from the environment and are never
 
 A configured external model endpoint proves only that a model backend is attached. It does not by itself prove GPU acceleration, model size, throughput, or quality; those require backend telemetry and benchmarks.
 
-## 4. Persist sparse parameters
+## 6. Persist sparse parameters
 
 Write an addressed value:
 
@@ -118,7 +190,7 @@ curl -sS \
 
 Physical allocation remains proportional to touched addresses; the symbolic astronomical upper bound is never expanded densely.
 
-## 5. Ingest and auto-encode/decode multimedia
+## 7. Ingest and auto-encode/decode multimedia
 
 Media ingestion accepts base64 bytes and an explicit modality:
 
@@ -131,13 +203,7 @@ Media ingestion accepts base64 bytes and an explicit modality:
 }
 ```
 
-POST this payload to:
-
-```text
-POST /v1/media
-```
-
-The returned SHA-256 digest is scoped by namespace. Submit an executable codec round-trip:
+POST to `/v1/media`. The returned SHA-256 digest is scoped by namespace. Submit an executable codec round-trip by POSTing:
 
 ```json
 {
@@ -146,13 +212,9 @@ The returned SHA-256 digest is scoped by namespace. Submit an executable codec r
 }
 ```
 
-POST to:
+to `/v1/jobs/codec`.
 
-```text
-POST /v1/jobs/codec
-```
-
-The worker performs:
+A worker performs:
 
 ```text
 media bytes
@@ -161,9 +223,9 @@ media bytes
   -> byte-for-byte reconstruction check
 ```
 
-This is a real deterministic auto-encoding/decoding transport primitive, but it is explicitly a lossless codec rather than a learned neural autoencoder. Learned image/audio/video codecs can replace or supplement this adapter later without changing the job/state contract.
+This is a real deterministic auto-encoding/decoding transport primitive, explicitly a lossless codec rather than a learned neural autoencoder. Learned image/audio/video codecs can attach later without changing the job/state contract.
 
-## 6. Data layout
+## 8. Data layout
 
 Default container paths:
 
@@ -178,40 +240,26 @@ SQLite stores:
 
 - sparse parameter values;
 - namespace-scoped media metadata;
-- durable job inputs/results/errors.
+- durable job inputs/results/errors;
+- 3D job targets and lease state;
+- worker coordinates, capabilities, load and heartbeats.
 
 Object bytes are content-addressed and deduplicated globally by SHA-256 while metadata ownership remains namespace-scoped.
 
-## 7. Failure semantics
+## 9. Observability
 
-Worker execution is transactional at the job-state boundary:
-
-```text
-queued -> running -> succeeded
-                  -> failed
-```
-
-An exception is stored in the job's `error` field. The API process and worker process are isolated so model/backend failures do not crash the control plane.
-
-The current worker intentionally does not auto-retry failed jobs. Retry policy should be added only with operation idempotency rules, attempt counters, backoff and dead-letter semantics.
-
-## 8. Observability
-
-Prometheus text metrics are available at:
-
-```text
-GET /metrics
-```
+Prometheus text metrics are available at `GET /metrics`.
 
 Current gauges include:
 
 - materialized sparse parameters;
 - namespace-scoped media metadata objects;
+- active workers inside the heartbeat TTL;
 - queued/running/succeeded/failed job counts.
 
-Readiness checks SQLite availability at `/readyz`; liveness is exposed at `/healthz`.
+Worker topology is available at `GET /v1/workers`. Readiness checks SQLite availability at `/readyz`; liveness is exposed at `/healthz`.
 
-## 9. Kubernetes
+## 10. Kubernetes
 
 Apply:
 
@@ -219,11 +267,11 @@ Apply:
 kubectl apply -f deploy/k8s/hypercloud.yaml
 ```
 
-The manifest intentionally runs **one pod** containing both API and worker with a `ReadWriteOnce` persistent volume. This is the correct topology for the SQLite/WAL reference backend.
+The manifest intentionally runs **one pod** containing API plus two worker sidecars sharing a `ReadWriteOnce` persistent volume. This exercises concurrent leased workers while respecting SQLite/WAL's single-node state boundary.
 
-Do not increase replicas while using this manifest's local SQLite state plane. Horizontal production scale requires replacing the persistence adapter with distributed state/object services and then introducing topology-aware workers.
+Do not increase pod replicas while using this manifest's SQLite state plane. Cross-node horizontal scale requires a distributed transactional job/metadata store and distributed object store first.
 
-## 10. Operational capability boundary
+## 11. Operational capability boundary
 
 Implemented and runnable:
 
@@ -234,19 +282,23 @@ Implemented and runnable:
 - content-addressed object persistence;
 - lossless multimedia encode/decode execution;
 - durable asynchronous jobs;
-- worker isolation and persisted failures;
+- deterministic 3D job targets;
+- multiworker registration and heartbeat state;
+- capability-aware spatial placement;
+- expiring worker leases and abandoned-job recovery;
+- retry limits and lease-owner fencing;
 - offline local response backend;
 - OpenAI-compatible neural model adapter;
 - optional API-key enforcement;
 - readiness/liveness/metrics;
-- Docker Compose deployment;
-- Kubernetes single-pod stateful deployment;
-- CI unit and full-stack execution tests.
+- Docker Compose two-cell worker deployment;
+- Kubernetes single-pod/two-worker stateful deployment;
+- CI unit and full-stack multiprocess execution tests.
 
 Not yet established by this reference deployment:
 
-- distributed database/object state;
-- multi-node worker leasing/heartbeats;
+- distributed database/object state across nodes;
+- renewable leases for arbitrarily long model calls;
 - GPU-aware scheduler or verified accelerator execution;
 - tensor/expert/pipeline parallel training;
 - learned image/audio/video generation adapters;
@@ -254,4 +306,4 @@ Not yet established by this reference deployment:
 - production tenant IAM, quotas and billing;
 - measured SLOs or astronomical physical model capacity.
 
-Those are infrastructure and model-data-plane increments, not properties that can be truthfully inferred from the symbolic virtual parameter extent.
+Those are infrastructure and model-data-plane increments, not properties that can be inferred from the symbolic virtual parameter extent.

--- a/examples/hypercloud_client.py
+++ b/examples/hypercloud_client.py
@@ -1,0 +1,64 @@
+"""Minimal Jarvis-X HyperCloud client using only the Python standard library."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from typing import Any
+from urllib.request import Request, urlopen
+
+
+def request_json(
+    method: str,
+    url: str,
+    payload: dict[str, Any] | None = None,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = Request(url, data=data, headers=headers, method=method)
+    with urlopen(request, timeout=30) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def wait_for_job(base_url: str, job_id: str, api_key: str | None, timeout: float) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        job = request_json("GET", f"{base_url}/v1/jobs/{job_id}", api_key=api_key)
+        if job["status"] in {"succeeded", "failed"}:
+            return job
+        time.sleep(0.25)
+    raise TimeoutError(f"job {job_id} did not complete within {timeout} seconds")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Submit a HyperCloud chat job")
+    parser.add_argument("prompt")
+    parser.add_argument("--namespace", default="demo")
+    parser.add_argument("--base-url", default=os.getenv("JARVISX_URL", "http://127.0.0.1:8080"))
+    parser.add_argument("--api-key", default=os.getenv("JARVISX_API_KEY"))
+    parser.add_argument("--timeout", type=float, default=120.0)
+    args = parser.parse_args()
+
+    queued = request_json(
+        "POST",
+        f"{args.base_url.rstrip('/')}/v1/chat",
+        {"namespace": args.namespace, "prompt": args.prompt},
+        args.api_key,
+    )
+    completed = wait_for_job(
+        args.base_url.rstrip("/"),
+        str(queued["id"]),
+        args.api_key,
+        args.timeout,
+    )
+    print(json.dumps(completed, indent=2, sort_keys=True))
+    return 0 if completed["status"] == "succeeded" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/cloud/__init__.py
+++ b/src/jarvisx/cloud/__init__.py
@@ -5,18 +5,28 @@ materialized state. Nothing in this package allocates a dense model matching
 the declared virtual parameter extent.
 """
 
+from .codec import LatentPacket, LosslessMultimodalCodec
 from .extent import HierarchicalAddress, SymbolicParameterExtent
 from .multimodal import MediaEnvelope, MediaKind
+from .operational import OperationalHyperCloud
+from .persistence import JobRecord, SQLiteStateStore
 from .routing import ShardCoordinate, SpatialShardRouter
 from .runtime import HyperCloudRuntime, SparseParameterStore
+from .worker import HyperCloudWorker
 
 __all__ = [
     "HierarchicalAddress",
     "HyperCloudRuntime",
+    "HyperCloudWorker",
+    "JobRecord",
+    "LatentPacket",
+    "LosslessMultimodalCodec",
     "MediaEnvelope",
     "MediaKind",
+    "OperationalHyperCloud",
     "ShardCoordinate",
     "SparseParameterStore",
     "SpatialShardRouter",
+    "SQLiteStateStore",
     "SymbolicParameterExtent",
 ]

--- a/src/jarvisx/cloud/__init__.py
+++ b/src/jarvisx/cloud/__init__.py
@@ -12,6 +12,12 @@ from .operational import OperationalHyperCloud
 from .persistence import JobRecord, SQLiteStateStore
 from .routing import ShardCoordinate, SpatialShardRouter
 from .runtime import HyperCloudRuntime, SparseParameterStore
+from .topology import (
+    PlacementDecision,
+    TopologyScheduler,
+    WorkerDescriptor,
+    manhattan_distance,
+)
 from .worker import HyperCloudWorker
 
 __all__ = [
@@ -24,9 +30,13 @@ __all__ = [
     "MediaEnvelope",
     "MediaKind",
     "OperationalHyperCloud",
+    "PlacementDecision",
     "ShardCoordinate",
     "SparseParameterStore",
     "SpatialShardRouter",
     "SQLiteStateStore",
     "SymbolicParameterExtent",
+    "TopologyScheduler",
+    "WorkerDescriptor",
+    "manhattan_distance",
 ]

--- a/src/jarvisx/cloud/__init__.py
+++ b/src/jarvisx/cloud/__init__.py
@@ -1,0 +1,22 @@
+"""Jarvis-X cloud-native sparse virtual LLM runtime.
+
+This package deliberately separates symbolic logical extent from physically
+materialized state. Nothing in this package allocates a dense model matching
+the declared virtual parameter extent.
+"""
+
+from .extent import HierarchicalAddress, SymbolicParameterExtent
+from .multimodal import MediaEnvelope, MediaKind
+from .routing import ShardCoordinate, SpatialShardRouter
+from .runtime import HyperCloudRuntime, SparseParameterStore
+
+__all__ = [
+    "HierarchicalAddress",
+    "HyperCloudRuntime",
+    "MediaEnvelope",
+    "MediaKind",
+    "ShardCoordinate",
+    "SparseParameterStore",
+    "SpatialShardRouter",
+    "SymbolicParameterExtent",
+]

--- a/src/jarvisx/cloud/api.py
+++ b/src/jarvisx/cloud/api.py
@@ -1,26 +1,28 @@
-"""FastAPI control plane for the Jarvis-X 3D HyperCloud runtime."""
+"""Operational FastAPI control plane for the Jarvis-X 3D HyperCloud runtime."""
 
 from __future__ import annotations
 
 import base64
 import binascii
+import hmac
+import os
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException, Response
 from pydantic import BaseModel, Field
 
 from .extent import HierarchicalAddress
 from .multimodal import MediaEnvelope, MediaKind
-from .runtime import HyperCloudRuntime
+from .operational import OperationalHyperCloud
 
 app = FastAPI(
     title="Jarvis-X 3D HyperCloud",
-    version="0.1.0",
+    version="0.2.0",
     description=(
-        "Sparse symbolic virtual-parameter control plane with deterministic 3D "
-        "routing and typed multimodal ingestion."
+        "Operational sparse virtual-parameter cloud with durable multimedia state, "
+        "deterministic 3D routing and asynchronous model/codec execution."
     ),
 )
-runtime = HyperCloudRuntime()
+runtime = OperationalHyperCloud.from_environment()
 
 
 class AddressRequest(BaseModel):
@@ -37,7 +39,18 @@ class MediaIngestRequest(BaseModel):
     namespace: str = Field(min_length=1, max_length=256)
     kind: MediaKind
     content_type: str = Field(min_length=1, max_length=256)
-    payload_base64: str = Field(min_length=1)
+    payload_base64: str = Field(min_length=1, max_length=64_000_000)
+
+
+class CodecJobRequest(BaseModel):
+    namespace: str = Field(min_length=1, max_length=256)
+    media_sha256: str = Field(min_length=64, max_length=64)
+
+
+class ChatJobRequest(BaseModel):
+    namespace: str = Field(min_length=1, max_length=256)
+    prompt: str = Field(min_length=1, max_length=1_000_000)
+    system: str | None = Field(default=None, max_length=100_000)
 
 
 def _address(digits: list[int]) -> HierarchicalAddress:
@@ -49,17 +62,70 @@ def _address(digits: list[int]) -> HierarchicalAddress:
     return address
 
 
+def _authorize(
+    x_api_key: str | None = Header(default=None),
+    authorization: str | None = Header(default=None),
+) -> None:
+    expected = os.getenv("JARVISX_API_KEY", "")
+    if not expected:
+        return
+    supplied = x_api_key
+    if supplied is None and authorization and authorization.startswith("Bearer "):
+        supplied = authorization[7:]
+    if supplied is None or not hmac.compare_digest(supplied, expected):
+        raise HTTPException(status_code=401, detail="invalid API key")
+
+
+def _backend_name() -> str:
+    return (
+        "openai-compatible"
+        if os.getenv("JARVISX_MODEL_BASE_URL", "").strip()
+        else "local-reference-non-llm"
+    )
+
+
 @app.get("/healthz")
 def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
-@app.get("/v1/runtime")
+@app.get("/readyz")
+def readiness() -> dict[str, str]:
+    assert runtime.state is not None
+    if not runtime.state.ping():
+        raise HTTPException(status_code=503, detail="state store unavailable")
+    return {"status": "ready"}
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    assert runtime.state is not None
+    jobs = runtime.state.job_counts()
+    lines = [
+        "# HELP jarvisx_hypercloud_materialized_parameters Sparse materialized parameter count.",
+        "# TYPE jarvisx_hypercloud_materialized_parameters gauge",
+        f"jarvisx_hypercloud_materialized_parameters {runtime.state.parameter_count()}",
+        "# HELP jarvisx_hypercloud_media_objects Content-addressed media object count.",
+        "# TYPE jarvisx_hypercloud_media_objects gauge",
+        f"jarvisx_hypercloud_media_objects {runtime.state.media_count()}",
+        "# HELP jarvisx_hypercloud_jobs Jobs by durable state.",
+        "# TYPE jarvisx_hypercloud_jobs gauge",
+    ]
+    for status, count in sorted(jobs.items()):
+        lines.append(f'jarvisx_hypercloud_jobs{{status="{status}"}} {count}')
+    return Response("\n".join(lines) + "\n", media_type="text/plain; version=0.0.4")
+
+
+@app.get("/v1/runtime", dependencies=[Depends(_authorize)])
 def describe_runtime() -> dict[str, object]:
-    return runtime.describe()
+    description = runtime.describe(backend_name=_backend_name())
+    description["authentication"] = {
+        "api_key_required": bool(os.getenv("JARVISX_API_KEY", ""))
+    }
+    return description
 
 
-@app.post("/v1/route")
+@app.post("/v1/route", dependencies=[Depends(_authorize)])
 def route_parameter(request: AddressRequest) -> dict[str, int]:
     coordinate = runtime.route(
         namespace=request.namespace,
@@ -69,7 +135,7 @@ def route_parameter(request: AddressRequest) -> dict[str, int]:
     return {"x": coordinate.x, "y": coordinate.y, "z": coordinate.z}
 
 
-@app.put("/v1/parameters")
+@app.put("/v1/parameters", dependencies=[Depends(_authorize)])
 def write_parameter(request: ParameterWriteRequest) -> dict[str, object]:
     address = _address(request.digits)
     coordinate = runtime.route(
@@ -77,26 +143,27 @@ def write_parameter(request: ParameterWriteRequest) -> dict[str, object]:
         modality=request.modality,
         address=address,
     )
-    runtime.store.set(request.namespace, address, request.value)
+    runtime.set_parameter(request.namespace, address, request.value)
+    assert runtime.state is not None
     return {
         "stored": True,
         "address": address.canonical(),
         "shard": {"x": coordinate.x, "y": coordinate.y, "z": coordinate.z},
-        "materialized_parameters": runtime.store.materialized_parameters,
+        "materialized_parameters": runtime.state.parameter_count(),
     }
 
 
-@app.post("/v1/parameters/read")
+@app.post("/v1/parameters/read", dependencies=[Depends(_authorize)])
 def read_parameter(request: AddressRequest) -> dict[str, object]:
     address = _address(request.digits)
     return {
         "address": address.canonical(),
-        "value": runtime.store.get(request.namespace, address),
+        "value": runtime.get_parameter(request.namespace, address),
     }
 
 
-@app.post("/v1/media")
-def ingest_media(request: MediaIngestRequest) -> dict[str, str | int]:
+@app.post("/v1/media", dependencies=[Depends(_authorize)])
+def ingest_media(request: MediaIngestRequest) -> dict[str, str | int | float]:
     try:
         payload = base64.b64decode(request.payload_base64, validate=True)
     except (binascii.Error, ValueError) as exc:
@@ -111,4 +178,39 @@ def ingest_media(request: MediaIngestRequest) -> dict[str, str | int]:
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
-    return runtime.ingest(namespace=request.namespace, media=envelope)
+    return runtime.ingest(request.namespace, envelope)
+
+
+@app.get("/v1/media/{digest}", dependencies=[Depends(_authorize)])
+def media_metadata(digest: str) -> dict[str, str | int | float]:
+    assert runtime.state is not None
+    record = runtime.state.media_record(digest)
+    if record is None:
+        raise HTTPException(status_code=404, detail="media object not found")
+    return record
+
+
+@app.post("/v1/jobs/codec", dependencies=[Depends(_authorize)])
+def enqueue_codec(request: CodecJobRequest) -> dict[str, object]:
+    try:
+        job = runtime.enqueue_codec(request.namespace, request.media_sha256)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="media object not found") from exc
+    return job.as_dict()
+
+
+@app.post("/v1/chat", dependencies=[Depends(_authorize)])
+def enqueue_chat(request: ChatJobRequest) -> dict[str, object]:
+    try:
+        job = runtime.enqueue_chat(request.namespace, request.prompt, request.system)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return job.as_dict()
+
+
+@app.get("/v1/jobs/{job_id}", dependencies=[Depends(_authorize)])
+def get_job(job_id: str) -> dict[str, object]:
+    job = runtime.job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    return job.as_dict()

--- a/src/jarvisx/cloud/api.py
+++ b/src/jarvisx/cloud/api.py
@@ -1,0 +1,114 @@
+"""FastAPI control plane for the Jarvis-X 3D HyperCloud runtime."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .extent import HierarchicalAddress
+from .multimodal import MediaEnvelope, MediaKind
+from .runtime import HyperCloudRuntime
+
+app = FastAPI(
+    title="Jarvis-X 3D HyperCloud",
+    version="0.1.0",
+    description=(
+        "Sparse symbolic virtual-parameter control plane with deterministic 3D "
+        "routing and typed multimodal ingestion."
+    ),
+)
+runtime = HyperCloudRuntime()
+
+
+class AddressRequest(BaseModel):
+    namespace: str = Field(min_length=1, max_length=256)
+    modality: str = Field(min_length=1, max_length=64)
+    digits: list[int] = Field(min_length=1, max_length=256)
+
+
+class ParameterWriteRequest(AddressRequest):
+    value: float
+
+
+class MediaIngestRequest(BaseModel):
+    namespace: str = Field(min_length=1, max_length=256)
+    kind: MediaKind
+    content_type: str = Field(min_length=1, max_length=256)
+    payload_base64: str = Field(min_length=1)
+
+
+def _address(digits: list[int]) -> HierarchicalAddress:
+    address = HierarchicalAddress(tuple(digits))
+    try:
+        address.validate(radix=runtime.extent.address_radix)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return address
+
+
+@app.get("/healthz")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/v1/runtime")
+def describe_runtime() -> dict[str, object]:
+    return runtime.describe()
+
+
+@app.post("/v1/route")
+def route_parameter(request: AddressRequest) -> dict[str, int]:
+    coordinate = runtime.route(
+        namespace=request.namespace,
+        modality=request.modality,
+        address=_address(request.digits),
+    )
+    return {"x": coordinate.x, "y": coordinate.y, "z": coordinate.z}
+
+
+@app.put("/v1/parameters")
+def write_parameter(request: ParameterWriteRequest) -> dict[str, object]:
+    address = _address(request.digits)
+    coordinate = runtime.route(
+        namespace=request.namespace,
+        modality=request.modality,
+        address=address,
+    )
+    runtime.store.set(request.namespace, address, request.value)
+    return {
+        "stored": True,
+        "address": address.canonical(),
+        "shard": {"x": coordinate.x, "y": coordinate.y, "z": coordinate.z},
+        "materialized_parameters": runtime.store.materialized_parameters,
+    }
+
+
+@app.post("/v1/parameters/read")
+def read_parameter(request: AddressRequest) -> dict[str, object]:
+    address = _address(request.digits)
+    return {
+        "address": address.canonical(),
+        "value": runtime.store.get(request.namespace, address),
+    }
+
+
+@app.post("/v1/media")
+def ingest_media(request: MediaIngestRequest) -> dict[str, str | int]:
+    try:
+        payload = base64.b64decode(request.payload_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise HTTPException(status_code=422, detail="payload_base64 is invalid") from exc
+
+    try:
+        envelope = MediaEnvelope(
+            kind=request.kind,
+            payload=payload,
+            content_type=request.content_type,
+        )
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return runtime.ingest(namespace=request.namespace, media=envelope)

--- a/src/jarvisx/cloud/api.py
+++ b/src/jarvisx/cloud/api.py
@@ -13,13 +13,14 @@ from pydantic import BaseModel, Field
 from .extent import HierarchicalAddress
 from .multimodal import MediaEnvelope, MediaKind
 from .operational import OperationalHyperCloud
+from .topology import WorkerDescriptor
 
 app = FastAPI(
     title="Jarvis-X 3D HyperCloud",
-    version="0.2.0",
+    version="0.3.0",
     description=(
-        "Operational sparse virtual-parameter cloud with durable multimedia state, "
-        "deterministic 3D routing and asynchronous model/codec execution."
+        "Operational sparse virtual-parameter cloud with leased 3D workers, durable "
+        "multimedia state, topology-aware routing and asynchronous model/codec execution."
     ),
 )
 runtime = OperationalHyperCloud.from_environment()
@@ -84,6 +85,21 @@ def _backend_name() -> str:
     )
 
 
+def _worker_payload(worker: WorkerDescriptor) -> dict[str, object]:
+    return {
+        "worker_id": worker.worker_id,
+        "coordinate": {
+            "x": worker.coordinate.x,
+            "y": worker.coordinate.y,
+            "z": worker.coordinate.z,
+        },
+        "capabilities": list(worker.capabilities),
+        "backend": worker.backend,
+        "load": worker.load,
+        "last_seen": worker.last_seen,
+    }
+
+
 @app.get("/healthz")
 def health() -> dict[str, str]:
     return {"status": "ok"}
@@ -101,6 +117,8 @@ def readiness() -> dict[str, str]:
 def metrics() -> Response:
     assert runtime.state is not None
     jobs = runtime.state.job_counts()
+    worker_ttl = float(os.getenv("JARVISX_WORKER_TTL_SECONDS", "30"))
+    workers = runtime.state.active_workers(ttl_seconds=worker_ttl)
     lines = [
         "# HELP jarvisx_hypercloud_materialized_parameters Sparse materialized parameter count.",
         "# TYPE jarvisx_hypercloud_materialized_parameters gauge",
@@ -108,6 +126,9 @@ def metrics() -> Response:
         "# HELP jarvisx_hypercloud_media_objects Namespace-scoped media metadata count.",
         "# TYPE jarvisx_hypercloud_media_objects gauge",
         f"jarvisx_hypercloud_media_objects {runtime.state.media_count()}",
+        "# HELP jarvisx_hypercloud_active_workers Live workers inside the heartbeat TTL.",
+        "# TYPE jarvisx_hypercloud_active_workers gauge",
+        f"jarvisx_hypercloud_active_workers {len(workers)}",
         "# HELP jarvisx_hypercloud_jobs Jobs by durable state.",
         "# TYPE jarvisx_hypercloud_jobs gauge",
     ]
@@ -123,6 +144,18 @@ def describe_runtime() -> dict[str, object]:
         "api_key_required": bool(os.getenv("JARVISX_API_KEY", ""))
     }
     return description
+
+
+@app.get("/v1/workers", dependencies=[Depends(_authorize)])
+def list_workers() -> dict[str, object]:
+    assert runtime.state is not None
+    worker_ttl = float(os.getenv("JARVISX_WORKER_TTL_SECONDS", "30"))
+    workers = runtime.state.active_workers(ttl_seconds=worker_ttl)
+    return {
+        "ttl_seconds": worker_ttl,
+        "count": len(workers),
+        "workers": [_worker_payload(worker) for worker in workers],
+    }
 
 
 @app.post("/v1/route", dependencies=[Depends(_authorize)])
@@ -214,3 +247,30 @@ def get_job(job_id: str) -> dict[str, object]:
     if job is None:
         raise HTTPException(status_code=404, detail="job not found")
     return job.as_dict()
+
+
+@app.get("/v1/jobs/{job_id}/placement", dependencies=[Depends(_authorize)])
+def job_placement(job_id: str) -> dict[str, object]:
+    job = runtime.job(job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="job not found")
+    if job.target is None:
+        return {"job_id": job_id, "target": None, "placement": None}
+    decision = runtime.placement_preview(job_id)
+    placement = None
+    if decision is not None:
+        placement = {
+            "worker_id": decision.worker_id,
+            "coordinate": {
+                "x": decision.coordinate.x,
+                "y": decision.coordinate.y,
+                "z": decision.coordinate.z,
+            },
+            "distance": decision.distance,
+            "score": decision.score,
+        }
+    return {
+        "job_id": job_id,
+        "target": {"x": job.target.x, "y": job.target.y, "z": job.target.z},
+        "placement": placement,
+    }

--- a/src/jarvisx/cloud/api.py
+++ b/src/jarvisx/cloud/api.py
@@ -105,7 +105,7 @@ def metrics() -> Response:
         "# HELP jarvisx_hypercloud_materialized_parameters Sparse materialized parameter count.",
         "# TYPE jarvisx_hypercloud_materialized_parameters gauge",
         f"jarvisx_hypercloud_materialized_parameters {runtime.state.parameter_count()}",
-        "# HELP jarvisx_hypercloud_media_objects Content-addressed media object count.",
+        "# HELP jarvisx_hypercloud_media_objects Namespace-scoped media metadata count.",
         "# TYPE jarvisx_hypercloud_media_objects gauge",
         f"jarvisx_hypercloud_media_objects {runtime.state.media_count()}",
         "# HELP jarvisx_hypercloud_jobs Jobs by durable state.",
@@ -182,9 +182,9 @@ def ingest_media(request: MediaIngestRequest) -> dict[str, str | int | float]:
 
 
 @app.get("/v1/media/{digest}", dependencies=[Depends(_authorize)])
-def media_metadata(digest: str) -> dict[str, str | int | float]:
+def media_metadata(digest: str, namespace: str) -> dict[str, str | int | float]:
     assert runtime.state is not None
-    record = runtime.state.media_record(digest)
+    record = runtime.state.media_record(namespace, digest)
     if record is None:
         raise HTTPException(status_code=404, detail="media object not found")
     return record

--- a/src/jarvisx/cloud/codec.py
+++ b/src/jarvisx/cloud/codec.py
@@ -1,0 +1,92 @@
+"""Deterministic lossless multimodal encode/decode substrate.
+
+This is intentionally a codec, not a claim of a learned neural autoencoder. It
+provides an executable encode/decode path for every supported media kind while
+model-specific learned codecs can be registered behind the same boundary.
+"""
+
+from __future__ import annotations
+
+import base64
+import zlib
+from dataclasses import dataclass
+from hashlib import sha256
+
+from .multimodal import MediaEnvelope, MediaKind
+
+
+@dataclass(frozen=True)
+class LatentPacket:
+    kind: MediaKind
+    content_type: str
+    algorithm: str
+    source_sha256: str
+    source_size: int
+    payload: bytes
+
+    @property
+    def encoded_size(self) -> int:
+        return len(self.payload)
+
+    @property
+    def compression_ratio(self) -> float:
+        return self.encoded_size / self.source_size
+
+    def descriptor(self) -> dict[str, str | int | float]:
+        return {
+            "kind": self.kind.value,
+            "content_type": self.content_type,
+            "algorithm": self.algorithm,
+            "source_sha256": self.source_sha256,
+            "source_size": self.source_size,
+            "encoded_size": self.encoded_size,
+            "compression_ratio": self.compression_ratio,
+            "latent_sha256": sha256(self.payload).hexdigest(),
+        }
+
+    def to_base64(self) -> str:
+        return base64.b64encode(self.payload).decode("ascii")
+
+
+class LosslessMultimodalCodec:
+    """Reference codec supporting text/image/audio/video/binary bytes."""
+
+    algorithm = "zlib-deflate-v1"
+
+    def __init__(self, compression_level: int = 6) -> None:
+        if not 0 <= compression_level <= 9:
+            raise ValueError("compression_level must be between 0 and 9")
+        self.compression_level = compression_level
+
+    def encode(self, media: MediaEnvelope) -> LatentPacket:
+        return LatentPacket(
+            kind=media.kind,
+            content_type=media.content_type,
+            algorithm=self.algorithm,
+            source_sha256=media.digest,
+            source_size=media.size_bytes,
+            payload=zlib.compress(media.payload, self.compression_level),
+        )
+
+    def decode(self, packet: LatentPacket) -> MediaEnvelope:
+        if packet.algorithm != self.algorithm:
+            raise ValueError(f"unsupported codec algorithm: {packet.algorithm}")
+        payload = zlib.decompress(packet.payload)
+        if len(payload) != packet.source_size:
+            raise RuntimeError("decoded size differs from source size")
+        if sha256(payload).hexdigest() != packet.source_sha256:
+            raise RuntimeError("decoded digest differs from source digest")
+        return MediaEnvelope(
+            kind=packet.kind,
+            payload=payload,
+            content_type=packet.content_type,
+        )
+
+    def roundtrip(self, media: MediaEnvelope) -> dict[str, str | int | float | bool]:
+        packet = self.encode(media)
+        reconstructed = self.decode(packet)
+        return {
+            **packet.descriptor(),
+            "reconstructed_sha256": reconstructed.digest,
+            "lossless": reconstructed.payload == media.payload,
+        }

--- a/src/jarvisx/cloud/extent.py
+++ b/src/jarvisx/cloud/extent.py
@@ -1,0 +1,68 @@
+"""Symbolic parameter-space contracts for the HyperCloud runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SymbolicParameterExtent:
+    """Describe a logical parameter count without expanding it into an integer.
+
+    The default represents::
+
+        1_000_000 ** (1_000_000 ** 1_000_000)
+
+    The value is intentionally symbolic. Constructing the corresponding dense
+    array, enumerating every address, or claiming that many physical weights is
+    outside the runtime contract.
+    """
+
+    base: int = 1_000_000
+    exponent_base: int = 1_000_000
+    exponent_exponent: int = 1_000_000
+
+    def __post_init__(self) -> None:
+        if self.base < 2 or self.exponent_base < 2 or self.exponent_exponent < 1:
+            raise ValueError("symbolic extent terms must be positive and non-trivial")
+
+    @property
+    def expression(self) -> str:
+        return f"{self.base}^({self.exponent_base}^{self.exponent_exponent})"
+
+    @property
+    def address_radix(self) -> int:
+        return self.base
+
+    def metadata(self) -> dict[str, int | str]:
+        return {
+            "expression": self.expression,
+            "base": self.base,
+            "exponent_base": self.exponent_base,
+            "exponent_exponent": self.exponent_exponent,
+            "allocation_semantics": "symbolic-sparse",
+        }
+
+
+@dataclass(frozen=True)
+class HierarchicalAddress:
+    """Finite sparse path into the symbolic virtual parameter space.
+
+    A client transmits only the path it actually touches. Each digit lies in
+    ``[0, radix)``. The runtime therefore never needs to materialize the full
+    logical index width implied by the symbolic extent.
+    """
+
+    digits: tuple[int, ...]
+
+    def validate(self, *, radix: int) -> None:
+        if radix < 2:
+            raise ValueError("radix must be at least 2")
+        if not self.digits:
+            raise ValueError("address must contain at least one digit")
+        for digit in self.digits:
+            if digit < 0 or digit >= radix:
+                raise ValueError(f"address digit {digit} is outside radix {radix}")
+
+    def canonical(self) -> str:
+        return ".".join(str(digit) for digit in self.digits)

--- a/src/jarvisx/cloud/inference.py
+++ b/src/jarvisx/cloud/inference.py
@@ -1,0 +1,129 @@
+"""Model inference adapters for HyperCloud workers.
+
+The local backend keeps the stack runnable without external credentials. The
+OpenAI-compatible adapter can target a self-hosted or managed chat endpoint by
+configuration, allowing the worker/data-plane boundary to remain provider
+neutral.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+class ChatBackend(Protocol):
+    name: str
+
+    def generate(self, *, prompt: str, system: str | None = None) -> dict[str, object]: ...
+
+
+@dataclass
+class LocalReferenceBackend:
+    """Deterministic offline backend used for smoke tests and local operation.
+
+    This backend is deliberately labelled reference/non-LLM. It proves the job,
+    worker and response path without making a neural-model capability claim.
+    """
+
+    name: str = "local-reference-non-llm"
+
+    def generate(self, *, prompt: str, system: str | None = None) -> dict[str, object]:
+        normalized = " ".join(prompt.strip().split())
+        if not normalized:
+            raise ValueError("prompt must not be empty")
+        prefix = "Jarvis-X operational reference backend"
+        if system:
+            prefix += f" [{system.strip()[:160]}]"
+        text = f"{prefix}: {normalized}"
+        return {
+            "backend": self.name,
+            "model": "deterministic-reference",
+            "text": text,
+            "input_characters": len(prompt),
+            "output_characters": len(text),
+            "neural_model": False,
+        }
+
+
+@dataclass
+class OpenAICompatibleBackend:
+    """Minimal dependency-free client for OpenAI-compatible chat servers."""
+
+    base_url: str
+    model: str
+    api_key: str | None = None
+    timeout_seconds: float = 120.0
+    name: str = "openai-compatible"
+
+    def __post_init__(self) -> None:
+        self.base_url = self.base_url.rstrip("/")
+        if not self.base_url.startswith(("http://", "https://")):
+            raise ValueError("model base URL must start with http:// or https://")
+        if not self.model:
+            raise ValueError("model name must not be empty")
+
+    def generate(self, *, prompt: str, system: str | None = None) -> dict[str, object]:
+        if not prompt.strip():
+            raise ValueError("prompt must not be empty")
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        body = json.dumps(
+            {
+                "model": self.model,
+                "messages": messages,
+                "temperature": 0.0,
+            }
+        ).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        request = Request(
+            f"{self.base_url}/v1/chat/completions",
+            data=body,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")[:2000]
+            raise RuntimeError(f"model backend HTTP {exc.code}: {detail}") from exc
+        except URLError as exc:
+            raise RuntimeError(f"model backend unavailable: {exc.reason}") from exc
+
+        try:
+            text = payload["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as exc:
+            raise RuntimeError("model backend returned an invalid chat-completions payload") from exc
+        usage = payload.get("usage") if isinstance(payload, dict) else None
+        return {
+            "backend": self.name,
+            "model": self.model,
+            "text": text,
+            "usage": usage,
+            "neural_model": True,
+        }
+
+
+def backend_from_environment() -> ChatBackend:
+    base_url = os.getenv("JARVISX_MODEL_BASE_URL", "").strip()
+    model = os.getenv("JARVISX_MODEL_NAME", "").strip()
+    if not base_url:
+        return LocalReferenceBackend()
+    if not model:
+        raise RuntimeError("JARVISX_MODEL_NAME is required when JARVISX_MODEL_BASE_URL is set")
+    timeout = float(os.getenv("JARVISX_MODEL_TIMEOUT_SECONDS", "120"))
+    return OpenAICompatibleBackend(
+        base_url=base_url,
+        model=model,
+        api_key=os.getenv("JARVISX_MODEL_API_KEY") or None,
+        timeout_seconds=timeout,
+    )

--- a/src/jarvisx/cloud/multimodal.py
+++ b/src/jarvisx/cloud/multimodal.py
@@ -1,0 +1,48 @@
+"""Typed multimodal envelopes used by the cloud runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from hashlib import sha256
+
+
+class MediaKind(str, Enum):
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    BINARY = "binary"
+
+
+@dataclass(frozen=True)
+class MediaEnvelope:
+    """Immutable media unit normalized before encoding or routing."""
+
+    kind: MediaKind
+    payload: bytes
+    content_type: str = "application/octet-stream"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.payload, bytes):
+            raise TypeError("payload must be bytes")
+        if not self.payload:
+            raise ValueError("payload must not be empty")
+        if not self.content_type:
+            raise ValueError("content_type must not be empty")
+
+    @property
+    def digest(self) -> str:
+        return sha256(self.payload).hexdigest()
+
+    @property
+    def size_bytes(self) -> int:
+        return len(self.payload)
+
+    def descriptor(self) -> dict[str, str | int]:
+        return {
+            "kind": self.kind.value,
+            "content_type": self.content_type,
+            "sha256": self.digest,
+            "size_bytes": self.size_bytes,
+        }

--- a/src/jarvisx/cloud/operational.py
+++ b/src/jarvisx/cloud/operational.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from hashlib import sha256
 from pathlib import Path
 
 from .extent import HierarchicalAddress, SymbolicParameterExtent
 from .multimodal import MediaEnvelope
 from .persistence import JobRecord, SQLiteStateStore
 from .routing import ShardCoordinate, SpatialShardRouter
+from .topology import PlacementDecision, TopologyScheduler
 
 
 @dataclass
@@ -17,6 +19,7 @@ class OperationalHyperCloud:
     extent: SymbolicParameterExtent = field(default_factory=SymbolicParameterExtent)
     router: SpatialShardRouter = field(default_factory=SpatialShardRouter)
     state: SQLiteStateStore | None = None
+    scheduler: TopologyScheduler = field(default_factory=TopologyScheduler)
 
     def __post_init__(self) -> None:
         if self.state is None:
@@ -49,6 +52,23 @@ class OperationalHyperCloud:
         address.validate(radix=self.extent.address_radix)
         return self.router.route(namespace=namespace, modality=modality, address=address)
 
+    def _address_for_key(self, key: str) -> HierarchicalAddress:
+        digest = sha256(key.encode("utf-8")).digest()
+        digits = tuple(
+            int.from_bytes(digest[offset : offset + 4], "big") % self.extent.address_radix
+            for offset in range(0, 24, 4)
+        )
+        address = HierarchicalAddress(digits)
+        address.validate(radix=self.extent.address_radix)
+        return address
+
+    def _job_target(self, *, namespace: str, modality: str, key: str) -> ShardCoordinate:
+        return self.route(
+            namespace=namespace,
+            modality=modality,
+            address=self._address_for_key(key),
+        )
+
     def set_parameter(self, namespace: str, address: HierarchicalAddress, value: float) -> None:
         address.validate(radix=self.extent.address_radix)
         assert self.state is not None
@@ -67,34 +87,60 @@ class OperationalHyperCloud:
 
     def enqueue_codec(self, namespace: str, digest: str) -> JobRecord:
         assert self.state is not None
-        if self.state.media_record(namespace, digest) is None:
+        record = self.state.media_record(namespace, digest)
+        if record is None:
             raise KeyError(digest)
-        return self.state.create_job(namespace, "codec_roundtrip", {"media_sha256": digest})
+        modality = str(record["kind"])
+        target = self._job_target(namespace=namespace, modality=modality, key=digest)
+        return self.state.create_job(
+            namespace,
+            "codec_roundtrip",
+            {"media_sha256": digest},
+            target=target,
+        )
 
     def enqueue_chat(self, namespace: str, prompt: str, system: str | None = None) -> JobRecord:
         if not prompt.strip():
             raise ValueError("prompt must not be empty")
         assert self.state is not None
+        key = f"{system or ''}\x1f{prompt}"
+        target = self._job_target(namespace=namespace, modality="text", key=key)
         return self.state.create_job(
             namespace,
             "chat",
             {"prompt": prompt, "system": system},
+            target=target,
         )
 
     def job(self, job_id: str) -> JobRecord | None:
         assert self.state is not None
         return self.state.get_job(job_id)
 
+    def placement_preview(self, job_id: str, *, worker_ttl_seconds: float = 30.0) -> PlacementDecision | None:
+        assert self.state is not None
+        job = self.state.get_job(job_id)
+        if job is None or job.target is None:
+            return None
+        capability = "chat" if job.operation == "chat" else "codec"
+        return self.scheduler.choose(
+            target=job.target,
+            workers=self.state.active_workers(ttl_seconds=worker_ttl_seconds),
+            capability=capability,
+        )
+
     def describe(self, *, backend_name: str | None = None) -> dict[str, object]:
         assert self.state is not None
         external_model_backend = bool(os.getenv("JARVISX_MODEL_BASE_URL", "").strip())
+        worker_ttl = float(os.getenv("JARVISX_WORKER_TTL_SECONDS", "30"))
+        workers = self.state.active_workers(ttl_seconds=worker_ttl)
         return {
             "runtime": "jarvisx-3d-hypercloud",
-            "status": "operational-reference",
+            "status": "operational-permeated",
             "virtual_parameter_extent": self.extent.metadata(),
             "deployment_lattice": {
                 "shape": self.router.shape,
                 "shards": self.router.shard_count,
+                "active_workers": len(workers),
             },
             "materialized_parameters": self.state.parameter_count(),
             "ingested_media_objects": self.state.media_count(),
@@ -104,6 +150,9 @@ class OperationalHyperCloud:
                 "dense_parameter_allocation": False,
                 "durable_local_state": True,
                 "persistent_job_queue": True,
+                "leased_worker_execution": True,
+                "abandoned_job_recovery": True,
+                "topology_aware_3d_placement": True,
                 "lossless_multimodal_codec": True,
                 "openai_compatible_model_adapter": True,
                 "external_model_backend_configured": external_model_backend,

--- a/src/jarvisx/cloud/operational.py
+++ b/src/jarvisx/cloud/operational.py
@@ -87,6 +87,7 @@ class OperationalHyperCloud:
 
     def describe(self, *, backend_name: str | None = None) -> dict[str, object]:
         assert self.state is not None
+        external_model_backend = bool(os.getenv("JARVISX_MODEL_BASE_URL", "").strip())
         return {
             "runtime": "jarvisx-3d-hypercloud",
             "status": "operational-reference",
@@ -105,9 +106,8 @@ class OperationalHyperCloud:
                 "persistent_job_queue": True,
                 "lossless_multimodal_codec": True,
                 "openai_compatible_model_adapter": True,
-                "distributed_accelerator_backend": bool(
-                    os.getenv("JARVISX_MODEL_BASE_URL", "").strip()
-                ),
+                "external_model_backend_configured": external_model_backend,
+                "distributed_accelerator_backend": False,
                 "deterministic_3d_routing": True,
             },
         }

--- a/src/jarvisx/cloud/operational.py
+++ b/src/jarvisx/cloud/operational.py
@@ -1,0 +1,113 @@
+"""Operational service layer combining virtual routing with durable state."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .extent import HierarchicalAddress, SymbolicParameterExtent
+from .multimodal import MediaEnvelope
+from .persistence import JobRecord, SQLiteStateStore
+from .routing import ShardCoordinate, SpatialShardRouter
+
+
+@dataclass
+class OperationalHyperCloud:
+    extent: SymbolicParameterExtent = field(default_factory=SymbolicParameterExtent)
+    router: SpatialShardRouter = field(default_factory=SpatialShardRouter)
+    state: SQLiteStateStore | None = None
+
+    def __post_init__(self) -> None:
+        if self.state is None:
+            self.state = SQLiteStateStore(":memory:", ".jarvisx-hypercloud-objects")
+
+    @classmethod
+    def from_environment(cls) -> "OperationalHyperCloud":
+        database = os.getenv("JARVISX_STATE_DB", "/tmp/jarvisx-hypercloud/state.db")
+        object_root = os.getenv("JARVISX_OBJECT_ROOT", "/tmp/jarvisx-hypercloud/objects")
+        shape_text = os.getenv("JARVISX_LATTICE_SHAPE", "16,16,16")
+        parts = tuple(int(part.strip()) for part in shape_text.split(","))
+        if len(parts) != 3 or any(part <= 0 for part in parts):
+            raise RuntimeError("JARVISX_LATTICE_SHAPE must contain three positive integers")
+        Path(database).parent.mkdir(parents=True, exist_ok=True)
+        Path(object_root).mkdir(parents=True, exist_ok=True)
+        return cls(
+            router=SpatialShardRouter(shape=parts),
+            state=SQLiteStateStore(database, object_root),
+        )
+
+    def route(
+        self,
+        *,
+        namespace: str,
+        modality: str,
+        address: HierarchicalAddress,
+    ) -> ShardCoordinate:
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        address.validate(radix=self.extent.address_radix)
+        return self.router.route(namespace=namespace, modality=modality, address=address)
+
+    def set_parameter(self, namespace: str, address: HierarchicalAddress, value: float) -> None:
+        address.validate(radix=self.extent.address_radix)
+        assert self.state is not None
+        self.state.set_parameter(namespace, address.canonical(), value)
+
+    def get_parameter(self, namespace: str, address: HierarchicalAddress) -> float | None:
+        address.validate(radix=self.extent.address_radix)
+        assert self.state is not None
+        return self.state.get_parameter(namespace, address.canonical())
+
+    def ingest(self, namespace: str, media: MediaEnvelope) -> dict[str, str | int | float]:
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        assert self.state is not None
+        return self.state.put_media(namespace, media)
+
+    def enqueue_codec(self, namespace: str, digest: str) -> JobRecord:
+        assert self.state is not None
+        if self.state.media_record(digest) is None:
+            raise KeyError(digest)
+        return self.state.create_job(namespace, "codec_roundtrip", {"media_sha256": digest})
+
+    def enqueue_chat(self, namespace: str, prompt: str, system: str | None = None) -> JobRecord:
+        if not prompt.strip():
+            raise ValueError("prompt must not be empty")
+        assert self.state is not None
+        return self.state.create_job(
+            namespace,
+            "chat",
+            {"prompt": prompt, "system": system},
+        )
+
+    def job(self, job_id: str) -> JobRecord | None:
+        assert self.state is not None
+        return self.state.get_job(job_id)
+
+    def describe(self, *, backend_name: str | None = None) -> dict[str, object]:
+        assert self.state is not None
+        return {
+            "runtime": "jarvisx-3d-hypercloud",
+            "status": "operational-reference",
+            "virtual_parameter_extent": self.extent.metadata(),
+            "deployment_lattice": {
+                "shape": self.router.shape,
+                "shards": self.router.shard_count,
+            },
+            "materialized_parameters": self.state.parameter_count(),
+            "ingested_media_objects": self.state.media_count(),
+            "jobs": self.state.job_counts(),
+            "chat_backend": backend_name,
+            "claims": {
+                "dense_parameter_allocation": False,
+                "durable_local_state": True,
+                "persistent_job_queue": True,
+                "lossless_multimodal_codec": True,
+                "openai_compatible_model_adapter": True,
+                "distributed_accelerator_backend": bool(
+                    os.getenv("JARVISX_MODEL_BASE_URL", "").strip()
+                ),
+                "deterministic_3d_routing": True,
+            },
+        }

--- a/src/jarvisx/cloud/operational.py
+++ b/src/jarvisx/cloud/operational.py
@@ -116,7 +116,12 @@ class OperationalHyperCloud:
         assert self.state is not None
         return self.state.get_job(job_id)
 
-    def placement_preview(self, job_id: str, *, worker_ttl_seconds: float = 30.0) -> PlacementDecision | None:
+    def placement_preview(
+        self,
+        job_id: str,
+        *,
+        worker_ttl_seconds: float = 30.0,
+    ) -> PlacementDecision | None:
         assert self.state is not None
         job = self.state.get_job(job_id)
         if job is None or job.target is None:
@@ -151,6 +156,7 @@ class OperationalHyperCloud:
                 "durable_local_state": True,
                 "persistent_job_queue": True,
                 "leased_worker_execution": True,
+                "renewable_worker_leases": True,
                 "abandoned_job_recovery": True,
                 "topology_aware_3d_placement": True,
                 "lossless_multimodal_codec": True,

--- a/src/jarvisx/cloud/operational.py
+++ b/src/jarvisx/cloud/operational.py
@@ -67,7 +67,7 @@ class OperationalHyperCloud:
 
     def enqueue_codec(self, namespace: str, digest: str) -> JobRecord:
         assert self.state is not None
-        if self.state.media_record(digest) is None:
+        if self.state.media_record(namespace, digest) is None:
             raise KeyError(digest)
         return self.state.create_job(namespace, "codec_roundtrip", {"media_sha256": digest})
 

--- a/src/jarvisx/cloud/persistence.py
+++ b/src/jarvisx/cloud/persistence.py
@@ -80,13 +80,14 @@ class SQLiteStateStore:
             );
 
             CREATE TABLE IF NOT EXISTS media (
-                digest TEXT PRIMARY KEY,
                 namespace TEXT NOT NULL,
+                digest TEXT NOT NULL,
                 kind TEXT NOT NULL,
                 content_type TEXT NOT NULL,
                 size_bytes INTEGER NOT NULL,
                 object_path TEXT NOT NULL,
-                created_at REAL NOT NULL
+                created_at REAL NOT NULL,
+                PRIMARY KEY(namespace, digest)
             );
 
             CREATE TABLE IF NOT EXISTS jobs (
@@ -103,6 +104,8 @@ class SQLiteStateStore:
 
             CREATE INDEX IF NOT EXISTS jobs_status_created_idx
                 ON jobs(status, created_at);
+            CREATE INDEX IF NOT EXISTS media_digest_idx
+                ON media(digest);
             """
         )
         self._connection.commit()
@@ -153,17 +156,17 @@ class SQLiteStateStore:
         with self._lock:
             self._connection.execute(
                 """
-                INSERT INTO media(digest, namespace, kind, content_type, size_bytes, object_path, created_at)
+                INSERT INTO media(namespace, digest, kind, content_type, size_bytes, object_path, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(digest) DO UPDATE SET
-                    namespace = excluded.namespace,
+                ON CONFLICT(namespace, digest) DO UPDATE SET
                     kind = excluded.kind,
                     content_type = excluded.content_type,
-                    size_bytes = excluded.size_bytes
+                    size_bytes = excluded.size_bytes,
+                    object_path = excluded.object_path
                 """,
                 (
-                    digest,
                     namespace,
+                    digest,
                     media.kind.value,
                     media.content_type,
                     media.size_bytes,
@@ -172,16 +175,16 @@ class SQLiteStateStore:
                 ),
             )
             self._connection.commit()
-        return self.media_record(digest) or {}
+        return self.media_record(namespace, digest) or {}
 
-    def media_record(self, digest: str) -> dict[str, str | int | float] | None:
+    def media_record(self, namespace: str, digest: str) -> dict[str, str | int | float] | None:
         with self._lock:
             row = self._connection.execute(
                 """
                 SELECT digest, namespace, kind, content_type, size_bytes, created_at
-                FROM media WHERE digest=?
+                FROM media WHERE namespace=? AND digest=?
                 """,
-                (digest,),
+                (namespace, digest),
             ).fetchone()
         if row is None:
             return None
@@ -194,11 +197,14 @@ class SQLiteStateStore:
             "created_at": float(row["created_at"]),
         }
 
-    def get_media(self, digest: str) -> MediaEnvelope | None:
+    def get_media(self, namespace: str, digest: str) -> MediaEnvelope | None:
         with self._lock:
             row = self._connection.execute(
-                "SELECT kind, content_type, object_path FROM media WHERE digest=?",
-                (digest,),
+                """
+                SELECT kind, content_type, object_path
+                FROM media WHERE namespace=? AND digest=?
+                """,
+                (namespace, digest),
             ).fetchone()
         if row is None:
             return None

--- a/src/jarvisx/cloud/persistence.py
+++ b/src/jarvisx/cloud/persistence.py
@@ -1,7 +1,7 @@
 """Durable state for the operational HyperCloud reference deployment.
 
 SQLite/WAL remains the zero-dependency single-node state backend. The schema
-also models worker registration, topology coordinates and expiring job leases
+also models worker registration, topology coordinates and renewable job leases
 so the same service contract can be moved to a distributed database later.
 """
 
@@ -135,7 +135,6 @@ class SQLiteStateStore:
                 ON workers(last_seen);
             """
         )
-        # Forward-compatible migration for databases created by HyperCloud 0.2.
         self._ensure_column("jobs", "target_x", "INTEGER")
         self._ensure_column("jobs", "target_y", "INTEGER")
         self._ensure_column("jobs", "target_z", "INTEGER")
@@ -285,6 +284,7 @@ class SQLiteStateStore:
         if not normalized:
             raise ValueError("worker requires at least one capability")
         now = time.time()
+        bounded_load = min(1.0, max(0.0, float(load)))
         with self._lock:
             self._connection.execute(
                 """
@@ -302,12 +302,12 @@ class SQLiteStateStore:
                     coordinate.z,
                     json.dumps(normalized),
                     backend,
-                    min(1.0, max(0.0, float(load))),
+                    bounded_load,
                     now,
                 ),
             )
             self._connection.commit()
-        return WorkerDescriptor(worker_id, coordinate, normalized, backend, float(load), now)
+        return WorkerDescriptor(worker_id, coordinate, normalized, backend, bounded_load, now)
 
     def heartbeat_worker(self, worker_id: str, *, load: float) -> bool:
         with self._lock:
@@ -355,7 +355,7 @@ class SQLiteStateStore:
             raise ValueError("max_attempts must be positive")
         job_id = uuid.uuid4().hex
         now = time.time()
-        target_values = (None, None, None)
+        target_values: tuple[int | None, int | None, int | None] = (None, None, None)
         if target is not None:
             target_values = (target.x, target.y, target.z)
         with self._lock:
@@ -474,7 +474,29 @@ class SQLiteStateStore:
                 raise
         return self.get_job(str(selected["id"]))
 
-    def complete_job(self, job_id: str, result: dict[str, Any], *, worker_id: str | None = None) -> bool:
+    def renew_job_lease(self, job_id: str, *, worker_id: str, lease_seconds: float) -> bool:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        now = time.time()
+        with self._lock:
+            cursor = self._connection.execute(
+                """
+                UPDATE jobs
+                SET lease_expires_at=?, updated_at=?
+                WHERE id=? AND status='running' AND lease_owner=?
+                """,
+                (now + lease_seconds, now, job_id, worker_id),
+            )
+            self._connection.commit()
+            return cursor.rowcount == 1
+
+    def complete_job(
+        self,
+        job_id: str,
+        result: dict[str, Any],
+        *,
+        worker_id: str | None = None,
+    ) -> bool:
         query = (
             "UPDATE jobs SET status='succeeded', result_json=?, error=NULL, "
             "lease_owner=NULL, lease_expires_at=NULL, updated_at=? WHERE id=? AND status='running'"

--- a/src/jarvisx/cloud/persistence.py
+++ b/src/jarvisx/cloud/persistence.py
@@ -1,9 +1,8 @@
-"""Durable local state for the operational HyperCloud reference deployment.
+"""Durable state for the operational HyperCloud reference deployment.
 
-SQLite in WAL mode gives the single-host/container deployment transactional
-persistence without introducing a service dependency. Horizontal production
-scale should replace this adapter with a distributed database/object store;
-the public service contract intentionally does not depend on SQLite details.
+SQLite/WAL remains the zero-dependency single-node state backend. The schema
+also models worker registration, topology coordinates and expiring job leases
+so the same service contract can be moved to a distributed database later.
 """
 
 from __future__ import annotations
@@ -15,9 +14,11 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from threading import RLock
-from typing import Any
+from typing import Any, Iterable
 
 from .multimodal import MediaEnvelope, MediaKind
+from .routing import ShardCoordinate
+from .topology import WorkerDescriptor, manhattan_distance
 
 
 @dataclass(frozen=True)
@@ -31,8 +32,16 @@ class JobRecord:
     error: str | None
     created_at: float
     updated_at: float
+    target: ShardCoordinate | None = None
+    lease_owner: str | None = None
+    lease_expires_at: float | None = None
+    attempts: int = 0
+    max_attempts: int = 3
 
     def as_dict(self) -> dict[str, Any]:
+        target = None
+        if self.target is not None:
+            target = {"x": self.target.x, "y": self.target.y, "z": self.target.z}
         return {
             "id": self.id,
             "namespace": self.namespace,
@@ -43,11 +52,16 @@ class JobRecord:
             "error": self.error,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
+            "target": target,
+            "lease_owner": self.lease_owner,
+            "lease_expires_at": self.lease_expires_at,
+            "attempts": self.attempts,
+            "max_attempts": self.max_attempts,
         }
 
 
 class SQLiteStateStore:
-    """Transactional parameter, media metadata and job persistence."""
+    """Transactional parameters, media, workers and leased jobs."""
 
     def __init__(self, database: str, object_root: str) -> None:
         self.database = database
@@ -102,13 +116,42 @@ class SQLiteStateStore:
                 updated_at REAL NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS workers (
+                worker_id TEXT PRIMARY KEY,
+                x INTEGER NOT NULL,
+                y INTEGER NOT NULL,
+                z INTEGER NOT NULL,
+                capabilities_json TEXT NOT NULL,
+                backend TEXT NOT NULL,
+                load REAL NOT NULL,
+                last_seen REAL NOT NULL
+            );
+
             CREATE INDEX IF NOT EXISTS jobs_status_created_idx
                 ON jobs(status, created_at);
             CREATE INDEX IF NOT EXISTS media_digest_idx
                 ON media(digest);
+            CREATE INDEX IF NOT EXISTS workers_last_seen_idx
+                ON workers(last_seen);
             """
         )
+        # Forward-compatible migration for databases created by HyperCloud 0.2.
+        self._ensure_column("jobs", "target_x", "INTEGER")
+        self._ensure_column("jobs", "target_y", "INTEGER")
+        self._ensure_column("jobs", "target_z", "INTEGER")
+        self._ensure_column("jobs", "lease_owner", "TEXT")
+        self._ensure_column("jobs", "lease_expires_at", "REAL")
+        self._ensure_column("jobs", "attempts", "INTEGER NOT NULL DEFAULT 0")
+        self._ensure_column("jobs", "max_attempts", "INTEGER NOT NULL DEFAULT 3")
         self._connection.commit()
+
+    def _ensure_column(self, table: str, name: str, definition: str) -> None:
+        columns = {
+            str(row["name"])
+            for row in self._connection.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        if name not in columns:
+            self._connection.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
 
     def ping(self) -> bool:
         with self._lock:
@@ -190,10 +233,10 @@ class SQLiteStateStore:
         if row is None:
             return None
         return {
-            "sha256": row["digest"],
-            "namespace": row["namespace"],
-            "kind": row["kind"],
-            "content_type": row["content_type"],
+            "sha256": str(row["digest"]),
+            "namespace": str(row["namespace"]),
+            "kind": str(row["kind"]),
+            "content_type": str(row["content_type"]),
             "size_bytes": int(row["size_bytes"]),
             "created_at": float(row["created_at"]),
         }
@@ -209,14 +252,14 @@ class SQLiteStateStore:
             ).fetchone()
         if row is None:
             return None
-        path = Path(row["object_path"])
+        path = Path(str(row["object_path"]))
         if not path.exists():
             raise FileNotFoundError(f"media object missing from object store: {digest}")
         payload = path.read_bytes()
         media = MediaEnvelope(
-            kind=MediaKind(row["kind"]),
+            kind=MediaKind(str(row["kind"])),
             payload=payload,
-            content_type=row["content_type"],
+            content_type=str(row["content_type"]),
         )
         if media.digest != digest:
             raise RuntimeError(f"media integrity check failed for {digest}")
@@ -226,17 +269,114 @@ class SQLiteStateStore:
         with self._lock:
             return int(self._connection.execute("SELECT COUNT(*) FROM media").fetchone()[0])
 
-    # ---- durable jobs ------------------------------------------------------
-    def create_job(self, namespace: str, operation: str, payload: dict[str, Any]) -> JobRecord:
-        job_id = uuid.uuid4().hex
+    # ---- worker topology ---------------------------------------------------
+    def register_worker(
+        self,
+        *,
+        worker_id: str,
+        coordinate: ShardCoordinate,
+        capabilities: Iterable[str],
+        backend: str,
+        load: float = 0.0,
+    ) -> WorkerDescriptor:
+        if not worker_id:
+            raise ValueError("worker_id must not be empty")
+        normalized = tuple(sorted(set(str(item) for item in capabilities if str(item))))
+        if not normalized:
+            raise ValueError("worker requires at least one capability")
         now = time.time()
         with self._lock:
             self._connection.execute(
                 """
-                INSERT INTO jobs(id, namespace, operation, status, input_json, created_at, updated_at)
-                VALUES (?, ?, ?, 'queued', ?, ?, ?)
+                INSERT INTO workers(worker_id, x, y, z, capabilities_json, backend, load, last_seen)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(worker_id) DO UPDATE SET
+                    x=excluded.x, y=excluded.y, z=excluded.z,
+                    capabilities_json=excluded.capabilities_json,
+                    backend=excluded.backend, load=excluded.load, last_seen=excluded.last_seen
                 """,
-                (job_id, namespace, operation, json.dumps(payload, sort_keys=True), now, now),
+                (
+                    worker_id,
+                    coordinate.x,
+                    coordinate.y,
+                    coordinate.z,
+                    json.dumps(normalized),
+                    backend,
+                    min(1.0, max(0.0, float(load))),
+                    now,
+                ),
+            )
+            self._connection.commit()
+        return WorkerDescriptor(worker_id, coordinate, normalized, backend, float(load), now)
+
+    def heartbeat_worker(self, worker_id: str, *, load: float) -> bool:
+        with self._lock:
+            cursor = self._connection.execute(
+                "UPDATE workers SET load=?, last_seen=? WHERE worker_id=?",
+                (min(1.0, max(0.0, float(load))), time.time(), worker_id),
+            )
+            self._connection.commit()
+            return cursor.rowcount == 1
+
+    def active_workers(self, *, ttl_seconds: float = 30.0) -> list[WorkerDescriptor]:
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be positive")
+        cutoff = time.time() - ttl_seconds
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT * FROM workers WHERE last_seen>=? ORDER BY worker_id", (cutoff,)
+            ).fetchall()
+        workers: list[WorkerDescriptor] = []
+        for row in rows:
+            capabilities = tuple(str(item) for item in json.loads(str(row["capabilities_json"])))
+            workers.append(
+                WorkerDescriptor(
+                    worker_id=str(row["worker_id"]),
+                    coordinate=ShardCoordinate(int(row["x"]), int(row["y"]), int(row["z"])),
+                    capabilities=capabilities,
+                    backend=str(row["backend"]),
+                    load=float(row["load"]),
+                    last_seen=float(row["last_seen"]),
+                )
+            )
+        return workers
+
+    # ---- durable leased jobs ----------------------------------------------
+    def create_job(
+        self,
+        namespace: str,
+        operation: str,
+        payload: dict[str, Any],
+        *,
+        target: ShardCoordinate | None = None,
+        max_attempts: int = 3,
+    ) -> JobRecord:
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be positive")
+        job_id = uuid.uuid4().hex
+        now = time.time()
+        target_values = (None, None, None)
+        if target is not None:
+            target_values = (target.x, target.y, target.z)
+        with self._lock:
+            self._connection.execute(
+                """
+                INSERT INTO jobs(
+                    id, namespace, operation, status, input_json,
+                    created_at, updated_at, target_x, target_y, target_z,
+                    attempts, max_attempts
+                ) VALUES (?, ?, ?, 'queued', ?, ?, ?, ?, ?, ?, 0, ?)
+                """,
+                (
+                    job_id,
+                    namespace,
+                    operation,
+                    json.dumps(payload, sort_keys=True),
+                    now,
+                    now,
+                    *target_values,
+                    max_attempts,
+                ),
             )
             self._connection.commit()
         record = self.get_job(job_id)
@@ -248,22 +388,82 @@ class SQLiteStateStore:
             row = self._connection.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
         return None if row is None else self._job_from_row(row)
 
-    def claim_next_job(self) -> JobRecord | None:
-        """Atomically claim the oldest queued job for one worker."""
+    def requeue_expired_leases(self) -> int:
+        now = time.time()
+        with self._lock:
+            requeued = self._requeue_expired_locked(now)
+            self._connection.commit()
+        return requeued
+
+    def _requeue_expired_locked(self, now: float) -> int:
+        failed = self._connection.execute(
+            """
+            UPDATE jobs
+            SET status='failed', error='worker lease expired after maximum attempts',
+                lease_owner=NULL, lease_expires_at=NULL, updated_at=?
+            WHERE status='running' AND lease_expires_at IS NOT NULL
+              AND lease_expires_at<? AND attempts>=max_attempts
+            """,
+            (now, now),
+        ).rowcount
+        requeued = self._connection.execute(
+            """
+            UPDATE jobs
+            SET status='queued', lease_owner=NULL, lease_expires_at=NULL, updated_at=?
+            WHERE status='running' AND lease_expires_at IS NOT NULL
+              AND lease_expires_at<? AND attempts<max_attempts
+            """,
+            (now, now),
+        ).rowcount
+        return max(0, failed) + max(0, requeued)
+
+    def claim_next_job(
+        self,
+        *,
+        worker_id: str,
+        coordinate: ShardCoordinate,
+        operations: Iterable[str],
+        lease_seconds: float = 30.0,
+    ) -> JobRecord | None:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
+        allowed = tuple(sorted(set(str(item) for item in operations if str(item))))
+        if not allowed:
+            return None
+        placeholders = ",".join("?" for _ in allowed)
+        now = time.time()
         with self._lock:
             cursor = self._connection.cursor()
             try:
                 cursor.execute("BEGIN IMMEDIATE")
-                row = cursor.execute(
-                    "SELECT * FROM jobs WHERE status='queued' ORDER BY created_at LIMIT 1"
-                ).fetchone()
-                if row is None:
+                self._requeue_expired_locked(now)
+                rows = cursor.execute(
+                    f"""
+                    SELECT * FROM jobs
+                    WHERE status='queued' AND operation IN ({placeholders})
+                    ORDER BY created_at LIMIT 64
+                    """,
+                    allowed,
+                ).fetchall()
+                if not rows:
                     self._connection.commit()
                     return None
-                now = time.time()
+
+                def rank(row: sqlite3.Row) -> tuple[int, float, str]:
+                    target = self._target_from_row(row)
+                    distance = 0 if target is None else manhattan_distance(coordinate, target)
+                    return distance, float(row["created_at"]), str(row["id"])
+
+                selected = min(rows, key=rank)
+                lease_expires = now + lease_seconds
                 cursor.execute(
-                    "UPDATE jobs SET status='running', updated_at=? WHERE id=? AND status='queued'",
-                    (now, row["id"]),
+                    """
+                    UPDATE jobs
+                    SET status='running', lease_owner=?, lease_expires_at=?,
+                        attempts=attempts+1, updated_at=?
+                    WHERE id=? AND status='queued'
+                    """,
+                    (worker_id, lease_expires, now, selected["id"]),
                 )
                 if cursor.rowcount != 1:
                     self._connection.rollback()
@@ -272,33 +472,38 @@ class SQLiteStateStore:
             except Exception:
                 self._connection.rollback()
                 raise
-        return self.get_job(str(row["id"]))
+        return self.get_job(str(selected["id"]))
 
-    def complete_job(self, job_id: str, result: dict[str, Any]) -> None:
+    def complete_job(self, job_id: str, result: dict[str, Any], *, worker_id: str | None = None) -> bool:
+        query = (
+            "UPDATE jobs SET status='succeeded', result_json=?, error=NULL, "
+            "lease_owner=NULL, lease_expires_at=NULL, updated_at=? WHERE id=? AND status='running'"
+        )
+        params: tuple[object, ...] = (json.dumps(result, sort_keys=True), time.time(), job_id)
+        if worker_id is not None:
+            query += " AND lease_owner=?"
+            params = (*params, worker_id)
         with self._lock:
-            self._connection.execute(
-                """
-                UPDATE jobs
-                SET status='succeeded', result_json=?, error=NULL, updated_at=?
-                WHERE id=?
-                """,
-                (json.dumps(result, sort_keys=True), time.time(), job_id),
-            )
+            cursor = self._connection.execute(query, params)
             self._connection.commit()
+            return cursor.rowcount == 1
 
-    def fail_job(self, job_id: str, error: str) -> None:
+    def fail_job(self, job_id: str, error: str, *, worker_id: str | None = None) -> bool:
+        query = (
+            "UPDATE jobs SET status='failed', error=?, lease_owner=NULL, "
+            "lease_expires_at=NULL, updated_at=? WHERE id=? AND status='running'"
+        )
+        params: tuple[object, ...] = (error[:4000], time.time(), job_id)
+        if worker_id is not None:
+            query += " AND lease_owner=?"
+            params = (*params, worker_id)
         with self._lock:
-            self._connection.execute(
-                """
-                UPDATE jobs
-                SET status='failed', error=?, updated_at=?
-                WHERE id=?
-                """,
-                (error[:4000], time.time(), job_id),
-            )
+            cursor = self._connection.execute(query, params)
             self._connection.commit()
+            return cursor.rowcount == 1
 
     def job_counts(self) -> dict[str, int]:
+        self.requeue_expired_leases()
         counts = {"queued": 0, "running": 0, "succeeded": 0, "failed": 0}
         with self._lock:
             rows = self._connection.execute(
@@ -309,15 +514,28 @@ class SQLiteStateStore:
         return counts
 
     @staticmethod
-    def _job_from_row(row: sqlite3.Row) -> JobRecord:
+    def _target_from_row(row: sqlite3.Row) -> ShardCoordinate | None:
+        if row["target_x"] is None or row["target_y"] is None or row["target_z"] is None:
+            return None
+        return ShardCoordinate(int(row["target_x"]), int(row["target_y"]), int(row["target_z"]))
+
+    @classmethod
+    def _job_from_row(cls, row: sqlite3.Row) -> JobRecord:
         return JobRecord(
             id=str(row["id"]),
             namespace=str(row["namespace"]),
             operation=str(row["operation"]),
             status=str(row["status"]),
-            input=json.loads(row["input_json"]),
-            result=None if row["result_json"] is None else json.loads(row["result_json"]),
+            input=json.loads(str(row["input_json"])),
+            result=None if row["result_json"] is None else json.loads(str(row["result_json"])),
             error=None if row["error"] is None else str(row["error"]),
             created_at=float(row["created_at"]),
             updated_at=float(row["updated_at"]),
+            target=cls._target_from_row(row),
+            lease_owner=None if row["lease_owner"] is None else str(row["lease_owner"]),
+            lease_expires_at=(
+                None if row["lease_expires_at"] is None else float(row["lease_expires_at"])
+            ),
+            attempts=int(row["attempts"]),
+            max_attempts=int(row["max_attempts"]),
         )

--- a/src/jarvisx/cloud/persistence.py
+++ b/src/jarvisx/cloud/persistence.py
@@ -1,0 +1,316 @@
+"""Durable local state for the operational HyperCloud reference deployment.
+
+SQLite in WAL mode gives the single-host/container deployment transactional
+persistence without introducing a service dependency. Horizontal production
+scale should replace this adapter with a distributed database/object store;
+the public service contract intentionally does not depend on SQLite details.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import Any
+
+from .multimodal import MediaEnvelope, MediaKind
+
+
+@dataclass(frozen=True)
+class JobRecord:
+    id: str
+    namespace: str
+    operation: str
+    status: str
+    input: dict[str, Any]
+    result: dict[str, Any] | None
+    error: str | None
+    created_at: float
+    updated_at: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "namespace": self.namespace,
+            "operation": self.operation,
+            "status": self.status,
+            "input": self.input,
+            "result": self.result,
+            "error": self.error,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class SQLiteStateStore:
+    """Transactional parameter, media metadata and job persistence."""
+
+    def __init__(self, database: str, object_root: str) -> None:
+        self.database = database
+        self.object_root = Path(object_root)
+        self.object_root.mkdir(parents=True, exist_ok=True)
+        if database != ":memory:":
+            Path(database).parent.mkdir(parents=True, exist_ok=True)
+        self._lock = RLock()
+        self._connection = sqlite3.connect(database, check_same_thread=False, timeout=30.0)
+        self._connection.row_factory = sqlite3.Row
+        with self._lock:
+            self._connection.execute("PRAGMA journal_mode=WAL")
+            self._connection.execute("PRAGMA synchronous=NORMAL")
+            self._connection.execute("PRAGMA foreign_keys=ON")
+            self._initialize()
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+    def _initialize(self) -> None:
+        self._connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS parameters (
+                namespace TEXT NOT NULL,
+                address TEXT NOT NULL,
+                value REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                PRIMARY KEY(namespace, address)
+            );
+
+            CREATE TABLE IF NOT EXISTS media (
+                digest TEXT PRIMARY KEY,
+                namespace TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                content_type TEXT NOT NULL,
+                size_bytes INTEGER NOT NULL,
+                object_path TEXT NOT NULL,
+                created_at REAL NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS jobs (
+                id TEXT PRIMARY KEY,
+                namespace TEXT NOT NULL,
+                operation TEXT NOT NULL,
+                status TEXT NOT NULL,
+                input_json TEXT NOT NULL,
+                result_json TEXT,
+                error TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS jobs_status_created_idx
+                ON jobs(status, created_at);
+            """
+        )
+        self._connection.commit()
+
+    def ping(self) -> bool:
+        with self._lock:
+            return self._connection.execute("SELECT 1").fetchone()[0] == 1
+
+    # ---- sparse parameters -------------------------------------------------
+    def set_parameter(self, namespace: str, address: str, value: float) -> None:
+        now = time.time()
+        with self._lock:
+            self._connection.execute(
+                """
+                INSERT INTO parameters(namespace, address, value, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(namespace, address) DO UPDATE SET
+                    value = excluded.value,
+                    updated_at = excluded.updated_at
+                """,
+                (namespace, address, float(value), now),
+            )
+            self._connection.commit()
+
+    def get_parameter(self, namespace: str, address: str) -> float | None:
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT value FROM parameters WHERE namespace=? AND address=?",
+                (namespace, address),
+            ).fetchone()
+        return None if row is None else float(row["value"])
+
+    def parameter_count(self) -> int:
+        with self._lock:
+            return int(self._connection.execute("SELECT COUNT(*) FROM parameters").fetchone()[0])
+
+    # ---- content-addressed multimedia -------------------------------------
+    def put_media(self, namespace: str, media: MediaEnvelope) -> dict[str, str | int | float]:
+        digest = media.digest
+        target = self.object_root / digest[:2] / digest[2:4] / digest
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if not target.exists():
+            temporary = target.with_suffix(f".{uuid.uuid4().hex}.tmp")
+            temporary.write_bytes(media.payload)
+            temporary.replace(target)
+
+        now = time.time()
+        with self._lock:
+            self._connection.execute(
+                """
+                INSERT INTO media(digest, namespace, kind, content_type, size_bytes, object_path, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(digest) DO UPDATE SET
+                    namespace = excluded.namespace,
+                    kind = excluded.kind,
+                    content_type = excluded.content_type,
+                    size_bytes = excluded.size_bytes
+                """,
+                (
+                    digest,
+                    namespace,
+                    media.kind.value,
+                    media.content_type,
+                    media.size_bytes,
+                    str(target),
+                    now,
+                ),
+            )
+            self._connection.commit()
+        return self.media_record(digest) or {}
+
+    def media_record(self, digest: str) -> dict[str, str | int | float] | None:
+        with self._lock:
+            row = self._connection.execute(
+                """
+                SELECT digest, namespace, kind, content_type, size_bytes, created_at
+                FROM media WHERE digest=?
+                """,
+                (digest,),
+            ).fetchone()
+        if row is None:
+            return None
+        return {
+            "sha256": row["digest"],
+            "namespace": row["namespace"],
+            "kind": row["kind"],
+            "content_type": row["content_type"],
+            "size_bytes": int(row["size_bytes"]),
+            "created_at": float(row["created_at"]),
+        }
+
+    def get_media(self, digest: str) -> MediaEnvelope | None:
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT kind, content_type, object_path FROM media WHERE digest=?",
+                (digest,),
+            ).fetchone()
+        if row is None:
+            return None
+        path = Path(row["object_path"])
+        if not path.exists():
+            raise FileNotFoundError(f"media object missing from object store: {digest}")
+        payload = path.read_bytes()
+        media = MediaEnvelope(
+            kind=MediaKind(row["kind"]),
+            payload=payload,
+            content_type=row["content_type"],
+        )
+        if media.digest != digest:
+            raise RuntimeError(f"media integrity check failed for {digest}")
+        return media
+
+    def media_count(self) -> int:
+        with self._lock:
+            return int(self._connection.execute("SELECT COUNT(*) FROM media").fetchone()[0])
+
+    # ---- durable jobs ------------------------------------------------------
+    def create_job(self, namespace: str, operation: str, payload: dict[str, Any]) -> JobRecord:
+        job_id = uuid.uuid4().hex
+        now = time.time()
+        with self._lock:
+            self._connection.execute(
+                """
+                INSERT INTO jobs(id, namespace, operation, status, input_json, created_at, updated_at)
+                VALUES (?, ?, ?, 'queued', ?, ?, ?)
+                """,
+                (job_id, namespace, operation, json.dumps(payload, sort_keys=True), now, now),
+            )
+            self._connection.commit()
+        record = self.get_job(job_id)
+        assert record is not None
+        return record
+
+    def get_job(self, job_id: str) -> JobRecord | None:
+        with self._lock:
+            row = self._connection.execute("SELECT * FROM jobs WHERE id=?", (job_id,)).fetchone()
+        return None if row is None else self._job_from_row(row)
+
+    def claim_next_job(self) -> JobRecord | None:
+        """Atomically claim the oldest queued job for one worker."""
+        with self._lock:
+            cursor = self._connection.cursor()
+            try:
+                cursor.execute("BEGIN IMMEDIATE")
+                row = cursor.execute(
+                    "SELECT * FROM jobs WHERE status='queued' ORDER BY created_at LIMIT 1"
+                ).fetchone()
+                if row is None:
+                    self._connection.commit()
+                    return None
+                now = time.time()
+                cursor.execute(
+                    "UPDATE jobs SET status='running', updated_at=? WHERE id=? AND status='queued'",
+                    (now, row["id"]),
+                )
+                if cursor.rowcount != 1:
+                    self._connection.rollback()
+                    return None
+                self._connection.commit()
+            except Exception:
+                self._connection.rollback()
+                raise
+        return self.get_job(str(row["id"]))
+
+    def complete_job(self, job_id: str, result: dict[str, Any]) -> None:
+        with self._lock:
+            self._connection.execute(
+                """
+                UPDATE jobs
+                SET status='succeeded', result_json=?, error=NULL, updated_at=?
+                WHERE id=?
+                """,
+                (json.dumps(result, sort_keys=True), time.time(), job_id),
+            )
+            self._connection.commit()
+
+    def fail_job(self, job_id: str, error: str) -> None:
+        with self._lock:
+            self._connection.execute(
+                """
+                UPDATE jobs
+                SET status='failed', error=?, updated_at=?
+                WHERE id=?
+                """,
+                (error[:4000], time.time(), job_id),
+            )
+            self._connection.commit()
+
+    def job_counts(self) -> dict[str, int]:
+        counts = {"queued": 0, "running": 0, "succeeded": 0, "failed": 0}
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT status, COUNT(*) AS count FROM jobs GROUP BY status"
+            ).fetchall()
+        for row in rows:
+            counts[str(row["status"])] = int(row["count"])
+        return counts
+
+    @staticmethod
+    def _job_from_row(row: sqlite3.Row) -> JobRecord:
+        return JobRecord(
+            id=str(row["id"]),
+            namespace=str(row["namespace"]),
+            operation=str(row["operation"]),
+            status=str(row["status"]),
+            input=json.loads(row["input_json"]),
+            result=None if row["result_json"] is None else json.loads(row["result_json"]),
+            error=None if row["error"] is None else str(row["error"]),
+            created_at=float(row["created_at"]),
+            updated_at=float(row["updated_at"]),
+        )

--- a/src/jarvisx/cloud/persistence.py
+++ b/src/jarvisx/cloud/persistence.py
@@ -112,7 +112,8 @@ class SQLiteStateStore:
 
     def ping(self) -> bool:
         with self._lock:
-            return self._connection.execute("SELECT 1").fetchone()[0] == 1
+            row = self._connection.execute("SELECT 1").fetchone()
+        return row is not None and int(row[0]) == 1
 
     # ---- sparse parameters -------------------------------------------------
     def set_parameter(self, namespace: str, address: str, value: float) -> None:

--- a/src/jarvisx/cloud/routing.py
+++ b/src/jarvisx/cloud/routing.py
@@ -1,0 +1,52 @@
+"""Deterministic 3D shard routing for sparse cloud state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import blake2b
+
+from .extent import HierarchicalAddress
+
+
+@dataclass(frozen=True)
+class ShardCoordinate:
+    x: int
+    y: int
+    z: int
+
+
+@dataclass(frozen=True)
+class SpatialShardRouter:
+    """Map logical addresses onto a finite 3D deployment lattice.
+
+    The lattice describes deployed workers/shards, not the full symbolic model
+    extent. Rendezvous-style rebalancing can be added later; this reference
+    router prioritizes deterministic reproducibility and bounded arithmetic.
+    """
+
+    shape: tuple[int, int, int] = (16, 16, 16)
+
+    def __post_init__(self) -> None:
+        if len(self.shape) != 3 or any(axis <= 0 for axis in self.shape):
+            raise ValueError("shape must contain three positive dimensions")
+
+    @property
+    def shard_count(self) -> int:
+        x, y, z = self.shape
+        return x * y * z
+
+    def route(
+        self,
+        *,
+        namespace: str,
+        modality: str,
+        address: HierarchicalAddress,
+    ) -> ShardCoordinate:
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        payload = f"{namespace}|{modality}|{address.canonical()}".encode("utf-8")
+        digest = blake2b(payload, digest_size=24, person=b"jarvisx-cloud").digest()
+        a = int.from_bytes(digest[0:8], "big")
+        b = int.from_bytes(digest[8:16], "big")
+        c = int.from_bytes(digest[16:24], "big")
+        return ShardCoordinate(a % self.shape[0], b % self.shape[1], c % self.shape[2])

--- a/src/jarvisx/cloud/runtime.py
+++ b/src/jarvisx/cloud/runtime.py
@@ -1,0 +1,101 @@
+"""Sparse multimodal HyperCloud runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from threading import RLock
+
+from .extent import HierarchicalAddress, SymbolicParameterExtent
+from .multimodal import MediaEnvelope
+from .routing import ShardCoordinate, SpatialShardRouter
+
+
+@dataclass
+class SparseParameterStore:
+    """Thread-safe materialized subset of a symbolic parameter space."""
+
+    extent: SymbolicParameterExtent = field(default_factory=SymbolicParameterExtent)
+    _values: dict[tuple[str, str], float] = field(default_factory=dict, init=False, repr=False)
+    _lock: RLock = field(default_factory=RLock, init=False, repr=False)
+
+    def set(self, namespace: str, address: HierarchicalAddress, value: float) -> None:
+        address.validate(radix=self.extent.address_radix)
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        key = (namespace, address.canonical())
+        with self._lock:
+            self._values[key] = float(value)
+
+    def get(self, namespace: str, address: HierarchicalAddress) -> float | None:
+        address.validate(radix=self.extent.address_radix)
+        key = (namespace, address.canonical())
+        with self._lock:
+            return self._values.get(key)
+
+    @property
+    def materialized_parameters(self) -> int:
+        with self._lock:
+            return len(self._values)
+
+
+@dataclass
+class HyperCloudRuntime:
+    """Reference control-plane runtime for sparse 3D multimodal execution.
+
+    It provides deterministic routing and bounded state materialization. Neural
+    kernels, distributed object stores, accelerator execution and model-specific
+    encoders/decoders attach behind this interface in later integration tracks.
+    """
+
+    extent: SymbolicParameterExtent = field(default_factory=SymbolicParameterExtent)
+    router: SpatialShardRouter = field(default_factory=SpatialShardRouter)
+    store: SparseParameterStore = field(init=False)
+    _media: dict[str, dict[str, str | int]] = field(default_factory=dict, init=False, repr=False)
+    _media_lock: RLock = field(default_factory=RLock, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self.store = SparseParameterStore(extent=self.extent)
+
+    def route(
+        self,
+        *,
+        namespace: str,
+        modality: str,
+        address: HierarchicalAddress,
+    ) -> ShardCoordinate:
+        address.validate(radix=self.extent.address_radix)
+        return self.router.route(namespace=namespace, modality=modality, address=address)
+
+    def ingest(self, *, namespace: str, media: MediaEnvelope) -> dict[str, str | int]:
+        if not namespace:
+            raise ValueError("namespace must not be empty")
+        record = {"namespace": namespace, **media.descriptor()}
+        with self._media_lock:
+            self._media[media.digest] = record
+        return record
+
+    def media_record(self, digest: str) -> dict[str, str | int] | None:
+        with self._media_lock:
+            record = self._media.get(digest)
+            return dict(record) if record is not None else None
+
+    def describe(self) -> dict[str, object]:
+        with self._media_lock:
+            media_objects = len(self._media)
+        return {
+            "runtime": "jarvisx-3d-hypercloud",
+            "status": "reference-control-plane",
+            "virtual_parameter_extent": self.extent.metadata(),
+            "deployment_lattice": {
+                "shape": self.router.shape,
+                "shards": self.router.shard_count,
+            },
+            "materialized_parameters": self.store.materialized_parameters,
+            "ingested_media_objects": media_objects,
+            "claims": {
+                "dense_parameter_allocation": False,
+                "distributed_accelerator_backend": False,
+                "multimodal_envelope_support": True,
+                "deterministic_3d_routing": True,
+            },
+        }

--- a/src/jarvisx/cloud/topology.py
+++ b/src/jarvisx/cloud/topology.py
@@ -1,0 +1,78 @@
+"""Topology primitives for leased 3D HyperCloud worker placement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .routing import ShardCoordinate
+
+
+@dataclass(frozen=True)
+class WorkerDescriptor:
+    """One live execution worker registered in the 3D fabric."""
+
+    worker_id: str
+    coordinate: ShardCoordinate
+    capabilities: tuple[str, ...]
+    backend: str
+    load: float
+    last_seen: float
+
+    def supports(self, capability: str) -> bool:
+        return capability in self.capabilities
+
+
+@dataclass(frozen=True)
+class PlacementDecision:
+    worker_id: str
+    coordinate: ShardCoordinate
+    distance: int
+    score: float
+
+
+def manhattan_distance(a: ShardCoordinate, b: ShardCoordinate) -> int:
+    """Return deterministic 3D Manhattan distance between two cells."""
+
+    return abs(a.x - b.x) + abs(a.y - b.y) + abs(a.z - b.z)
+
+
+class TopologyScheduler:
+    """Choose the nearest capable worker while accounting for reported load.
+
+    The reference score is intentionally transparent rather than adaptive magic:
+
+        score = distance + load_weight * clamped_load
+
+    Lower is better. Stable worker-id ordering makes ties deterministic.
+    """
+
+    def __init__(self, *, load_weight: float = 4.0) -> None:
+        if load_weight < 0:
+            raise ValueError("load_weight must be non-negative")
+        self.load_weight = float(load_weight)
+
+    def choose(
+        self,
+        *,
+        target: ShardCoordinate,
+        workers: Iterable[WorkerDescriptor],
+        capability: str,
+    ) -> PlacementDecision | None:
+        candidates: list[PlacementDecision] = []
+        for worker in workers:
+            if not worker.supports(capability):
+                continue
+            distance = manhattan_distance(target, worker.coordinate)
+            load = min(1.0, max(0.0, float(worker.load)))
+            candidates.append(
+                PlacementDecision(
+                    worker_id=worker.worker_id,
+                    coordinate=worker.coordinate,
+                    distance=distance,
+                    score=float(distance) + self.load_weight * load,
+                )
+            )
+        if not candidates:
+            return None
+        return min(candidates, key=lambda item: (item.score, item.distance, item.worker_id))

--- a/src/jarvisx/cloud/worker.py
+++ b/src/jarvisx/cloud/worker.py
@@ -30,9 +30,9 @@ class HyperCloudWorker:
     def execute(self, job: JobRecord) -> dict[str, Any]:
         if job.operation == "codec_roundtrip":
             digest = str(job.input["media_sha256"])
-            media = self.state.get_media(digest)
+            media = self.state.get_media(job.namespace, digest)
             if media is None:
-                raise KeyError(f"media object not found: {digest}")
+                raise KeyError(f"media object not found in namespace {job.namespace}: {digest}")
             result = self.codec.roundtrip(media)
             result["operation"] = job.operation
             return result

--- a/src/jarvisx/cloud/worker.py
+++ b/src/jarvisx/cloud/worker.py
@@ -9,6 +9,7 @@ import socket
 import time
 import uuid
 from hashlib import blake2b
+from threading import Event, Thread
 from typing import Any
 
 from .codec import LosslessMultimodalCodec
@@ -20,7 +21,7 @@ LOGGER = logging.getLogger("jarvisx.hypercloud.worker")
 
 
 class HyperCloudWorker:
-    """A registered worker that claims jobs under an expiring ownership lease."""
+    """A registered worker that claims and renews expiring ownership leases."""
 
     def __init__(
         self,
@@ -81,6 +82,19 @@ class HyperCloudWorker:
 
         raise ValueError(f"unsupported job operation: {job.operation}")
 
+    def _renew_lease_until_stopped(self, job_id: str, stop: Event) -> None:
+        interval = max(0.005, min(5.0, self.lease_seconds / 3.0))
+        while not stop.wait(interval):
+            renewed = self.state.renew_job_lease(
+                job_id,
+                worker_id=self.worker_id,
+                lease_seconds=self.lease_seconds,
+            )
+            self.state.heartbeat_worker(self.worker_id, load=1.0)
+            if not renewed:
+                LOGGER.warning("lease renewal lost for job %s worker=%s", job_id, self.worker_id)
+                return
+
     def run_once(self) -> bool:
         self.state.heartbeat_worker(self.worker_id, load=0.0)
         job = self.state.claim_next_job(
@@ -103,23 +117,40 @@ class HyperCloudWorker:
             job.attempts,
             job.max_attempts,
         )
+
+        stop = Event()
+        renewer = Thread(
+            target=self._renew_lease_until_stopped,
+            args=(job.id, stop),
+            name=f"lease-{self.worker_id}-{job.id[:8]}",
+            daemon=True,
+        )
+        renewer.start()
+        result: dict[str, Any] | None = None
+        execution_error: Exception | None = None
         try:
             result = self.execute(job)
         except Exception as exc:  # worker boundary must persist all failures
+            execution_error = exc
             LOGGER.exception("job %s failed", job.id)
+        finally:
+            stop.set()
+            renewer.join(timeout=max(0.05, min(1.0, self.lease_seconds)))
+
+        if execution_error is not None:
             self.state.fail_job(
                 job.id,
-                f"{type(exc).__name__}: {exc}",
+                f"{type(execution_error).__name__}: {execution_error}",
                 worker_id=self.worker_id,
             )
         else:
+            assert result is not None
             committed = self.state.complete_job(job.id, result, worker_id=self.worker_id)
             if not committed:
                 LOGGER.warning("job %s result rejected because lease ownership changed", job.id)
             else:
                 LOGGER.info("completed job %s", job.id)
-        finally:
-            self.state.heartbeat_worker(self.worker_id, load=0.0)
+        self.state.heartbeat_worker(self.worker_id, load=0.0)
         return True
 
     def run_forever(self, poll_seconds: float = 0.25) -> None:
@@ -154,7 +185,7 @@ def _shape_from_environment() -> tuple[int, int, int]:
     )
     if len(parts) != 3 or any(part <= 0 for part in parts):
         raise RuntimeError("JARVISX_LATTICE_SHAPE must contain three positive integers")
-    return parts
+    return parts[0], parts[1], parts[2]
 
 
 def _worker_identity() -> str:
@@ -171,8 +202,12 @@ def _worker_coordinate(worker_id: str, shape: tuple[int, int, int]) -> ShardCoor
         parts = tuple(int(part.strip()) for part in explicit.split(","))
         if len(parts) != 3:
             raise RuntimeError("JARVISX_WORKER_COORD must contain x,y,z")
-        coordinate = ShardCoordinate(*parts)
-        if not (0 <= coordinate.x < shape[0] and 0 <= coordinate.y < shape[1] and 0 <= coordinate.z < shape[2]):
+        coordinate = ShardCoordinate(parts[0], parts[1], parts[2])
+        if not (
+            0 <= coordinate.x < shape[0]
+            and 0 <= coordinate.y < shape[1]
+            and 0 <= coordinate.z < shape[2]
+        ):
             raise RuntimeError("JARVISX_WORKER_COORD is outside JARVISX_LATTICE_SHAPE")
         return coordinate
 

--- a/src/jarvisx/cloud/worker.py
+++ b/src/jarvisx/cloud/worker.py
@@ -33,12 +33,11 @@ class HyperCloudWorker:
             media = self.state.get_media(job.namespace, digest)
             if media is None:
                 raise KeyError(f"media object not found in namespace {job.namespace}: {digest}")
-            result = self.codec.roundtrip(media)
-            result["operation"] = job.operation
-            return result
+            codec_result = self.codec.roundtrip(media)
+            return {**codec_result, "operation": job.operation}
 
         if job.operation == "chat":
-            result = self.backend.generate(
+            chat_result = self.backend.generate(
                 prompt=str(job.input.get("prompt", "")),
                 system=(
                     None
@@ -46,8 +45,7 @@ class HyperCloudWorker:
                     else str(job.input.get("system"))
                 ),
             )
-            result["operation"] = job.operation
-            return result
+            return {**chat_result, "operation": job.operation}
 
         raise ValueError(f"unsupported job operation: {job.operation}")
 

--- a/src/jarvisx/cloud/worker.py
+++ b/src/jarvisx/cloud/worker.py
@@ -1,0 +1,110 @@
+"""Durable HyperCloud job worker."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import time
+from typing import Any
+
+from .codec import LosslessMultimodalCodec
+from .inference import ChatBackend, backend_from_environment
+from .persistence import JobRecord, SQLiteStateStore
+
+LOGGER = logging.getLogger("jarvisx.hypercloud.worker")
+
+
+class HyperCloudWorker:
+    def __init__(
+        self,
+        state: SQLiteStateStore,
+        *,
+        backend: ChatBackend | None = None,
+        codec: LosslessMultimodalCodec | None = None,
+    ) -> None:
+        self.state = state
+        self.backend = backend or backend_from_environment()
+        self.codec = codec or LosslessMultimodalCodec()
+
+    def execute(self, job: JobRecord) -> dict[str, Any]:
+        if job.operation == "codec_roundtrip":
+            digest = str(job.input["media_sha256"])
+            media = self.state.get_media(digest)
+            if media is None:
+                raise KeyError(f"media object not found: {digest}")
+            result = self.codec.roundtrip(media)
+            result["operation"] = job.operation
+            return result
+
+        if job.operation == "chat":
+            result = self.backend.generate(
+                prompt=str(job.input.get("prompt", "")),
+                system=(
+                    None
+                    if job.input.get("system") is None
+                    else str(job.input.get("system"))
+                ),
+            )
+            result["operation"] = job.operation
+            return result
+
+        raise ValueError(f"unsupported job operation: {job.operation}")
+
+    def run_once(self) -> bool:
+        job = self.state.claim_next_job()
+        if job is None:
+            return False
+        LOGGER.info("claimed job %s operation=%s", job.id, job.operation)
+        try:
+            result = self.execute(job)
+        except Exception as exc:  # worker boundary must record all failures
+            LOGGER.exception("job %s failed", job.id)
+            self.state.fail_job(job.id, f"{type(exc).__name__}: {exc}")
+        else:
+            self.state.complete_job(job.id, result)
+            LOGGER.info("completed job %s", job.id)
+        return True
+
+    def run_forever(self, poll_seconds: float = 0.25) -> None:
+        if poll_seconds <= 0:
+            raise ValueError("poll_seconds must be positive")
+        LOGGER.info("worker started backend=%s", self.backend.name)
+        while True:
+            processed = self.run_once()
+            if not processed:
+                time.sleep(poll_seconds)
+
+
+def _state_from_environment() -> SQLiteStateStore:
+    return SQLiteStateStore(
+        os.getenv("JARVISX_STATE_DB", "/tmp/jarvisx-hypercloud/state.db"),
+        os.getenv("JARVISX_OBJECT_ROOT", "/tmp/jarvisx-hypercloud/objects"),
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Jarvis-X HyperCloud worker")
+    parser.add_argument("--once", action="store_true", help="process at most one queued job")
+    parser.add_argument(
+        "--poll-seconds",
+        type=float,
+        default=float(os.getenv("JARVISX_WORKER_POLL_SECONDS", "0.25")),
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=os.getenv("JARVISX_LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    state = _state_from_environment()
+    worker = HyperCloudWorker(state)
+    if args.once:
+        worker.run_once()
+        return 0
+    worker.run_forever(args.poll_seconds)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/cloud/worker.py
+++ b/src/jarvisx/cloud/worker.py
@@ -1,31 +1,63 @@
-"""Durable HyperCloud job worker."""
+"""Durable leased HyperCloud worker."""
 
 from __future__ import annotations
 
 import argparse
 import logging
 import os
+import socket
 import time
+import uuid
+from hashlib import blake2b
 from typing import Any
 
 from .codec import LosslessMultimodalCodec
 from .inference import ChatBackend, backend_from_environment
 from .persistence import JobRecord, SQLiteStateStore
+from .routing import ShardCoordinate
 
 LOGGER = logging.getLogger("jarvisx.hypercloud.worker")
 
 
 class HyperCloudWorker:
+    """A registered worker that claims jobs under an expiring ownership lease."""
+
     def __init__(
         self,
         state: SQLiteStateStore,
         *,
         backend: ChatBackend | None = None,
         codec: LosslessMultimodalCodec | None = None,
+        worker_id: str | None = None,
+        coordinate: ShardCoordinate | None = None,
+        capabilities: tuple[str, ...] = ("chat", "codec"),
+        lease_seconds: float = 300.0,
     ) -> None:
+        if lease_seconds <= 0:
+            raise ValueError("lease_seconds must be positive")
         self.state = state
         self.backend = backend or backend_from_environment()
         self.codec = codec or LosslessMultimodalCodec()
+        self.worker_id = worker_id or f"worker-{uuid.uuid4().hex[:12]}"
+        self.coordinate = coordinate or ShardCoordinate(0, 0, 0)
+        self.capabilities = tuple(sorted(set(capabilities)))
+        self.lease_seconds = float(lease_seconds)
+        self.state.register_worker(
+            worker_id=self.worker_id,
+            coordinate=self.coordinate,
+            capabilities=self.capabilities,
+            backend=self.backend.name,
+            load=0.0,
+        )
+
+    @property
+    def operations(self) -> tuple[str, ...]:
+        operations: list[str] = []
+        if "chat" in self.capabilities:
+            operations.append("chat")
+        if "codec" in self.capabilities:
+            operations.append("codec_roundtrip")
+        return tuple(operations)
 
     def execute(self, job: JobRecord) -> dict[str, Any]:
         if job.operation == "codec_roundtrip":
@@ -50,24 +82,58 @@ class HyperCloudWorker:
         raise ValueError(f"unsupported job operation: {job.operation}")
 
     def run_once(self) -> bool:
-        job = self.state.claim_next_job()
+        self.state.heartbeat_worker(self.worker_id, load=0.0)
+        job = self.state.claim_next_job(
+            worker_id=self.worker_id,
+            coordinate=self.coordinate,
+            operations=self.operations,
+            lease_seconds=self.lease_seconds,
+        )
         if job is None:
             return False
-        LOGGER.info("claimed job %s operation=%s", job.id, job.operation)
+        self.state.heartbeat_worker(self.worker_id, load=1.0)
+        LOGGER.info(
+            "claimed job %s operation=%s worker=%s cell=(%s,%s,%s) attempt=%s/%s",
+            job.id,
+            job.operation,
+            self.worker_id,
+            self.coordinate.x,
+            self.coordinate.y,
+            self.coordinate.z,
+            job.attempts,
+            job.max_attempts,
+        )
         try:
             result = self.execute(job)
-        except Exception as exc:  # worker boundary must record all failures
+        except Exception as exc:  # worker boundary must persist all failures
             LOGGER.exception("job %s failed", job.id)
-            self.state.fail_job(job.id, f"{type(exc).__name__}: {exc}")
+            self.state.fail_job(
+                job.id,
+                f"{type(exc).__name__}: {exc}",
+                worker_id=self.worker_id,
+            )
         else:
-            self.state.complete_job(job.id, result)
-            LOGGER.info("completed job %s", job.id)
+            committed = self.state.complete_job(job.id, result, worker_id=self.worker_id)
+            if not committed:
+                LOGGER.warning("job %s result rejected because lease ownership changed", job.id)
+            else:
+                LOGGER.info("completed job %s", job.id)
+        finally:
+            self.state.heartbeat_worker(self.worker_id, load=0.0)
         return True
 
     def run_forever(self, poll_seconds: float = 0.25) -> None:
         if poll_seconds <= 0:
             raise ValueError("poll_seconds must be positive")
-        LOGGER.info("worker started backend=%s", self.backend.name)
+        LOGGER.info(
+            "worker started id=%s backend=%s cell=(%s,%s,%s) capabilities=%s",
+            self.worker_id,
+            self.backend.name,
+            self.coordinate.x,
+            self.coordinate.y,
+            self.coordinate.z,
+            ",".join(self.capabilities),
+        )
         while True:
             processed = self.run_once()
             if not processed:
@@ -78,6 +144,43 @@ def _state_from_environment() -> SQLiteStateStore:
     return SQLiteStateStore(
         os.getenv("JARVISX_STATE_DB", "/tmp/jarvisx-hypercloud/state.db"),
         os.getenv("JARVISX_OBJECT_ROOT", "/tmp/jarvisx-hypercloud/objects"),
+    )
+
+
+def _shape_from_environment() -> tuple[int, int, int]:
+    parts = tuple(
+        int(part.strip())
+        for part in os.getenv("JARVISX_LATTICE_SHAPE", "16,16,16").split(",")
+    )
+    if len(parts) != 3 or any(part <= 0 for part in parts):
+        raise RuntimeError("JARVISX_LATTICE_SHAPE must contain three positive integers")
+    return parts
+
+
+def _worker_identity() -> str:
+    configured = os.getenv("JARVISX_WORKER_ID", "").strip()
+    if configured:
+        return configured
+    host = socket.gethostname().strip() or "host"
+    return f"{host}-{os.getpid()}"
+
+
+def _worker_coordinate(worker_id: str, shape: tuple[int, int, int]) -> ShardCoordinate:
+    explicit = os.getenv("JARVISX_WORKER_COORD", "").strip()
+    if explicit:
+        parts = tuple(int(part.strip()) for part in explicit.split(","))
+        if len(parts) != 3:
+            raise RuntimeError("JARVISX_WORKER_COORD must contain x,y,z")
+        coordinate = ShardCoordinate(*parts)
+        if not (0 <= coordinate.x < shape[0] and 0 <= coordinate.y < shape[1] and 0 <= coordinate.z < shape[2]):
+            raise RuntimeError("JARVISX_WORKER_COORD is outside JARVISX_LATTICE_SHAPE")
+        return coordinate
+
+    digest = blake2b(worker_id.encode("utf-8"), digest_size=12, person=b"jx-worker").digest()
+    return ShardCoordinate(
+        int.from_bytes(digest[0:4], "big") % shape[0],
+        int.from_bytes(digest[4:8], "big") % shape[1],
+        int.from_bytes(digest[8:12], "big") % shape[2],
     )
 
 
@@ -95,8 +198,22 @@ def main(argv: list[str] | None = None) -> int:
         level=os.getenv("JARVISX_LOG_LEVEL", "INFO").upper(),
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+    shape = _shape_from_environment()
+    worker_id = _worker_identity()
+    coordinate = _worker_coordinate(worker_id, shape)
+    capabilities = tuple(
+        item.strip()
+        for item in os.getenv("JARVISX_WORKER_CAPABILITIES", "chat,codec").split(",")
+        if item.strip()
+    )
     state = _state_from_environment()
-    worker = HyperCloudWorker(state)
+    worker = HyperCloudWorker(
+        state,
+        worker_id=worker_id,
+        coordinate=coordinate,
+        capabilities=capabilities,
+        lease_seconds=float(os.getenv("JARVISX_JOB_LEASE_SECONDS", "300")),
+    )
     if args.once:
         worker.run_once()
         return 0

--- a/tests/test_hypercloud_leases.py
+++ b/tests/test_hypercloud_leases.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import time
+
+from jarvisx.cloud import ShardCoordinate, SQLiteStateStore
+
+
+def test_active_owner_can_renew_job_lease(tmp_path) -> None:
+    state = SQLiteStateStore(str(tmp_path / "state.db"), str(tmp_path / "objects"))
+    queued = state.create_job("demo", "chat", {"prompt": "long inference"})
+    claimed = state.claim_next_job(
+        worker_id="worker-owner",
+        coordinate=ShardCoordinate(0, 0, 0),
+        operations=("chat",),
+        lease_seconds=0.05,
+    )
+    assert claimed is not None and claimed.id == queued.id
+
+    time.sleep(0.01)
+    assert state.renew_job_lease(
+        queued.id,
+        worker_id="worker-owner",
+        lease_seconds=0.20,
+    ) is True
+
+    # Past the original lease, but safely inside the renewed lease.
+    time.sleep(0.06)
+    assert state.requeue_expired_leases() == 0
+    running = state.get_job(queued.id)
+    assert running is not None
+    assert running.status == "running"
+    assert running.lease_owner == "worker-owner"
+
+    assert state.complete_job(
+        queued.id,
+        {"text": "done"},
+        worker_id="worker-owner",
+    ) is True
+    state.close()
+
+
+def test_non_owner_cannot_renew_job_lease(tmp_path) -> None:
+    state = SQLiteStateStore(str(tmp_path / "state.db"), str(tmp_path / "objects"))
+    queued = state.create_job("demo", "chat", {"prompt": "fenced"})
+    claimed = state.claim_next_job(
+        worker_id="worker-owner",
+        coordinate=ShardCoordinate(0, 0, 0),
+        operations=("chat",),
+        lease_seconds=1.0,
+    )
+    assert claimed is not None
+
+    assert state.renew_job_lease(
+        queued.id,
+        worker_id="worker-stale",
+        lease_seconds=1.0,
+    ) is False
+    state.close()

--- a/tests/test_hypercloud_operational.py
+++ b/tests/test_hypercloud_operational.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from jarvisx.cloud import (
@@ -8,6 +10,7 @@ from jarvisx.cloud import (
     MediaEnvelope,
     MediaKind,
     OperationalHyperCloud,
+    ShardCoordinate,
     SQLiteStateStore,
 )
 from jarvisx.cloud.inference import LocalReferenceBackend
@@ -67,8 +70,10 @@ def test_identical_media_can_exist_in_multiple_namespaces_without_metadata_colli
     service.ingest("tenant-a", media)
     service.ingest("tenant-b", media)
 
-    assert state.media_record("tenant-a", media.digest)["namespace"] == "tenant-a"
-    assert state.media_record("tenant-b", media.digest)["namespace"] == "tenant-b"
+    tenant_a = state.media_record("tenant-a", media.digest)
+    tenant_b = state.media_record("tenant-b", media.digest)
+    assert tenant_a is not None and tenant_a["namespace"] == "tenant-a"
+    assert tenant_b is not None and tenant_b["namespace"] == "tenant-b"
     assert state.media_count() == 2
     state.close()
 
@@ -84,7 +89,13 @@ def test_codec_job_runs_end_to_end_through_durable_worker(tmp_path) -> None:
     service.ingest("demo", media)
     queued = service.enqueue_codec("demo", media.digest)
 
-    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+    assert queued.target is not None
+    worker = HyperCloudWorker(
+        state,
+        backend=LocalReferenceBackend(),
+        worker_id="codec-worker",
+        coordinate=queued.target,
+    )
     assert worker.run_once() is True
 
     completed = service.job(queued.id)
@@ -94,6 +105,8 @@ def test_codec_job_runs_end_to_end_through_durable_worker(tmp_path) -> None:
     assert completed.result["lossless"] is True
     assert completed.result["reconstructed_sha256"] == media.digest
     assert completed.result["compression_ratio"] < 1.0
+    assert completed.attempts == 1
+    assert completed.lease_owner is None
     state.close()
 
 
@@ -121,7 +134,13 @@ def test_chat_job_runs_end_to_end_without_external_credentials(tmp_path) -> None
         "Be concise",
     )
 
-    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+    assert queued.target is not None
+    worker = HyperCloudWorker(
+        state,
+        backend=LocalReferenceBackend(),
+        worker_id="chat-worker",
+        coordinate=queued.target,
+    )
     assert worker.run_once() is True
 
     completed = service.job(queued.id)
@@ -134,29 +153,193 @@ def test_chat_job_runs_end_to_end_without_external_credentials(tmp_path) -> None
     state.close()
 
 
-def test_worker_persists_failure_for_unknown_operation(tmp_path) -> None:
+def test_worker_only_claims_supported_operations(tmp_path) -> None:
     state = _state(tmp_path)
     bad = state.create_job("demo", "not-supported", {})
-    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+    worker = HyperCloudWorker(
+        state,
+        backend=LocalReferenceBackend(),
+        worker_id="bounded-worker",
+        capabilities=("chat", "codec"),
+    )
 
-    assert worker.run_once() is True
-    failed = state.get_job(bad.id)
-
-    assert failed is not None
-    assert failed.status == "failed"
-    assert failed.error is not None
-    assert "unsupported job operation" in failed.error
+    assert worker.run_once() is False
+    untouched = state.get_job(bad.id)
+    assert untouched is not None
+    assert untouched.status == "queued"
+    assert untouched.attempts == 0
     state.close()
 
 
-def test_runtime_description_reports_operational_boundaries(tmp_path) -> None:
+def test_worker_registry_and_placement_choose_nearest_capable_worker(tmp_path) -> None:
     state = _state(tmp_path)
     service = OperationalHyperCloud(state=state)
+    queued = service.enqueue_chat("demo", "Route me geometrically")
+    assert queued.target is not None
+
+    target = queued.target
+    far = ShardCoordinate((target.x + 7) % 16, (target.y + 7) % 16, (target.z + 7) % 16)
+    state.register_worker(
+        worker_id="far-worker",
+        coordinate=far,
+        capabilities=("chat",),
+        backend="test",
+        load=0.0,
+    )
+    state.register_worker(
+        worker_id="near-worker",
+        coordinate=target,
+        capabilities=("chat",),
+        backend="test",
+        load=0.2,
+    )
+    state.register_worker(
+        worker_id="codec-only",
+        coordinate=target,
+        capabilities=("codec",),
+        backend="test",
+        load=0.0,
+    )
+
+    decision = service.placement_preview(queued.id)
+    assert decision is not None
+    assert decision.worker_id == "near-worker"
+    assert decision.distance == 0
+    assert len(state.active_workers()) == 3
+    state.close()
+
+
+def test_claim_prefers_spatially_local_job_over_older_remote_job(tmp_path) -> None:
+    state = _state(tmp_path)
+    remote = state.create_job(
+        "demo",
+        "chat",
+        {"prompt": "remote"},
+        target=ShardCoordinate(15, 15, 15),
+    )
+    local = state.create_job(
+        "demo",
+        "chat",
+        {"prompt": "local"},
+        target=ShardCoordinate(1, 1, 1),
+    )
+
+    claimed = state.claim_next_job(
+        worker_id="worker-a",
+        coordinate=ShardCoordinate(1, 1, 1),
+        operations=("chat",),
+        lease_seconds=10.0,
+    )
+
+    assert claimed is not None
+    assert claimed.id == local.id
+    assert claimed.id != remote.id
+    assert claimed.lease_owner == "worker-a"
+    assert claimed.attempts == 1
+    state.close()
+
+
+def test_expired_job_lease_is_requeued_and_reclaimable(tmp_path) -> None:
+    state = _state(tmp_path)
+    queued = state.create_job(
+        "demo",
+        "chat",
+        {"prompt": "recover me"},
+        target=ShardCoordinate(2, 2, 2),
+        max_attempts=2,
+    )
+    first = state.claim_next_job(
+        worker_id="worker-dead",
+        coordinate=ShardCoordinate(2, 2, 2),
+        operations=("chat",),
+        lease_seconds=0.01,
+    )
+    assert first is not None and first.id == queued.id
+
+    time.sleep(0.02)
+    assert state.requeue_expired_leases() == 1
+    recovered = state.get_job(queued.id)
+    assert recovered is not None
+    assert recovered.status == "queued"
+    assert recovered.lease_owner is None
+
+    second = state.claim_next_job(
+        worker_id="worker-replacement",
+        coordinate=ShardCoordinate(2, 2, 2),
+        operations=("chat",),
+        lease_seconds=10.0,
+    )
+    assert second is not None
+    assert second.id == queued.id
+    assert second.attempts == 2
+    state.close()
+
+
+def test_expired_lease_fails_job_after_maximum_attempts(tmp_path) -> None:
+    state = _state(tmp_path)
+    queued = state.create_job(
+        "demo",
+        "chat",
+        {"prompt": "one shot"},
+        max_attempts=1,
+    )
+    claimed = state.claim_next_job(
+        worker_id="worker-dead",
+        coordinate=ShardCoordinate(0, 0, 0),
+        operations=("chat",),
+        lease_seconds=0.01,
+    )
+    assert claimed is not None
+
+    time.sleep(0.02)
+    state.requeue_expired_leases()
+    failed = state.get_job(queued.id)
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.error == "worker lease expired after maximum attempts"
+    state.close()
+
+
+def test_lease_owner_fences_stale_worker_completion(tmp_path) -> None:
+    state = _state(tmp_path)
+    queued = state.create_job("demo", "chat", {"prompt": "fence me"})
+    claimed = state.claim_next_job(
+        worker_id="worker-owner",
+        coordinate=ShardCoordinate(0, 0, 0),
+        operations=("chat",),
+        lease_seconds=10.0,
+    )
+    assert claimed is not None
+
+    assert state.complete_job(queued.id, {"text": "stale"}, worker_id="worker-other") is False
+    still_running = state.get_job(queued.id)
+    assert still_running is not None and still_running.status == "running"
+
+    assert state.complete_job(queued.id, {"text": "committed"}, worker_id="worker-owner") is True
+    completed = state.get_job(queued.id)
+    assert completed is not None and completed.status == "succeeded"
+    assert completed.result == {"text": "committed"}
+    state.close()
+
+
+def test_runtime_description_reports_permeated_boundaries(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    HyperCloudWorker(
+        state,
+        backend=LocalReferenceBackend(),
+        worker_id="registered-worker",
+        coordinate=ShardCoordinate(3, 4, 5),
+    )
 
     description = service.describe(backend_name="local-reference-non-llm")
 
-    assert description["status"] == "operational-reference"
+    assert description["status"] == "operational-permeated"
+    assert description["deployment_lattice"]["active_workers"] == 1
     assert description["claims"]["durable_local_state"] is True
+    assert description["claims"]["leased_worker_execution"] is True
+    assert description["claims"]["abandoned_job_recovery"] is True
+    assert description["claims"]["topology_aware_3d_placement"] is True
     assert description["claims"]["lossless_multimodal_codec"] is True
     assert description["claims"]["dense_parameter_allocation"] is False
     assert description["claims"]["distributed_accelerator_backend"] is False

--- a/tests/test_hypercloud_operational.py
+++ b/tests/test_hypercloud_operational.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.cloud import (
+    HierarchicalAddress,
+    HyperCloudWorker,
+    MediaEnvelope,
+    MediaKind,
+    OperationalHyperCloud,
+    SQLiteStateStore,
+)
+from jarvisx.cloud.inference import LocalReferenceBackend
+
+
+def _state(tmp_path):
+    return SQLiteStateStore(
+        str(tmp_path / "state.db"),
+        str(tmp_path / "objects"),
+    )
+
+
+def test_sparse_parameters_survive_store_restart(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    address = HierarchicalAddress((17, 42, 999_999))
+
+    service.set_parameter("tenant-a", address, 0.875)
+    assert service.get_parameter("tenant-a", address) == pytest.approx(0.875)
+    state.close()
+
+    reopened = _state(tmp_path)
+    service2 = OperationalHyperCloud(state=reopened)
+    assert service2.get_parameter("tenant-a", address) == pytest.approx(0.875)
+    assert reopened.parameter_count() == 1
+    reopened.close()
+
+
+def test_media_is_content_addressed_and_integrity_checked(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    media = MediaEnvelope(
+        kind=MediaKind.VIDEO,
+        payload=b"frame-stream-" * 200,
+        content_type="video/example",
+    )
+
+    record = service.ingest("demo", media)
+    restored = state.get_media(media.digest)
+
+    assert record["sha256"] == media.digest
+    assert restored is not None
+    assert restored.payload == media.payload
+    assert state.media_count() == 1
+    state.close()
+
+
+def test_codec_job_runs_end_to_end_through_durable_worker(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    media = MediaEnvelope(
+        kind=MediaKind.IMAGE,
+        payload=b"repeating-pixel-data" * 500,
+        content_type="image/example",
+    )
+    service.ingest("demo", media)
+    queued = service.enqueue_codec("demo", media.digest)
+
+    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+    assert worker.run_once() is True
+
+    completed = service.job(queued.id)
+    assert completed is not None
+    assert completed.status == "succeeded"
+    assert completed.result is not None
+    assert completed.result["lossless"] is True
+    assert completed.result["reconstructed_sha256"] == media.digest
+    assert completed.result["compression_ratio"] < 1.0
+    state.close()
+
+
+def test_chat_job_runs_end_to_end_without_external_credentials(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    queued = service.enqueue_chat(
+        "demo",
+        "Explain sparse virtual parameters.",
+        "Be concise",
+    )
+
+    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+    assert worker.run_once() is True
+
+    completed = service.job(queued.id)
+    assert completed is not None
+    assert completed.status == "succeeded"
+    assert completed.result is not None
+    assert completed.result["backend"] == "local-reference-non-llm"
+    assert completed.result["neural_model"] is False
+    assert "sparse virtual parameters" in str(completed.result["text"])
+    state.close()
+
+
+def test_worker_persists_failure_for_unknown_operation(tmp_path) -> None:
+    state = _state(tmp_path)
+    bad = state.create_job("demo", "not-supported", {})
+    worker = HyperCloudWorker(state, backend=LocalReferenceBackend())
+
+    assert worker.run_once() is True
+    failed = state.get_job(bad.id)
+
+    assert failed is not None
+    assert failed.status == "failed"
+    assert failed.error is not None
+    assert "unsupported job operation" in failed.error
+    state.close()
+
+
+def test_runtime_description_reports_operational_boundaries(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+
+    description = service.describe(backend_name="local-reference-non-llm")
+
+    assert description["status"] == "operational-reference"
+    assert description["claims"]["durable_local_state"] is True
+    assert description["claims"]["lossless_multimodal_codec"] is True
+    assert description["claims"]["dense_parameter_allocation"] is False
+    state.close()

--- a/tests/test_hypercloud_operational.py
+++ b/tests/test_hypercloud_operational.py
@@ -46,12 +46,30 @@ def test_media_is_content_addressed_and_integrity_checked(tmp_path) -> None:
     )
 
     record = service.ingest("demo", media)
-    restored = state.get_media(media.digest)
+    restored = state.get_media("demo", media.digest)
 
     assert record["sha256"] == media.digest
     assert restored is not None
     assert restored.payload == media.payload
     assert state.media_count() == 1
+    state.close()
+
+
+def test_identical_media_can_exist_in_multiple_namespaces_without_metadata_collision(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    media = MediaEnvelope(
+        kind=MediaKind.AUDIO,
+        payload=b"same-audio-bytes" * 50,
+        content_type="audio/example",
+    )
+
+    service.ingest("tenant-a", media)
+    service.ingest("tenant-b", media)
+
+    assert state.media_record("tenant-a", media.digest)["namespace"] == "tenant-a"
+    assert state.media_record("tenant-b", media.digest)["namespace"] == "tenant-b"
+    assert state.media_count() == 2
     state.close()
 
 
@@ -76,6 +94,21 @@ def test_codec_job_runs_end_to_end_through_durable_worker(tmp_path) -> None:
     assert completed.result["lossless"] is True
     assert completed.result["reconstructed_sha256"] == media.digest
     assert completed.result["compression_ratio"] < 1.0
+    state.close()
+
+
+def test_codec_job_cannot_cross_namespace_boundary(tmp_path) -> None:
+    state = _state(tmp_path)
+    service = OperationalHyperCloud(state=state)
+    media = MediaEnvelope(
+        kind=MediaKind.BINARY,
+        payload=b"private-tenant-object",
+        content_type="application/octet-stream",
+    )
+    service.ingest("tenant-a", media)
+
+    with pytest.raises(KeyError):
+        service.enqueue_codec("tenant-b", media.digest)
     state.close()
 
 
@@ -126,4 +159,5 @@ def test_runtime_description_reports_operational_boundaries(tmp_path) -> None:
     assert description["claims"]["durable_local_state"] is True
     assert description["claims"]["lossless_multimodal_codec"] is True
     assert description["claims"]["dense_parameter_allocation"] is False
+    assert description["claims"]["distributed_accelerator_backend"] is False
     state.close()

--- a/tests/test_hypercloud_runtime.py
+++ b/tests/test_hypercloud_runtime.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.cloud import (
+    HierarchicalAddress,
+    HyperCloudRuntime,
+    MediaEnvelope,
+    MediaKind,
+    SpatialShardRouter,
+    SymbolicParameterExtent,
+)
+
+
+def test_symbolic_extent_does_not_expand_parameter_count() -> None:
+    extent = SymbolicParameterExtent()
+
+    assert extent.expression == "1000000^(1000000^1000000)"
+    assert extent.address_radix == 1_000_000
+    assert extent.metadata()["allocation_semantics"] == "symbolic-sparse"
+
+
+def test_hierarchical_address_rejects_digits_outside_radix() -> None:
+    address = HierarchicalAddress((1, 2, 1_000_000))
+
+    with pytest.raises(ValueError, match="outside radix"):
+        address.validate(radix=1_000_000)
+
+
+def test_3d_routing_is_deterministic_and_bounded() -> None:
+    router = SpatialShardRouter(shape=(4, 5, 6))
+    address = HierarchicalAddress((10, 20, 30, 40))
+
+    first = router.route(namespace="model-a", modality="text", address=address)
+    second = router.route(namespace="model-a", modality="text", address=address)
+
+    assert first == second
+    assert 0 <= first.x < 4
+    assert 0 <= first.y < 5
+    assert 0 <= first.z < 6
+
+
+def test_parameter_store_materializes_only_touched_addresses() -> None:
+    runtime = HyperCloudRuntime()
+    address = HierarchicalAddress((7, 11, 13))
+
+    assert runtime.store.materialized_parameters == 0
+    assert runtime.store.get("tenant/model", address) is None
+
+    runtime.store.set("tenant/model", address, 0.125)
+
+    assert runtime.store.get("tenant/model", address) == pytest.approx(0.125)
+    assert runtime.store.materialized_parameters == 1
+    assert runtime.describe()["claims"]["dense_parameter_allocation"] is False
+
+
+def test_multimodal_ingest_is_content_addressed() -> None:
+    runtime = HyperCloudRuntime()
+    media = MediaEnvelope(
+        kind=MediaKind.IMAGE,
+        payload=b"synthetic-image-bytes",
+        content_type="image/example",
+    )
+
+    record = runtime.ingest(namespace="demo", media=media)
+
+    assert record["kind"] == "image"
+    assert record["sha256"] == media.digest
+    assert runtime.media_record(media.digest) == record
+    assert runtime.describe()["ingested_media_objects"] == 1
+
+
+def test_modality_changes_spatial_route() -> None:
+    runtime = HyperCloudRuntime(router=SpatialShardRouter(shape=(32, 32, 32)))
+    address = HierarchicalAddress((101, 202, 303))
+
+    text_route = runtime.route(namespace="demo", modality="text", address=address)
+    video_route = runtime.route(namespace="demo", modality="video", address=address)
+
+    assert text_route != video_route


### PR DESCRIPTION
## Summary

Permeates the Jarvis-X HyperCloud operational baseline through execution, topology, persistence and deployment while preserving the core invariant that virtual extent is not physical allocation.

The system remains a physically bounded sparse runtime over the symbolic `1,000,000^(1,000,000^1,000,000)` namespace; this PR does not misrepresent that namespace as a densely instantiated model.

## Operational capabilities

- symbolic astronomical virtual parameter namespace without dense expansion
- finite hierarchical sparse parameter addressing
- deterministic `(x, y, z)` parameter and job routing
- durable SQLite/WAL sparse parameter persistence
- namespace-scoped media metadata with globally content-addressed SHA-256 objects
- typed text/image/audio/video/binary envelopes
- executable lossless multimodal encode/decode with reconstruction verification
- durable asynchronous job state
- deterministic 3D target coordinates for executable jobs
- persistent worker registry with 3D coordinates, capabilities, backend, load and heartbeats
- capability-aware topology scheduler using spatial distance plus bounded load
- worker claims that prefer spatially local compatible jobs
- expiring **and renewable** worker leases
- lease-owner fencing for renewal, completion and failure
- attempt counters, bounded retries and abandoned-job recovery
- local deterministic reference backend plus OpenAI-compatible model adapter
- FastAPI control plane including worker topology and job-placement introspection
- optional API-key/Bearer authentication
- liveness, readiness and Prometheus-format metrics including active worker count
- Docker Compose deployment with two concurrent worker cells
- Kubernetes single-pod deployment with API + two worker sidecars + PVC, respecting SQLite's single-node consistency boundary
- GHCR publishing workflow
- unit/invariant tests for restart persistence, namespace isolation, topology placement, lease expiry/recovery, ownership fencing and lease renewal
- full-stack CI that boots the two-worker fabric, verifies registration, executes a 3D-targeted chat job and checks topology metrics
- operator runbook and environment template

## Capability boundary

This PR establishes a real multiprocess leased worker fabric on the single-node SQLite/WAL reference state plane. It does **not** claim cross-node distributed state, verified GPU acceleration, tensor/expert/pipeline-parallel training, learned multimedia generation, production IAM/billing, measured SLOs, or astronomical physical parameter capacity.

The next scale boundary is explicit: replace SQLite/local objects with distributed transactional metadata/job state plus distributed object storage, then allow worker pods to spread across nodes and add accelerator-aware scheduling/telemetry.

## Validation

Dedicated HyperCloud CI exercises the actual API -> durable queue -> leased worker -> result path with two concurrent worker processes. Repository-wide tests, mypy, dependency audit, package validation, empirical validation and CodeQL remain authoritative broader gates.

Operational instructions: `docs/HYPERCLOUD_OPERATIONS.md`.