### PR TITLE
Evolve kinetic 3D runtime with JXK2 rate-distortion capsules

### DIFF
--- a/.github/workflows/kinetic3d.yml
+++ b/.github/workflows/kinetic3d.yml
@@ -6,9 +6,11 @@ on:
     paths:
       - "src/jarvisx/kinetic3d.py"
       - "src/jarvisx/kinetic3d_backend.py"
+      - "src/jarvisx/kinetic3d_capsule.py"
       - "src/jarvisx/kinetic3d_api.py"
       - "tests/test_kinetic3d.py"
       - "tests/test_kinetic3d_backend.py"
+      - "tests/test_kinetic3d_capsule.py"
       - "native/kinetic3d_backend.cpp"
       - "deploy/kinetic3d/**"
       - ".github/workflows/kinetic3d.yml"
@@ -17,9 +19,11 @@ on:
     paths:
       - "src/jarvisx/kinetic3d.py"
       - "src/jarvisx/kinetic3d_backend.py"
+      - "src/jarvisx/kinetic3d_capsule.py"
       - "src/jarvisx/kinetic3d_api.py"
       - "tests/test_kinetic3d.py"
       - "tests/test_kinetic3d_backend.py"
+      - "tests/test_kinetic3d_capsule.py"
       - "native/kinetic3d_backend.cpp"
       - "deploy/kinetic3d/**"
       - ".github/workflows/kinetic3d.yml"
@@ -39,9 +43,9 @@ jobs:
       - name: Install
         run: python -m pip install -e ".[test]"
       - name: Unit tests
-        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py
+        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py tests/test_kinetic3d_capsule.py
       - name: Compile modules
-        run: python -m compileall -q src/jarvisx/kinetic3d.py src/jarvisx/kinetic3d_backend.py src/jarvisx/kinetic3d_api.py
+        run: python -m compileall -q src/jarvisx/kinetic3d.py src/jarvisx/kinetic3d_backend.py src/jarvisx/kinetic3d_capsule.py src/jarvisx/kinetic3d_api.py
 
   native-parity:
     runs-on: ubuntu-latest
@@ -55,10 +59,10 @@ jobs:
         run: python -m pip install -e ".[test]"
       - name: Compile native backend
         run: g++ -O3 -std=c++17 -fPIC -shared native/kinetic3d_backend.cpp -o /tmp/libjarvisx_kinetic3d.so
-      - name: Native parity tests
+      - name: Native parity and capsule tests
         env:
           JARVISX_KINETIC3D_NATIVE_LIB: /tmp/libjarvisx_kinetic3d.so
-        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py
+        run: pytest -q tests/test_kinetic3d.py tests/test_kinetic3d_backend.py tests/test_kinetic3d_capsule.py
 
   container-smoke:
     runs-on: ubuntu-latest
@@ -68,11 +72,11 @@ jobs:
         run: docker build -f deploy/kinetic3d/Dockerfile -t jarvisx-kinetic3d:test .
       - name: Start runtime
         run: docker run -d --rm --name jarvisx-kinetic3d -p 8000:8000 jarvisx-kinetic3d:test
-      - name: Wait for health and native backend
+      - name: Wait for health, native backend and JXK2
         run: |
           for i in $(seq 1 30); do
             if health=$(curl --fail --silent http://127.0.0.1:8000/healthz); then
-              python -c 'import json,sys; d=json.loads(sys.argv[1]); assert "native-cpu" in d["available_backends"]' "$health"
+              python -c 'import json,sys; d=json.loads(sys.argv[1]); assert "native-cpu" in d["available_backends"]; assert d["capsule_format"] == "JXK2"; assert d["adaptive_planner"] == "deterministic-rate-distortion"' "$health"
               exit 0
             fi
             sleep 1
@@ -93,6 +97,14 @@ jobs:
             -d '{"session_id":"ci","shape":[2,2,2],"values":[1,1,1,1,1,1,9,1],"active_threshold":0.1,"coarse_factor":2,"refine_threshold":0,"tolerance":0,"backend":"auto"}' \
             http://127.0.0.1:8000/v1/kinetic3d/execute)
           python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["verification"]["passed"]; assert d["epoch_after"] == 2; assert d["active_indices"] == [6]; assert d["telemetry"]["active_cells"] == 1; assert d["telemetry"]["backend"] == "native-cpu"' "$response"
+      - name: Execute adaptive JXK2 transition
+        run: |
+          payload=$(python -c 'import json; print(json.dumps({"session_id":"adaptive-ci","shape":[4,4,4],"values":[2.0]*64,"tolerance":0.0,"backend":"auto"}))')
+          response=$(curl --fail --silent \
+            -H 'content-type: application/json' \
+            -d "$payload" \
+            http://127.0.0.1:8000/v2/kinetic3d/execute-adaptive)
+          python -c 'import json,sys; d=json.loads(sys.argv[1]); assert d["committed"]; assert d["verification"]["passed"]; assert d["telemetry"]["backend"] == "native-cpu"; assert d["capsule"]["format"] == "JXK2"; assert d["capsule"]["bytes"] > 0; assert d["adaptive_plan"]["selected"]["max_abs_error"] == 0.0' "$response"
       - name: Inspect committed world state
         run: |
           state=$(curl --fail --silent http://127.0.0.1:8000/v1/kinetic3d/state/ci)

--- a/docs/KINETIC3D_JXK2_RATE_DISTORTION.md
+++ b/docs/KINETIC3D_JXK2_RATE_DISTORTION.md
@@ -1,0 +1,191 @@
+# Kinetic 3D JXK2 Rate-Distortion Capsule
+
+## Status
+
+This document specifies the next bounded execution layer above the native kinetic 3D backend.
+
+It adds two capabilities that were previously missing:
+
+1. a self-describing, integrity-sealed delta capsule that can be decoded independently from the live runtime when supplied with the exact predictor it is bound to;
+2. deterministic rate-distortion planning that searches a bounded set of spatial codec parameters and selects the smallest valid capsule under an explicit maximum-error budget.
+
+This is a measurable codec/runtime optimization. It is **not** a claim of universal state-of-the-art compression, learned neural coding, GPU leadership, or information-theoretic optimality.
+
+## Runtime path
+
+```text
+OBSERVE W_t
+  -> obtain committed predictor W_hat_t
+  -> deterministic candidate search
+       active threshold tau_a
+       coarse factor k
+       refinement threshold tau_r
+  -> reject candidates with max reconstruction error > Lambda
+  -> serialize every admissible candidate as JXK2
+  -> select minimum transport bytes with deterministic tie breaks
+  -> execute selected plan on requested backend
+  -> VERIFY
+  -> COMMIT
+  -> build JXK2 capsule from authoritative reconstruction path
+  -> independent capsule decode against predictor digest
+  -> EMIT
+```
+
+The planning oracle uses the pure-Python reference backend so plan selection is deterministic and independent of wall-clock timing. The selected plan may then execute on `cpu-reference`, `native-cpu`, or a future backend that satisfies the same semantic contract.
+
+## Rate-distortion objective
+
+For each candidate `m`, Jarvis-X measures:
+
+- maximum absolute reconstruction error `E_max,m`;
+- MSE;
+- active cell count;
+- coarse latent count;
+- fine correction count;
+- exact serialized JXK2 byte length `B_m`.
+
+Only candidates satisfying
+
+```text
+E_max,m <= Lambda
+```
+
+are admissible.
+
+The primary selection rule is
+
+```text
+m* = argmin B_m
+```
+
+with deterministic tie breaks over error, active work, correction count and spatial parameters.
+
+This makes the optimization falsifiable: the selected candidate must actually serialize to the reported byte count and independently reconstruct within the requested error budget.
+
+## JXK2 transport format
+
+The capsule is a predictor-bound delta object.
+
+```text
+fixed header
+  magic = JXK2
+  version
+  shape X/Y/Z
+  active threshold
+  coarse factor
+  refinement threshold
+  tolerance
+  active/coarse/fine counts
+  SHA-256(predictor float64 image)
+
+active-set payload
+  run-length encoded active indices
+
+coarse payload
+  block coordinate varints
+  float64 coarse residual
+
+fine payload
+  delta-coded active index
+  float64 correction
+
+SHA-256(all preceding capsule bytes)
+```
+
+The active set is encoded as runs rather than as a dense mask or one fixed-width index per voxel. Spatially coherent change can therefore remain compact while sparse irregular updates remain explicit.
+
+## Reconstruction
+
+Given a verified capsule and the exact predictor:
+
+```text
+reconstructed = predictor
+for each active index i:
+    reconstructed[i] += coarse[block(i)]
+for each fine correction (i, delta_i):
+    reconstructed[i] += delta_i
+```
+
+The predictor must hash to the digest embedded in the capsule. A capsule cannot silently apply to the wrong committed world.
+
+## Integrity and failure semantics
+
+The parser fails closed on:
+
+- bad magic or unsupported version;
+- checksum mismatch;
+- truncated varints or float payloads;
+- non-finite numerical metadata;
+- out-of-bounds or overlapping active runs;
+- duplicate/out-of-range coarse blocks;
+- fine corrections for inactive cells;
+- coarse-block coverage that does not exactly match the active set;
+- trailing unparsed payload bytes;
+- predictor digest mismatch during decode.
+
+The adaptive API additionally decodes the newly generated capsule independently and requires it to reproduce the committed reconstruction before emitting the result.
+
+## API
+
+Adaptive execution:
+
+```text
+POST /v2/kinetic3d/execute-adaptive
+```
+
+Input:
+
+```json
+{
+  "session_id": "demo",
+  "shape": [8, 8, 8],
+  "values": ["512 numeric values"],
+  "tolerance": 0.0,
+  "backend": "auto"
+}
+```
+
+The response includes:
+
+- ordinary kinetic verification and transaction state;
+- selected rate-distortion plan and all admissible candidates;
+- JXK2 byte count and actual wire compression ratio;
+- transport SHA-256;
+- Base64 capsule bytes.
+
+Independent decode:
+
+```text
+POST /v2/kinetic3d/decode-capsule
+```
+
+The caller supplies the Base64 capsule and predictor vector. Decode fails if the predictor digest differs from the one bound into the capsule.
+
+## Why this is deeper than the previous layer
+
+The prior kinetic runtime exposed latent values and a value-count compression proxy, but the latent was not a complete transport artifact. Index and metadata overhead were not represented in that proxy.
+
+JXK2 changes the measurement boundary:
+
+```text
+before: scalar latent count / source scalar count
+now:    exact serialized capsule bytes / raw float64 bytes
+```
+
+A ratio greater than one is reported only when the actual JXK2 transport is smaller than the raw float64 source image. Small or irregular volumes are allowed to report expansion rather than a fabricated compression win.
+
+## Capability boundary
+
+This implementation establishes a deterministic, reversible, predictor-bound sparse 3D transport and bounded rate-distortion search. It does not establish external SOTA performance by itself.
+
+A defensible SOTA claim requires a benchmark suite against relevant current codecs/runtimes on shared datasets and hardware, including at minimum:
+
+- rate-distortion curves;
+- encode/decode throughput;
+- end-to-end latency;
+- resident and transferred bytes;
+- energy where measurable;
+- corruption/recovery behavior;
+- exact-versus-lossy operating points.
+
+Until those comparative experiments are green, the correct claim is: **Jarvis-X now has the machinery required to optimize and measure this axis rigorously.**

--- a/src/jarvisx/kinetic3d_api.py
+++ b/src/jarvisx/kinetic3d_api.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from base64 import b64decode, b64encode
+from binascii import Error as BinasciiError
+from hashlib import sha256
 from threading import Lock
 
 from fastapi import FastAPI, HTTPException, Response
@@ -7,21 +10,33 @@ from pydantic import BaseModel, Field
 
 from .kinetic3d import Kinetic3DRuntime, MAX_KINETIC_VOXELS, Shape3D
 from .kinetic3d_backend import available_backends
+from .kinetic3d_capsule import (
+    CapsuleError,
+    build_capsule,
+    decode_capsule,
+    parse_capsule,
+    plan_rate_distortion,
+)
 
 app = FastAPI(
     title="Jarvis-X Kinetic 3D Runtime",
-    version="1.1.0",
-    description="Predictive sparse 3D execution with native backend routing and verify-before-commit state.",
+    version="2.0.0",
+    description=(
+        "Predictive sparse 3D execution with native backend routing, deterministic "
+        "rate-distortion planning, reversible JXK2 capsules, and verify-before-commit state."
+    ),
 )
 
 _sessions: dict[str, Kinetic3DRuntime] = {}
 _session_lock = Lock()
 _metrics_lock = Lock()
 _executions = 0
+_adaptive_executions = 0
 _failures = 0
 _commits = 0
 _total_active_cells = 0
 _total_cells = 0
+_total_capsule_bytes = 0
 
 
 class KineticExecuteRequest(BaseModel):
@@ -36,6 +51,20 @@ class KineticExecuteRequest(BaseModel):
     backend: str = Field(default="auto", min_length=1, max_length=32)
 
 
+class AdaptiveExecuteRequest(BaseModel):
+    session_id: str = Field(default="default", min_length=1, max_length=128)
+    shape: Shape3D
+    values: list[float]
+    previous: list[float] | None = None
+    tolerance: float = Field(default=0.0, ge=0.0)
+    backend: str = Field(default="auto", min_length=1, max_length=32)
+
+
+class CapsuleDecodeRequest(BaseModel):
+    capsule_base64: str = Field(min_length=1, max_length=32_000_000)
+    prediction: list[float]
+
+
 def _runtime_for(session_id: str) -> Kinetic3DRuntime:
     with _session_lock:
         runtime = _sessions.get(session_id)
@@ -45,15 +74,35 @@ def _runtime_for(session_id: str) -> Kinetic3DRuntime:
         return runtime
 
 
+def _prediction_for(
+    runtime: Kinetic3DRuntime,
+    previous: list[float] | None,
+    shape: Shape3D,
+) -> list[float]:
+    if len(shape) != 3 or any(dimension < 1 for dimension in shape):
+        raise ValueError("shape must contain exactly three positive dimensions")
+    count = shape[0] * shape[1] * shape[2]
+    if count > MAX_KINETIC_VOXELS:
+        raise ValueError(f"voxel count {count} exceeds runtime limit {MAX_KINETIC_VOXELS}")
+    if previous is not None:
+        return list(previous)
+    if runtime.committed_shape == shape and runtime.committed_world is not None:
+        return list(runtime.committed_world)
+    return [0.0] * count
+
+
 @app.get("/healthz")
 def healthz() -> dict[str, object]:
     return {
         "status": "ok",
         "runtime": "kinetic3d",
+        "api_version": "2.0.0",
         "backend_policy": "auto",
         "available_backends": list(available_backends()),
         "max_voxels": MAX_KINETIC_VOXELS,
         "execution_model": "predict-residual-active-encode-refine-decode-verify-commit",
+        "adaptive_planner": "deterministic-rate-distortion",
+        "capsule_format": "JXK2",
     }
 
 
@@ -90,6 +139,99 @@ def execute_kinetic3d(request: KineticExecuteRequest) -> dict[str, object]:
     return payload
 
 
+@app.post("/v2/kinetic3d/execute-adaptive")
+def execute_adaptive_kinetic3d(request: AdaptiveExecuteRequest) -> dict[str, object]:
+    global _executions, _adaptive_executions, _failures, _commits
+    global _total_active_cells, _total_cells, _total_capsule_bytes
+
+    runtime = _runtime_for(request.session_id)
+    try:
+        with _session_lock:
+            prediction = _prediction_for(runtime, request.previous, request.shape)
+            plan = plan_rate_distortion(
+                request.values,
+                prediction,
+                request.shape,
+                tolerance=request.tolerance,
+            )
+            selected = plan.selected
+            result = runtime.execute(
+                request.values,
+                request.shape,
+                previous=prediction,
+                active_threshold=selected.active_threshold,
+                coarse_factor=selected.coarse_factor,
+                refine_threshold=selected.refine_threshold,
+                tolerance=request.tolerance,
+                backend=request.backend,
+            )
+            if not result.committed:
+                raise RuntimeError("selected backend diverged from the verified rate-distortion plan")
+
+            capsule_bytes = build_capsule(
+                shape=result.shape,
+                prediction=result.prediction,
+                active_threshold=selected.active_threshold,
+                coarse_factor=selected.coarse_factor,
+                refine_threshold=selected.refine_threshold,
+                tolerance=request.tolerance,
+                active_indices=result.active_indices,
+                coarse_values=tuple(
+                    (item.block, item.residual) for item in result.coarse_latent
+                ),
+                fine_corrections=tuple(
+                    (item.index, item.correction) for item in result.fine_corrections
+                ),
+            )
+            independently_decoded = decode_capsule(capsule_bytes, result.prediction)
+            if independently_decoded != result.reconstructed:
+                raise RuntimeError("JXK2 capsule decode does not reproduce committed reconstruction")
+            capsule = parse_capsule(capsule_bytes)
+    except ValueError as exc:
+        with _metrics_lock:
+            _failures += 1
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    except (CapsuleError, RuntimeError) as exc:
+        with _metrics_lock:
+            _failures += 1
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    with _metrics_lock:
+        _executions += 1
+        _adaptive_executions += 1
+        _commits += 1
+        _total_active_cells += result.telemetry.active_cells
+        _total_cells += result.telemetry.total_cells
+        _total_capsule_bytes += len(capsule_bytes)
+
+    payload: dict[str, object] = result.as_payload()
+    payload["session_id"] = request.session_id
+    payload["adaptive_plan"] = plan.as_payload()
+    payload["capsule"] = {
+        **capsule.as_payload(),
+        "bytes": len(capsule_bytes),
+        "transport_sha256": sha256(capsule_bytes).hexdigest(),
+        "wire_compression_ratio": (len(request.values) * 8) / len(capsule_bytes),
+        "base64": b64encode(capsule_bytes).decode("ascii"),
+    }
+    return payload
+
+
+@app.post("/v2/kinetic3d/decode-capsule")
+def decode_kinetic_capsule(request: CapsuleDecodeRequest) -> dict[str, object]:
+    try:
+        data = b64decode(request.capsule_base64, validate=True)
+        capsule = parse_capsule(data)
+        reconstructed = capsule.decode(request.prediction)
+    except (BinasciiError, ValueError, CapsuleError) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    return {
+        "capsule": {**capsule.as_payload(), "bytes": len(data)},
+        "reconstructed": list(reconstructed),
+    }
+
+
 @app.get("/v1/kinetic3d/state/{session_id}")
 def session_state(session_id: str) -> dict[str, object]:
     with _session_lock:
@@ -119,10 +261,12 @@ def reset_session(session_id: str) -> dict[str, object]:
 def metrics() -> Response:
     with _metrics_lock:
         executions = _executions
+        adaptive_executions = _adaptive_executions
         failures = _failures
         commits = _commits
         active = _total_active_cells
         cells = _total_cells
+        capsule_bytes = _total_capsule_bytes
 
     active_fraction = active / cells if cells else 0.0
     body = "\n".join(
@@ -130,6 +274,9 @@ def metrics() -> Response:
             "# HELP jarvisx_kinetic3d_executions_total Successful API executions.",
             "# TYPE jarvisx_kinetic3d_executions_total counter",
             f"jarvisx_kinetic3d_executions_total {executions}",
+            "# HELP jarvisx_kinetic3d_adaptive_executions_total Adaptive planned executions.",
+            "# TYPE jarvisx_kinetic3d_adaptive_executions_total counter",
+            f"jarvisx_kinetic3d_adaptive_executions_total {adaptive_executions}",
             "# HELP jarvisx_kinetic3d_failures_total Rejected API executions.",
             "# TYPE jarvisx_kinetic3d_failures_total counter",
             f"jarvisx_kinetic3d_failures_total {failures}",
@@ -139,6 +286,9 @@ def metrics() -> Response:
             "# HELP jarvisx_kinetic3d_active_fraction Cumulative active cell fraction.",
             "# TYPE jarvisx_kinetic3d_active_fraction gauge",
             f"jarvisx_kinetic3d_active_fraction {active_fraction}",
+            "# HELP jarvisx_kinetic3d_capsule_bytes_total JXK2 transport bytes emitted.",
+            "# TYPE jarvisx_kinetic3d_capsule_bytes_total counter",
+            f"jarvisx_kinetic3d_capsule_bytes_total {capsule_bytes}",
             "",
         ]
     )

--- a/src/jarvisx/kinetic3d_capsule.py
+++ b/src/jarvisx/kinetic3d_capsule.py
@@ -1,0 +1,535 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+from math import isfinite
+from struct import Struct, pack, unpack_from
+from typing import Sequence
+
+from .kinetic3d_backend import ReferenceBackend
+
+Shape3D = tuple[int, int, int]
+Block3D = tuple[int, int, int]
+
+MAGIC = b"JXK2"
+VERSION = 1
+MAX_CAPSULE_VOXELS = 1_048_576
+_HEADER = Struct("<4sBBBBIIIdddIIII32s")
+_CHECKSUM_BYTES = 32
+
+
+class CapsuleError(ValueError):
+    """Raised when a kinetic capsule is malformed or cannot be verified."""
+
+
+@dataclass(frozen=True)
+class PlanCandidate:
+    active_threshold: float
+    coarse_factor: int
+    refine_threshold: float
+    max_abs_error: float
+    mse: float
+    active_cells: int
+    coarse_values: int
+    fine_corrections: int
+    capsule_bytes: int
+    raw_bytes: int
+
+    @property
+    def wire_compression_ratio(self) -> float:
+        return self.raw_bytes / self.capsule_bytes
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "active_threshold": self.active_threshold,
+            "coarse_factor": self.coarse_factor,
+            "refine_threshold": self.refine_threshold,
+            "max_abs_error": self.max_abs_error,
+            "mse": self.mse,
+            "active_cells": self.active_cells,
+            "coarse_values": self.coarse_values,
+            "fine_corrections": self.fine_corrections,
+            "capsule_bytes": self.capsule_bytes,
+            "raw_bytes": self.raw_bytes,
+            "wire_compression_ratio": self.wire_compression_ratio,
+        }
+
+
+@dataclass(frozen=True)
+class AdaptivePlan:
+    tolerance: float
+    selected: PlanCandidate
+    candidates: tuple[PlanCandidate, ...]
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "tolerance": self.tolerance,
+            "selected": self.selected.as_payload(),
+            "candidate_count": len(self.candidates),
+            "candidates": [candidate.as_payload() for candidate in self.candidates],
+        }
+
+
+@dataclass(frozen=True)
+class KineticCapsule:
+    shape: Shape3D
+    active_threshold: float
+    coarse_factor: int
+    refine_threshold: float
+    tolerance: float
+    active_indices: tuple[int, ...]
+    coarse_values: tuple[tuple[Block3D, float], ...]
+    fine_corrections: tuple[tuple[int, float], ...]
+    predictor_checksum_sha256: str
+    checksum_sha256: str
+
+    def decode(self, prediction: Sequence[float]) -> tuple[float, ...]:
+        count = _validate_shape(self.shape)
+        predictor = _validate_vector("prediction", prediction, count)
+        if _checksum_f64(predictor) != self.predictor_checksum_sha256:
+            raise CapsuleError("prediction checksum does not match capsule predictor")
+
+        coarse_map = dict(self.coarse_values)
+        reconstructed = list(predictor)
+        active_set = set(self.active_indices)
+        for index in self.active_indices:
+            block = _block_for(self.shape, index, self.coarse_factor)
+            try:
+                reconstructed[index] += coarse_map[block]
+            except KeyError as exc:
+                raise CapsuleError("active index references a missing coarse block") from exc
+
+        seen_fine: set[int] = set()
+        for index, correction in self.fine_corrections:
+            if index not in active_set:
+                raise CapsuleError("fine correction references an inactive index")
+            if index in seen_fine:
+                raise CapsuleError("duplicate fine correction index")
+            seen_fine.add(index)
+            reconstructed[index] += correction
+
+        return tuple(reconstructed)
+
+    def as_payload(self) -> dict[str, object]:
+        return {
+            "format": MAGIC.decode("ascii"),
+            "version": VERSION,
+            "shape": list(self.shape),
+            "active_threshold": self.active_threshold,
+            "coarse_factor": self.coarse_factor,
+            "refine_threshold": self.refine_threshold,
+            "tolerance": self.tolerance,
+            "active_cells": len(self.active_indices),
+            "coarse_values": len(self.coarse_values),
+            "fine_corrections": len(self.fine_corrections),
+            "predictor_checksum_sha256": self.predictor_checksum_sha256,
+            "checksum_sha256": self.checksum_sha256,
+        }
+
+
+def _voxel_count(shape: Shape3D) -> int:
+    sx, sy, sz = shape
+    return sx * sy * sz
+
+
+def _validate_shape(shape: Shape3D) -> int:
+    if len(shape) != 3 or any(not isinstance(dimension, int) or dimension < 1 for dimension in shape):
+        raise ValueError("shape must contain exactly three positive integer dimensions")
+    count = _voxel_count(shape)
+    if count > MAX_CAPSULE_VOXELS:
+        raise ValueError(f"voxel count {count} exceeds capsule limit {MAX_CAPSULE_VOXELS}")
+    return count
+
+
+def _validate_vector(name: str, values: Sequence[float], count: int) -> list[float]:
+    if len(values) != count:
+        raise ValueError(f"{name} length {len(values)} does not match voxel count {count}")
+    result = [float(value) for value in values]
+    if not all(isfinite(value) for value in result):
+        raise ValueError(f"{name} values must all be finite")
+    return result
+
+
+def _xyz(shape: Shape3D, index: int) -> tuple[int, int, int]:
+    sx, sy, _ = shape
+    plane = sx * sy
+    z, rem = divmod(index, plane)
+    y, x = divmod(rem, sx)
+    return x, y, z
+
+
+def _block_for(shape: Shape3D, index: int, factor: int) -> Block3D:
+    x, y, z = _xyz(shape, index)
+    return x // factor, y // factor, z // factor
+
+
+def _checksum_f64(values: Sequence[float]) -> str:
+    digest = sha256()
+    for value in values:
+        digest.update(pack("<d", value))
+    return digest.hexdigest()
+
+
+def _encode_uvarint(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("uvarint value must be non-negative")
+    output = bytearray()
+    while value >= 0x80:
+        output.append((value & 0x7F) | 0x80)
+        value >>= 7
+    output.append(value)
+    return bytes(output)
+
+
+def _decode_uvarint(data: bytes, offset: int, limit: int) -> tuple[int, int]:
+    value = 0
+    shift = 0
+    while offset < limit:
+        byte = data[offset]
+        offset += 1
+        value |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return value, offset
+        shift += 7
+        if shift > 63:
+            raise CapsuleError("uvarint exceeds 64-bit range")
+    raise CapsuleError("truncated uvarint")
+
+
+def _active_runs(indices: Sequence[int]) -> tuple[tuple[int, int], ...]:
+    if not indices:
+        return ()
+    runs: list[tuple[int, int]] = []
+    start = previous = indices[0]
+    for index in indices[1:]:
+        if index == previous + 1:
+            previous = index
+            continue
+        runs.append((start, previous - start + 1))
+        start = previous = index
+    runs.append((start, previous - start + 1))
+    return tuple(runs)
+
+
+def build_capsule(
+    *,
+    shape: Shape3D,
+    prediction: Sequence[float],
+    active_threshold: float,
+    coarse_factor: int,
+    refine_threshold: float,
+    tolerance: float,
+    active_indices: Sequence[int],
+    coarse_values: Sequence[tuple[Block3D, float]],
+    fine_corrections: Sequence[tuple[int, float]],
+) -> bytes:
+    count = _validate_shape(shape)
+    predictor = _validate_vector("prediction", prediction, count)
+    if not isfinite(active_threshold) or active_threshold < 0:
+        raise ValueError("active_threshold must be finite and non-negative")
+    if not 1 <= coarse_factor <= 32:
+        raise ValueError("coarse_factor must be between 1 and 32")
+    if not isfinite(refine_threshold) or refine_threshold < 0:
+        raise ValueError("refine_threshold must be finite and non-negative")
+    if not isfinite(tolerance) or tolerance < 0:
+        raise ValueError("tolerance must be finite and non-negative")
+
+    active = tuple(int(index) for index in active_indices)
+    if any(index < 0 or index >= count for index in active):
+        raise ValueError("active index is outside the volume")
+    if tuple(sorted(set(active))) != active:
+        raise ValueError("active indices must be strictly increasing and unique")
+
+    coarse = tuple(sorted(((tuple(block), float(value)) for block, value in coarse_values)))
+    coarse_blocks = [block for block, _ in coarse]
+    if len(set(coarse_blocks)) != len(coarse_blocks):
+        raise ValueError("coarse blocks must be unique")
+    sx, sy, sz = shape
+    bx_count = (sx + coarse_factor - 1) // coarse_factor
+    by_count = (sy + coarse_factor - 1) // coarse_factor
+    bz_count = (sz + coarse_factor - 1) // coarse_factor
+    for block, value in coarse:
+        if len(block) != 3 or not all(isinstance(axis, int) for axis in block):
+            raise ValueError("coarse block must contain three integer coordinates")
+        bx, by, bz = block
+        if not (0 <= bx < bx_count and 0 <= by < by_count and 0 <= bz < bz_count):
+            raise ValueError("coarse block lies outside the volume")
+        if not isfinite(value):
+            raise ValueError("coarse values must be finite")
+
+    fine = tuple((int(index), float(value)) for index, value in fine_corrections)
+    if tuple(sorted(index for index, _ in fine)) != tuple(index for index, _ in fine):
+        raise ValueError("fine correction indices must be sorted")
+    if len({index for index, _ in fine}) != len(fine):
+        raise ValueError("fine correction indices must be unique")
+    active_set = set(active)
+    for index, value in fine:
+        if index not in active_set:
+            raise ValueError("fine correction references an inactive index")
+        if not isfinite(value):
+            raise ValueError("fine corrections must be finite")
+
+    required_blocks = {_block_for(shape, index, coarse_factor) for index in active}
+    if required_blocks != set(coarse_blocks):
+        raise ValueError("coarse block set must exactly cover active indices")
+
+    runs = _active_runs(active)
+    predictor_digest = bytes.fromhex(_checksum_f64(predictor))
+    body = bytearray(
+        _HEADER.pack(
+            MAGIC,
+            VERSION,
+            0,
+            coarse_factor,
+            0,
+            sx,
+            sy,
+            sz,
+            active_threshold,
+            refine_threshold,
+            tolerance,
+            len(active),
+            len(runs),
+            len(coarse),
+            len(fine),
+            predictor_digest,
+        )
+    )
+
+    previous_end = -1
+    for start, length in runs:
+        baseline = previous_end + 1
+        body.extend(_encode_uvarint(start - baseline))
+        body.extend(_encode_uvarint(length))
+        previous_end = start + length - 1
+
+    for (bx, by, bz), value in coarse:
+        body.extend(_encode_uvarint(bx))
+        body.extend(_encode_uvarint(by))
+        body.extend(_encode_uvarint(bz))
+        body.extend(pack("<d", value))
+
+    previous_fine = -1
+    for index, correction in fine:
+        body.extend(_encode_uvarint(index - previous_fine - 1))
+        body.extend(pack("<d", correction))
+        previous_fine = index
+
+    digest = sha256(body).digest()
+    body.extend(digest)
+    return bytes(body)
+
+
+def parse_capsule(data: bytes) -> KineticCapsule:
+    if len(data) < _HEADER.size + _CHECKSUM_BYTES:
+        raise CapsuleError("capsule is truncated")
+    payload_limit = len(data) - _CHECKSUM_BYTES
+    expected_digest = data[payload_limit:]
+    actual_digest = sha256(data[:payload_limit]).digest()
+    if actual_digest != expected_digest:
+        raise CapsuleError("capsule checksum mismatch")
+
+    (
+        magic,
+        version,
+        flags,
+        coarse_factor,
+        reserved,
+        sx,
+        sy,
+        sz,
+        active_threshold,
+        refine_threshold,
+        tolerance,
+        active_count,
+        run_count,
+        coarse_count,
+        fine_count,
+        predictor_digest,
+    ) = _HEADER.unpack_from(data, 0)
+    if magic != MAGIC:
+        raise CapsuleError("unknown capsule magic")
+    if version != VERSION:
+        raise CapsuleError(f"unsupported capsule version {version}")
+    if flags != 0 or reserved != 0:
+        raise CapsuleError("unsupported capsule flags")
+    if not 1 <= coarse_factor <= 32:
+        raise CapsuleError("invalid coarse factor")
+    if not all(isfinite(value) and value >= 0 for value in (active_threshold, refine_threshold, tolerance)):
+        raise CapsuleError("invalid threshold metadata")
+
+    shape: Shape3D = (sx, sy, sz)
+    count = _validate_shape(shape)
+    if active_count > count or run_count > active_count or fine_count > active_count:
+        raise CapsuleError("capsule count metadata exceeds volume bounds")
+
+    offset = _HEADER.size
+    active: list[int] = []
+    previous_end = -1
+    for _ in range(run_count):
+        start_delta, offset = _decode_uvarint(data, offset, payload_limit)
+        length, offset = _decode_uvarint(data, offset, payload_limit)
+        if length < 1:
+            raise CapsuleError("active run length must be positive")
+        start = previous_end + 1 + start_delta
+        end = start + length - 1
+        if start <= previous_end or end >= count:
+            raise CapsuleError("active run is outside the volume or overlaps")
+        active.extend(range(start, end + 1))
+        previous_end = end
+    if len(active) != active_count:
+        raise CapsuleError("active run count does not match active cell count")
+
+    coarse: list[tuple[Block3D, float]] = []
+    bx_count = (sx + coarse_factor - 1) // coarse_factor
+    by_count = (sy + coarse_factor - 1) // coarse_factor
+    bz_count = (sz + coarse_factor - 1) // coarse_factor
+    for _ in range(coarse_count):
+        bx, offset = _decode_uvarint(data, offset, payload_limit)
+        by, offset = _decode_uvarint(data, offset, payload_limit)
+        bz, offset = _decode_uvarint(data, offset, payload_limit)
+        if offset + 8 > payload_limit:
+            raise CapsuleError("truncated coarse value")
+        (value,) = unpack_from("<d", data, offset)
+        offset += 8
+        if not isfinite(value):
+            raise CapsuleError("non-finite coarse value")
+        if not (bx < bx_count and by < by_count and bz < bz_count):
+            raise CapsuleError("coarse block lies outside the volume")
+        coarse.append(((bx, by, bz), value))
+    coarse_blocks = [block for block, _ in coarse]
+    if len(set(coarse_blocks)) != len(coarse_blocks):
+        raise CapsuleError("duplicate coarse block")
+
+    fine: list[tuple[int, float]] = []
+    previous_fine = -1
+    active_set = set(active)
+    for _ in range(fine_count):
+        delta, offset = _decode_uvarint(data, offset, payload_limit)
+        index = previous_fine + 1 + delta
+        if offset + 8 > payload_limit:
+            raise CapsuleError("truncated fine correction")
+        (correction,) = unpack_from("<d", data, offset)
+        offset += 8
+        if index <= previous_fine or index not in active_set:
+            raise CapsuleError("invalid fine correction index")
+        if not isfinite(correction):
+            raise CapsuleError("non-finite fine correction")
+        fine.append((index, correction))
+        previous_fine = index
+
+    if offset != payload_limit:
+        raise CapsuleError("capsule contains trailing payload bytes")
+
+    required_blocks = {_block_for(shape, index, coarse_factor) for index in active}
+    if required_blocks != set(coarse_blocks):
+        raise CapsuleError("coarse blocks do not exactly cover active indices")
+
+    return KineticCapsule(
+        shape=shape,
+        active_threshold=active_threshold,
+        coarse_factor=coarse_factor,
+        refine_threshold=refine_threshold,
+        tolerance=tolerance,
+        active_indices=tuple(active),
+        coarse_values=tuple(coarse),
+        fine_corrections=tuple(fine),
+        predictor_checksum_sha256=predictor_digest.hex(),
+        checksum_sha256=expected_digest.hex(),
+    )
+
+
+def decode_capsule(data: bytes, prediction: Sequence[float]) -> tuple[float, ...]:
+    return parse_capsule(data).decode(prediction)
+
+
+def _candidate_thresholds(tolerance: float) -> tuple[float, ...]:
+    if tolerance == 0.0:
+        return (0.0,)
+    return tuple(sorted({0.0, tolerance * 0.25, tolerance * 0.5, tolerance}))
+
+
+def plan_rate_distortion(
+    current: Sequence[float],
+    prediction: Sequence[float],
+    shape: Shape3D,
+    *,
+    tolerance: float,
+    coarse_factors: Sequence[int] = (1, 2, 4, 8),
+) -> AdaptivePlan:
+    count = _validate_shape(shape)
+    observed = _validate_vector("current", current, count)
+    predictor = _validate_vector("prediction", prediction, count)
+    if not isfinite(tolerance) or tolerance < 0:
+        raise ValueError("tolerance must be finite and non-negative")
+
+    factors = tuple(sorted(set(int(factor) for factor in coarse_factors)))
+    if not factors or any(not 1 <= factor <= 32 for factor in factors):
+        raise ValueError("coarse_factors must contain values between 1 and 32")
+
+    backend = ReferenceBackend()
+    thresholds = _candidate_thresholds(tolerance)
+    raw_bytes = count * 8
+    candidates: list[PlanCandidate] = []
+
+    for active_threshold in thresholds:
+        for coarse_factor in factors:
+            for refine_threshold in thresholds:
+                step = backend.step(
+                    observed,
+                    predictor,
+                    shape,
+                    active_threshold=active_threshold,
+                    coarse_factor=coarse_factor,
+                    refine_threshold=refine_threshold,
+                )
+                errors = [source - target for source, target in zip(observed, step.reconstructed)]
+                mse = sum(error * error for error in errors) / count
+                max_abs_error = max((abs(error) for error in errors), default=0.0)
+                if max_abs_error > tolerance:
+                    continue
+                capsule = build_capsule(
+                    shape=shape,
+                    prediction=predictor,
+                    active_threshold=active_threshold,
+                    coarse_factor=coarse_factor,
+                    refine_threshold=refine_threshold,
+                    tolerance=tolerance,
+                    active_indices=step.active_indices,
+                    coarse_values=step.coarse_values,
+                    fine_corrections=step.fine_corrections,
+                )
+                candidates.append(
+                    PlanCandidate(
+                        active_threshold=active_threshold,
+                        coarse_factor=coarse_factor,
+                        refine_threshold=refine_threshold,
+                        max_abs_error=max_abs_error,
+                        mse=mse,
+                        active_cells=len(step.active_indices),
+                        coarse_values=len(step.coarse_values),
+                        fine_corrections=len(step.fine_corrections),
+                        capsule_bytes=len(capsule),
+                        raw_bytes=raw_bytes,
+                    )
+                )
+
+    if not candidates:
+        raise RuntimeError("no rate-distortion candidate satisfies the requested tolerance")
+
+    ordered = tuple(
+        sorted(
+            candidates,
+            key=lambda candidate: (
+                candidate.capsule_bytes,
+                candidate.max_abs_error,
+                candidate.active_cells,
+                candidate.fine_corrections,
+                candidate.coarse_values,
+                candidate.coarse_factor,
+                candidate.refine_threshold,
+                candidate.active_threshold,
+            ),
+        )
+    )
+    return AdaptivePlan(tolerance=tolerance, selected=ordered[0], candidates=ordered)

--- a/tests/test_kinetic3d_capsule.py
+++ b/tests/test_kinetic3d_capsule.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.kinetic3d_backend import ReferenceBackend
+from jarvisx.kinetic3d_capsule import (
+    CapsuleError,
+    build_capsule,
+    decode_capsule,
+    parse_capsule,
+    plan_rate_distortion,
+)
+
+
+def _capsule_for(
+    current: list[float],
+    prediction: list[float],
+    shape: tuple[int, int, int],
+    *,
+    active_threshold: float = 0.0,
+    coarse_factor: int = 2,
+    refine_threshold: float = 0.0,
+    tolerance: float = 0.0,
+) -> bytes:
+    step = ReferenceBackend().step(
+        current,
+        prediction,
+        shape,
+        active_threshold=active_threshold,
+        coarse_factor=coarse_factor,
+        refine_threshold=refine_threshold,
+    )
+    return build_capsule(
+        shape=shape,
+        prediction=prediction,
+        active_threshold=active_threshold,
+        coarse_factor=coarse_factor,
+        refine_threshold=refine_threshold,
+        tolerance=tolerance,
+        active_indices=step.active_indices,
+        coarse_values=step.coarse_values,
+        fine_corrections=step.fine_corrections,
+    )
+
+
+def test_jxk2_capsule_is_self_describing_reversible_and_integrity_sealed() -> None:
+    shape = (8, 8, 8)
+    prediction = [0.0] * 512
+    current = [5.0] * 512
+    capsule_bytes = _capsule_for(current, prediction, shape, coarse_factor=8)
+
+    capsule = parse_capsule(capsule_bytes)
+    assert capsule.shape == shape
+    assert capsule.coarse_factor == 8
+    assert len(capsule.active_indices) == 512
+    assert len(capsule.coarse_values) == 1
+    assert len(capsule.fine_corrections) == 0
+    assert capsule.decode(prediction) == tuple(current)
+    assert len(capsule_bytes) < len(current) * 8
+
+    corrupted = bytearray(capsule_bytes)
+    corrupted[-33] ^= 0x01
+    with pytest.raises(CapsuleError, match="checksum"):
+        parse_capsule(bytes(corrupted))
+
+
+def test_capsule_binds_delta_to_exact_predictor() -> None:
+    shape = (2, 2, 2)
+    prediction = [1.0] * 8
+    current = [1.0, 1.0, 1.0, 4.0, 1.0, 1.0, 1.0, 1.0]
+    capsule_bytes = _capsule_for(current, prediction, shape, coarse_factor=2)
+
+    assert decode_capsule(capsule_bytes, prediction) == tuple(current)
+    with pytest.raises(CapsuleError, match="prediction checksum"):
+        decode_capsule(capsule_bytes, [0.0] * 8)
+
+
+def test_irregular_volume_uses_fine_corrections_and_round_trips_exactly() -> None:
+    shape = (2, 2, 2)
+    prediction = [0.0] * 8
+    current = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]
+    capsule_bytes = _capsule_for(current, prediction, shape, coarse_factor=2)
+    capsule = parse_capsule(capsule_bytes)
+
+    assert capsule.decode(prediction) == tuple(current)
+    assert len(capsule.coarse_values) == 1
+    assert len(capsule.fine_corrections) > 0
+
+
+def test_rate_distortion_planner_prefers_large_uniform_block_for_exact_change() -> None:
+    shape = (8, 8, 8)
+    prediction = [0.0] * 512
+    current = [2.0] * 512
+
+    plan = plan_rate_distortion(current, prediction, shape, tolerance=0.0)
+
+    assert plan.selected.coarse_factor == 8
+    assert plan.selected.active_cells == 512
+    assert plan.selected.coarse_values == 1
+    assert plan.selected.fine_corrections == 0
+    assert plan.selected.max_abs_error == 0.0
+    assert plan.selected.wire_compression_ratio > 1.0
+
+
+def test_rate_distortion_planner_is_deterministic_and_respects_error_budget() -> None:
+    shape = (4, 4, 4)
+    prediction = [0.0] * 64
+    current = [float(index % 7) / 10.0 for index in range(64)]
+
+    first = plan_rate_distortion(current, prediction, shape, tolerance=0.2)
+    second = plan_rate_distortion(current, prediction, shape, tolerance=0.2)
+
+    assert first == second
+    assert first.selected.max_abs_error <= 0.2
+    assert 1 <= len(first.candidates) <= 64
+    assert first.selected.capsule_bytes == min(candidate.capsule_bytes for candidate in first.candidates)
+
+
+def test_capsule_validation_fails_closed() -> None:
+    with pytest.raises(CapsuleError, match="truncated"):
+        parse_capsule(b"JXK2")
+
+    shape = (1, 1, 1)
+    prediction = [0.0]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        build_capsule(
+            shape=shape,
+            prediction=prediction,
+            active_threshold=0.0,
+            coarse_factor=1,
+            refine_threshold=0.0,
+            tolerance=0.0,
+            active_indices=[0, 0],
+            coarse_values=[((0, 0, 0), 1.0)],
+            fine_corrections=[],
+        )


### PR DESCRIPTION
## Objective

Push the merged kinetic 3D runtime beyond its current fixed-parameter/value-count boundary by making the latent independently transportable and the spatial codec plan automatically selectable under an explicit reconstruction-error budget.

## What changed

- adds `src/jarvisx/kinetic3d_capsule.py`
  - JXK2 predictor-bound delta capsule
  - fixed versioned header
  - SHA-256 predictor binding
  - run-length active-set encoding
  - varint spatial metadata
  - coarse residual + selective fine-correction payload
  - whole-capsule SHA-256 integrity seal
  - fail-closed parser and independent decoder
- adds deterministic rate-distortion planning
  - bounded search over active threshold, coarse factor and refinement threshold
  - rejects every candidate above the caller's max-error budget
  - serializes admissible candidates and ranks by actual JXK2 bytes, not latent-value proxy counts
  - deterministic tie-breaking independent of wall-clock latency
- upgrades the FastAPI service to v2
  - `POST /v2/kinetic3d/execute-adaptive`
  - `POST /v2/kinetic3d/decode-capsule`
  - Base64 JXK2 transport, exact byte count, wire compression ratio and transport hash
  - independent decode must reproduce the committed reconstruction before emission
- extends Prometheus telemetry with adaptive execution and emitted capsule-byte counters
- adds capsule/planner regression tests and extends native/container CI
- adds `docs/KINETIC3D_JXK2_RATE_DISTORTION.md`

## Operational loop

```text
OBSERVE
 -> PREDICT
 -> bounded rate-distortion candidate search
 -> serialize admissible plans as JXK2
 -> select minimum actual transport bytes under max-error budget
 -> execute selected plan on requested backend
 -> VERIFY
 -> COMMIT
 -> build authoritative JXK2 capsule
 -> independently decode against predictor digest
 -> EMIT
```

## Important correction to the previous compression metric

The existing kinetic runtime reports a scalar-value compression ratio. That metric does not include active indices or transport metadata.

This PR introduces an exact wire metric:

```text
wire_compression_ratio = raw_float64_bytes / serialized_JXK2_bytes
```

Small or irregular states are therefore allowed to report expansion. Compression is claimed only when the emitted transport is actually smaller than the raw source representation.

## Verification boundaries

JXK2 fails closed on checksum mismatch, unsupported version/flags, truncated varints or floating payloads, non-finite metadata, invalid/overlapping active runs, invalid coarse coverage, fine corrections outside the active set, trailing payload bytes and predictor mismatch.

Adaptive planning uses the reference backend as a deterministic correctness oracle. The selected plan then executes on `cpu-reference`, `native-cpu`, or a future semantic-parity backend. Verification/commit authority remains outside the acceleration backend.

## SOTA boundary

This change intentionally does **not** claim external state-of-the-art compression or throughput. It creates the machinery needed for a defensible comparison: explicit rate-distortion budgets, actual serialized bytes, deterministic plans, independently decodable artifacts and backend-neutral execution.

A genuine SOTA claim remains contingent on comparative datasets/hardware and measured rate-distortion, throughput, latency, memory traffic, energy and recovery results.
