### PR TITLE
Operationalize end-to-end 3D Bit Code runtime

### DIFF
--- a/.github/workflows/bitcode3d-e2e.yml
+++ b/.github/workflows/bitcode3d-e2e.yml
@@ -1,0 +1,64 @@
+name: 3D Bit Code E2E
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/jarvisx/bitcode3d.py"
+      - "src/jarvisx/bitcode3d_api.py"
+      - "tests/test_bitcode3d.py"
+      - "deploy/bitcode3d/**"
+      - ".github/workflows/bitcode3d-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/bitcode3d.py"
+      - "src/jarvisx/bitcode3d_api.py"
+      - "tests/test_bitcode3d.py"
+      - "deploy/bitcode3d/**"
+      - ".github/workflows/bitcode3d-e2e.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  reference-runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install -e ".[test]"
+      - name: Unit tests
+        run: pytest -q tests/test_bitcode3d.py
+      - name: Compile modules
+        run: python -m compileall -q src/jarvisx/bitcode3d.py src/jarvisx/bitcode3d_api.py
+
+  container-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build runtime image
+        run: docker build -f deploy/bitcode3d/Dockerfile -t jarvisx-bitcode3d:test .
+      - name: Start runtime
+        run: docker run -d --rm --name jarvisx-bitcode3d -p 8000:8000 jarvisx-bitcode3d:test
+      - name: Wait for health
+        run: |
+          for i in $(seq 1 30); do
+            if curl --fail --silent http://127.0.0.1:8000/healthz >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs jarvisx-bitcode3d
+          exit 1
+      - name: Execute 3D Bit Code request
+        run: |
+          response=$(curl --fail --silent \
+            -H 'content-type: application/json' \
+            -d '{"shape":[2,2,2],"values":[0,1,2,3,4,5,6,7],"pool":2,"tolerance":4}' \
+            http://127.0.0.1:8000/v1/bitcode3d/execute)
+          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert len(d["bytecode"]) == 11' "$response"

--- a/deploy/bitcode3d/Dockerfile
+++ b/deploy/bitcode3d/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md /app/
+COPY src /app/src
+RUN python -m pip install --no-cache-dir .
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=5 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2).read()"
+
+CMD ["uvicorn", "jarvisx.bitcode3d_api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]

--- a/deploy/bitcode3d/docker-compose.yml
+++ b/deploy/bitcode3d/docker-compose.yml
@@ -1,0 +1,36 @@
+services:
+  bitcode3d:
+    build:
+      context: ../..
+      dockerfile: deploy/bitcode3d/Dockerfile
+    restart: unless-stopped
+    expose:
+      - "8000"
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=2).read()"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  envoy:
+    image: envoyproxy/envoy:v1.31.0
+    restart: unless-stopped
+    depends_on:
+      bitcode3d:
+        condition: service_healthy
+    volumes:
+      - ./envoy.yaml:/etc/envoy/envoy.yaml:ro
+    ports:
+      - "8080:8080"
+      - "9901:9901"
+
+  prometheus:
+    image: prom/prometheus:v3.0.1
+    restart: unless-stopped
+    depends_on:
+      bitcode3d:
+        condition: service_healthy
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"

--- a/deploy/bitcode3d/envoy.yaml
+++ b/deploy/bitcode3d/envoy.yaml
@@ -1,0 +1,48 @@
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 9901
+
+static_resources:
+  listeners:
+    - name: edge_listener
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: bitcode3d_ingress
+                codec_type: AUTO
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: bitcode3d
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: bitcode3d_service
+                            timeout: 30s
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+  clusters:
+    - name: bitcode3d_service
+      connect_timeout: 2s
+      type: STRICT_DNS
+      load_assignment:
+        cluster_name: bitcode3d_service
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: bitcode3d
+                      port_value: 8000

--- a/deploy/bitcode3d/prometheus.yml
+++ b/deploy/bitcode3d/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: jarvisx-bitcode3d
+    static_configs:
+      - targets: ["bitcode3d:8000"]
+    metrics_path: /metrics

--- a/docs/BITCODE3D_E2E_RUNTIME.md
+++ b/docs/BITCODE3D_E2E_RUNTIME.md
@@ -1,0 +1,133 @@
+# Jarvis-X 3D Bit Code End-to-End Runtime
+
+## Status
+
+This is the runnable reference path that connects network ingress to a bounded 3D Q16.16 encode/decode execution loop, deterministic verification, and out-of-band telemetry.
+
+It is deliberately narrower than the canonical 256-bit swarm ISA. The 32-bit words are the compact edge/lowering ABI used by this vertical slice; they do not replace the higher-level canonical instruction frame.
+
+## Runtime path
+
+```text
+HTTP/2-capable edge (Envoy)
+  -> FastAPI ingress
+  -> bounded host staging
+  -> FP input validation
+  -> Q16.16 saturating conversion
+  -> 3D spatial packing
+  -> ENCODE3D contraction
+  -> latent core
+  -> DECODE3D expansion
+  -> deterministic VERIFY
+  -> response emission
+
+                 +-> /metrics -> Prometheus
+```
+
+The 3D coordinate attached to every instruction is interpreted as:
+
+- `x`: pipeline position;
+- `y`: logical execution tick;
+- `z`: execution depth, from ingress at `z=0` to latent core at `z=4` and back out.
+
+## Compact 32-bit instruction
+
+```text
+31          24 23  20 19  16 15  12 11                 0
++-------------+------+------+------+---------------------+
+| opcode 8 b  | dst  | src1 | src2 | signed immediate 12 |
++-------------+------+------+------+---------------------+
+```
+
+The current end-to-end program is:
+
+```text
+NET_RX
+HOST_STAGE
+Q16_CONVERT
+PACK3D
+ENCODE3D
+LATENT_WRITE
+DECODE3D
+VERIFY
+TELEMETRY
+EMIT
+HALT
+```
+
+`ENCODE3D` uses deterministic block-average contraction. `DECODE3D` expands each latent block back across its source region. This gives the runtime a concrete, testable codec today while keeping the backend contract stable for a future CUDA implementation.
+
+## Numerical representation
+
+Inputs are converted to Q16.16:
+
+\[
+q = \operatorname{clip}(\operatorname{round}(x 2^{16}), -2^{31}, 2^{31}-1)
+\]
+
+Non-finite values are rejected. Values outside the fixed-point range saturate and increment the telemetry clipping counter.
+
+The verifier computes reconstruction MSE, maximum absolute error, and SHA-256 over the reconstructed signed 32-bit Q16.16 cells. A request is marked `passed` when maximum absolute error is within the caller's tolerance.
+
+## Resource bounds
+
+The reference runtime defaults to a maximum of 1,048,576 active input voxels per request. Shape and payload length must agree exactly. These bounds are part of the fail-closed execution contract rather than advisory metadata.
+
+## Run locally
+
+```bash
+docker compose -f deploy/bitcode3d/docker-compose.yml up --build
+```
+
+Ingress is exposed on port `8080`, Envoy admin on `9901`, and Prometheus on `9090`.
+
+Example request:
+
+```bash
+curl -sS \
+  -H 'content-type: application/json' \
+  -d '{
+    "shape": [2, 2, 2],
+    "values": [0, 1, 2, 3, 4, 5, 6, 7],
+    "pool": 2,
+    "tolerance": 4
+  }' \
+  http://127.0.0.1:8080/v1/bitcode3d/execute
+```
+
+Health:
+
+```bash
+curl -sS http://127.0.0.1:8080/healthz
+```
+
+Metrics:
+
+```bash
+curl -sS http://127.0.0.1:8080/metrics
+```
+
+## What is operational now
+
+- networked request/response service;
+- 32-bit compact Bit Code compilation and decode;
+- 3D spatial instruction coordinates;
+- bounded Q16.16 conversion with saturation accounting;
+- deterministic 3D encode/latent/decode execution;
+- closed-loop verification and checksum;
+- Prometheus telemetry endpoint;
+- Envoy ingress tier;
+- Docker deployment;
+- unit and container smoke CI.
+
+## Backend boundary
+
+The current `ENCODE3D` and `DECODE3D` operators are CPU reference kernels. Their observable contract is intentionally separated from the backend. A CUDA implementation can replace those operators while preserving:
+
+1. the 32-bit lowering words;
+2. Q16.16 semantics;
+3. shape and resource checks;
+4. deterministic verification;
+5. API and telemetry schemas.
+
+That boundary prevents the architecture from claiming GPU execution before GPU kernels are actually compiled and validated on supported hardware.

--- a/src/jarvisx/bitcode3d.py
+++ b/src/jarvisx/bitcode3d.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import IntEnum
+from hashlib import sha256
+from math import isfinite
+from struct import pack
+from time import perf_counter
+from typing import Sequence
+
+Q_FRAC_BITS = 16
+Q_SCALE = 1 << Q_FRAC_BITS
+Q_MIN = -(1 << 31)
+Q_MAX = (1 << 31) - 1
+MAX_VOXELS = 1_048_576
+
+Shape3D = tuple[int, int, int]
+
+
+class Opcode(IntEnum):
+    """Compact 32-bit edge/lowering ISA opcodes for the 3D runtime."""
+
+    NOP = 0x00
+    NET_RX = 0x10
+    HOST_STAGE = 0x11
+    Q16_CONVERT = 0x20
+    PACK3D = 0x21
+    ENCODE3D = 0x30
+    LATENT_WRITE = 0x31
+    DECODE3D = 0x40
+    VERIFY = 0x50
+    TELEMETRY = 0x60
+    EMIT = 0x70
+    HALT = 0xFF
+
+
+@dataclass(frozen=True)
+class Instruction32:
+    """32-bit instruction: opcode[31:24], dst[23:20], src1[19:16], src2[15:12], imm[11:0]."""
+
+    opcode: Opcode
+    dst: int = 0
+    src1: int = 0
+    src2: int = 0
+    imm: int = 0
+
+    def encode(self) -> int:
+        for name, value in (("dst", self.dst), ("src1", self.src1), ("src2", self.src2)):
+            if not 0 <= value <= 0xF:
+                raise ValueError(f"{name} must fit in 4 bits")
+        if not -2048 <= self.imm <= 2047:
+            raise ValueError("imm must fit in signed 12 bits")
+        return (
+            (int(self.opcode) << 24)
+            | (self.dst << 20)
+            | (self.src1 << 16)
+            | (self.src2 << 12)
+            | (self.imm & 0xFFF)
+        )
+
+    @classmethod
+    def decode(cls, word: int) -> "Instruction32":
+        if not 0 <= word <= 0xFFFFFFFF:
+            raise ValueError("word must fit in unsigned 32 bits")
+        opcode_raw = (word >> 24) & 0xFF
+        imm_raw = word & 0xFFF
+        imm = imm_raw - 0x1000 if imm_raw & 0x800 else imm_raw
+        try:
+            opcode = Opcode(opcode_raw)
+        except ValueError as exc:
+            raise ValueError(f"unknown opcode 0x{opcode_raw:02X}") from exc
+        return cls(
+            opcode=opcode,
+            dst=(word >> 20) & 0xF,
+            src1=(word >> 16) & 0xF,
+            src2=(word >> 12) & 0xF,
+            imm=imm,
+        )
+
+
+@dataclass(frozen=True)
+class SpatialInstruction:
+    word: int
+    x: int
+    y: int
+    z: int
+    stage: str
+
+    @property
+    def instruction(self) -> Instruction32:
+        return Instruction32.decode(self.word)
+
+    def as_payload(self) -> dict[str, object]:
+        decoded = self.instruction
+        return {
+            "word": self.word,
+            "hex": f"0x{self.word:08X}",
+            "opcode": decoded.opcode.name,
+            "x": self.x,
+            "y": self.y,
+            "z": self.z,
+            "stage": self.stage,
+        }
+
+
+@dataclass(frozen=True)
+class Verification:
+    mse: float
+    max_abs_error: float
+    tolerance: float
+    passed: bool
+    checksum_sha256: str
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "mse": self.mse,
+            "max_abs_error": self.max_abs_error,
+            "tolerance": self.tolerance,
+            "passed": self.passed,
+            "checksum_sha256": self.checksum_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class Telemetry:
+    cycles: int
+    active_cells: int
+    latent_cells: int
+    clipped_values: int
+    elapsed_ms: float
+    stages: tuple[str, ...]
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "cycles": self.cycles,
+            "active_cells": self.active_cells,
+            "latent_cells": self.latent_cells,
+            "clipped_values": self.clipped_values,
+            "elapsed_ms": self.elapsed_ms,
+            "stages": list(self.stages),
+        }
+
+
+@dataclass(frozen=True)
+class BitCode3DResult:
+    input_shape: Shape3D
+    latent_shape: Shape3D
+    latent: tuple[float, ...]
+    reconstructed: tuple[float, ...]
+    bytecode: tuple[int, ...]
+    spatial_program: tuple[SpatialInstruction, ...]
+    verification: Verification
+    telemetry: Telemetry
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "input_shape": list(self.input_shape),
+            "latent_shape": list(self.latent_shape),
+            "latent": list(self.latent),
+            "reconstructed": list(self.reconstructed),
+            "bytecode": [f"0x{word:08X}" for word in self.bytecode],
+            "spatial_program": [item.as_payload() for item in self.spatial_program],
+            "verification": self.verification.as_payload(),
+            "telemetry": self.telemetry.as_payload(),
+        }
+
+
+@dataclass
+class _ExecutionState:
+    values: list[float]
+    shape: Shape3D
+    pool: int
+    tolerance: float
+    q_input: list[int] = field(default_factory=list)
+    latent_q: list[int] = field(default_factory=list)
+    latent_shape: Shape3D = (0, 0, 0)
+    reconstructed_q: list[int] = field(default_factory=list)
+    clipped_values: int = 0
+    verification: Verification | None = None
+
+
+def quantize_q16_16(value: float) -> tuple[int, bool]:
+    if not isfinite(value):
+        raise ValueError("all input values must be finite")
+    scaled = round(value * Q_SCALE)
+    clipped = scaled < Q_MIN or scaled > Q_MAX
+    return min(max(scaled, Q_MIN), Q_MAX), clipped
+
+
+def dequantize_q16_16(value: int) -> float:
+    return value / Q_SCALE
+
+
+def _voxel_count(shape: Shape3D) -> int:
+    sx, sy, sz = shape
+    return sx * sy * sz
+
+
+def _index(shape: Shape3D, x: int, y: int, z: int) -> int:
+    sx, sy, _ = shape
+    return (z * sy + y) * sx + x
+
+
+def _round_div(numerator: int, denominator: int) -> int:
+    if numerator >= 0:
+        return (numerator + denominator // 2) // denominator
+    return -((-numerator + denominator // 2) // denominator)
+
+
+def _pool3d(values: Sequence[int], shape: Shape3D, factor: int) -> tuple[list[int], Shape3D]:
+    sx, sy, sz = shape
+    latent_shape = (
+        (sx + factor - 1) // factor,
+        (sy + factor - 1) // factor,
+        (sz + factor - 1) // factor,
+    )
+    lx, ly, lz = latent_shape
+    latent: list[int] = []
+    for z0 in range(lz):
+        for y0 in range(ly):
+            for x0 in range(lx):
+                total = 0
+                count = 0
+                for dz in range(factor):
+                    z = z0 * factor + dz
+                    if z >= sz:
+                        break
+                    for dy in range(factor):
+                        y = y0 * factor + dy
+                        if y >= sy:
+                            break
+                        for dx in range(factor):
+                            x = x0 * factor + dx
+                            if x >= sx:
+                                break
+                            total += values[_index(shape, x, y, z)]
+                            count += 1
+                latent.append(_round_div(total, count))
+    return latent, latent_shape
+
+
+def _expand3d(
+    values: Sequence[int], latent_shape: Shape3D, output_shape: Shape3D, factor: int
+) -> list[int]:
+    sx, sy, sz = output_shape
+    reconstructed = [0] * _voxel_count(output_shape)
+    for z in range(sz):
+        for y in range(sy):
+            for x in range(sx):
+                source = _index(latent_shape, x // factor, y // factor, z // factor)
+                reconstructed[_index(output_shape, x, y, z)] = values[source]
+    return reconstructed
+
+
+def _checksum_q16(values: Sequence[int]) -> str:
+    digest = sha256()
+    for value in values:
+        digest.update(pack("<i", value))
+    return digest.hexdigest()
+
+
+def compile_spatial_program(pool: int) -> tuple[SpatialInstruction, ...]:
+    """Compile the fixed end-to-end request path into 3D-addressed 32-bit words."""
+
+    if not 1 <= pool <= 16:
+        raise ValueError("pool must be between 1 and 16")
+    stages = (
+        (Opcode.NET_RX, 0, "network-ingress"),
+        (Opcode.HOST_STAGE, 1, "host-orchestration"),
+        (Opcode.Q16_CONVERT, 2, "q16.16-transmutation"),
+        (Opcode.PACK3D, 2, "spatial-pack"),
+        (Opcode.ENCODE3D, 3, "latent-contract"),
+        (Opcode.LATENT_WRITE, 4, "latent-core"),
+        (Opcode.DECODE3D, 3, "latent-expand"),
+        (Opcode.VERIFY, 2, "closed-loop-verify"),
+        (Opcode.TELEMETRY, 1, "out-of-band-telemetry"),
+        (Opcode.EMIT, 0, "network-egress"),
+        (Opcode.HALT, 0, "halt"),
+    )
+    program: list[SpatialInstruction] = []
+    for tick, (opcode, z, stage) in enumerate(stages):
+        imm = pool if opcode in {Opcode.ENCODE3D, Opcode.DECODE3D} else 0
+        word = Instruction32(opcode=opcode, imm=imm).encode()
+        program.append(SpatialInstruction(word=word, x=tick, y=tick, z=z, stage=stage))
+    return tuple(program)
+
+
+class BitCode3DRuntime:
+    """Deterministic sparse 3D Bit Code reference runtime.
+
+    The implementation is intentionally backend-neutral: the instruction stream,
+    Q16.16 representation, validation semantics, and telemetry remain stable while
+    ENCODE3D/DECODE3D can later be lowered to CUDA kernels without changing the API.
+    """
+
+    def __init__(self, *, max_voxels: int = MAX_VOXELS) -> None:
+        if max_voxels < 1:
+            raise ValueError("max_voxels must be positive")
+        self.max_voxels = max_voxels
+
+    def execute(
+        self,
+        values: Sequence[float],
+        shape: Shape3D,
+        *,
+        pool: int = 2,
+        tolerance: float = 1.0,
+    ) -> BitCode3DResult:
+        if len(shape) != 3 or any(dimension < 1 for dimension in shape):
+            raise ValueError("shape must contain exactly three positive dimensions")
+        count = _voxel_count(shape)
+        if count > self.max_voxels:
+            raise ValueError(f"voxel count {count} exceeds runtime limit {self.max_voxels}")
+        if len(values) != count:
+            raise ValueError(f"values length {len(values)} does not match shape voxel count {count}")
+        if not isfinite(tolerance) or tolerance < 0:
+            raise ValueError("tolerance must be a finite non-negative number")
+
+        program = compile_spatial_program(pool)
+        state = _ExecutionState(
+            values=[float(value) for value in values],
+            shape=shape,
+            pool=pool,
+            tolerance=tolerance,
+        )
+        stages: list[str] = []
+        started = perf_counter()
+        cycles = 0
+
+        for spatial in program:
+            instruction = spatial.instruction
+            stages.append(spatial.stage)
+            cycles += 1
+
+            if instruction.opcode is Opcode.NET_RX:
+                continue
+            if instruction.opcode is Opcode.HOST_STAGE:
+                continue
+            if instruction.opcode is Opcode.Q16_CONVERT:
+                quantized: list[int] = []
+                clipped = 0
+                for value in state.values:
+                    q_value, was_clipped = quantize_q16_16(value)
+                    quantized.append(q_value)
+                    clipped += int(was_clipped)
+                state.q_input = quantized
+                state.clipped_values = clipped
+                continue
+            if instruction.opcode is Opcode.PACK3D:
+                if len(state.q_input) != count:
+                    raise RuntimeError("PACK3D requires a complete Q16.16 input volume")
+                continue
+            if instruction.opcode is Opcode.ENCODE3D:
+                state.latent_q, state.latent_shape = _pool3d(
+                    state.q_input, state.shape, instruction.imm
+                )
+                continue
+            if instruction.opcode is Opcode.LATENT_WRITE:
+                if not state.latent_q:
+                    raise RuntimeError("LATENT_WRITE requires encoded state")
+                continue
+            if instruction.opcode is Opcode.DECODE3D:
+                state.reconstructed_q = _expand3d(
+                    state.latent_q, state.latent_shape, state.shape, instruction.imm
+                )
+                continue
+            if instruction.opcode is Opcode.VERIFY:
+                if len(state.reconstructed_q) != count:
+                    raise RuntimeError("VERIFY requires a complete reconstruction")
+                errors = [
+                    dequantize_q16_16(source - reconstructed)
+                    for source, reconstructed in zip(state.q_input, state.reconstructed_q)
+                ]
+                mse = sum(error * error for error in errors) / count
+                max_abs_error = max((abs(error) for error in errors), default=0.0)
+                state.verification = Verification(
+                    mse=mse,
+                    max_abs_error=max_abs_error,
+                    tolerance=tolerance,
+                    passed=max_abs_error <= tolerance,
+                    checksum_sha256=_checksum_q16(state.reconstructed_q),
+                )
+                continue
+            if instruction.opcode in {Opcode.TELEMETRY, Opcode.EMIT}:
+                continue
+            if instruction.opcode is Opcode.HALT:
+                break
+            raise RuntimeError(f"unsupported 3D Bit Code opcode {instruction.opcode.name}")
+
+        verification = state.verification
+        if verification is None:
+            raise RuntimeError("program halted without verification")
+
+        elapsed_ms = (perf_counter() - started) * 1000.0
+        telemetry = Telemetry(
+            cycles=cycles,
+            active_cells=count,
+            latent_cells=len(state.latent_q),
+            clipped_values=state.clipped_values,
+            elapsed_ms=elapsed_ms,
+            stages=tuple(stages),
+        )
+        return BitCode3DResult(
+            input_shape=shape,
+            latent_shape=state.latent_shape,
+            latent=tuple(dequantize_q16_16(value) for value in state.latent_q),
+            reconstructed=tuple(dequantize_q16_16(value) for value in state.reconstructed_q),
+            bytecode=tuple(item.word for item in program),
+            spatial_program=program,
+            verification=verification,
+            telemetry=telemetry,
+        )

--- a/src/jarvisx/bitcode3d_api.py
+++ b/src/jarvisx/bitcode3d_api.py
@@ -59,7 +59,8 @@ def execute_bitcode3d(request: ExecuteRequest) -> dict[str, object]:
         _executions += 1
         _total_cycles += result.telemetry.cycles
         _total_active_cells += result.telemetry.active_cells
-    return result.as_payload()
+    payload: dict[str, object] = result.as_payload()
+    return payload
 
 
 @app.get("/metrics", response_class=Response)

--- a/src/jarvisx/bitcode3d_api.py
+++ b/src/jarvisx/bitcode3d_api.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from threading import Lock
+
+from fastapi import FastAPI, HTTPException, Response
+from pydantic import BaseModel, Field
+
+from .bitcode3d import BitCode3DRuntime, MAX_VOXELS, Shape3D
+
+app = FastAPI(
+    title="Jarvis-X 3D Bit Code Runtime",
+    version="1.0.0",
+    description="Bounded end-to-end Q16.16 3D encode/decode execution service.",
+)
+
+_runtime = BitCode3DRuntime()
+_metrics_lock = Lock()
+_executions = 0
+_failures = 0
+_total_cycles = 0
+_total_active_cells = 0
+
+
+class ExecuteRequest(BaseModel):
+    shape: Shape3D
+    values: list[float]
+    pool: int = Field(default=2, ge=1, le=16)
+    tolerance: float = Field(default=1.0, ge=0.0)
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, object]:
+    return {
+        "status": "ok",
+        "runtime": "bitcode3d",
+        "max_voxels": MAX_VOXELS,
+        "isa": "32-bit compact lowering",
+        "numeric_format": "Q16.16",
+    }
+
+
+@app.post("/v1/bitcode3d/execute")
+def execute_bitcode3d(request: ExecuteRequest) -> dict[str, object]:
+    global _executions, _failures, _total_cycles, _total_active_cells
+
+    try:
+        result = _runtime.execute(
+            request.values,
+            request.shape,
+            pool=request.pool,
+            tolerance=request.tolerance,
+        )
+    except ValueError as exc:
+        with _metrics_lock:
+            _failures += 1
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    with _metrics_lock:
+        _executions += 1
+        _total_cycles += result.telemetry.cycles
+        _total_active_cells += result.telemetry.active_cells
+    return result.as_payload()
+
+
+@app.get("/metrics", response_class=Response)
+def metrics() -> Response:
+    with _metrics_lock:
+        executions = _executions
+        failures = _failures
+        cycles = _total_cycles
+        active_cells = _total_active_cells
+
+    body = "\n".join(
+        [
+            "# HELP jarvisx_bitcode3d_executions_total Successful runtime executions.",
+            "# TYPE jarvisx_bitcode3d_executions_total counter",
+            f"jarvisx_bitcode3d_executions_total {executions}",
+            "# HELP jarvisx_bitcode3d_failures_total Rejected runtime executions.",
+            "# TYPE jarvisx_bitcode3d_failures_total counter",
+            f"jarvisx_bitcode3d_failures_total {failures}",
+            "# HELP jarvisx_bitcode3d_cycles_total Executed 32-bit instruction cycles.",
+            "# TYPE jarvisx_bitcode3d_cycles_total counter",
+            f"jarvisx_bitcode3d_cycles_total {cycles}",
+            "# HELP jarvisx_bitcode3d_active_cells_total Input voxels processed.",
+            "# TYPE jarvisx_bitcode3d_active_cells_total counter",
+            f"jarvisx_bitcode3d_active_cells_total {active_cells}",
+            "",
+        ]
+    )
+    return Response(content=body, media_type="text/plain; version=0.0.4")

--- a/tests/test_bitcode3d.py
+++ b/tests/test_bitcode3d.py
@@ -1,0 +1,102 @@
+import math
+
+import pytest
+
+from jarvisx import bitcode3d as b3
+
+
+def test_instruction32_round_trip_and_bounds() -> None:
+    instruction = b3.Instruction32(
+        opcode=b3.Opcode.ENCODE3D, dst=1, src1=2, src2=3, imm=-7
+    )
+    encoded = instruction.encode()
+
+    assert 0 <= encoded <= 0xFFFFFFFF
+    assert b3.Instruction32.decode(encoded) == instruction
+
+    with pytest.raises(ValueError, match="dst"):
+        b3.Instruction32(opcode=b3.Opcode.NOP, dst=16).encode()
+    with pytest.raises(ValueError, match="signed 12 bits"):
+        b3.Instruction32(opcode=b3.Opcode.NOP, imm=2048).encode()
+    with pytest.raises(ValueError, match="unsigned 32 bits"):
+        b3.Instruction32.decode(1 << 32)
+    with pytest.raises(ValueError, match="unknown opcode"):
+        b3.Instruction32.decode(0xFE000000)
+
+
+def test_q16_quantization_saturates_and_rejects_non_finite_values() -> None:
+    value, clipped = b3.quantize_q16_16(1.5)
+    assert value == int(1.5 * b3.Q_SCALE)
+    assert clipped is False
+    assert b3.dequantize_q16_16(value) == 1.5
+
+    high, high_clipped = b3.quantize_q16_16(1e20)
+    low, low_clipped = b3.quantize_q16_16(-1e20)
+    assert high == b3.Q_MAX and high_clipped
+    assert low == b3.Q_MIN and low_clipped
+
+    with pytest.raises(ValueError, match="finite"):
+        b3.quantize_q16_16(math.inf)
+
+
+def test_end_to_end_3d_contract_expand_verify_is_deterministic() -> None:
+    runtime = b3.BitCode3DRuntime()
+    first = runtime.execute(list(range(8)), (2, 2, 2), pool=2, tolerance=4.0)
+    second = runtime.execute(list(range(8)), (2, 2, 2), pool=2, tolerance=4.0)
+
+    assert first.input_shape == (2, 2, 2)
+    assert first.latent_shape == (1, 1, 1)
+    assert first.latent == (3.5,)
+    assert first.reconstructed == (3.5,) * 8
+    assert first.verification.mse == 5.25
+    assert first.verification.max_abs_error == 3.5
+    assert first.verification.passed is True
+    assert first.verification.checksum_sha256 == second.verification.checksum_sha256
+    assert first.bytecode == second.bytecode
+    assert first.telemetry.cycles == len(first.bytecode) == 11
+    assert first.telemetry.active_cells == 8
+    assert first.telemetry.latent_cells == 1
+    assert [step.instruction.opcode for step in first.spatial_program] == [
+        b3.Opcode.NET_RX,
+        b3.Opcode.HOST_STAGE,
+        b3.Opcode.Q16_CONVERT,
+        b3.Opcode.PACK3D,
+        b3.Opcode.ENCODE3D,
+        b3.Opcode.LATENT_WRITE,
+        b3.Opcode.DECODE3D,
+        b3.Opcode.VERIFY,
+        b3.Opcode.TELEMETRY,
+        b3.Opcode.EMIT,
+        b3.Opcode.HALT,
+    ]
+
+
+def test_pool_one_is_exact_q16_roundtrip() -> None:
+    result = b3.BitCode3DRuntime().execute(
+        [0.125, -0.5, 3.25], (3, 1, 1), pool=1, tolerance=0.0
+    )
+
+    assert result.latent_shape == (3, 1, 1)
+    assert result.reconstructed == (0.125, -0.5, 3.25)
+    assert result.verification.mse == 0.0
+    assert result.verification.passed is True
+    payload = result.as_payload()
+    assert payload["bytecode"][0] == "0x10000000"
+    assert payload["spatial_program"][4]["opcode"] == "ENCODE3D"
+
+
+def test_runtime_bounds_and_validation_fail_closed() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        b3.BitCode3DRuntime(max_voxels=0)
+
+    runtime = b3.BitCode3DRuntime(max_voxels=4)
+    with pytest.raises(ValueError, match="three positive dimensions"):
+        runtime.execute([1.0], (1, 0, 1))
+    with pytest.raises(ValueError, match="exceeds runtime limit"):
+        runtime.execute([0.0] * 8, (2, 2, 2))
+    with pytest.raises(ValueError, match="does not match"):
+        b3.BitCode3DRuntime().execute([1.0], (2, 1, 1))
+    with pytest.raises(ValueError, match="tolerance"):
+        b3.BitCode3DRuntime().execute([1.0], (1, 1, 1), tolerance=-1.0)
+    with pytest.raises(ValueError, match="pool"):
+        b3.compile_spatial_program(0)


### PR DESCRIPTION
## Summary

Operationalizes the diagrammed request path as a bounded, runnable 3D Bit Code vertical slice:

- compact 32-bit lowering ISA with 3D spatial coordinates
- Q16.16 saturating numerical transmutation
- deterministic `ENCODE3D -> latent -> DECODE3D` execution
- fail-closed shape/resource validation
- closed-loop reconstruction verification + SHA-256 checksum
- FastAPI network ingress/egress
- Prometheus-compatible telemetry
- Envoy HTTP/2-capable edge ingress
- Docker Compose deployment
- unit tests and container smoke CI

## Runtime flow

`NET_RX -> HOST_STAGE -> Q16_CONVERT -> PACK3D -> ENCODE3D -> LATENT_WRITE -> DECODE3D -> VERIFY -> TELEMETRY -> EMIT -> HALT`

The spatial program maps pipeline position to `x`, logical tick to `y`, and execution depth to `z`, reaching the latent core at `z=4` before expanding back to egress.

## Important backend boundary

This PR makes the full network-to-verification path operational now using deterministic CPU reference kernels for `ENCODE3D` and `DECODE3D`. It does **not** claim CUDA execution yet. The backend contract is isolated so CUDA kernels can replace the reference operators without changing the 32-bit ABI, Q16.16 semantics, API schema, bounds, or verification contract.

## Validation

Local reference tests were executed for instruction encode/decode, saturation, deterministic contraction/expansion, exact pool=1 roundtrip, and fail-closed resource checks. GitHub Actions adds a container build, health check, and end-to-end request smoke test.