### PR TITLE
Permeate Bit Matrix 3D into the Jarvis-X runtime

### DIFF
--- a/.github/workflows/bitmatrix3d.yml
+++ b/.github/workflows/bitmatrix3d.yml
@@ -1,0 +1,38 @@
+name: Bit Matrix 3D Runtime
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/jarvisx/bitmatrix3d*.py"
+      - "tests/test_bitmatrix3d.py"
+      - "pyproject.toml"
+      - ".github/workflows/bitmatrix3d.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/bitmatrix3d*.py"
+      - "tests/test_bitmatrix3d.py"
+      - "pyproject.toml"
+      - ".github/workflows/bitmatrix3d.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  codec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install -e ".[test]"
+      - name: Bit Matrix invariant suite
+        run: pytest tests/test_bitmatrix3d.py --no-cov
+      - name: Compile smoke
+        run: python -m compileall -q src/jarvisx/bitmatrix3d.py src/jarvisx/bitmatrix3d_cli.py
+      - name: CLI round-trip smoke
+        run: jarvisx-bitmatrix3d "JARVIS X" --x 8 --y 8 --z 8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ jarvisx-hyperion = "jarvisx.hyperion_cli:main"
 jarvisx-dr-moagi = "jarvisx.dr_moagi_autoexec_cli:main"
 jarvisx-dr-moagi-os = "jarvisx.dr_moagi_os_cli:main"
 jarvisx-dr-moagi-frontier = "jarvisx.dr_moagi_frontier_cli:main"
+jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/bitmatrix3d.py
+++ b/src/jarvisx/bitmatrix3d.py
@@ -1,0 +1,313 @@
+"""Deterministic Bit Matrix 3D codec-runtime.
+
+The runtime provides a lossless, renderer-independent transport from bytes/text
+into a bounded 3D Boolean lattice and back again.
+
+Canonical layout::
+
+    [0..31]             unsigned 32-bit big-endian payload byte length
+    [32..32+n*8-1]      payload bits, big-endian within each byte
+    [remaining cells]   zero padding
+
+The lattice is traversed X-fastest, then Y, then Z::
+
+    index = z * (x_size * y_size) + y * x_size + x
+
+The implementation deliberately separates the authoritative information state
+from visualization.  A renderer may rotate, scale, colour or animate active
+voxels without modifying the encoded lattice.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Sequence
+
+_HEADER_BITS = 32
+_MAX_PAYLOAD_BYTES = (1 << _HEADER_BITS) - 1
+
+
+@dataclass(frozen=True, slots=True)
+class Dimensions3D:
+    """Positive logical dimensions of a Bit Matrix lattice."""
+
+    x: int
+    y: int
+    z: int
+
+    def __post_init__(self) -> None:
+        for name, value in (("x", self.x), ("y", self.y), ("z", self.z)):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+
+    @property
+    def cells(self) -> int:
+        return self.x * self.y * self.z
+
+    @property
+    def payload_capacity_bytes(self) -> int:
+        if self.cells < _HEADER_BITS:
+            return 0
+        return (self.cells - _HEADER_BITS) // 8
+
+
+@dataclass(frozen=True, slots=True)
+class Coordinate3D:
+    """Integer coordinate in a bounded Bit Matrix lattice."""
+
+    x: int
+    y: int
+    z: int
+
+
+@dataclass(frozen=True, slots=True)
+class BitMatrix3D:
+    """Immutable canonical 3D Boolean lattice.
+
+    ``bits`` is stored linearly using the canonical X -> Y -> Z traversal.
+    The immutable tuple keeps the codec state deterministic and safe to share
+    with renderers or downstream runtime stages.
+    """
+
+    dimensions: Dimensions3D
+    bits: tuple[bool, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.bits) != self.dimensions.cells:
+            raise ValueError(
+                "bit count does not match dimensions: "
+                f"{len(self.bits)} != {self.dimensions.cells}"
+            )
+        if any(type(bit) is not bool for bit in self.bits):
+            raise TypeError("bits must contain bool values only")
+
+    @property
+    def active_count(self) -> int:
+        return sum(self.bits)
+
+    def bit_at(self, coordinate: Coordinate3D) -> bool:
+        return self.bits[coordinate_to_index(coordinate, self.dimensions)]
+
+    def active_coordinates(self) -> Iterator[Coordinate3D]:
+        for index, bit in enumerate(self.bits):
+            if bit:
+                yield index_to_coordinate(index, self.dimensions)
+
+
+@dataclass(frozen=True, slots=True)
+class DecodeResult:
+    """Decoded payload plus structural metadata."""
+
+    payload: bytes
+    declared_length: int
+    payload_capacity_bytes: int
+    padding_bits: int
+
+
+def _validate_index(index: int, dimensions: Dimensions3D) -> None:
+    if isinstance(index, bool) or not isinstance(index, int):
+        raise TypeError("index must be an integer")
+    if not 0 <= index < dimensions.cells:
+        raise IndexError("index outside lattice")
+
+
+def coordinate_to_index(coordinate: Coordinate3D, dimensions: Dimensions3D) -> int:
+    """Map ``(x, y, z)`` to the canonical X-fastest linear address."""
+
+    if not isinstance(coordinate, Coordinate3D):
+        raise TypeError("coordinate must be Coordinate3D")
+    for name, value, bound in (
+        ("x", coordinate.x, dimensions.x),
+        ("y", coordinate.y, dimensions.y),
+        ("z", coordinate.z, dimensions.z),
+    ):
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"coordinate {name} must be an integer")
+        if not 0 <= value < bound:
+            raise IndexError(f"coordinate {name} outside lattice")
+    return coordinate.z * dimensions.x * dimensions.y + coordinate.y * dimensions.x + coordinate.x
+
+
+def index_to_coordinate(index: int, dimensions: Dimensions3D) -> Coordinate3D:
+    """Invert the canonical linear address transform exactly."""
+
+    _validate_index(index, dimensions)
+    plane = dimensions.x * dimensions.y
+    z, within_plane = divmod(index, plane)
+    y, x = divmod(within_plane, dimensions.x)
+    return Coordinate3D(x=x, y=y, z=z)
+
+
+def _bits_from_uint32(value: int) -> list[bool]:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("header value must be an integer")
+    if not 0 <= value <= _MAX_PAYLOAD_BYTES:
+        raise ValueError("header value does not fit uint32")
+    return [bool((value >> shift) & 1) for shift in range(31, -1, -1)]
+
+
+def _uint32_from_bits(bits: Sequence[bool]) -> int:
+    if len(bits) != _HEADER_BITS:
+        raise ValueError("uint32 header must contain exactly 32 bits")
+    value = 0
+    for bit in bits:
+        if type(bit) is not bool:
+            raise TypeError("header bits must contain bool values only")
+        value = (value << 1) | int(bit)
+    return value
+
+
+def _bits_from_bytes(payload: bytes) -> list[bool]:
+    output: list[bool] = []
+    for byte in payload:
+        output.extend(bool((byte >> shift) & 1) for shift in range(7, -1, -1))
+    return output
+
+
+def _bytes_from_bits(bits: Sequence[bool]) -> bytes:
+    if len(bits) % 8:
+        raise ValueError("payload bit count must be divisible by 8")
+    output = bytearray()
+    for offset in range(0, len(bits), 8):
+        value = 0
+        for bit in bits[offset : offset + 8]:
+            if type(bit) is not bool:
+                raise TypeError("payload bits must contain bool values only")
+            value = (value << 1) | int(bit)
+        output.append(value)
+    return bytes(output)
+
+
+def encode_bytes(payload: bytes, dimensions: Dimensions3D) -> BitMatrix3D:
+    """Encode bytes into a canonical fixed-size Bit Matrix 3D lattice."""
+
+    if not isinstance(payload, bytes):
+        raise TypeError("payload must be bytes")
+    if dimensions.cells < _HEADER_BITS:
+        raise ValueError("lattice requires at least 32 cells for the length header")
+    if len(payload) > _MAX_PAYLOAD_BYTES:
+        raise ValueError("payload exceeds uint32 length header")
+    if len(payload) > dimensions.payload_capacity_bytes:
+        raise ValueError(
+            "payload exceeds lattice capacity: "
+            f"{len(payload)} > {dimensions.payload_capacity_bytes} bytes"
+        )
+
+    logical_bits = _bits_from_uint32(len(payload))
+    logical_bits.extend(_bits_from_bytes(payload))
+    logical_bits.extend([False] * (dimensions.cells - len(logical_bits)))
+    return BitMatrix3D(dimensions=dimensions, bits=tuple(logical_bits))
+
+
+def encode_text(text: str, dimensions: Dimensions3D, *, encoding: str = "utf-8") -> BitMatrix3D:
+    """Encode text using UTF-8 by default, then map it into the 3D lattice."""
+
+    if not isinstance(text, str):
+        raise TypeError("text must be str")
+    return encode_bytes(text.encode(encoding), dimensions)
+
+
+def decode_bytes(matrix: BitMatrix3D, *, require_zero_padding: bool = True) -> DecodeResult:
+    """Decode and structurally validate a canonical Bit Matrix 3D lattice."""
+
+    if not isinstance(matrix, BitMatrix3D):
+        raise TypeError("matrix must be BitMatrix3D")
+    if matrix.dimensions.cells < _HEADER_BITS:
+        raise ValueError("lattice is too small to contain a header")
+
+    declared_length = _uint32_from_bits(matrix.bits[:_HEADER_BITS])
+    capacity = matrix.dimensions.payload_capacity_bytes
+    if declared_length > capacity:
+        raise ValueError(
+            "declared payload length exceeds lattice capacity: "
+            f"{declared_length} > {capacity} bytes"
+        )
+
+    payload_end = _HEADER_BITS + declared_length * 8
+    payload = _bytes_from_bits(matrix.bits[_HEADER_BITS:payload_end])
+    padding = matrix.bits[payload_end:]
+    if require_zero_padding and any(padding):
+        raise ValueError("non-zero bits found in canonical padding region")
+
+    return DecodeResult(
+        payload=payload,
+        declared_length=declared_length,
+        payload_capacity_bytes=capacity,
+        padding_bits=len(padding),
+    )
+
+
+def decode_text(
+    matrix: BitMatrix3D,
+    *,
+    encoding: str = "utf-8",
+    require_zero_padding: bool = True,
+) -> str:
+    """Decode a text payload from the lattice."""
+
+    result = decode_bytes(matrix, require_zero_padding=require_zero_padding)
+    return result.payload.decode(encoding)
+
+
+def from_active_coordinates(
+    dimensions: Dimensions3D,
+    coordinates: Iterable[Coordinate3D],
+) -> BitMatrix3D:
+    """Materialize a matrix from sparse active coordinates.
+
+    This is the renderer/storage bridge: only active voxels need to be carried
+    by a sparse transport, while reconstruction restores the authoritative
+    dense logical lattice before decoding.
+    """
+
+    bits = [False] * dimensions.cells
+    for coordinate in coordinates:
+        index = coordinate_to_index(coordinate, dimensions)
+        bits[index] = True
+    return BitMatrix3D(dimensions=dimensions, bits=tuple(bits))
+
+
+def normalized_scene_coordinate(
+    coordinate: Coordinate3D,
+    dimensions: Dimensions3D,
+    *,
+    scale: float = 1.0,
+) -> tuple[float, float, float]:
+    """Map a logical voxel to a centred renderer-independent scene position."""
+
+    if isinstance(scale, bool) or not isinstance(scale, (int, float)):
+        raise TypeError("scale must be numeric")
+    coordinate_to_index(coordinate, dimensions)  # validates coordinate
+    return (
+        (coordinate.x - (dimensions.x - 1) / 2.0) * float(scale),
+        (coordinate.y - (dimensions.y - 1) / 2.0) * float(scale),
+        (coordinate.z - (dimensions.z - 1) / 2.0) * float(scale),
+    )
+
+
+def verify_round_trip(payload: bytes, dimensions: Dimensions3D) -> bool:
+    """Return True only when encode -> sparse transport -> decode is exact."""
+
+    encoded = encode_bytes(payload, dimensions)
+    sparse_copy = from_active_coordinates(dimensions, encoded.active_coordinates())
+    decoded = decode_bytes(sparse_copy)
+    return decoded.payload == payload
+
+
+__all__ = [
+    "BitMatrix3D",
+    "Coordinate3D",
+    "DecodeResult",
+    "Dimensions3D",
+    "coordinate_to_index",
+    "decode_bytes",
+    "decode_text",
+    "encode_bytes",
+    "encode_text",
+    "from_active_coordinates",
+    "index_to_coordinate",
+    "normalized_scene_coordinate",
+    "verify_round_trip",
+]

--- a/src/jarvisx/bitmatrix3d_cli.py
+++ b/src/jarvisx/bitmatrix3d_cli.py
@@ -1,0 +1,55 @@
+"""CLI for the deterministic Bit Matrix 3D codec-runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Sequence
+
+from .bitmatrix3d import Dimensions3D, decode_text, encode_text
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx-bitmatrix3d",
+        description="Encode UTF-8 text into a deterministic 3D bit lattice and verify round-trip decoding.",
+    )
+    parser.add_argument("text", help="UTF-8 text to encode")
+    parser.add_argument("--x", type=int, default=16, help="X lattice dimension")
+    parser.add_argument("--y", type=int, default=16, help="Y lattice dimension")
+    parser.add_argument("--z", type=int, default=16, help="Z lattice dimension")
+    parser.add_argument(
+        "--coordinates",
+        action="store_true",
+        help="Include active voxel coordinates in JSON output",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    dimensions = Dimensions3D(args.x, args.y, args.z)
+    matrix = encode_text(args.text, dimensions)
+    decoded = decode_text(matrix)
+
+    result: dict[str, object] = {
+        "dimensions": {"x": dimensions.x, "y": dimensions.y, "z": dimensions.z},
+        "cells": dimensions.cells,
+        "payload_capacity_bytes": dimensions.payload_capacity_bytes,
+        "payload_bytes": len(args.text.encode("utf-8")),
+        "active_voxels": matrix.active_count,
+        "round_trip_ok": decoded == args.text,
+        "decoded": decoded,
+    }
+    if args.coordinates:
+        result["active_coordinates"] = [
+            {"x": coordinate.x, "y": coordinate.y, "z": coordinate.z}
+            for coordinate in matrix.active_coordinates()
+        ]
+
+    print(json.dumps(result, indent=2, ensure_ascii=False, sort_keys=True))
+    return 0 if decoded == args.text else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_bitmatrix3d.py
+++ b/tests/test_bitmatrix3d.py
@@ -1,0 +1,166 @@
+import pytest
+
+from jarvisx.bitmatrix3d import (
+    BitMatrix3D,
+    Coordinate3D,
+    Dimensions3D,
+    coordinate_to_index,
+    decode_bytes,
+    decode_text,
+    encode_bytes,
+    encode_text,
+    from_active_coordinates,
+    index_to_coordinate,
+    normalized_scene_coordinate,
+    verify_round_trip,
+)
+
+
+def test_dimensions_capacity_and_validation() -> None:
+    dimensions = Dimensions3D(8, 8, 2)
+    assert dimensions.cells == 128
+    assert dimensions.payload_capacity_bytes == 12
+
+    with pytest.raises(ValueError):
+        Dimensions3D(0, 2, 2)
+    with pytest.raises(TypeError):
+        Dimensions3D(True, 2, 2)
+
+
+def test_index_coordinate_bijection_x_fastest() -> None:
+    dimensions = Dimensions3D(4, 3, 2)
+    expected = {
+        0: Coordinate3D(0, 0, 0),
+        1: Coordinate3D(1, 0, 0),
+        3: Coordinate3D(3, 0, 0),
+        4: Coordinate3D(0, 1, 0),
+        11: Coordinate3D(3, 2, 0),
+        12: Coordinate3D(0, 0, 1),
+        23: Coordinate3D(3, 2, 1),
+    }
+    for index, coordinate in expected.items():
+        assert index_to_coordinate(index, dimensions) == coordinate
+        assert coordinate_to_index(coordinate, dimensions) == index
+
+    for index in range(dimensions.cells):
+        coordinate = index_to_coordinate(index, dimensions)
+        assert coordinate_to_index(coordinate, dimensions) == index
+
+
+def test_coordinate_bounds_are_fail_closed() -> None:
+    dimensions = Dimensions3D(2, 2, 2)
+    with pytest.raises(IndexError):
+        coordinate_to_index(Coordinate3D(2, 0, 0), dimensions)
+    with pytest.raises(IndexError):
+        index_to_coordinate(8, dimensions)
+    with pytest.raises(TypeError):
+        index_to_coordinate(True, dimensions)
+
+
+def test_ascii_round_trip_and_header_layout() -> None:
+    dimensions = Dimensions3D(8, 8, 2)
+    matrix = encode_text("JARVIS", dimensions)
+
+    # Six bytes encoded as uint32 big-endian: 00000000 00000000 00000000 00000110
+    assert matrix.bits[:24] == (False,) * 24
+    assert matrix.bits[24:32] == (
+        False,
+        False,
+        False,
+        False,
+        False,
+        True,
+        True,
+        False,
+    )
+    assert decode_text(matrix) == "JARVIS"
+
+
+def test_utf8_round_trip() -> None:
+    dimensions = Dimensions3D(16, 16, 4)
+    text = "Dr Moagi — 3D Δ Ξ 🚀"
+    matrix = encode_text(text, dimensions)
+    assert decode_text(matrix) == text
+
+
+def test_arbitrary_bytes_round_trip() -> None:
+    dimensions = Dimensions3D(16, 16, 2)
+    payload = bytes(range(32)) + b"\x00\xff\x80"
+    matrix = encode_bytes(payload, dimensions)
+    decoded = decode_bytes(matrix)
+    assert decoded.payload == payload
+    assert decoded.declared_length == len(payload)
+    assert decoded.payload_capacity_bytes == dimensions.payload_capacity_bytes
+    assert decoded.padding_bits == dimensions.cells - 32 - len(payload) * 8
+
+
+def test_capacity_is_enforced() -> None:
+    dimensions = Dimensions3D(8, 8, 1)  # 64 bits => 4 payload bytes
+    assert dimensions.payload_capacity_bytes == 4
+    encode_bytes(b"1234", dimensions)
+    with pytest.raises(ValueError, match="exceeds lattice capacity"):
+        encode_bytes(b"12345", dimensions)
+
+    with pytest.raises(ValueError, match="at least 32 cells"):
+        encode_bytes(b"", Dimensions3D(3, 3, 3))
+
+
+def test_sparse_active_transport_is_lossless() -> None:
+    dimensions = Dimensions3D(16, 8, 2)
+    payload = b"Bit Matrix 3D"
+    matrix = encode_bytes(payload, dimensions)
+    active = tuple(matrix.active_coordinates())
+    rebuilt = from_active_coordinates(dimensions, active)
+
+    assert rebuilt == matrix
+    assert decode_bytes(rebuilt).payload == payload
+    assert verify_round_trip(payload, dimensions)
+
+
+def test_duplicate_sparse_coordinates_are_idempotent() -> None:
+    dimensions = Dimensions3D(4, 4, 4)
+    coordinate = Coordinate3D(1, 2, 3)
+    matrix = from_active_coordinates(dimensions, [coordinate, coordinate])
+    assert matrix.active_count == 1
+    assert matrix.bit_at(coordinate)
+
+
+def test_declared_length_larger_than_capacity_is_rejected() -> None:
+    dimensions = Dimensions3D(8, 8, 1)
+    # uint32 header declares 5 bytes, but this lattice can hold only 4.
+    bits = [False] * dimensions.cells
+    bits[29] = True
+    bits[31] = True
+    matrix = BitMatrix3D(dimensions, tuple(bits))
+    with pytest.raises(ValueError, match="declared payload length exceeds"):
+        decode_bytes(matrix)
+
+
+def test_non_zero_padding_is_rejected_by_default() -> None:
+    dimensions = Dimensions3D(8, 8, 2)
+    matrix = encode_bytes(b"A", dimensions)
+    bits = list(matrix.bits)
+    bits[-1] = True
+    noncanonical = BitMatrix3D(dimensions, tuple(bits))
+
+    with pytest.raises(ValueError, match="non-zero bits"):
+        decode_bytes(noncanonical)
+    assert decode_bytes(noncanonical, require_zero_padding=False).payload == b"A"
+
+
+def test_bitmatrix_shape_and_type_validation() -> None:
+    dimensions = Dimensions3D(2, 2, 8)
+    with pytest.raises(ValueError, match="bit count"):
+        BitMatrix3D(dimensions, (False,))
+    with pytest.raises(TypeError, match="bool"):
+        BitMatrix3D(dimensions, tuple([False] * 31 + [1]))  # type: ignore[list-item]
+
+
+def test_normalized_scene_coordinate_centres_geometry() -> None:
+    dimensions = Dimensions3D(3, 3, 3)
+    assert normalized_scene_coordinate(Coordinate3D(1, 1, 1), dimensions) == (0.0, 0.0, 0.0)
+    assert normalized_scene_coordinate(Coordinate3D(2, 1, 0), dimensions, scale=2.0) == (
+        2.0,
+        0.0,
+        -2.0,
+    )


### PR DESCRIPTION
## Summary

Operationalizes the Bit Matrix 3D transport as a deterministic Jarvis-X codec-runtime layer.

### Data path

`bytes/text -> 32-bit length header -> big-endian payload bits -> X-fastest/Y/Z lattice -> sparse active voxels -> exact reverse decode`

### Added

- canonical `BitMatrix3D` immutable runtime state
- exact `index <-> (x,y,z)` bijection
- UTF-8 and arbitrary-byte encode/decode
- hard lattice-capacity validation
- canonical zero-padding validation
- sparse active-voxel materialization and reconstruction
- renderer-independent centred scene coordinates
- explicit encode -> sparse transport -> decode round-trip verifier
- `jarvisx-bitmatrix3d` CLI
- invariant/regression tests
- dedicated GitHub Actions workflow with compile and CLI smoke tests

### Architectural boundary

This PR deliberately keeps the authoritative codec state independent of rendering. Rotation, animation, shaders, and visualization may operate on derived scene coordinates without mutating the encoded lattice.

This is the lossless substrate needed before layering learned 3D latent dynamics, adaptive refinement, or volumetric state evolution on top.

## Invariants

- `decode(encode(payload)) == payload`
- `coordinate_to_index(index_to_coordinate(i)) == i`
- header is unsigned 32-bit big-endian payload byte length
- payload bits are big-endian within each byte
- traversal is X-fastest, then Y, then Z
- persistent canonical padding is zero
- declared payload length cannot exceed lattice capacity
