### PR TITLE
Lock DM-vOmegaXi+ inward fixed-point law

### DIFF
--- a/configs/dm_vomegaxi_fixed_point.json
+++ b/configs/dm_vomegaxi_fixed_point.json
@@ -1,0 +1,44 @@
+{
+  "schema": "jarvisx.dm-vomegaxi-fixed-point-law/v1",
+  "law_id": "DM-vOmegaXi+",
+  "locked": true,
+  "fixed_point_equation": "H* = F_DM(H*)",
+  "operator_stack": [
+    "Psi",
+    "Phi",
+    "Lambda^-1",
+    "Omega",
+    "Theta"
+  ],
+  "decoder_pairing": "D(Phi(Psi))",
+  "logical_hypervolume_tb": "1000000000000000000000000000",
+  "materialization": "sparse-active-support-only",
+  "semantic_uncertainty": {
+    "symbol": "hbar_semantic",
+    "metric": "gamma = max(semantic_floor, reconstruction_rms)",
+    "semantic_floor": 1e-12,
+    "interpretation": "internal reconstruction-gap proxy; never epistemic identity with external reality"
+  },
+  "lambda_inverse": {
+    "latent_bound": 1.0,
+    "operation": "clip latent amplitudes into [-latent_bound, +latent_bound]"
+  },
+  "omega": {
+    "historical_retention": 0.5,
+    "operation": "Omega_{t+1} = rho * Omega_t + (1-rho) * D_t"
+  },
+  "theta": {
+    "gain": 0.5,
+    "max_delta": 0.25,
+    "operation": "bounded projection toward Omega_{t+1}",
+    "policy_gate": "optional external callable; rejection is transactional"
+  },
+  "fixed_point_acceptance": {
+    "tolerance": 1e-6,
+    "condition": "max(||H_{t+1}-H_t||, ||H_{t+1}-D_t||, ||H_{t+1}-Omega_{t+1}||) <= tolerance"
+  },
+  "audit": {
+    "algorithm": "SHA-256",
+    "mode": "append-only hash chain"
+  }
+}

--- a/docs/dm-vomegaxi-fixed-point-law.md
+++ b/docs/dm-vomegaxi-fixed-point-law.md
@@ -1,0 +1,198 @@
+# DM-vOmegaXi+ Fixed-Point Law
+
+## Status
+
+**Locked operational baseline.**
+
+This document defines the executable interpretation of the inward-folded Dr Moagi 3D auto-encoding/decoding law over the `Psi -> Phi -> Lambda^-1 -> Omega -> Theta` operator stack.
+
+The implementation is deliberately bounded and testable. The stated `10^27 TB` hyper-volume is treated as a **logical address-space descriptor**, not as resident RAM, VRAM, disk, or a claim of literal lossless compression. Only active sparse coordinates are materialized.
+
+## Canonical fixed-point statement
+
+The governing internal fixed point is
+
+```text
+H* = F_DM(H*)
+```
+
+with the executable operator map
+
+```text
+Psi_t
+  -> Phi(Psi_t)
+  -> Lambda^-1(Phi_t)
+  -> D(Phi_t)
+  -> Omega_t(D_t)
+  -> Theta(Psi_t, Omega_{t+1})
+  -> H_{t+1}
+```
+
+`H*` is therefore a self-consistent state of the **internal runtime operator**. It is not defined as perfect identity between the internal model and external reality.
+
+## Operator semantics
+
+| Operator | Runtime meaning | Measurable implementation |
+|---|---|---|
+| `Psi` | Active 3D field state | Sparse coordinate/value map |
+| `Phi` | Description / spatial compression | `SparseBlockCodec3D.encode` |
+| `Lambda^-1` | Constraint inversion into the latent bottleneck | Latent amplitude projection into a finite bound |
+| `Omega_t` | Holographic/recurrent inward memory coupling | Historical retention plus decoded-state injection at local coordinates |
+| `Theta` | Stability/alignment projection | Bounded state delta plus optional external policy gate |
+| `hbar_semantic` | Irreducible semantic uncertainty floor | Strictly positive lower bound on `gamma` |
+
+The decoder `D` is paired with `Phi` to close the auto-encoding/decoding loop.
+
+## Phi: description operator
+
+For an active sparse field `Psi_t`, `Phi` maps active coordinates into a compact block latent representation:
+
+```text
+Phi_t = Phi(Psi_t)
+```
+
+The current reference codec uses quantized block means. Alternative learned or accelerator codecs may replace it behind the same boundary, provided they preserve sparse-support and transactional invariants.
+
+## Lambda^-1: bottleneck projection
+
+The reference implementation bounds every latent amplitude:
+
+```text
+z'_i = clip(z_i, -B_lambda, +B_lambda)
+```
+
+This is the operational meaning of constraint inversion in the current baseline: the high-dimensional description is forced through a finite latent admissible set before decoding.
+
+## Omega_t: recurrent inward fold
+
+Historical state is folded back into the current coordinate support:
+
+```text
+Omega_{t+1}(r) = rho * Omega_t(r) + (1-rho) * D_t(r)
+```
+
+where `rho in [0, 1)` is the historical-retention coefficient.
+
+No dense 3D tensor is created. The recurrence exists only over active support.
+
+## Theta: stability and policy projection
+
+The numerical part of `Theta` moves the authoritative state toward recurrent memory using a bounded delta:
+
+```text
+delta_t(r) = clip(
+    theta_gain * (Omega_{t+1}(r) - Psi_t(r)),
+    -theta_max_delta,
+    +theta_max_delta
+)
+
+H_{t+1}(r) = clip(
+    Psi_t(r) + delta_t(r),
+    value_min,
+    value_max
+)
+```
+
+An optional external `theta_gate(candidate) -> bool` may impose higher-level structural, policy, or ethical constraints. A failed gate rejects the candidate transactionally; the authoritative state is left unchanged.
+
+The reference implementation does **not** claim that a scalar numerical parameter can itself establish moral truth.
+
+## hbar_semantic and the reality gap
+
+The runtime keeps a strictly positive semantic uncertainty floor:
+
+```text
+gamma_t = max(hbar_semantic, reconstruction_rms_t)
+```
+
+`reconstruction_rms_t` is a measurable internal map-to-map discrepancy. `gamma_t` is therefore an engineering proxy for description uncertainty, not a measurement of metaphysical or external-world truth.
+
+This distinction allows the internal system to become self-consistent while preserving the map/territory boundary:
+
+```text
+H* = F_DM(H*)
+
+gamma* >= hbar_semantic > 0
+```
+
+## Fixed-point acceptance
+
+A state is accepted as `H*` when the next state, decoded description, and recurrent memory all agree within tolerance:
+
+```text
+R_t = max(
+    RMS(H_{t+1}, H_t),
+    RMS(H_{t+1}, D_t),
+    RMS(H_{t+1}, Omega_{t+1})
+)
+
+converged <=> R_t <= epsilon_fp
+```
+
+This criterion is deterministic and independently testable.
+
+## Hyper-volume semantics
+
+The locked metadata value is:
+
+```text
+logical_hypervolume_tb = 10^27
+```
+
+Operationally this means only that the abstraction may describe a logical domain of that declared scale. The implementation never attempts to allocate `10^27 TB` or a corresponding dense lattice.
+
+The runtime invariant is:
+
+```text
+materialized_state = active_sparse_support << logical_domain
+```
+
+This is the only interpretation compatible with finite hardware.
+
+## Transaction and audit invariants
+
+Every fixed-point step follows:
+
+```text
+snapshot
+ -> encode
+ -> latent-bound projection
+ -> decode active support
+ -> recurrent fold
+ -> Theta projection
+ -> finite/resource/policy validation
+ -> commit OR rollback
+ -> SHA-256 journal append
+```
+
+The journal is an integrity chain, not encryption.
+
+## Reference API
+
+```python
+from jarvisx.dm_vomegaxi_fixed_point import DMvOmegaXiFixedPointEngine
+
+engine = DMvOmegaXiFixedPointEngine()
+engine.load({
+    (32, 32, 32): 1.0,
+    (33, 32, 32): 0.75,
+})
+
+reports = engine.run_until_fixed_point()
+assert engine.journal.verify()
+print(reports[-1].converged)
+print(engine.status())
+```
+
+## Locked invariants
+
+1. `H*` is an internal operator fixed point, not an assertion of omniscience.
+2. `hbar_semantic > 0` is mandatory.
+3. `10^27 TB` remains logical metadata and is never densely allocated.
+4. `Lambda^-1` must preserve a finite latent admissible set.
+5. `Theta` must bound each state transition and may reject candidates transactionally.
+6. `Omega_t` is recurrent and local to active sparse support.
+7. A rejected candidate cannot mutate authoritative state.
+8. Every attempted transition is hash-journaled.
+9. Fixed-point convergence must be measured, not declared.
+10. Any future learned codec or accelerator backend must preserve these invariants.

--- a/src/jarvisx/dm_vomegaxi_fixed_point.py
+++ b/src/jarvisx/dm_vomegaxi_fixed_point.py
@@ -1,0 +1,362 @@
+"""Executable fixed-point contract for the locked Dr Moagi DM-vOmegaXi+ law.
+
+The module translates the symbolic Psi--Phi--Lambda--Omega--Theta stack into a
+bounded sparse reference runtime.  The fixed point is an *internal operator*
+fixed point, H* = F_DM(H*).  It is deliberately not interpreted as identity
+between an internal model and external reality: ``semantic_floor`` keeps a
+strictly positive map--territory uncertainty floor.
+
+The 10^27 TB hyper-volume is represented only as logical metadata.  This module
+never allocates that volume; it materializes active sparse support only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Callable, Mapping
+
+from .dr_moagi_autoexec import (
+    AutoExecPolicy,
+    HashChainJournal,
+    SparseBlockCodec3D,
+    SparseLatent3D,
+    SparseParser3D,
+)
+from .dr_moagi_field_runtime import Coordinate, SparseField
+
+ThetaGate = Callable[[Mapping[Coordinate, float]], bool]
+
+
+@dataclass(frozen=True)
+class DMvOmegaXiFixedPointConfig:
+    """Bounded executable contract for DM-vOmegaXi+.
+
+    ``logical_hypervolume_tb`` is address-space metadata, not resident memory.
+    ``omega_memory`` is the historical retention coefficient in Omega_t.
+    ``theta_gain`` and ``theta_max_delta`` bound each inward stabilization step.
+    """
+
+    side: int = 64
+    max_active_cells: int = 50_000
+    value_min: float = -1.0
+    value_max: float = 1.0
+    policy: AutoExecPolicy = field(default_factory=AutoExecPolicy)
+    latent_bound: float = 1.0
+    omega_memory: float = 0.5
+    theta_gain: float = 0.5
+    theta_max_delta: float = 0.25
+    fixed_point_tolerance: float = 1.0e-6
+    semantic_floor: float = 1.0e-12
+    max_iterations: int = 64
+    logical_hypervolume_tb: int = 10**27
+
+    def __post_init__(self) -> None:
+        if isinstance(self.side, bool) or not isinstance(self.side, int) or self.side <= 0:
+            raise ValueError("side must be a positive integer")
+        if (
+            isinstance(self.max_active_cells, bool)
+            or not isinstance(self.max_active_cells, int)
+            or self.max_active_cells <= 0
+        ):
+            raise ValueError("max_active_cells must be a positive integer")
+        if (
+            isinstance(self.max_iterations, bool)
+            or not isinstance(self.max_iterations, int)
+            or self.max_iterations <= 0
+        ):
+            raise ValueError("max_iterations must be a positive integer")
+        if self.logical_hypervolume_tb <= 0:
+            raise ValueError("logical_hypervolume_tb must be positive")
+
+        for name in (
+            "value_min",
+            "value_max",
+            "latent_bound",
+            "omega_memory",
+            "theta_gain",
+            "theta_max_delta",
+            "fixed_point_tolerance",
+            "semantic_floor",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+        if self.latent_bound <= 0.0:
+            raise ValueError("latent_bound must be positive")
+        if not 0.0 <= self.omega_memory < 1.0:
+            raise ValueError("omega_memory must be in [0, 1)")
+        if not 0.0 < self.theta_gain <= 1.0:
+            raise ValueError("theta_gain must be in (0, 1]")
+        if self.theta_max_delta <= 0.0:
+            raise ValueError("theta_max_delta must be positive")
+        if self.fixed_point_tolerance < 0.0:
+            raise ValueError("fixed_point_tolerance must be non-negative")
+        if self.semantic_floor <= 0.0:
+            raise ValueError("semantic_floor must be strictly positive")
+
+
+@dataclass(frozen=True)
+class FixedPointReport:
+    iteration: int
+    committed: bool
+    active_cells: int
+    latent_cells: int
+    reconstruction_rms: float
+    memory_rms: float
+    theta_rms: float
+    fixed_point_residual: float
+    semantic_gap: float
+    converged: bool
+    theta_gate_passed: bool
+    rejection_reason: str | None
+    state_hash: str
+    journal_hash: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class DMvOmegaXiFixedPointEngine:
+    """Sparse inward-folded fixed-point engine.
+
+    One iteration implements the measurable runtime interpretation:
+
+        Psi_t
+          -> Phi(Psi_t)                  spatial description / encoding
+          -> Lambda^-1(Phi_t)             bounded latent projection
+          -> D(Phi_t)                     sparse reconstruction
+          -> Omega_t(D_t)                 recurrent inward memory fold
+          -> Theta(Psi_t, Omega_{t+1})     bounded stability projection
+          -> H_{t+1}
+
+    H* is accepted when the authoritative state, decoded description, and
+    recurrent memory agree within ``fixed_point_tolerance``.  The separate
+    semantic gap gamma never falls below ``semantic_floor``.
+    """
+
+    LAW_ID = "DM-vOmegaXi+"
+    OPERATOR_STACK = ("Psi", "Phi", "Lambda^-1", "Omega", "Theta")
+
+    def __init__(
+        self,
+        config: DMvOmegaXiFixedPointConfig | None = None,
+        *,
+        theta_gate: ThetaGate | None = None,
+        journal_path: str | Path | None = None,
+    ) -> None:
+        self.config = config or DMvOmegaXiFixedPointConfig()
+        self.theta_gate = theta_gate
+        self.parser = SparseParser3D(
+            side=self.config.side,
+            max_active_cells=self.config.max_active_cells,
+            value_min=self.config.value_min,
+            value_max=self.config.value_max,
+            prune_epsilon=self.config.policy.prune_epsilon,
+        )
+        self.codec = SparseBlockCodec3D(self.config.policy)
+        self.journal = HashChainJournal(journal_path)
+        self._state: SparseField = {}
+        self._memory: SparseField = {}
+        self._iteration = 0
+        self._loaded = False
+        self.reports: list[FixedPointReport] = []
+
+    def load(self, source: Mapping[Coordinate, float]) -> SparseField:
+        state = self.parser.parse(source)
+        self._state = dict(state)
+        self._memory = dict(state)
+        self._iteration = 0
+        self.reports.clear()
+        self._loaded = True
+        return self.snapshot()
+
+    def snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._state)
+
+    def memory_snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._memory)
+
+    def phi(self, field: Mapping[Coordinate, float]) -> SparseLatent3D:
+        """Phi: spatial description/compression into the sparse latent field."""
+        return self.codec.encode(field)
+
+    def lambda_inverse(self, latent: SparseLatent3D) -> SparseLatent3D:
+        """Lambda^-1: project latent amplitudes into the bounded bottleneck."""
+        bound = self.config.latent_bound
+        cells = tuple(
+            replace(cell, value=max(-bound, min(bound, float(cell.value))))
+            for cell in latent.cells
+        )
+        return replace(latent, cells=cells)
+
+    def omega_fold(
+        self,
+        decoded: Mapping[Coordinate, float],
+        support: tuple[Coordinate, ...],
+    ) -> SparseField:
+        """Omega_t: fold historical state back into local voxel coordinates."""
+        retain = self.config.omega_memory
+        inject = 1.0 - retain
+        return {
+            coordinate: retain * self._memory.get(coordinate, self._state.get(coordinate, 0.0))
+            + inject * float(decoded.get(coordinate, 0.0))
+            for coordinate in support
+        }
+
+    def theta_project(
+        self,
+        current: Mapping[Coordinate, float],
+        folded: Mapping[Coordinate, float],
+    ) -> SparseField:
+        """Theta: bounded numerical/stability projection over active support."""
+        result: SparseField = {}
+        gain = self.config.theta_gain
+        cap = self.config.theta_max_delta
+        eps = self.config.policy.prune_epsilon
+        for coordinate in sorted(set(current) | set(folded)):
+            value = float(current.get(coordinate, 0.0))
+            target = float(folded.get(coordinate, 0.0))
+            delta = gain * (target - value)
+            delta = max(-cap, min(cap, delta))
+            projected = max(
+                self.config.value_min,
+                min(self.config.value_max, value + delta),
+            )
+            if abs(projected) > eps:
+                result[coordinate] = projected
+        return result
+
+    def step(self) -> FixedPointReport:
+        self._require_loaded()
+        current = dict(self._state)
+        support = tuple(sorted(current))
+
+        latent = self.phi(current)
+        bounded_latent = self.lambda_inverse(latent)
+        decoded = self.codec.decode(bounded_latent, support)
+        folded = self.omega_fold(decoded, support)
+        candidate = self.theta_project(current, folded)
+
+        reconstruction_rms = self._rms(current, decoded)
+        memory_rms = self._rms(candidate, folded)
+        theta_rms = self._rms(candidate, current)
+        representation_rms = self._rms(candidate, decoded)
+        residual = max(theta_rms, memory_rms, representation_rms)
+        semantic_gap = max(self.config.semantic_floor, reconstruction_rms)
+
+        rejection_reason: str | None = None
+        theta_gate_passed = True
+        if len(candidate) > self.config.max_active_cells:
+            rejection_reason = "active-cell budget exceeded"
+        elif not self._finite(candidate):
+            rejection_reason = "non-finite candidate state"
+        elif self.theta_gate is not None:
+            theta_gate_passed = bool(self.theta_gate(candidate))
+            if not theta_gate_passed:
+                rejection_reason = "Theta policy gate rejected candidate"
+
+        committed = rejection_reason is None
+        if committed:
+            self._state = candidate
+            self._memory = folded
+            self._iteration += 1
+
+        converged = bool(committed and residual <= self.config.fixed_point_tolerance)
+        authoritative = self._state if committed else current
+        provisional = FixedPointReport(
+            iteration=self._iteration,
+            committed=committed,
+            active_cells=len(authoritative),
+            latent_cells=bounded_latent.latent_cells,
+            reconstruction_rms=reconstruction_rms,
+            memory_rms=memory_rms,
+            theta_rms=theta_rms,
+            fixed_point_residual=residual,
+            semantic_gap=semantic_gap,
+            converged=converged,
+            theta_gate_passed=theta_gate_passed,
+            rejection_reason=rejection_reason,
+            state_hash=self._state_hash(authoritative),
+        )
+        record = provisional.as_dict()
+        record.pop("journal_hash", None)
+        digest = self.journal.append(record)
+        report = replace(provisional, journal_hash=digest)
+        self.reports.append(report)
+        return report
+
+    def run_until_fixed_point(self, max_iterations: int | None = None) -> tuple[FixedPointReport, ...]:
+        self._require_loaded()
+        limit = self.config.max_iterations if max_iterations is None else max_iterations
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("max_iterations must be a positive integer")
+        for _ in range(limit):
+            report = self.step()
+            if report.converged or not report.committed:
+                break
+        return tuple(self.reports)
+
+    def status(self) -> dict[str, object]:
+        self._require_loaded()
+        latent = self.lambda_inverse(self.phi(self._state))
+        latest = self.reports[-1] if self.reports else None
+        return {
+            "law": self.LAW_ID,
+            "locked": True,
+            "operator_stack": list(self.OPERATOR_STACK),
+            "fixed_point_equation": "H* = F_DM(H*)",
+            "iteration": self._iteration,
+            "active_cells": len(self._state),
+            "latent_cells": latent.latent_cells,
+            "logical_hypervolume_tb": str(self.config.logical_hypervolume_tb),
+            "materialization": "sparse-active-support-only",
+            "semantic_floor": self.config.semantic_floor,
+            "semantic_gap": latest.semantic_gap if latest else None,
+            "fixed_point_residual": latest.fixed_point_residual if latest else None,
+            "converged": latest.converged if latest else False,
+            "state_hash": self._state_hash(self._state),
+            "journal_head": self.journal.head,
+            "journal_valid": self.journal.verify(),
+        }
+
+    @staticmethod
+    def _rms(
+        left: Mapping[Coordinate, float],
+        right: Mapping[Coordinate, float],
+    ) -> float:
+        support = set(left) | set(right)
+        if not support:
+            return 0.0
+        mse = sum(
+            (float(left.get(coordinate, 0.0)) - float(right.get(coordinate, 0.0))) ** 2
+            for coordinate in support
+        ) / len(support)
+        return math.sqrt(mse)
+
+    @staticmethod
+    def _finite(field: Mapping[Coordinate, float]) -> bool:
+        return all(math.isfinite(float(value)) for value in field.values())
+
+    @staticmethod
+    def _state_hash(field: Mapping[Coordinate, float]) -> str:
+        canonical = [
+            [coordinate[0], coordinate[1], coordinate[2], float(field[coordinate])]
+            for coordinate in sorted(field)
+        ]
+        payload = json.dumps(canonical, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def _require_loaded(self) -> None:
+        if not self._loaded:
+            raise RuntimeError("load a sparse 3D field before fixed-point execution")

--- a/tests/test_dm_vomegaxi_fixed_point.py
+++ b/tests/test_dm_vomegaxi_fixed_point.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dm_vomegaxi_fixed_point import (
+    DMvOmegaXiFixedPointConfig,
+    DMvOmegaXiFixedPointEngine,
+)
+from jarvisx.dr_moagi_autoexec import AutoExecPolicy
+
+
+def _config(**overrides):
+    values = dict(
+        side=16,
+        max_active_cells=64,
+        value_min=-2.0,
+        value_max=2.0,
+        policy=AutoExecPolicy(block_size=2, quantization=0.01, prune_epsilon=0.0),
+        latent_bound=1.0,
+        omega_memory=0.5,
+        theta_gain=0.5,
+        theta_max_delta=0.25,
+        fixed_point_tolerance=1.0e-8,
+        semantic_floor=1.0e-12,
+        max_iterations=128,
+    )
+    values.update(overrides)
+    return DMvOmegaXiFixedPointConfig(**values)
+
+
+def test_exact_internal_fixed_point_keeps_positive_semantic_floor():
+    engine = DMvOmegaXiFixedPointEngine(_config())
+    field = {(2, 2, 2): 0.75, (3, 2, 2): 0.75}
+    engine.load(field)
+
+    report = engine.step()
+
+    assert report.committed
+    assert report.converged
+    assert report.fixed_point_residual == pytest.approx(0.0)
+    assert report.semantic_gap == pytest.approx(engine.config.semantic_floor)
+    assert engine.snapshot() == field
+    assert engine.status()["fixed_point_equation"] == "H* = F_DM(H*)"
+
+
+def test_lossy_description_folds_inward_until_self_consistent():
+    engine = DMvOmegaXiFixedPointEngine(_config(fixed_point_tolerance=1.0e-5))
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): 0.5})
+
+    reports = engine.run_until_fixed_point()
+
+    assert reports[-1].converged
+    assert reports[-1].fixed_point_residual <= engine.config.fixed_point_tolerance
+    state = engine.snapshot()
+    assert state[(2, 2, 2)] == pytest.approx(0.75, abs=1.0e-4)
+    assert state[(3, 2, 2)] == pytest.approx(0.75, abs=1.0e-4)
+    assert reports[-1].semantic_gap >= engine.config.semantic_floor
+
+
+def test_lambda_inverse_bounds_latent_bottleneck():
+    engine = DMvOmegaXiFixedPointEngine(_config(latent_bound=0.25))
+    engine.load({(2, 2, 2): 1.5, (3, 2, 2): 1.0})
+
+    bounded = engine.lambda_inverse(engine.phi(engine.snapshot()))
+
+    assert bounded.cells
+    assert all(abs(cell.value) <= 0.25 for cell in bounded.cells)
+
+
+def test_logical_hypervolume_is_metadata_not_dense_materialization():
+    engine = DMvOmegaXiFixedPointEngine(
+        _config(side=1_000_000, logical_hypervolume_tb=10**27)
+    )
+    engine.load({(1, 2, 3): 0.8, (999_999, 999_999, 999_999): 0.6})
+
+    status = engine.status()
+
+    assert status["logical_hypervolume_tb"] == str(10**27)
+    assert status["materialization"] == "sparse-active-support-only"
+    assert status["active_cells"] == 2
+
+
+def test_theta_policy_gate_can_reject_without_committing():
+    engine = DMvOmegaXiFixedPointEngine(_config(), theta_gate=lambda _: False)
+    initial = {(2, 2, 2): 1.0, (3, 2, 2): 0.5}
+    engine.load(initial)
+
+    report = engine.step()
+
+    assert not report.committed
+    assert not report.theta_gate_passed
+    assert report.rejection_reason == "Theta policy gate rejected candidate"
+    assert engine.snapshot() == initial
+    assert engine.journal.verify()
+
+
+def test_hash_chained_fixed_point_journal_round_trips(tmp_path):
+    path = tmp_path / "dm-vomegaxi-fixed-point.jsonl"
+    engine = DMvOmegaXiFixedPointEngine(_config(), journal_path=path)
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): 0.5})
+
+    engine.run_until_fixed_point()
+
+    assert path.exists()
+    assert engine.journal.verify()
+    assert len(engine.journal.head) == 64


### PR DESCRIPTION
## Summary

Operationalizes the locked inward-folded Dr Moagi `DM-vOmegaXi+` law as a bounded sparse fixed-point runtime over the `Psi -> Phi -> Lambda^-1 -> Omega -> Theta` stack.

### Added

- `src/jarvisx/dm_vomegaxi_fixed_point.py`
  - executable `H* = F_DM(H*)` operator map
  - sparse `Phi` description/encoding
  - bounded `Lambda^-1` latent projection
  - recurrent local `Omega_t` inward fold
  - bounded `Theta` stability projection with optional transactional policy gate
  - strictly positive `hbar_semantic` / reality-gap floor
  - measured fixed-point residual and convergence
  - SHA-256 hash-chained transition journal
- `configs/dm_vomegaxi_fixed_point.json`
  - machine-readable locked operator contract
- `docs/dm-vomegaxi-fixed-point-law.md`
  - formal execution semantics and invariants
- `tests/test_dm_vomegaxi_fixed_point.py`
  - exact fixed point
  - lossy inward convergence
  - latent constraint projection
  - logical-volume/non-dense materialization invariant
  - Theta rollback
  - audit-chain verification

## Critical semantics

- `10^27 TB` is logical hyper-volume metadata only; the implementation materializes active sparse support and never attempts a dense allocation.
- `H*` is an internal operator fixed point, not an assertion that the internal map is identical to external reality.
- `gamma >= hbar_semantic > 0` remains invariant even at internal convergence.
- The built-in Theta operator enforces numerical/structural stability. Higher-level ethical/policy constraints are supplied through the optional `theta_gate` and are transactional.

## Fixed-point acceptance

`R_t = max(RMS(H_{t+1}, H_t), RMS(H_{t+1}, D_t), RMS(H_{t+1}, Omega_{t+1}))`

Convergence is accepted only when `R_t <= epsilon_fp`.
