### PR TITLE
Permeate kinetic 3D runtime into native backend

### DIFF
--- a/.github/workflows/kinetic3d.yml
+++ b/.github/workflows/kinetic3d.yml
@@ -5,16 +5,22 @@ on:
     branches: [main]
     paths:
       - "src/jarvisx/kinetic3d.py"
+      - "src/jarvisx/kinetic3d_backend.py"
       - "src/jarvisx/kinetic3d_api.py"
       - "tests/test_kinetic3d.py"
+      - "tests/test_kinetic3d_backend.py"
+      - "native/kinetic3d_backend.cpp"
       - "deploy/kinetic3d/**"
       - ".github/workflows/kinetic3d.yml"
   push:
     branches: [main]
     paths:
       - "src/jarvisx/kinetic3d.py"
+      - "src/jarvisx/kinetic3d_backend.py"
       - "src/jarvisx/kinetic3d_api.py"
       - "tests/test_kinetic3d.py"
+      - "tests/test_kinetic3d_backend.py"
+      - "native/kinetic3d_backend.cpp"
       - "deploy/kinetic3d/**"
       - ".github/workflows/kinetic3d.yml"
 
@@ -33,9 +39,26 @@ jobs:
       - name: Install
         run: python -m pip install -e ".[test]"
       - name: Unit tests
-        run: pytest -q tests/test_kinetic3d.py
+        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py
       - name: Compile modules
-        run: python -m compileall -q src/jarvisx/kinetic3d.py src/jarvisx/kinetic3d_api.py
+        run: python -m compileall -q src/jarvisx/kinetic3d.py src/jarvisx/kinetic3d_backend.py src/jarvisx/kinetic3d_api.py
+
+  native-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install -e ".[test]"
+      - name: Compile native backend
+        run: g++ -O3 -std=c++17 -fPIC -shared native/kinetic3d_backend.cpp -o /tmp/libjarvisx_kinetic3d.so
+      - name: Native parity tests
+        env:
+          JARVISX_KINETIC3D_NATIVE_LIB: /tmp/libjarvisx_kinetic3d.so
+        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py
 
   container-smoke:
     runs-on: ubuntu-latest
@@ -45,10 +68,11 @@ jobs:
         run: docker build -f deploy/kinetic3d/Dockerfile -t jarvisx-kinetic3d:test .
       - name: Start runtime
         run: docker run -d --rm --name jarvisx-kinetic3d -p 8000:8000 jarvisx-kinetic3d:test
-      - name: Wait for health
+      - name: Wait for health and native backend
         run: |
           for i in $(seq 1 30); do
-            if curl --fail --silent http://127.0.0.1:8000/healthz >/dev/null; then
+            if health=$(curl --fail --silent http://127.0.0.1:8000/healthz); then
+              python -c 'import json,sys; d=json.loads(sys.argv[1]); assert "native-cpu" in d["available_backends"]' "$health"
               exit 0
             fi
             sleep 1
@@ -59,16 +83,16 @@ jobs:
         run: |
           response=$(curl --fail --silent \
             -H 'content-type: application/json' \
-            -d '{"session_id":"ci","shape":[2,2,2],"values":[1,1,1,1,1,1,1,1],"active_threshold":0,"coarse_factor":2,"refine_threshold":0,"tolerance":0}' \
+            -d '{"session_id":"ci","shape":[2,2,2],"values":[1,1,1,1,1,1,1,1],"active_threshold":0,"coarse_factor":2,"refine_threshold":0,"tolerance":0,"backend":"auto"}' \
             http://127.0.0.1:8000/v1/kinetic3d/execute)
-          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert d["committed"]; assert d["epoch_after"] == 1; assert d["telemetry"]["latent_values"] == 1' "$response"
+          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert d["committed"]; assert d["epoch_after"] == 1; assert d["telemetry"]["latent_values"] == 1; assert d["telemetry"]["backend"] == "native-cpu"' "$response"
       - name: Execute sparse kinetic update
         run: |
           response=$(curl --fail --silent \
             -H 'content-type: application/json' \
-            -d '{"session_id":"ci","shape":[2,2,2],"values":[1,1,1,1,1,1,9,1],"active_threshold":0.1,"coarse_factor":2,"refine_threshold":0,"tolerance":0}' \
+            -d '{"session_id":"ci","shape":[2,2,2],"values":[1,1,1,1,1,1,9,1],"active_threshold":0.1,"coarse_factor":2,"refine_threshold":0,"tolerance":0,"backend":"auto"}' \
             http://127.0.0.1:8000/v1/kinetic3d/execute)
-          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert d["epoch_after"] == 2; assert d["active_indices"] == [6]; assert d["telemetry"]["active_cells"] == 1' "$response"
+          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert d["epoch_after"] == 2; assert d["active_indices"] == [6]; assert d["telemetry"]["active_cells"] == 1; assert d["telemetry"]["backend"] == "native-cpu"' "$response"
       - name: Inspect committed world state
         run: |
           state=$(curl --fail --silent http://127.0.0.1:8000/v1/kinetic3d/state/ci)

--- a/deploy/kinetic3d/Dockerfile
+++ b/deploy/kinetic3d/Dockerfile
@@ -1,13 +1,28 @@
+FROM debian:bookworm-slim AS native-build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY native/kinetic3d_backend.cpp /src/kinetic3d_backend.cpp
+RUN mkdir -p /out \
+    && g++ -O3 -std=c++17 -fPIC -shared \
+       /src/kinetic3d_backend.cpp \
+       -o /out/libjarvisx_kinetic3d.so
+
 FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PIP_DISABLE_PIP_VERSION_CHECK=1
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    JARVISX_KINETIC3D_NATIVE_LIB=/opt/jarvisx-native/libjarvisx_kinetic3d.so
 
 WORKDIR /app
 
 COPY pyproject.toml README.md /app/
 COPY src /app/src
+COPY --from=native-build /out/libjarvisx_kinetic3d.so /opt/jarvisx-native/libjarvisx_kinetic3d.so
 RUN python -m pip install --no-cache-dir .
 
 EXPOSE 8000

--- a/docs/PERMEATION3D_NATIVE_BACKEND.md
+++ b/docs/PERMEATION3D_NATIVE_BACKEND.md
@@ -1,0 +1,145 @@
+# Jarvis-X Permeation 3D Native Backend
+
+## Purpose
+
+This layer pushes the kinetic 3D runtime one level deeper into the execution stack without changing its observable state law.
+
+```text
+Kinetic Spatial IR
+  -> backend router
+  -> native C++ active-volume kernel
+  -> hierarchical residual reconstruction
+  -> verification
+  -> commit
+```
+
+The pure Python implementation remains the correctness oracle. The runtime can now select `native-cpu` when a compiled backend is installed and falls back to `cpu-reference` otherwise.
+
+## Backend contract
+
+Every backend receives:
+
+- current 3D values;
+- predicted 3D values;
+- `(sx, sy, sz)` shape;
+- active threshold;
+- coarse block factor;
+- fine-refinement threshold.
+
+It must return exactly the same semantic state:
+
+- residual field;
+- active indices;
+- one coarse residual per active block;
+- fine corrections;
+- reconstructed world.
+
+The runtime itself still performs verification, integrity hashing, transaction commit, epoch management, telemetry, and API state management. Hardware kernels therefore cannot bypass the verification boundary.
+
+## Native execution
+
+`native/kinetic3d_backend.cpp` exports a C ABI function that performs the active-volume numerical path in compiled C++.
+
+For each cell:
+
+\[
+R_i = W_i - \hat W_i
+\]
+
+and
+
+\[
+i \in A \iff |R_i| > \tau_{active}.
+\]
+
+Active cells are grouped into spatial blocks. The kernel computes:
+
+\[
+z_b = \frac{1}{|A_b|}\sum_{i\in A_b}R_i.
+\]
+
+It reconstructs each active cell as:
+
+\[
+\tilde W_i = \hat W_i + z_b + \delta_i,
+\]
+
+where the fine correction is emitted only when:
+
+\[
+|R_i-z_b| > \tau_{refine}.
+\]
+
+Inactive cells remain at their predicted state.
+
+## Native library discovery
+
+The Python runtime loads the shared library only through the explicit environment variable:
+
+```text
+JARVISX_KINETIC3D_NATIVE_LIB=/path/to/libjarvisx_kinetic3d.so
+```
+
+`backend=auto` uses the native backend if that library exists and loads successfully. Otherwise it falls back to the Python reference implementation.
+
+`backend=native-cpu` fails closed if the library is unavailable.
+
+## Container path
+
+The kinetic Docker image now has a multi-stage build:
+
+1. compile the C++ kernel with `g++ -O3 -fPIC -shared`;
+2. copy only the resulting shared library into the Python runtime image;
+3. expose its location through `JARVISX_KINETIC3D_NATIVE_LIB`;
+4. run the API with backend policy `auto`.
+
+The container smoke test verifies that `native-cpu` is available and that actual state transitions report `telemetry.backend == "native-cpu"`.
+
+## Verification boundary
+
+Backend acceleration does not change transactional semantics:
+
+```text
+EXECUTE BACKEND
+  -> RECONSTRUCT
+  -> COMPUTE MSE / MAX ERROR / SHA-256
+  -> VERIFY
+  -> COMMIT only if tolerance passes
+```
+
+Thus:
+
+\[
+\neg VERIFY \Rightarrow \neg COMMIT.
+\]
+
+The authoritative 3D world and epoch remain unchanged after failed verification.
+
+## CI evidence
+
+The dedicated workflow validates three levels independently:
+
+- reference-runtime tests with no native library present;
+- native parity tests using a compiled shared library;
+- Docker end-to-end execution where `auto` resolves to `native-cpu`.
+
+This prevents a native backend from being treated as operational merely because source code exists: it must compile, load, reproduce reference semantics, survive stateful transitions, and pass transaction verification.
+
+## Next permeation boundary
+
+The next backend enters through the same contract:
+
+```text
+Kinetic Spatial IR
+   |-- cpu-reference
+   |-- native-cpu
+   |-- triton-gpu        (next)
+   |-- cuda-native       (next)
+   `-- distributed-path  (later)
+```
+
+The target remains measurable rather than declarative:
+
+\[
+\eta = \frac{\text{verified useful state transitions}}{\text{time} + \text{bytes moved} + \text{energy} + \text{recovery cost}}.
+\]

--- a/native/kinetic3d_backend.cpp
+++ b/native/kinetic3d_backend.cpp
@@ -1,0 +1,131 @@
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+std::size_t block_index(
+    int x,
+    int y,
+    int z,
+    int sx,
+    int sy,
+    int sz,
+    int factor,
+    int &bx_count,
+    int &by_count,
+    int &bz_count
+) {
+    bx_count = (sx + factor - 1) / factor;
+    by_count = (sy + factor - 1) / factor;
+    bz_count = (sz + factor - 1) / factor;
+    const int bx = x / factor;
+    const int by = y / factor;
+    const int bz = z / factor;
+    return static_cast<std::size_t>((bz * by_count + by) * bx_count + bx);
+}
+
+}  // namespace
+
+extern "C" int jx_kinetic3d_step(
+    const double *current,
+    const double *prediction,
+    std::size_t count,
+    int sx,
+    int sy,
+    int sz,
+    double active_threshold,
+    int coarse_factor,
+    double refine_threshold,
+    double *residual,
+    double *reconstructed,
+    std::uint8_t *active_mask,
+    double *coarse_per_cell,
+    double *fine_per_cell
+) {
+    if (
+        current == nullptr || prediction == nullptr || residual == nullptr ||
+        reconstructed == nullptr || active_mask == nullptr || coarse_per_cell == nullptr ||
+        fine_per_cell == nullptr
+    ) {
+        return 1;
+    }
+    if (sx < 1 || sy < 1 || sz < 1 || coarse_factor < 1) {
+        return 2;
+    }
+    const std::size_t expected = static_cast<std::size_t>(sx) * static_cast<std::size_t>(sy) *
+                                 static_cast<std::size_t>(sz);
+    if (expected != count) {
+        return 3;
+    }
+    if (!std::isfinite(active_threshold) || active_threshold < 0.0 ||
+        !std::isfinite(refine_threshold) || refine_threshold < 0.0) {
+        return 4;
+    }
+
+    const int bx_count = (sx + coarse_factor - 1) / coarse_factor;
+    const int by_count = (sy + coarse_factor - 1) / coarse_factor;
+    const int bz_count = (sz + coarse_factor - 1) / coarse_factor;
+    const std::size_t block_count = static_cast<std::size_t>(bx_count) *
+                                    static_cast<std::size_t>(by_count) *
+                                    static_cast<std::size_t>(bz_count);
+    std::vector<double> block_sum(block_count, 0.0);
+    std::vector<std::size_t> block_active(block_count, 0);
+
+    for (std::size_t index = 0; index < count; ++index) {
+        residual[index] = current[index] - prediction[index];
+        reconstructed[index] = prediction[index];
+        coarse_per_cell[index] = 0.0;
+        fine_per_cell[index] = 0.0;
+        const bool active = std::abs(residual[index]) > active_threshold;
+        active_mask[index] = active ? 1U : 0U;
+        if (!active) {
+            continue;
+        }
+
+        const int plane = sx * sy;
+        const int z = static_cast<int>(index) / plane;
+        const int rem = static_cast<int>(index) % plane;
+        const int y = rem / sx;
+        const int x = rem % sx;
+        const std::size_t block = static_cast<std::size_t>(
+            ((z / coarse_factor) * by_count + (y / coarse_factor)) * bx_count +
+            (x / coarse_factor)
+        );
+        block_sum[block] += residual[index];
+        block_active[block] += 1;
+    }
+
+    std::vector<double> block_mean(block_count, 0.0);
+    for (std::size_t block = 0; block < block_count; ++block) {
+        if (block_active[block] != 0U) {
+            block_mean[block] = block_sum[block] / static_cast<double>(block_active[block]);
+        }
+    }
+
+    for (std::size_t index = 0; index < count; ++index) {
+        if (active_mask[index] == 0U) {
+            continue;
+        }
+        const int plane = sx * sy;
+        const int z = static_cast<int>(index) / plane;
+        const int rem = static_cast<int>(index) % plane;
+        const int y = rem / sx;
+        const int x = rem % sx;
+        const std::size_t block = static_cast<std::size_t>(
+            ((z / coarse_factor) * by_count + (y / coarse_factor)) * bx_count +
+            (x / coarse_factor)
+        );
+        const double coarse = block_mean[block];
+        coarse_per_cell[index] = coarse;
+        reconstructed[index] += coarse;
+
+        const double correction = residual[index] - coarse;
+        if (std::abs(correction) > refine_threshold) {
+            reconstructed[index] += correction;
+            fine_per_cell[index] = correction;
+        }
+    }
+    return 0;
+}

--- a/src/jarvisx/kinetic3d.py
+++ b/src/jarvisx/kinetic3d.py
@@ -8,6 +8,8 @@ from struct import pack
 from time import perf_counter
 from typing import Sequence
 
+from .kinetic3d_backend import resolve_backend
+
 Shape3D = tuple[int, int, int]
 Block3D = tuple[int, int, int]
 MAX_KINETIC_VOXELS = 1_048_576
@@ -244,17 +246,17 @@ def compile_kinetic_ir() -> tuple[SpatialIRNode, ...]:
 class Kinetic3DRuntime:
     """Transactional predictive 3D runtime with sparse residual execution.
 
-    This is a deterministic CPU reference backend. It operationalizes four ideas:
-    persistent world prediction, active-volume execution, hierarchical latent
-    residuals, and verify-before-commit state transitions. The backend boundary is
-    intentionally explicit so GPU/Triton lowering can replace the reference loops
-    without changing observable state semantics.
+    The state/IR/verification contract is backend-neutral. ``auto`` uses the native
+    C++ active-volume kernel when it is explicitly installed and falls back to the
+    pure Python correctness oracle otherwise. Future Triton/CUDA backends can enter
+    through the same boundary without changing the observable kinetic semantics.
     """
 
-    def __init__(self, *, max_voxels: int = MAX_KINETIC_VOXELS) -> None:
+    def __init__(self, *, max_voxels: int = MAX_KINETIC_VOXELS, backend: str = "auto") -> None:
         if max_voxels < 1:
             raise ValueError("max_voxels must be positive")
         self.max_voxels = max_voxels
+        self.backend = backend
         self._committed_world: tuple[float, ...] | None = None
         self._committed_shape: Shape3D | None = None
         self._epoch = 0
@@ -295,6 +297,7 @@ class Kinetic3DRuntime:
         coarse_factor: int = 2,
         refine_threshold: float = 0.0,
         tolerance: float = 0.0,
+        backend: str | None = None,
     ) -> Kinetic3DResult:
         count = _validate_shape(shape, self.max_voxels)
         observed = _validate_vector("current", current, count)
@@ -311,22 +314,29 @@ class Kinetic3DRuntime:
         epoch_before = self._epoch
         ir = compile_kinetic_ir()
         prediction = self._prediction(previous, shape, count)
-        residual = [value - predicted for value, predicted in zip(observed, prediction)]
-        active_indices = tuple(
-            index for index, error in enumerate(residual) if abs(error) > active_threshold
+        selected_backend = resolve_backend(backend or self.backend)
+        backend_result = selected_backend.step(
+            observed,
+            prediction,
+            shape,
+            active_threshold=active_threshold,
+            coarse_factor=coarse_factor,
+            refine_threshold=refine_threshold,
         )
+        residual = list(backend_result.residual)
+        active_indices = backend_result.active_indices
+        reconstructed = list(backend_result.reconstructed)
+        coarse_values = dict(backend_result.coarse_values)
 
         grouped: dict[Block3D, list[int]] = {}
         for index in active_indices:
             grouped.setdefault(_block_for(shape, index, coarse_factor), []).append(index)
 
-        coarse_values: dict[Block3D, float] = {}
         coarse_latent: list[CoarseLatent] = []
         schedule: list[PathAssignment] = []
         for path_id, block in enumerate(sorted(grouped)):
             indices = grouped[block]
-            value = sum(residual[index] for index in indices) / len(indices)
-            coarse_values[block] = value
+            value = coarse_values[block]
             coarse_latent.append(
                 CoarseLatent(block=block, residual=value, active_count=len(indices))
             )
@@ -335,21 +345,15 @@ class Kinetic3DRuntime:
                     path_id=path_id,
                     block=block,
                     active_cells=len(indices),
-                    resource="cpu-reference:0",
+                    resource=f"{selected_backend.name}:0",
                     estimated_cost=float(len(indices)),
                 )
             )
 
-        reconstructed = list(prediction)
-        fine_corrections: list[FineCorrection] = []
-        for index in active_indices:
-            block = _block_for(shape, index, coarse_factor)
-            coarse = coarse_values[block]
-            reconstructed[index] += coarse
-            correction = residual[index] - coarse
-            if abs(correction) > refine_threshold:
-                reconstructed[index] += correction
-                fine_corrections.append(FineCorrection(index=index, correction=correction))
+        fine_corrections = [
+            FineCorrection(index=index, correction=correction)
+            for index, correction in backend_result.fine_corrections
+        ]
 
         errors = [source - target for source, target in zip(observed, reconstructed)]
         mse = sum(error * error for error in errors) / count
@@ -388,7 +392,7 @@ class Kinetic3DRuntime:
             value_compression_ratio=value_compression_ratio,
             estimated_bytes_moved=estimated_bytes_moved,
             elapsed_ms=(perf_counter() - started) * 1000.0,
-            backend="cpu-reference",
+            backend=selected_backend.name,
         )
 
         return Kinetic3DResult(

--- a/src/jarvisx/kinetic3d_api.py
+++ b/src/jarvisx/kinetic3d_api.py
@@ -6,11 +6,12 @@ from fastapi import FastAPI, HTTPException, Response
 from pydantic import BaseModel, Field
 
 from .kinetic3d import Kinetic3DRuntime, MAX_KINETIC_VOXELS, Shape3D
+from .kinetic3d_backend import available_backends
 
 app = FastAPI(
     title="Jarvis-X Kinetic 3D Runtime",
-    version="1.0.0",
-    description="Predictive sparse 3D execution with hierarchical residuals and verify-before-commit state.",
+    version="1.1.0",
+    description="Predictive sparse 3D execution with native backend routing and verify-before-commit state.",
 )
 
 _sessions: dict[str, Kinetic3DRuntime] = {}
@@ -32,6 +33,7 @@ class KineticExecuteRequest(BaseModel):
     coarse_factor: int = Field(default=2, ge=1, le=32)
     refine_threshold: float = Field(default=0.0, ge=0.0)
     tolerance: float = Field(default=0.0, ge=0.0)
+    backend: str = Field(default="auto", min_length=1, max_length=32)
 
 
 def _runtime_for(session_id: str) -> Kinetic3DRuntime:
@@ -48,7 +50,8 @@ def healthz() -> dict[str, object]:
     return {
         "status": "ok",
         "runtime": "kinetic3d",
-        "backend": "cpu-reference",
+        "backend_policy": "auto",
+        "available_backends": list(available_backends()),
         "max_voxels": MAX_KINETIC_VOXELS,
         "execution_model": "predict-residual-active-encode-refine-decode-verify-commit",
     }
@@ -69,6 +72,7 @@ def execute_kinetic3d(request: KineticExecuteRequest) -> dict[str, object]:
                 coarse_factor=request.coarse_factor,
                 refine_threshold=request.refine_threshold,
                 tolerance=request.tolerance,
+                backend=request.backend,
             )
     except ValueError as exc:
         with _metrics_lock:

--- a/src/jarvisx/kinetic3d_backend.py
+++ b/src/jarvisx/kinetic3d_backend.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import ctypes
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, Sequence
+
+Shape3D = tuple[int, int, int]
+Block3D = tuple[int, int, int]
+
+
+class BackendUnavailable(ValueError):
+    """Raised when an explicitly requested execution backend cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class BackendStepResult:
+    residual: tuple[float, ...]
+    active_indices: tuple[int, ...]
+    coarse_values: tuple[tuple[Block3D, float], ...]
+    fine_corrections: tuple[tuple[int, float], ...]
+    reconstructed: tuple[float, ...]
+
+
+class KineticBackend(Protocol):
+    name: str
+
+    def step(
+        self,
+        current: Sequence[float],
+        prediction: Sequence[float],
+        shape: Shape3D,
+        *,
+        active_threshold: float,
+        coarse_factor: int,
+        refine_threshold: float,
+    ) -> BackendStepResult: ...
+
+
+def _xyz(shape: Shape3D, index: int) -> tuple[int, int, int]:
+    sx, sy, _ = shape
+    plane = sx * sy
+    z, rem = divmod(index, plane)
+    y, x = divmod(rem, sx)
+    return x, y, z
+
+
+def _block_for(shape: Shape3D, index: int, factor: int) -> Block3D:
+    x, y, z = _xyz(shape, index)
+    return x // factor, y // factor, z // factor
+
+
+class ReferenceBackend:
+    """Pure Python semantics reference used as the correctness oracle."""
+
+    name = "cpu-reference"
+
+    def step(
+        self,
+        current: Sequence[float],
+        prediction: Sequence[float],
+        shape: Shape3D,
+        *,
+        active_threshold: float,
+        coarse_factor: int,
+        refine_threshold: float,
+    ) -> BackendStepResult:
+        residual = [value - predicted for value, predicted in zip(current, prediction)]
+        active_indices = tuple(
+            index for index, error in enumerate(residual) if abs(error) > active_threshold
+        )
+
+        grouped: dict[Block3D, list[int]] = {}
+        for index in active_indices:
+            grouped.setdefault(_block_for(shape, index, coarse_factor), []).append(index)
+
+        coarse_values: dict[Block3D, float] = {}
+        for block in sorted(grouped):
+            indices = grouped[block]
+            coarse_values[block] = sum(residual[index] for index in indices) / len(indices)
+
+        reconstructed = list(prediction)
+        fine_corrections: list[tuple[int, float]] = []
+        for index in active_indices:
+            block = _block_for(shape, index, coarse_factor)
+            coarse = coarse_values[block]
+            reconstructed[index] += coarse
+            correction = residual[index] - coarse
+            if abs(correction) > refine_threshold:
+                reconstructed[index] += correction
+                fine_corrections.append((index, correction))
+
+        return BackendStepResult(
+            residual=tuple(residual),
+            active_indices=active_indices,
+            coarse_values=tuple((block, coarse_values[block]) for block in sorted(coarse_values)),
+            fine_corrections=tuple(fine_corrections),
+            reconstructed=tuple(reconstructed),
+        )
+
+
+class NativeBackend:
+    """ctypes bridge to the compiled C++ active-volume backend."""
+
+    name = "native-cpu"
+
+    def __init__(self, library_path: str | os.PathLike[str]) -> None:
+        self.library_path = str(library_path)
+        try:
+            self._library = ctypes.CDLL(self.library_path)
+        except OSError as exc:
+            raise BackendUnavailable(f"unable to load native backend: {self.library_path}") from exc
+
+        function = self._library.jx_kinetic3d_step
+        double_ptr = ctypes.POINTER(ctypes.c_double)
+        byte_ptr = ctypes.POINTER(ctypes.c_uint8)
+        function.argtypes = [
+            double_ptr,
+            double_ptr,
+            ctypes.c_size_t,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_double,
+            ctypes.c_int,
+            ctypes.c_double,
+            double_ptr,
+            double_ptr,
+            byte_ptr,
+            double_ptr,
+            double_ptr,
+        ]
+        function.restype = ctypes.c_int
+        self._step_function = function
+
+    def step(
+        self,
+        current: Sequence[float],
+        prediction: Sequence[float],
+        shape: Shape3D,
+        *,
+        active_threshold: float,
+        coarse_factor: int,
+        refine_threshold: float,
+    ) -> BackendStepResult:
+        count = len(current)
+        current_array = (ctypes.c_double * count)(*current)
+        prediction_array = (ctypes.c_double * count)(*prediction)
+        residual_array = (ctypes.c_double * count)()
+        reconstructed_array = (ctypes.c_double * count)()
+        active_mask = (ctypes.c_uint8 * count)()
+        coarse_per_cell = (ctypes.c_double * count)()
+        fine_per_cell = (ctypes.c_double * count)()
+        sx, sy, sz = shape
+
+        status = self._step_function(
+            current_array,
+            prediction_array,
+            count,
+            sx,
+            sy,
+            sz,
+            active_threshold,
+            coarse_factor,
+            refine_threshold,
+            residual_array,
+            reconstructed_array,
+            active_mask,
+            coarse_per_cell,
+            fine_per_cell,
+        )
+        if status != 0:
+            raise RuntimeError(f"native kinetic backend failed with status {status}")
+
+        active_indices = tuple(index for index in range(count) if active_mask[index])
+        coarse_values: dict[Block3D, float] = {}
+        for index in active_indices:
+            block = _block_for(shape, index, coarse_factor)
+            coarse_values.setdefault(block, coarse_per_cell[index])
+
+        fine_corrections = tuple(
+            (index, fine_per_cell[index])
+            for index in active_indices
+            if fine_per_cell[index] != 0.0
+        )
+        return BackendStepResult(
+            residual=tuple(residual_array[index] for index in range(count)),
+            active_indices=active_indices,
+            coarse_values=tuple((block, coarse_values[block]) for block in sorted(coarse_values)),
+            fine_corrections=fine_corrections,
+            reconstructed=tuple(reconstructed_array[index] for index in range(count)),
+        )
+
+
+def _native_library_candidate() -> Path | None:
+    configured = os.environ.get("JARVISX_KINETIC3D_NATIVE_LIB")
+    if configured:
+        return Path(configured)
+    return None
+
+
+def native_backend_available() -> bool:
+    candidate = _native_library_candidate()
+    if candidate is None or not candidate.is_file():
+        return False
+    try:
+        NativeBackend(candidate)
+    except BackendUnavailable:
+        return False
+    return True
+
+
+def available_backends() -> tuple[str, ...]:
+    names = [ReferenceBackend.name]
+    if native_backend_available():
+        names.append(NativeBackend.name)
+    return tuple(names)
+
+
+def resolve_backend(name: str) -> KineticBackend:
+    normalized = name.strip().lower()
+    if normalized == "cpu-reference":
+        return ReferenceBackend()
+    if normalized == "native-cpu":
+        candidate = _native_library_candidate()
+        if candidate is None or not candidate.is_file():
+            raise BackendUnavailable(
+                "native-cpu backend requested but JARVISX_KINETIC3D_NATIVE_LIB is unavailable"
+            )
+        return NativeBackend(candidate)
+    if normalized == "auto":
+        candidate = _native_library_candidate()
+        if candidate is not None and candidate.is_file():
+            try:
+                return NativeBackend(candidate)
+            except BackendUnavailable:
+                pass
+        return ReferenceBackend()
+    raise ValueError("backend must be one of: auto, cpu-reference, native-cpu")

--- a/tests/test_kinetic3d_backend.py
+++ b/tests/test_kinetic3d_backend.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from jarvisx.kinetic3d import Kinetic3DRuntime
+from jarvisx.kinetic3d_backend import (
+    BackendUnavailable,
+    NativeBackend,
+    ReferenceBackend,
+    available_backends,
+    resolve_backend,
+)
+
+
+def _native_from_env() -> NativeBackend:
+    path = os.environ.get("JARVISX_KINETIC3D_NATIVE_LIB")
+    if not path or not Path(path).is_file():
+        pytest.skip("native kinetic backend is not compiled in this test environment")
+    return NativeBackend(path)
+
+
+def test_auto_falls_back_to_reference_without_native_library(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVISX_KINETIC3D_NATIVE_LIB", raising=False)
+    assert resolve_backend("auto").name == "cpu-reference"
+    assert available_backends() == ("cpu-reference",)
+
+
+def test_explicit_missing_native_backend_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("JARVISX_KINETIC3D_NATIVE_LIB", raising=False)
+    with pytest.raises(BackendUnavailable, match="native-cpu backend requested"):
+        resolve_backend("native-cpu")
+
+
+def test_reference_backend_semantics() -> None:
+    backend = ReferenceBackend()
+    result = backend.step(
+        [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+        [0.0] * 8,
+        (2, 2, 2),
+        active_threshold=0.0,
+        coarse_factor=2,
+        refine_threshold=10.0,
+    )
+    assert result.active_indices == tuple(range(1, 8))
+    assert result.coarse_values == (((0, 0, 0), 4.0),)
+    assert result.reconstructed == pytest.approx((0.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0, 4.0))
+
+
+def test_native_backend_matches_reference_for_sparse_change() -> None:
+    native = _native_from_env()
+    reference = ReferenceBackend()
+    current = [1.0] * 64
+    prediction = current.copy()
+    current[3] = 8.0
+    current[42] = -5.0
+    kwargs = {
+        "active_threshold": 0.1,
+        "coarse_factor": 2,
+        "refine_threshold": 0.0,
+    }
+
+    expected = reference.step(current, prediction, (4, 4, 4), **kwargs)
+    actual = native.step(current, prediction, (4, 4, 4), **kwargs)
+
+    assert actual.active_indices == expected.active_indices
+    assert actual.coarse_values == pytest.approx(expected.coarse_values)
+    assert actual.fine_corrections == pytest.approx(expected.fine_corrections)
+    assert actual.residual == pytest.approx(expected.residual)
+    assert actual.reconstructed == pytest.approx(expected.reconstructed)
+
+
+def test_runtime_reports_native_backend_when_available() -> None:
+    _native_from_env()
+    runtime = Kinetic3DRuntime(backend="native-cpu")
+    result = runtime.execute(
+        [2.0] * 8,
+        (2, 2, 2),
+        active_threshold=0.0,
+        coarse_factor=2,
+        refine_threshold=0.0,
+        tolerance=0.0,
+    )
+
+    assert result.verification.passed
+    assert result.telemetry.backend == "native-cpu"
+    assert result.schedule[0].resource == "native-cpu:0"

--- a/tests/test_kinetic3d_backend.py
+++ b/tests/test_kinetic3d_backend.py
@@ -66,8 +66,18 @@ def test_native_backend_matches_reference_for_sparse_change() -> None:
     actual = native.step(current, prediction, (4, 4, 4), **kwargs)
 
     assert actual.active_indices == expected.active_indices
-    assert actual.coarse_values == pytest.approx(expected.coarse_values)
-    assert actual.fine_corrections == pytest.approx(expected.fine_corrections)
+    assert [block for block, _ in actual.coarse_values] == [
+        block for block, _ in expected.coarse_values
+    ]
+    assert [value for _, value in actual.coarse_values] == pytest.approx(
+        [value for _, value in expected.coarse_values]
+    )
+    assert [index for index, _ in actual.fine_corrections] == [
+        index for index, _ in expected.fine_corrections
+    ]
+    assert [value for _, value in actual.fine_corrections] == pytest.approx(
+        [value for _, value in expected.fine_corrections]
+    )
     assert actual.residual == pytest.approx(expected.residual)
     assert actual.reconstructed == pytest.approx(expected.reconstructed)
 


### PR DESCRIPTION
## Summary

Permeates the kinetic 3D runtime one layer deeper into compiled execution while preserving the existing spatial state law and verify-before-commit semantics.

### Added

- pluggable kinetic backend contract
- pure-Python `cpu-reference` correctness oracle
- compiled C++ `native-cpu` active-volume backend via a narrow C ABI
- deterministic `auto` backend routing with fail-closed explicit native selection
- native backend identity propagated into path assignments and telemetry
- multi-stage Docker build that compiles and installs the native shared library
- native/reference parity tests
- container smoke validation that `auto` actually executes `native-cpu`
- backend documentation and explicit next lowering boundary

## Execution law preserved

`OBSERVE -> PREDICT -> RESIDUAL -> ACTIVE_SET -> ENCODE_COARSE -> LATENT_WRITE -> REFINE -> DECODE -> VERIFY -> COMMIT -> TELEMETRY -> EMIT -> HALT`

The accelerated backend is allowed to compute residuals, active-set selection, coarse block means, selective fine corrections, and reconstruction. It is **not** allowed to bypass verification, hashing, transaction commit, epoch management, or session state.

## Operational boundary

This is a real native C++ backend, not a CUDA/Triton claim. GPU execution remains the next lowering target. The API, spatial IR, residual codec, verification contract, and state transition semantics remain backend-neutral.

## Validation

The workflow independently checks:

1. reference runtime with no native library present;
2. a compiled native shared library against the reference semantics;
3. the production container, where `backend=auto` must resolve to and report `native-cpu` across stateful transitions.