### PR TITLE
Add bounded inward 3D meta-optimizer

### DIFF
--- a/docs/DR_MOAGI_3D_META_OPTIMIZER.md
+++ b/docs/DR_MOAGI_3D_META_OPTIMIZER.md
@@ -1,0 +1,169 @@
+# Dr Moagi Inward 3D Meta-Optimizer
+
+## Purpose
+
+The inward meta-optimizer turns the Dr Moagi runtime onto its own **bounded operational configuration**. It does not rewrite source code. It evaluates alternate runtime configurations in isolated replay kernels and promotes a configuration only when it improves a multi-metric objective without violating reconstruction or state-fidelity regression gates.
+
+The meta-state is:
+
+```text
+C_n = (compression_n, adaptation_n, dynamics_n)
+```
+
+with a local 3D search coordinate:
+
+```text
+delta = (dx, dy, dz),  dx,dy,dz in {-1,0,+1}
+```
+
+The three axes are:
+
+```text
+X = compression geometry
+    block_size, quantization, prune_epsilon
+
+Y = adaptive dynamics
+    DM-DD learning_rate, rho, omega_gain, latent budget, pass depth
+
+Z = spatial/fixed-point dynamics
+    contraction, attenuation, fixed-point pass depth
+```
+
+## Inward optimization law
+
+For current runtime configuration `C_n`, deterministic replay suite `B_n`, objective `J`, and bounded neighbourhood `N_3(C_n)`:
+
+```text
+C* = argmin_{C in N_3(C_n)} J(C; B_n)
+```
+
+Promotion is transactional:
+
+```text
+C_(n+1) = C*    if Pi_meta(C*, C_n) = ACCEPT
+C_(n+1) = C_n   otherwise
+```
+
+The system-wide invariant remains:
+
+```text
+PROVISIONAL != AUTHORITATIVE
+```
+
+A candidate runtime is always executed in a separate `DrMoagiOSKernel`; it cannot mutate the production state during evaluation.
+
+## Multi-metric objective
+
+The current reference objective combines:
+
+- AutoExec reconstruction MSE;
+- DM-DD residual RMS;
+- fixed-point residual;
+- anchor drift from the replay input;
+- exact DMOS2 transport bytes per source cell;
+- active/latent compute proxy;
+- phase-velocity activity;
+- a large rejection penalty.
+
+No single sparsity or reconstruction number is treated as sufficient evidence of improvement.
+
+## Robustness replay
+
+Each candidate is evaluated on three deterministic workloads:
+
+1. the bounded authoritative sparse state sample;
+2. a deterministic ±3% amplitude perturbation;
+3. a one-voxel spatial translation.
+
+The final score combines mean and worst-case replay performance:
+
+```text
+J_robust = mean(J_i) + 0.25 * max(J_i)
+```
+
+This prevents the search from overfitting only the exact current state.
+
+## Successive halving
+
+The search does not fully evaluate all 26 neighbours at maximum depth. It performs:
+
+```text
+26-neighbour lattice
+ -> bounded candidate subset
+ -> short probe replay
+ -> rank
+ -> survivor set
+ -> confirmation replay
+ -> meta gate
+```
+
+This keeps inward self-optimization bounded and reduces search cost relative to exhaustive full-depth evaluation.
+
+## Meta promotion gate
+
+A candidate can be promoted only if:
+
+```text
+candidate rejected == false
+relative score improvement >= configured threshold
+candidate reconstruction MSE <= baseline MSE * allowed_regression
+candidate anchor drift <= baseline drift * allowed_regression
+```
+
+On promotion, `SelfOptimizing3DSystem` constructs a fresh kernel with the promoted configuration, restores the authoritative sparse state, carries forward DM-DD `Omega`, `Theta`, and iteration, preserves the OS cycle, verifies exact transport, persists a checkpoint, and atomically swaps the wrapper's active kernel reference.
+
+The old kernel remains untouched during search.
+
+## Self-reference loop
+
+The higher-order runtime is therefore:
+
+```text
+X_t
+ -> DrMoagiOSKernel(C_n)
+ -> operational reports
+ -> inward meta-observation
+ -> 3D candidate lattice
+ -> isolated replay kernels
+ -> robust ranking
+ -> Pi_meta
+ -> C_(n+1)
+ -> next OS cycle
+```
+
+or:
+
+```text
+M_(n+1) = Pi_meta[ MetaSearch(M_n, Replay(M_n)) ]
+```
+
+where `M_n` contains both the ordinary Dr Moagi state and its operational configuration.
+
+## CLI
+
+Run a bounded demo search:
+
+```bash
+python -m jarvisx.dr_moagi_meta_cli demo --side 16 --max-candidates 13 --pretty
+```
+
+Or optimize against a sparse JSON field:
+
+```bash
+python -m jarvisx.dr_moagi_meta_cli file field.json --side 64 --pretty
+```
+
+## SOTA boundary
+
+The optimizer is **designed to search for configurations that outperform its incumbent runtime on matched replay workloads**. This is not the same as proving state-of-the-art performance.
+
+The report deliberately emits:
+
+```text
+claim_status = unverified_against_external_sota
+external_sota_verified = false
+```
+
+until a matched external baseline, benchmark protocol, hardware environment and reproducible results are supplied.
+
+That boundary is intentional: self-improvement is an empirical property, and "beyond SOTA" requires matched external evidence rather than internal self-comparison alone.

--- a/src/jarvisx/dr_moagi_meta_cli.py
+++ b/src/jarvisx/dr_moagi_meta_cli.py
@@ -1,0 +1,88 @@
+"""CLI for bounded inward 3D meta-optimization of the Dr Moagi runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .dr_moagi_meta_optimizer import MetaSearchConfig, SelfOptimizing3DSystem
+from .dr_moagi_os import DrMoagiOSConfig, DrMoagiOSKernel, demo_field
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m jarvisx.dr_moagi_meta_cli",
+        description="Benchmark and promote bounded 3D Dr Moagi runtime configurations.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    demo = sub.add_parser("demo", help="Optimize the deterministic sparse demo field")
+    demo.add_argument("--side", type=int, default=16)
+    demo.add_argument("--max-candidates", type=int, default=13)
+    demo.add_argument("--probe-cycles", type=int, default=1)
+    demo.add_argument("--confirm-cycles", type=int, default=3)
+    demo.add_argument("--max-eval-cells", type=int, default=2048)
+    demo.add_argument("--pretty", action="store_true")
+
+    file_cmd = sub.add_parser("file", help="Optimize a sparse JSON field")
+    file_cmd.add_argument("path", type=Path)
+    file_cmd.add_argument("--side", type=int, default=64)
+    file_cmd.add_argument("--max-candidates", type=int, default=13)
+    file_cmd.add_argument("--probe-cycles", type=int, default=1)
+    file_cmd.add_argument("--confirm-cycles", type=int, default=3)
+    file_cmd.add_argument("--max-eval-cells", type=int, default=2048)
+    file_cmd.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def _load_field(path: Path) -> dict[tuple[int, int, int], float]:
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    rows = raw.get("field") if isinstance(raw, dict) else raw
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("JSON must contain a non-empty list or {'field': [...]} object")
+    field: dict[tuple[int, int, int], float] = {}
+    for row in rows:
+        if isinstance(row, dict):
+            coordinate = int(row["x"]), int(row["y"]), int(row["z"])
+            value = float(row["value"])
+        elif isinstance(row, list) and len(row) == 4:
+            coordinate = int(row[0]), int(row[1]), int(row[2])
+            value = float(row[3])
+        else:
+            raise ValueError("each field row must be {x,y,z,value} or [x,y,z,value]")
+        field[coordinate] = value
+    return field
+
+
+def _run(args: argparse.Namespace) -> dict[str, object]:
+    config = DrMoagiOSConfig(side=args.side, max_active_cells=50_000, state_dir=None)
+    kernel = DrMoagiOSKernel(config)
+    kernel.boot(restore=False)
+    source = demo_field(args.side) if args.command == "demo" else _load_field(args.path)
+    kernel.load(source)
+    search = MetaSearchConfig(
+        max_candidates=args.max_candidates,
+        probe_cycles=args.probe_cycles,
+        confirm_cycles=args.confirm_cycles,
+        max_eval_cells=args.max_eval_cells,
+        survivors=min(4, args.max_candidates),
+    )
+    system = SelfOptimizing3DSystem(kernel, search=search)
+    report = system.turn_inward()
+    return {
+        "meta_report": report.as_dict(),
+        "runtime_status": system.status(),
+    }
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    payload = _run(args)
+    print(json.dumps(payload, indent=2 if args.pretty else None, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_meta_optimizer.py
+++ b/src/jarvisx/dr_moagi_meta_optimizer.py
@@ -423,10 +423,10 @@ class SelfOptimizing3DSystem:
         self.meta_journal.append(record)
         return report
 
-    def step(self):  # type: ignore[no-untyped-def]
+    def step(self):
         return self.kernel.step()
 
-    def run(self, cycles: int):  # type: ignore[no-untyped-def]
+    def run(self, cycles: int):
         return self.kernel.run(cycles)
 
     def status(self) -> dict[str, object]:

--- a/src/jarvisx/dr_moagi_meta_optimizer.py
+++ b/src/jarvisx/dr_moagi_meta_optimizer.py
@@ -1,0 +1,520 @@
+"""Bounded inward 3D meta-optimization for the Dr Moagi operating runtime.
+
+The optimizer turns the runtime onto its *configuration*, not onto arbitrary
+source code.  It searches a three-axis neighbourhood:
+
+    X: compression geometry  (block size, quantization, pruning)
+    Y: adaptive dynamics     (DM-DD learning rate, memory and pass depth)
+    Z: spatial dynamics      (fold/attenuation and fixed-point depth)
+
+Every candidate is replayed in an isolated DrMoagiOSKernel against deterministic
+robustness workloads.  Promotion is allowed only when the candidate improves a
+multi-metric objective without materially regressing reconstruction or anchor
+fidelity.  The production state remains authoritative until the meta gate accepts
+and the wrapper atomically swaps to the promoted kernel configuration.
+
+This is self-optimization of a bounded policy/model configuration.  It does not
+rewrite Python source, execute host commands, or assert state-of-the-art status
+without matched external benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Mapping
+
+from .dr_moagi_autoexec import HashChainJournal
+from .dr_moagi_field_runtime import Coordinate, SparseField
+from .dr_moagi_os import DrMoagiOSConfig, DrMoagiOSKernel, OSLifecycle
+
+
+@dataclass(frozen=True, order=True)
+class MetaVector3D:
+    """A signed displacement in the bounded 3D policy lattice."""
+
+    compression: int = 0
+    adaptation: int = 0
+    dynamics: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("compression", "adaptation", "dynamics"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value not in (-1, 0, 1):
+                raise ValueError(f"{name} must be one of -1, 0, +1")
+
+    @property
+    def manhattan(self) -> int:
+        return abs(self.compression) + abs(self.adaptation) + abs(self.dynamics)
+
+
+@dataclass(frozen=True)
+class MetaSearchConfig:
+    max_candidates: int = 13
+    probe_cycles: int = 1
+    confirm_cycles: int = 3
+    max_eval_cells: int = 2_048
+    survivors: int = 4
+    min_relative_improvement: float = 0.01
+    max_metric_regression: float = 0.05
+    rejection_penalty: float = 1_000.0
+
+    def __post_init__(self) -> None:
+        for name in ("max_candidates", "probe_cycles", "confirm_cycles", "max_eval_cells", "survivors"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        for name in ("min_relative_improvement", "max_metric_regression", "rejection_penalty"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)) or float(value) < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class MetaMetrics:
+    score: float
+    reconstruction_mse: float
+    distiller_residual_rms: float
+    fixed_point_residual: float
+    anchor_drift_mse: float
+    transport_bytes_per_source_cell: float
+    compute_proxy: float
+    mean_phase_velocity: float
+    rejected: bool
+    workloads: int
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MetaCandidateResult:
+    vector: MetaVector3D
+    config: DrMoagiOSConfig
+    metrics: MetaMetrics
+    stage: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "vector": asdict(self.vector),
+            "config": _config_dict(self.config),
+            "metrics": self.metrics.as_dict(),
+            "stage": self.stage,
+        }
+
+
+@dataclass(frozen=True)
+class MetaOptimizationReport:
+    baseline: MetaCandidateResult
+    best: MetaCandidateResult
+    promoted: bool
+    relative_improvement: float
+    evaluated_candidates: int
+    promoted_config: DrMoagiOSConfig | None
+    claim_status: str = "unverified_against_external_sota"
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "baseline": self.baseline.as_dict(),
+            "best": self.best.as_dict(),
+            "promoted": self.promoted,
+            "relative_improvement": self.relative_improvement,
+            "evaluated_candidates": self.evaluated_candidates,
+            "promoted_config": (
+                _config_dict(self.promoted_config) if self.promoted_config is not None else None
+            ),
+            "claim_status": self.claim_status,
+        }
+
+
+class DrMoagi3DMetaOptimizer:
+    """Search a bounded 3D configuration lattice using deterministic replay."""
+
+    def __init__(self, search: MetaSearchConfig | None = None) -> None:
+        self.search = search or MetaSearchConfig()
+
+    def optimize(
+        self,
+        source: Mapping[Coordinate, float],
+        base_config: DrMoagiOSConfig,
+    ) -> MetaOptimizationReport:
+        bounded = _bounded_source(source, self.search.max_eval_cells)
+        if not bounded:
+            raise ValueError("meta-optimizer requires a non-empty sparse state")
+
+        baseline_config = replace(base_config, state_dir=None, auto_optimize=False)
+        baseline = MetaCandidateResult(
+            vector=MetaVector3D(),
+            config=baseline_config,
+            metrics=self._evaluate(baseline_config, bounded, self.search.confirm_cycles),
+            stage="baseline",
+        )
+
+        vectors = self._vectors()[: self.search.max_candidates]
+        probes: list[MetaCandidateResult] = []
+        for vector in vectors:
+            candidate_config = self.candidate_config(base_config, vector)
+            probes.append(
+                MetaCandidateResult(
+                    vector=vector,
+                    config=candidate_config,
+                    metrics=self._evaluate(candidate_config, bounded, self.search.probe_cycles),
+                    stage="probe",
+                )
+            )
+
+        ranked = sorted(probes, key=lambda result: (result.metrics.score, result.vector))
+        survivor_count = min(self.search.survivors, len(ranked))
+        confirmed: list[MetaCandidateResult] = []
+        for probe in ranked[:survivor_count]:
+            confirmed.append(
+                MetaCandidateResult(
+                    vector=probe.vector,
+                    config=probe.config,
+                    metrics=self._evaluate(probe.config, bounded, self.search.confirm_cycles),
+                    stage="confirm",
+                )
+            )
+
+        best = min([baseline, *confirmed], key=lambda result: (result.metrics.score, result.vector))
+        relative = _relative_improvement(baseline.metrics.score, best.metrics.score)
+        promoted = best.vector != MetaVector3D() and self._promotion_gate(baseline, best, relative)
+        return MetaOptimizationReport(
+            baseline=baseline,
+            best=best,
+            promoted=promoted,
+            relative_improvement=relative,
+            evaluated_candidates=1 + len(probes) + len(confirmed),
+            promoted_config=(best.config if promoted else None),
+        )
+
+    def candidate_config(
+        self,
+        base: DrMoagiOSConfig,
+        vector: MetaVector3D,
+    ) -> DrMoagiOSConfig:
+        dx, dy, dz = vector.compression, vector.adaptation, vector.dynamics
+
+        block = base.block_size
+        quant = base.quantization
+        prune = base.prune_epsilon
+        if dx < 0:
+            block = max(1, block // 2)
+            quant = max(1.0e-9, quant * 0.5)
+            prune = max(0.0, prune * 0.5)
+        elif dx > 0:
+            block = min(16, block * 2)
+            quant = min(1.0, quant * 2.0)
+            prune = min(1.0, prune + 0.005)
+
+        lr = base.deep_distiller_learning_rate
+        rho = base.deep_distiller_rho
+        omega_gain = base.deep_distiller_omega_gain
+        dd_passes = base.deep_distiller_passes
+        latent = base.deep_distiller_max_latent_cells
+        if dy < 0:
+            lr *= 0.70
+            rho = min(0.98, rho + 0.03)
+            omega_gain *= 0.85
+            dd_passes = max(1, dd_passes - 1) if base.deep_distiller_enabled else 0
+            latent = max(1, int(latent * 0.85))
+        elif dy > 0:
+            lr *= 1.30
+            rho = max(0.0, rho - 0.03)
+            omega_gain *= 1.15
+            dd_passes = min(4, max(1, dd_passes + 1)) if base.deep_distiller_enabled else 0
+            latent = min(base.max_active_cells, max(1, int(latent * 1.15)))
+
+        contraction = base.contraction
+        attenuation = base.attenuation
+        fp_passes = base.fixed_point_passes
+        if dz < 0:
+            contraction *= 0.75
+            attenuation *= 0.75
+            fp_passes = max(0, fp_passes - 1)
+        elif dz > 0:
+            contraction = min(0.95, contraction * 1.25)
+            attenuation *= 1.25
+            fp_passes = min(4, fp_passes + 1)
+
+        return replace(
+            base,
+            block_size=block,
+            quantization=quant,
+            prune_epsilon=prune,
+            deep_distiller_learning_rate=lr,
+            deep_distiller_rho=rho,
+            deep_distiller_omega_gain=omega_gain,
+            deep_distiller_passes=dd_passes,
+            deep_distiller_max_latent_cells=latent,
+            contraction=contraction,
+            attenuation=attenuation,
+            fixed_point_passes=fp_passes,
+            auto_optimize=False,
+            state_dir=None,
+        )
+
+    def _vectors(self) -> list[MetaVector3D]:
+        values = (-1, 0, 1)
+        vectors = [
+            MetaVector3D(x, y, z)
+            for x in values
+            for y in values
+            for z in values
+            if (x, y, z) != (0, 0, 0)
+        ]
+        return sorted(vectors, key=lambda value: (value.manhattan, value))
+
+    def _evaluate(
+        self,
+        config: DrMoagiOSConfig,
+        source: SparseField,
+        cycles: int,
+    ) -> MetaMetrics:
+        workload_metrics = [
+            self._evaluate_workload(config, workload, cycles)
+            for workload in _robustness_workloads(source, config.side)
+        ]
+        mean_score = sum(item.score for item in workload_metrics) / len(workload_metrics)
+        worst_score = max(item.score for item in workload_metrics)
+
+        def mean(name: str) -> float:
+            return sum(float(getattr(item, name)) for item in workload_metrics) / len(
+                workload_metrics
+            )
+
+        return MetaMetrics(
+            score=mean_score + 0.25 * worst_score,
+            reconstruction_mse=mean("reconstruction_mse"),
+            distiller_residual_rms=mean("distiller_residual_rms"),
+            fixed_point_residual=mean("fixed_point_residual"),
+            anchor_drift_mse=mean("anchor_drift_mse"),
+            transport_bytes_per_source_cell=mean("transport_bytes_per_source_cell"),
+            compute_proxy=mean("compute_proxy"),
+            mean_phase_velocity=mean("mean_phase_velocity"),
+            rejected=any(item.rejected for item in workload_metrics),
+            workloads=len(workload_metrics),
+        )
+
+    def _evaluate_workload(
+        self,
+        config: DrMoagiOSConfig,
+        source: SparseField,
+        cycles: int,
+    ) -> MetaMetrics:
+        kernel = DrMoagiOSKernel(replace(config, state_dir=None, auto_optimize=False))
+        kernel.boot(restore=False)
+        kernel.load(source)
+        reports = kernel.run(cycles)
+        final = _snapshot_field(kernel)
+        rejected = any(not report.committed for report in reports)
+        count = max(1, len(reports))
+        reconstruction = sum(float(report.reconstruction_mse) for report in reports) / count
+        distiller = sum(float(report.distiller_residual_rms or 0.0) for report in reports) / count
+        fixed = sum(float(report.fixed_point_residual or 0.0) for report in reports) / count
+        phase = sum(float(report.phase_velocity) for report in reports) / count
+        transport = float(reports[-1].transport_bytes if reports else 0) / max(1, len(source))
+        compute_proxy = sum(
+            (float(report.active_cells_after) + float(report.latent_cells)) / max(1, len(source))
+            for report in reports
+        ) / count
+        drift = _field_mse(source, final)
+        score = (
+            6.0 * reconstruction
+            + 4.0 * distiller * distiller
+            + 2.0 * fixed * fixed
+            + 4.0 * drift
+            + 0.010 * transport
+            + 0.20 * compute_proxy
+            + 0.25 * phase
+            + (self.search.rejection_penalty if rejected else 0.0)
+        )
+        return MetaMetrics(
+            score=score,
+            reconstruction_mse=reconstruction,
+            distiller_residual_rms=distiller,
+            fixed_point_residual=fixed,
+            anchor_drift_mse=drift,
+            transport_bytes_per_source_cell=transport,
+            compute_proxy=compute_proxy,
+            mean_phase_velocity=phase,
+            rejected=rejected,
+            workloads=1,
+        )
+
+    def _promotion_gate(
+        self,
+        baseline: MetaCandidateResult,
+        best: MetaCandidateResult,
+        relative: float,
+    ) -> bool:
+        if best.metrics.rejected:
+            return False
+        if relative < self.search.min_relative_improvement:
+            return False
+        regression = 1.0 + self.search.max_metric_regression
+        eps = 1.0e-12
+        if best.metrics.reconstruction_mse > baseline.metrics.reconstruction_mse * regression + eps:
+            return False
+        if best.metrics.anchor_drift_mse > baseline.metrics.anchor_drift_mse * regression + eps:
+            return False
+        return True
+
+
+class SelfOptimizing3DSystem:
+    """A higher-order runtime that can benchmark and promote its own configuration."""
+
+    def __init__(
+        self,
+        kernel: DrMoagiOSKernel,
+        *,
+        search: MetaSearchConfig | None = None,
+    ) -> None:
+        self.kernel = kernel
+        self.optimizer = DrMoagi3DMetaOptimizer(search)
+        self.meta_epoch = 0
+        self.last_meta_report: MetaOptimizationReport | None = None
+        journal_path: Path | None = None
+        if kernel.config.state_dir is not None:
+            journal_path = kernel.config.state_dir / "meta-journal.jsonl"
+        self.meta_journal = HashChainJournal(journal_path)
+
+    def turn_inward(self) -> MetaOptimizationReport:
+        if self.kernel.lifecycle is OSLifecycle.RUNNING:
+            raise RuntimeError("stop autorun before meta-optimization")
+        if not self.kernel.loaded:
+            raise RuntimeError("load a sparse state before meta-optimization")
+
+        before_status = self.kernel.status()
+        before_hash = str(before_status["state_hash"])
+        source = _snapshot_field(self.kernel)
+        adaptive = self.kernel._distiller.adaptive_snapshot()
+        old_cycle = self.kernel.cycle
+        old_state_dir = self.kernel.config.state_dir
+
+        report = self.optimizer.optimize(source, self.kernel.config)
+        self.meta_epoch += 1
+        if report.promoted and report.promoted_config is not None:
+            if str(self.kernel.status()["state_hash"]) != before_hash:
+                raise RuntimeError("authoritative state changed during meta-optimization")
+            promoted_config = replace(report.promoted_config, state_dir=old_state_dir)
+            promoted = DrMoagiOSKernel(promoted_config)
+            promoted.boot(restore=False)
+            promoted.load(source)
+            promoted._distiller.restore_adaptive_state(
+                source,
+                omega=adaptive.omega,
+                theta=adaptive.theta,
+                iteration=adaptive.iteration,
+            )
+            promoted._cycle = old_cycle
+            promoted._transport_packet = promoted._verified_transport(source)
+            promoted._persist_checkpoint()
+            self.kernel = promoted
+
+        self.last_meta_report = report
+        record = report.as_dict()
+        record["meta_epoch"] = self.meta_epoch
+        record["state_hash"] = before_hash
+        self.meta_journal.append(record)
+        return report
+
+    def step(self):  # type: ignore[no-untyped-def]
+        return self.kernel.step()
+
+    def run(self, cycles: int):  # type: ignore[no-untyped-def]
+        return self.kernel.run(cycles)
+
+    def status(self) -> dict[str, object]:
+        return {
+            **self.kernel.status(),
+            "meta_optimizer": {
+                "epoch": self.meta_epoch,
+                "search_space": "3D bounded policy lattice",
+                "axes": {
+                    "x": "compression geometry",
+                    "y": "adaptive dynamics",
+                    "z": "spatial/fixed-point dynamics",
+                },
+                "journal_head": self.meta_journal.head,
+                "journal_valid": self.meta_journal.verify(),
+                "last_report": (
+                    self.last_meta_report.as_dict() if self.last_meta_report is not None else None
+                ),
+                "external_sota_verified": False,
+            },
+        }
+
+
+def _config_dict(config: DrMoagiOSConfig) -> dict[str, object]:
+    raw = asdict(config)
+    state_dir = raw.get("state_dir")
+    raw["state_dir"] = str(state_dir) if state_dir is not None else None
+    return raw
+
+
+def _snapshot_field(kernel: DrMoagiOSKernel) -> SparseField:
+    snap = kernel.snapshot(limit=kernel.config.max_active_cells)
+    rows = snap.get("cells")
+    if not isinstance(rows, list):
+        raise RuntimeError("kernel snapshot cells are unavailable")
+    result: SparseField = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise RuntimeError("invalid kernel snapshot row")
+        result[(int(row["x"]), int(row["y"]), int(row["z"]))] = float(row["value"])
+    return result
+
+
+def _bounded_source(source: Mapping[Coordinate, float], limit: int) -> SparseField:
+    ordered = sorted(source.items())
+    if len(ordered) <= limit:
+        return dict(ordered)
+    stride = len(ordered) / limit
+    indices = [min(len(ordered) - 1, int(index * stride)) for index in range(limit)]
+    return {ordered[index][0]: float(ordered[index][1]) for index in indices}
+
+
+def _robustness_workloads(source: SparseField, side: int) -> tuple[SparseField, ...]:
+    base = dict(source)
+    amplitude: SparseField = {}
+    shifted: SparseField = {}
+    for coordinate, value in sorted(source.items()):
+        digest = hashlib.sha256(repr(coordinate).encode("ascii")).digest()[0]
+        factor = 0.97 if digest & 1 else 1.03
+        amplitude[coordinate] = float(value) * factor
+        x, y, z = coordinate
+        shifted[((x + 1) % side, y, z)] = float(value)
+    return base, amplitude, shifted
+
+
+def _field_mse(reference: Mapping[Coordinate, float], candidate: Mapping[Coordinate, float]) -> float:
+    keys = set(reference) | set(candidate)
+    if not keys:
+        return 0.0
+    error = 0.0
+    for key in keys:
+        delta = float(reference.get(key, 0.0)) - float(candidate.get(key, 0.0))
+        error += delta * delta
+    return error / len(keys)
+
+
+def _relative_improvement(baseline: float, candidate: float) -> float:
+    if baseline <= 0.0:
+        return 0.0 if candidate >= baseline else 1.0
+    return max(0.0, (baseline - candidate) / baseline)
+
+
+__all__ = [
+    "DrMoagi3DMetaOptimizer",
+    "MetaCandidateResult",
+    "MetaMetrics",
+    "MetaOptimizationReport",
+    "MetaSearchConfig",
+    "MetaVector3D",
+    "SelfOptimizing3DSystem",
+]

--- a/tests/test_dr_moagi_meta_optimizer.py
+++ b/tests/test_dr_moagi_meta_optimizer.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.dr_moagi_meta_optimizer import (
+    DrMoagi3DMetaOptimizer,
+    MetaSearchConfig,
+    MetaVector3D,
+    SelfOptimizing3DSystem,
+)
+from jarvisx.dr_moagi_os import DrMoagiOSConfig, DrMoagiOSKernel, demo_field
+
+
+def _search() -> MetaSearchConfig:
+    return MetaSearchConfig(
+        max_candidates=3,
+        probe_cycles=1,
+        confirm_cycles=1,
+        max_eval_cells=64,
+        survivors=1,
+        min_relative_improvement=0.0,
+    )
+
+
+def test_meta_vector_is_a_bounded_3d_lattice_coordinate():
+    assert MetaVector3D(-1, 0, 1).manhattan == 2
+    with pytest.raises(ValueError):
+        MetaVector3D(2, 0, 0)
+
+
+def test_candidate_config_moves_all_three_operational_axes_without_expanding_state_dir():
+    base = DrMoagiOSConfig(
+        side=16,
+        max_active_cells=256,
+        block_size=2,
+        quantization=0.01,
+        prune_epsilon=0.01,
+        deep_distiller_max_latent_cells=128,
+        deep_distiller_learning_rate=0.05,
+        contraction=0.08,
+        attenuation=0.10,
+        fixed_point_passes=1,
+        state_dir=None,
+    )
+    optimizer = DrMoagi3DMetaOptimizer(_search())
+    candidate = optimizer.candidate_config(base, MetaVector3D(1, 1, 1))
+
+    assert candidate.block_size == 4
+    assert candidate.quantization > base.quantization
+    assert candidate.prune_epsilon > base.prune_epsilon
+    assert candidate.deep_distiller_learning_rate > base.deep_distiller_learning_rate
+    assert candidate.deep_distiller_max_latent_cells <= candidate.max_active_cells
+    assert candidate.contraction > base.contraction
+    assert candidate.attenuation > base.attenuation
+    assert candidate.fixed_point_passes >= base.fixed_point_passes
+    assert candidate.state_dir is None
+    assert candidate.auto_optimize is False
+
+
+def test_optimizer_replays_candidates_and_refuses_unverified_sota_claim():
+    config = DrMoagiOSConfig(
+        side=16,
+        max_active_cells=512,
+        fixed_point_passes=1,
+        state_dir=None,
+    )
+    optimizer = DrMoagi3DMetaOptimizer(_search())
+    report = optimizer.optimize(demo_field(16), config)
+
+    assert report.evaluated_candidates == 5
+    assert report.baseline.metrics.workloads == 3
+    assert report.best.metrics.workloads == 3
+    assert report.best.metrics.score >= 0.0
+    assert report.claim_status == "unverified_against_external_sota"
+    if report.promoted:
+        assert report.promoted_config is not None
+        assert report.relative_improvement >= 0.0
+
+
+def test_self_optimizing_wrapper_preserves_authoritative_state_across_meta_epoch(tmp_path):
+    config = DrMoagiOSConfig(
+        side=16,
+        max_active_cells=512,
+        fixed_point_passes=1,
+        state_dir=tmp_path,
+    )
+    kernel = DrMoagiOSKernel(config)
+    kernel.boot(restore=False)
+    kernel.load(demo_field(16))
+    kernel.step()
+    before = kernel.status()
+    before_hash = before["state_hash"]
+    before_iteration = before["distiller"]["iteration"]
+    before_cycle = kernel.cycle
+
+    system = SelfOptimizing3DSystem(kernel, search=_search())
+    report = system.turn_inward()
+    after = system.status()
+
+    assert after["state_hash"] == before_hash
+    assert after["cycle"] == before_cycle
+    assert after["distiller"]["iteration"] == before_iteration
+    assert after["meta_optimizer"]["epoch"] == 1
+    assert after["meta_optimizer"]["journal_valid"] is True
+    assert after["meta_optimizer"]["external_sota_verified"] is False
+    assert system.meta_journal.verify()
+    if report.promoted:
+        assert report.promoted_config is not None
+        assert system.kernel.config.state_dir == tmp_path
+
+
+def test_meta_optimizer_is_bounded_by_evaluation_sample():
+    config = DrMoagiOSConfig(side=64, max_active_cells=1_000, state_dir=None)
+    source = {
+        (index % 64, (index // 64) % 64, (index // (64 * 64)) % 64): 0.75
+        for index in range(300)
+    }
+    report = DrMoagi3DMetaOptimizer(
+        replace(_search(), max_eval_cells=32, max_candidates=1, survivors=1)
+    ).optimize(source, config)
+
+    assert report.evaluated_candidates == 3
+    assert report.baseline.metrics.workloads == 3


### PR DESCRIPTION
## Summary

Turns the Dr Moagi runtime inward onto its own bounded operational configuration through a transactional 3D meta-optimization layer.

Meta axes:

```text
X = compression geometry
Y = adaptive DM-DD dynamics
Z = spatial/fixed-point dynamics
```

For each meta epoch, the runtime:

```text
authoritative sparse state
 -> bounded deterministic replay sample
 -> 3D neighbourhood candidates
 -> isolated DrMoagiOSKernel probes
 -> multi-metric ranking
 -> successive-halving confirmation
 -> Pi_meta regression gate
 -> atomic configuration promotion or retain incumbent
```

## Added

- `dr_moagi_meta_optimizer.py`
  - 3D bounded policy lattice
  - deterministic three-workload robustness replay
  - multi-metric objective over reconstruction, residuals, anchor drift, transport, compute proxy and phase activity
  - successive-halving candidate evaluation
  - transactional promotion gate
  - `SelfOptimizing3DSystem` wrapper preserving state, DM-DD Omega/Theta/iteration and OS cycle on promotion
  - separate hash-chained meta journal
- `dr_moagi_meta_cli.py`
  - demo and JSON-field inward optimization commands
- regression tests for bounded search, candidate movement, state preservation, meta journal integrity and SOTA-claim boundary
- documentation of the meta law and operational limits

## SOTA boundary

The runtime can prove improvement over its incumbent on its own matched replay workloads. It deliberately reports `unverified_against_external_sota` and `external_sota_verified=false` until matched external baselines, hardware, benchmark protocols and reproducible results are supplied.

This is configuration/model-policy self-optimization, not arbitrary source-code self-rewriting or host command execution.