### PR TITLE
Operationalize Dr Moagi Deep Distiller IP-locked auto-iteration

### DIFF
--- a/.github/workflows/dr-moagi-deep-distiller.yml
+++ b/.github/workflows/dr-moagi-deep-distiller.yml
@@ -1,0 +1,42 @@
+name: Dr Moagi Deep Distiller
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_deep_distiller*.py"
+      - "src/jarvisx/dm_vo_xi_operational.py"
+      - "tests/test_dr_moagi_deep_distiller.py"
+      - "docs/DR_MOAGI_DEEP_DISTILLER.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-deep-distiller.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_deep_distiller*.py"
+      - "src/jarvisx/dm_vo_xi_operational.py"
+      - "tests/test_dr_moagi_deep_distiller.py"
+      - "docs/DR_MOAGI_DEEP_DISTILLER.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-deep-distiller.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  deep-distiller:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install
+        run: python -m pip install -e ".[test]"
+      - name: Compile runtime
+        run: python -m py_compile src/jarvisx/dr_moagi_deep_distiller.py src/jarvisx/dr_moagi_deep_distiller_cli.py src/jarvisx/dm_vo_xi_operational.py
+      - name: Constitutional regression suite
+        run: pytest tests/test_dr_moagi_deep_distiller.py --no-cov
+      - name: CLI smoke
+        run: jarvisx-deep-distiller --side 16 --steps 4 --max-active 64 --max-latent 32

--- a/docs/DR_MOAGI_DEEP_DISTILLER.md
+++ b/docs/DR_MOAGI_DEEP_DISTILLER.md
@@ -1,0 +1,214 @@
+# Dr Moagi Deep Distiller (DM-DD)
+
+**Status:** Operational reference runtime  
+**Product name:** Dr Moagi Deep Distiller  
+**Law ID:** `DM-DD`  
+**Commit policy:** `Pi_Lambda-atomic`
+
+## 1. Definition
+
+Deep Distiller is the product-facing form of the IP-locked residual auto-iteration network. It repeatedly compresses, reconstructs, measures residual error, updates persistent residual memory, proposes a residual-gradient parameter step, and commits the complete next state only through `Pi_Lambda`.
+
+The canonical loop is
+
+```text
+Z_t         = E_Theta(X_t)
+X_hat_t     = D_Theta(Z_t)
+E_t         = X_t - X_hat_t
+Omega_t+1   = rho * Omega_t + (1-rho) * E_t
+Theta'_t+1  = Theta_t - eta * grad_Theta ||E_t||^2
+X'_t+1      = X_hat_t + omega * Omega_t+1
+(X,Omega,Theta)_t+1 = Pi_Lambda(X',Omega',Theta')
+```
+
+A tick has exactly two phases:
+
+```text
+PROPOSE -> GATE -> ATOMIC COMMIT | REJECT
+```
+
+No provisional state, memory, or parameter value is authoritative before the gate passes.
+
+## 2. IP lock
+
+`IP-locked` has a concrete runtime meaning in this implementation:
+
+1. **Commit lock** — `X`, `Omega`, and `Theta` commit together only after `Pi_Lambda` accepts the full candidate.
+2. **Parameter lock** — the reference `Theta` changes only through the explicit residual-gradient rule inside `theta_candidate`.
+3. **Budget lock** — state and latent active-cell ceilings are hard configuration invariants.
+4. **Finite-value lock** — non-finite state, memory, or parameters fail closed.
+5. **Value-domain lock** — committed state must remain inside configured numerical bounds.
+6. **Audit lock** — every accepted or rejected tick is appended to the hash-chained journal.
+
+Rejected proposals may be recorded for audit but cannot mutate authoritative runtime state.
+
+## 3. Reference codec
+
+The reference implementation uses two bounded learnable scalar parameters:
+
+```text
+Theta = {
+    encoder_gain,
+    decoder_gain,
+}
+```
+
+Encoding is a deterministic sparse bottleneck:
+
+```text
+z_i = encoder_gain * x_i
+```
+
+followed by a configured prune threshold and deterministic top-K active-cell budget.
+
+Decoding is
+
+```text
+x_hat_i = decoder_gain * z_i
+```
+
+on retained latent support.
+
+This deliberately small model makes the gradient and constitutional commit boundary directly testable. A production neural encoder/decoder can replace these scalar maps without changing the transactional law.
+
+## 4. Residual gradient
+
+For mean squared residual loss
+
+```text
+L = mean_i (x_i - decoder_gain * encoder_gain * x_i)^2
+```
+
+on retained latent support, the reference gradients are
+
+```text
+dL/d encoder_gain = -2 * decoder_gain * mean_i(x_i * e_i)
+dL/d decoder_gain = -2 * mean_i(z_i * e_i)
+```
+
+The discrete top-K support is held fixed during one tick; the implementation therefore uses a straight-through reference approximation across the bottleneck selection boundary.
+
+Each parameter delta is independently capped by `theta_max_delta` and then clipped to the configured `Theta` interval.
+
+## 5. Omega memory
+
+Residual memory is an EMA:
+
+```text
+Omega_t+1 = rho * Omega_t + (1-rho) * E_t
+```
+
+with optional pruning. The next state proposal is
+
+```text
+X'_t+1 = X_hat_t + omega_gain * Omega_t+1
+```
+
+so the decoder output is corrected by bounded historical residual information.
+
+## 6. Pi_Lambda constitutional gate
+
+`Pi_Lambda` validates the entire candidate transaction:
+
+```text
+Candidate = {
+    X_prime,
+    Omega_prime,
+    Theta_prime,
+    latent_cells,
+}
+```
+
+The built-in gate rejects candidates that violate:
+
+```text
+active_cells <= max_active_cells
+latent_cells <= max_latent_cells
+all values finite
+value_min <= X_prime <= value_max
+theta_min <= Theta_prime <= theta_max
+```
+
+An optional external policy may add further admissibility rules.
+
+If any check fails:
+
+```text
+X_t+1     = X_t
+Omega_t+1 = Omega_t
+Theta_t+1 = Theta_t
+```
+
+The rejection is fail-closed and the auto-iteration loop stops.
+
+## 7. Stopping semantics
+
+A run terminates when any of the following occurs:
+
+```text
+residual_rms <= residual_tolerance
+max_iterations reached
+Pi_Lambda rejects a candidate
+```
+
+The fixed-point target is operationally
+
+```text
+E* ~= 0
+X* = Pi_Lambda(X*)
+grad_Theta L* ~= 0
+```
+
+but convergence is reported from measured residual rather than asserted symbolically.
+
+## 8. Sparse / no-silent-expansion rule
+
+The logical lattice side defaults to `1000`, but the implementation never allocates `1000^3` cells. Only sparse active support is materialized.
+
+The runtime has separate ceilings for:
+
+```text
+max_active_cells
+max_latent_cells
+```
+
+A larger logical lattice is metadata unless an explicit gated expansion policy is implemented.
+
+## 9. Relationship to existing Jarvis-X laws
+
+| Name | Role |
+|---|---|
+| `DM-vOmegaXi+` | Existing bounded inward fixed-point operator and semantic-gap runtime |
+| Latent Moagi flow | Optional continuous latent dynamics |
+| DM-Lambda / geometric AE | Research geometry/Ricci branch; not required by DM-DD |
+| **Deep Distiller** | Product-facing transactional residual auto-iteration network |
+
+The existing `dm_vomegaxi_fixed_point.py` remains intact. `dm_vo_xi_operational.py` is a compatibility surface that resolves to the Deep Distiller implementation.
+
+## 10. CLI
+
+After installation:
+
+```bash
+jarvisx-deep-distiller --side 16 --steps 8
+```
+
+The CLI prints JSON containing per-tick residuals, gradient values, committed parameters, hashes, journal status, and final lock state.
+
+## 11. Constitutional invariant
+
+The defining implementation invariant is:
+
+```text
+PROVISIONAL != AUTHORITATIVE
+```
+
+until
+
+```text
+Pi_Lambda(candidate) == ACCEPT
+```
+
+This is the operational meaning of:
+
+> Deep Distiller = residual auto-iteration under constitutional commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ jarvisx-dr-moagi = "jarvisx.dr_moagi_autoexec_cli:main"
 jarvisx-dr-moagi-os = "jarvisx.dr_moagi_os_cli:main"
 jarvisx-dr-moagi-frontier = "jarvisx.dr_moagi_frontier_cli:main"
 jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
+jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/dm_vo_xi_operational.py
+++ b/src/jarvisx/dm_vo_xi_operational.py
@@ -1,0 +1,22 @@
+"""Compatibility surface for the operational DM-vOmegaXi / Deep Distiller law.
+
+The historical name ``dm_vo_xi_operational`` now resolves to the product-facing
+Dr Moagi Deep Distiller implementation. New code should import directly from
+``jarvisx.dr_moagi_deep_distiller``.
+"""
+
+from .dr_moagi_deep_distiller import (
+    DeepDistiller,
+    DeepDistillerCandidate,
+    DeepDistillerConfig,
+    DeepDistillerReport,
+    DeepDistillerTheta,
+)
+
+__all__ = [
+    "DeepDistiller",
+    "DeepDistillerCandidate",
+    "DeepDistillerConfig",
+    "DeepDistillerReport",
+    "DeepDistillerTheta",
+]

--- a/src/jarvisx/dr_moagi_deep_distiller.py
+++ b/src/jarvisx/dr_moagi_deep_distiller.py
@@ -1,0 +1,457 @@
+"""Dr Moagi Deep Distiller (DM-DD): IP-locked residual auto-iteration.
+
+DM-DD is a bounded sparse reference implementation of the operational law::
+
+    Z_t         = E_Theta(X_t)
+    X_hat_t     = D_Theta(Z_t)
+    E_t         = X_t - X_hat_t
+    Omega_t+1   = rho * Omega_t + (1-rho) * E_t
+    Theta'_t+1  = Theta_t - eta * grad_Theta ||E_t||^2
+    X'_t+1      = X_hat_t + omega * Omega_t+1
+    (X,Omega,Theta)_t+1 = Pi_Lambda(X',Omega',Theta')
+
+The constitutional lock is transactional: state, residual memory, and parameters
+commit together or none of them commit. Rejected proposals may be journaled for
+audit, but never become authoritative runtime state.
+
+The implementation is intentionally sparse and finite. ``logical_side`` describes
+a logical lattice; only active coordinates are materialized. No dense N^3 volume
+or unbudgeted parameter/code expansion is permitted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Callable, Mapping
+
+from .dr_moagi_autoexec import AutoExecPolicy, HashChainJournal, SparseParser3D
+from .dr_moagi_field_runtime import Coordinate, SparseField
+
+
+@dataclass(frozen=True)
+class DeepDistillerTheta:
+    """Minimal learnable codec parameters for the reference distiller.
+
+    The encoder/decoder gains make the residual gradient explicit and testable.
+    Production encoders may replace these scalar maps while preserving the same
+    propose -> Pi_Lambda -> atomic-commit contract.
+    """
+
+    encoder_gain: float = 0.80
+    decoder_gain: float = 0.80
+
+
+@dataclass(frozen=True)
+class DeepDistillerConfig:
+    logical_side: int = 1000
+    max_active_cells: int = 50_000
+    max_latent_cells: int = 25_000
+    value_min: float = -1.0
+    value_max: float = 1.0
+    rho: float = 0.90
+    omega_gain: float = 0.25
+    learning_rate: float = 0.05
+    theta_min: float = 0.05
+    theta_max: float = 2.0
+    theta_max_delta: float = 0.10
+    residual_tolerance: float = 1.0e-6
+    latent_prune_epsilon: float = 0.0
+    memory_prune_epsilon: float = 0.0
+    max_iterations: int = 64
+    policy: AutoExecPolicy = field(default_factory=AutoExecPolicy)
+
+    def __post_init__(self) -> None:
+        for name in ("logical_side", "max_active_cells", "max_latent_cells", "max_iterations"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.max_latent_cells > self.max_active_cells:
+            raise ValueError("max_latent_cells cannot exceed max_active_cells")
+        for name in (
+            "value_min",
+            "value_max",
+            "rho",
+            "omega_gain",
+            "learning_rate",
+            "theta_min",
+            "theta_max",
+            "theta_max_delta",
+            "residual_tolerance",
+            "latent_prune_epsilon",
+            "memory_prune_epsilon",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+        if not 0.0 <= self.rho < 1.0:
+            raise ValueError("rho must be in [0, 1)")
+        if self.omega_gain < 0.0:
+            raise ValueError("omega_gain must be non-negative")
+        if self.learning_rate < 0.0:
+            raise ValueError("learning_rate must be non-negative")
+        if self.theta_min <= 0.0 or self.theta_min >= self.theta_max:
+            raise ValueError("theta bounds must satisfy 0 < theta_min < theta_max")
+        if self.theta_max_delta <= 0.0:
+            raise ValueError("theta_max_delta must be positive")
+        if self.residual_tolerance < 0.0:
+            raise ValueError("residual_tolerance must be non-negative")
+        if self.latent_prune_epsilon < 0.0 or self.memory_prune_epsilon < 0.0:
+            raise ValueError("prune epsilons must be non-negative")
+
+
+@dataclass(frozen=True)
+class DeepDistillerCandidate:
+    state: SparseField
+    omega: SparseField
+    theta: DeepDistillerTheta
+    latent_cells: int
+
+
+DeepDistillerGate = Callable[[DeepDistillerCandidate], bool]
+
+
+@dataclass(frozen=True)
+class DeepDistillerReport:
+    iteration: int
+    committed: bool
+    converged: bool
+    active_cells: int
+    latent_cells: int
+    residual_rms: float
+    omega_rms: float
+    loss: float
+    grad_encoder: float
+    grad_decoder: float
+    encoder_gain: float
+    decoder_gain: float
+    gate_passed: bool
+    rejection_reason: str | None
+    state_hash: str
+    theta_hash: str
+    journal_hash: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class DeepDistiller:
+    """Transactional residual auto-iteration network.
+
+    ``Pi_Lambda`` is represented by :meth:`pi_lambda`. The method validates the
+    complete proposal (X, Omega, Theta) before :meth:`step` mutates any
+    authoritative state.
+    """
+
+    LAW_ID = "DM-DD"
+    PRODUCT_NAME = "Dr Moagi Deep Distiller"
+    COMMIT_POLICY = "Pi_Lambda-atomic"
+
+    def __init__(
+        self,
+        config: DeepDistillerConfig | None = None,
+        *,
+        theta: DeepDistillerTheta | None = None,
+        gate: DeepDistillerGate | None = None,
+        journal_path: str | Path | None = None,
+    ) -> None:
+        self.config = config or DeepDistillerConfig()
+        self._theta = theta or DeepDistillerTheta()
+        self._validate_theta(self._theta)
+        self.gate = gate
+        self.parser = SparseParser3D(
+            side=self.config.logical_side,
+            max_active_cells=self.config.max_active_cells,
+            value_min=self.config.value_min,
+            value_max=self.config.value_max,
+            prune_epsilon=self.config.policy.prune_epsilon,
+        )
+        self.journal = HashChainJournal(journal_path)
+        self._state: SparseField = {}
+        self._omega: SparseField = {}
+        self._iteration = 0
+        self._loaded = False
+        self.reports: list[DeepDistillerReport] = []
+
+    @property
+    def theta(self) -> DeepDistillerTheta:
+        return self._theta
+
+    def load(self, source: Mapping[Coordinate, float]) -> SparseField:
+        """Admit initial state through parser + Pi_Lambda before authority."""
+        parsed = self.parser.parse(source)
+        initial = DeepDistillerCandidate(
+            state=dict(parsed), omega={}, theta=self._theta, latent_cells=0
+        )
+        passed, reason = self.pi_lambda(initial)
+        if not passed:
+            raise ValueError(f"initial state rejected by Pi_Lambda: {reason}")
+        self._state = dict(parsed)
+        self._omega = {}
+        self._iteration = 0
+        self.reports.clear()
+        self._loaded = True
+        return self.snapshot()
+
+    def snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._state)
+
+    def omega_snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._omega)
+
+    def encode(self, state: Mapping[Coordinate, float], theta: DeepDistillerTheta) -> SparseField:
+        """Distill X -> Z with bounded deterministic sparse top-K support."""
+        eps = self.config.latent_prune_epsilon
+        scored: list[tuple[float, Coordinate, float]] = []
+        for coordinate, raw in state.items():
+            value = theta.encoder_gain * float(raw)
+            if abs(value) > eps:
+                scored.append((abs(value), coordinate, value))
+        scored.sort(key=lambda item: (-item[0], item[1]))
+        selected = scored[: self.config.max_latent_cells]
+        return {coordinate: value for _, coordinate, value in selected}
+
+    @staticmethod
+    def decode(latent: Mapping[Coordinate, float], theta: DeepDistillerTheta) -> SparseField:
+        return {
+            coordinate: theta.decoder_gain * float(value)
+            for coordinate, value in latent.items()
+        }
+
+    @staticmethod
+    def residual(
+        state: Mapping[Coordinate, float], reconstructed: Mapping[Coordinate, float]
+    ) -> SparseField:
+        result: SparseField = {}
+        for coordinate in set(state) | set(reconstructed):
+            value = float(state.get(coordinate, 0.0)) - float(reconstructed.get(coordinate, 0.0))
+            if value != 0.0:
+                result[coordinate] = value
+        return result
+
+    def omega_update(self, residual: Mapping[Coordinate, float]) -> SparseField:
+        retain = self.config.rho
+        inject = 1.0 - retain
+        eps = self.config.memory_prune_epsilon
+        result: SparseField = {}
+        for coordinate in set(self._omega) | set(residual):
+            value = retain * float(self._omega.get(coordinate, 0.0)) + inject * float(
+                residual.get(coordinate, 0.0)
+            )
+            if abs(value) > eps:
+                result[coordinate] = value
+        return result
+
+    def residual_gradient(
+        self,
+        state: Mapping[Coordinate, float],
+        latent: Mapping[Coordinate, float],
+        residual: Mapping[Coordinate, float],
+        theta: DeepDistillerTheta,
+    ) -> tuple[float, float]:
+        """Gradient of mean squared residual on retained latent support.
+
+        Top-K support selection is treated as fixed during one tick (a standard
+        straight-through reference approximation for this discrete bottleneck).
+        """
+        count = max(1, len(set(state) | set(residual)))
+        grad_encoder = 0.0
+        grad_decoder = 0.0
+        for coordinate, z_value in latent.items():
+            x_value = float(state.get(coordinate, 0.0))
+            error = float(residual.get(coordinate, 0.0))
+            grad_encoder += -2.0 * theta.decoder_gain * x_value * error / count
+            grad_decoder += -2.0 * float(z_value) * error / count
+        return grad_encoder, grad_decoder
+
+    def theta_candidate(
+        self, theta: DeepDistillerTheta, grad_encoder: float, grad_decoder: float
+    ) -> DeepDistillerTheta:
+        eta = self.config.learning_rate
+        cap = self.config.theta_max_delta
+
+        def update(value: float, gradient: float) -> float:
+            delta = max(-cap, min(cap, -eta * gradient))
+            return max(self.config.theta_min, min(self.config.theta_max, value + delta))
+
+        return DeepDistillerTheta(
+            encoder_gain=update(theta.encoder_gain, grad_encoder),
+            decoder_gain=update(theta.decoder_gain, grad_decoder),
+        )
+
+    def state_candidate(
+        self,
+        reconstructed: Mapping[Coordinate, float],
+        omega: Mapping[Coordinate, float],
+    ) -> SparseField:
+        result: SparseField = {}
+        eps = self.config.policy.prune_epsilon
+        for coordinate in set(reconstructed) | set(omega):
+            value = float(reconstructed.get(coordinate, 0.0)) + self.config.omega_gain * float(
+                omega.get(coordinate, 0.0)
+            )
+            if abs(value) > eps:
+                result[coordinate] = value
+        return result
+
+    def pi_lambda(self, candidate: DeepDistillerCandidate) -> tuple[bool, str | None]:
+        """Constitutional admissibility gate over the complete candidate."""
+        if len(candidate.state) > self.config.max_active_cells:
+            return False, "active-cell budget exceeded"
+        if candidate.latent_cells > self.config.max_latent_cells:
+            return False, "latent-cell budget exceeded"
+        if not self._finite(candidate.state) or not self._finite(candidate.omega):
+            return False, "non-finite state or Omega"
+        for value in candidate.state.values():
+            if not self.config.value_min <= float(value) <= self.config.value_max:
+                return False, "state value outside constitutional bounds"
+        try:
+            self._validate_theta(candidate.theta)
+        except (TypeError, ValueError) as exc:
+            return False, f"Theta rejected: {exc}"
+        if self.gate is not None and not bool(self.gate(candidate)):
+            return False, "external Pi_Lambda policy rejected candidate"
+        return True, None
+
+    def step(self) -> DeepDistillerReport:
+        self._require_loaded()
+        current = dict(self._state)
+        current_theta = self._theta
+
+        latent = self.encode(current, current_theta)
+        reconstructed = self.decode(latent, current_theta)
+        error = self.residual(current, reconstructed)
+        omega_candidate = self.omega_update(error)
+        grad_encoder, grad_decoder = self.residual_gradient(
+            current, latent, error, current_theta
+        )
+        theta_candidate = self.theta_candidate(current_theta, grad_encoder, grad_decoder)
+        next_state = self.state_candidate(reconstructed, omega_candidate)
+        candidate = DeepDistillerCandidate(
+            state=next_state,
+            omega=omega_candidate,
+            theta=theta_candidate,
+            latent_cells=len(latent),
+        )
+
+        residual_rms = self._rms(error)
+        omega_rms = self._rms(omega_candidate)
+        loss = residual_rms * residual_rms
+        gate_passed, rejection_reason = self.pi_lambda(candidate)
+        committed = gate_passed
+
+        if committed:
+            # Atomic authoritative commit boundary.
+            self._state = dict(candidate.state)
+            self._omega = dict(candidate.omega)
+            self._theta = candidate.theta
+            self._iteration += 1
+
+        converged = bool(committed and residual_rms <= self.config.residual_tolerance)
+        authoritative_state = self._state if committed else current
+        authoritative_theta = self._theta if committed else current_theta
+        provisional = DeepDistillerReport(
+            iteration=self._iteration,
+            committed=committed,
+            converged=converged,
+            active_cells=len(authoritative_state),
+            latent_cells=len(latent),
+            residual_rms=residual_rms,
+            omega_rms=omega_rms,
+            loss=loss,
+            grad_encoder=grad_encoder,
+            grad_decoder=grad_decoder,
+            encoder_gain=authoritative_theta.encoder_gain,
+            decoder_gain=authoritative_theta.decoder_gain,
+            gate_passed=gate_passed,
+            rejection_reason=rejection_reason,
+            state_hash=self._state_hash(authoritative_state),
+            theta_hash=self._theta_hash(authoritative_theta),
+        )
+        record = provisional.as_dict()
+        record.pop("journal_hash", None)
+        digest = self.journal.append(record)
+        report = replace(provisional, journal_hash=digest)
+        self.reports.append(report)
+        return report
+
+    def run(self, max_iterations: int | None = None) -> tuple[DeepDistillerReport, ...]:
+        self._require_loaded()
+        limit = self.config.max_iterations if max_iterations is None else max_iterations
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("max_iterations must be a positive integer")
+        for _ in range(limit):
+            report = self.step()
+            if report.converged or not report.committed:
+                break
+        return tuple(self.reports)
+
+    def status(self) -> dict[str, object]:
+        self._require_loaded()
+        latest = self.reports[-1] if self.reports else None
+        return {
+            "law": self.LAW_ID,
+            "product": self.PRODUCT_NAME,
+            "ip_locked": True,
+            "commit_policy": self.COMMIT_POLICY,
+            "iteration": self._iteration,
+            "logical_side": self.config.logical_side,
+            "materialization": "sparse-active-support-only",
+            "active_cells": len(self._state),
+            "max_active_cells": self.config.max_active_cells,
+            "max_latent_cells": self.config.max_latent_cells,
+            "theta": asdict(self._theta),
+            "residual_rms": latest.residual_rms if latest else None,
+            "converged": latest.converged if latest else False,
+            "state_hash": self._state_hash(self._state),
+            "theta_hash": self._theta_hash(self._theta),
+            "journal_head": self.journal.head,
+            "journal_valid": self.journal.verify(),
+        }
+
+    def _validate_theta(self, theta: DeepDistillerTheta) -> None:
+        for name in ("encoder_gain", "decoder_gain"):
+            value = getattr(theta, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+            if not self.config.theta_min <= float(value) <= self.config.theta_max:
+                raise ValueError(f"{name} outside configured Theta bounds")
+
+    @staticmethod
+    def _finite(field: Mapping[Coordinate, float]) -> bool:
+        return all(math.isfinite(float(value)) for value in field.values())
+
+    @staticmethod
+    def _rms(field: Mapping[Coordinate, float]) -> float:
+        if not field:
+            return 0.0
+        return math.sqrt(sum(float(value) ** 2 for value in field.values()) / len(field))
+
+    @staticmethod
+    def _state_hash(field: Mapping[Coordinate, float]) -> str:
+        canonical = [
+            [coordinate[0], coordinate[1], coordinate[2], float(field[coordinate])]
+            for coordinate in sorted(field)
+        ]
+        payload = json.dumps(canonical, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    @staticmethod
+    def _theta_hash(theta: DeepDistillerTheta) -> str:
+        payload = json.dumps(asdict(theta), sort_keys=True, separators=(",", ":")).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def _require_loaded(self) -> None:
+        if not self._loaded:
+            raise RuntimeError("load a sparse 3D field before Deep Distiller execution")

--- a/src/jarvisx/dr_moagi_deep_distiller_cli.py
+++ b/src/jarvisx/dr_moagi_deep_distiller_cli.py
@@ -1,0 +1,52 @@
+"""Command-line interface for the Dr Moagi Deep Distiller runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+from .dr_moagi_deep_distiller import DeepDistiller, DeepDistillerConfig
+
+
+def _demo_field(side: int) -> dict[tuple[int, int, int], float]:
+    points = {
+        (0, 0, 0): 1.0,
+        (1 % side, 0, 0): 0.75,
+        (0, 1 % side, 0): -0.50,
+        (0, 0, 1 % side): 0.25,
+    }
+    return {coordinate: value for coordinate, value in points.items() if all(axis < side for axis in coordinate)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the IP-locked Dr Moagi Deep Distiller")
+    parser.add_argument("--side", type=int, default=16, help="logical lattice side")
+    parser.add_argument("--steps", type=int, default=8, help="maximum distillation ticks")
+    parser.add_argument("--tolerance", type=float, default=1.0e-6, help="residual stop tolerance")
+    parser.add_argument("--max-active", type=int, default=4096, help="maximum committed active cells")
+    parser.add_argument("--max-latent", type=int, default=2048, help="maximum latent active cells")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    config = DeepDistillerConfig(
+        logical_side=args.side,
+        max_active_cells=args.max_active,
+        max_latent_cells=min(args.max_latent, args.max_active),
+        residual_tolerance=args.tolerance,
+        max_iterations=args.steps,
+    )
+    engine = DeepDistiller(config)
+    engine.load(_demo_field(args.side))
+    reports = engine.run(args.steps)
+    output = {
+        "status": engine.status(),
+        "reports": [report.as_dict() for report in reports],
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0 if all(report.committed for report in reports) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dr_moagi_deep_distiller.py
+++ b/tests/test_dr_moagi_deep_distiller.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.dm_vo_xi_operational import DeepDistiller as CompatibilityDeepDistiller
+from jarvisx.dr_moagi_deep_distiller import (
+    DeepDistiller,
+    DeepDistillerConfig,
+    DeepDistillerTheta,
+)
+
+
+def _field() -> dict[tuple[int, int, int], float]:
+    return {
+        (0, 0, 0): 1.0,
+        (1, 0, 0): 0.5,
+        (0, 1, 0): -0.25,
+    }
+
+
+def _config(**overrides: object) -> DeepDistillerConfig:
+    values: dict[str, object] = {
+        "logical_side": 8,
+        "max_active_cells": 16,
+        "max_latent_cells": 16,
+        "max_iterations": 8,
+        "learning_rate": 0.05,
+        "omega_gain": 0.25,
+        "rho": 0.5,
+    }
+    values.update(overrides)
+    return DeepDistillerConfig(**values)  # type: ignore[arg-type]
+
+
+def test_deep_distiller_commits_state_memory_and_theta_together() -> None:
+    engine = DeepDistiller(_config(), theta=DeepDistillerTheta(0.8, 0.8))
+    before = engine.load(_field())
+    theta_before = engine.theta
+
+    report = engine.step()
+
+    assert report.committed is True
+    assert report.iteration == 1
+    assert report.residual_rms > 0.0
+    assert engine.snapshot() != before
+    assert engine.omega_snapshot()
+    assert engine.theta != theta_before
+    assert engine.theta.encoder_gain > theta_before.encoder_gain
+    assert engine.theta.decoder_gain > theta_before.decoder_gain
+    assert engine.status()["ip_locked"] is True
+    assert engine.status()["journal_valid"] is True
+
+
+def test_gate_rejection_is_atomic_for_state_omega_and_theta() -> None:
+    def gate(candidate: object) -> bool:
+        # Initial admission has zero latent cells; runtime proposals do not.
+        return getattr(candidate, "latent_cells") == 0
+
+    engine = DeepDistiller(_config(), theta=DeepDistillerTheta(0.8, 0.8), gate=gate)
+    original_state = engine.load(_field())
+    original_omega = engine.omega_snapshot()
+    original_theta = engine.theta
+
+    report = engine.step()
+
+    assert report.committed is False
+    assert report.gate_passed is False
+    assert report.rejection_reason == "external Pi_Lambda policy rejected candidate"
+    assert report.iteration == 0
+    assert engine.snapshot() == original_state
+    assert engine.omega_snapshot() == original_omega
+    assert engine.theta == original_theta
+    assert engine.status()["journal_valid"] is True
+
+
+def test_exact_codec_fixed_point_stops_on_zero_residual() -> None:
+    engine = DeepDistiller(
+        _config(residual_tolerance=0.0),
+        theta=DeepDistillerTheta(encoder_gain=1.0, decoder_gain=1.0),
+    )
+    original = engine.load(_field())
+
+    reports = engine.run()
+
+    assert len(reports) == 1
+    assert reports[0].committed is True
+    assert reports[0].converged is True
+    assert reports[0].residual_rms == 0.0
+    assert reports[0].grad_encoder == 0.0
+    assert reports[0].grad_decoder == 0.0
+    assert engine.snapshot() == original
+
+
+def test_encoder_enforces_sparse_latent_budget_without_dense_expansion() -> None:
+    engine = DeepDistiller(_config(max_latent_cells=1))
+    engine.load(_field())
+
+    latent = engine.encode(engine.snapshot(), engine.theta)
+    report = engine.step()
+
+    assert len(latent) == 1
+    assert report.latent_cells == 1
+    assert report.active_cells <= engine.config.max_active_cells
+    assert engine.status()["materialization"] == "sparse-active-support-only"
+
+
+def test_parameter_update_is_residual_gradient_and_bounded() -> None:
+    engine = DeepDistiller(
+        _config(learning_rate=100.0, theta_max_delta=0.01),
+        theta=DeepDistillerTheta(0.8, 0.8),
+    )
+    engine.load(_field())
+
+    report = engine.step()
+
+    assert report.committed is True
+    assert math.isclose(engine.theta.encoder_gain, 0.81, rel_tol=0.0, abs_tol=1.0e-12)
+    assert math.isclose(engine.theta.decoder_gain, 0.81, rel_tol=0.0, abs_tol=1.0e-12)
+
+
+def test_load_rejects_initial_state_when_constitutional_gate_rejects() -> None:
+    engine = DeepDistiller(_config(), gate=lambda candidate: False)
+
+    with pytest.raises(ValueError, match="initial state rejected by Pi_Lambda"):
+        engine.load(_field())
+
+
+def test_run_stops_immediately_on_gate_reject() -> None:
+    def gate(candidate: object) -> bool:
+        return getattr(candidate, "latent_cells") == 0
+
+    engine = DeepDistiller(_config(max_iterations=10), gate=gate)
+    engine.load(_field())
+
+    reports = engine.run()
+
+    assert len(reports) == 1
+    assert reports[0].committed is False
+
+
+def test_configuration_prevents_latent_budget_exceeding_state_budget() -> None:
+    with pytest.raises(ValueError, match="max_latent_cells cannot exceed max_active_cells"):
+        DeepDistillerConfig(max_active_cells=2, max_latent_cells=3)
+
+
+def test_compatibility_surface_resolves_to_product_runtime() -> None:
+    assert CompatibilityDeepDistiller is DeepDistiller


### PR DESCRIPTION
## Summary

Adds the **Dr Moagi Deep Distiller (DM-DD)** as the product-facing IP-locked residual auto-iteration network.

Canonical tick:

```text
Z_t         = E_Theta(X_t)
X_hat_t     = D_Theta(Z_t)
E_t         = X_t - X_hat_t
Omega_t+1   = rho * Omega_t + (1-rho) * E_t
Theta'_t+1  = Theta_t - eta * grad_Theta ||E_t||^2
X'_t+1      = X_hat_t + omega * Omega_t+1
(X,Omega,Theta)_t+1 = Pi_Lambda(X',Omega',Theta')
```

## Constitutional lock

`Pi_Lambda` validates the **complete candidate transaction** before any authoritative mutation. State, Omega, and Theta either commit together or none commit.

Built-in gates enforce:

- active-state budget
- latent active-cell budget
- finite numerical state
- configured state-value bounds
- configured Theta bounds
- optional external policy gate

Rejected proposals are fail-closed and may be hash-journaled for audit without becoming authoritative state.

## Implementation

- `src/jarvisx/dr_moagi_deep_distiller.py`
  - deterministic sparse top-K bottleneck
  - explicit encode/decode/residual loop
  - EMA Omega residual memory
  - measurable residual-gradient Theta update
  - bounded parameter delta
  - transactional `Pi_Lambda`
  - hash-chained audit journal
  - convergence / gate-reject stopping semantics
- `src/jarvisx/dm_vo_xi_operational.py`
  - compatibility surface for the operational historical name
- `src/jarvisx/dr_moagi_deep_distiller_cli.py`
  - `jarvisx-deep-distiller`
- `tests/test_dr_moagi_deep_distiller.py`
  - atomic rejection test across X/Omega/Theta
  - exact fixed-point convergence
  - bounded residual-gradient update
  - sparse latent budget / no dense expansion
  - compatibility surface and configuration guards
- `docs/DR_MOAGI_DEEP_DISTILLER.md`
  - operational contract and relationship to DM-vOmegaXi+
- dedicated GitHub Actions workflow

## Architectural boundary

The existing `dm_vomegaxi_fixed_point.py` remains intact as the bounded fixed-point / semantic-gap research engine. DM-DD does not silently reinterpret its `Theta` projection as gradient learning; instead it introduces a separate runtime where the parameter update is explicit and testable.

## Core invariant

```text
PROVISIONAL != AUTHORITATIVE
```

until

```text
Pi_Lambda(candidate) == ACCEPT
```

Deep Distiller = residual auto-iteration under constitutional commit.