### PR TITLE
Refine and auto-optimize the Dr Moagi 3D geometry

### DIFF
--- a/.github/workflows/dmvx-matrix-pages.yml
+++ b/.github/workflows/dmvx-matrix-pages.yml
@@ -8,11 +8,13 @@ on:
     paths:
       - "apps/dmvx-matrix/**"
       - "apps/permeation-transport/**"
+      - "apps/dr-moagi-geometry/**"
       - ".github/workflows/dmvx-matrix-pages.yml"
   pull_request:
     paths:
       - "apps/dmvx-matrix/**"
       - "apps/permeation-transport/**"
+      - "apps/dr-moagi-geometry/**"
       - ".github/workflows/dmvx-matrix-pages.yml"
   workflow_dispatch:
 
@@ -40,10 +42,17 @@ jobs:
         run: node --test apps/dmvx-matrix/test_core.mjs
       - name: Run permeation transport invariants
         run: node --test apps/permeation-transport/test_core.mjs
+      - name: Run Dr Moagi geometry optimizer invariants
+        run: node --test apps/dr-moagi-geometry/test_core.mjs
       - name: Smoke-check permeation browser entrypoint
         run: |
           grep -q "DM-vΩΞ⁺ PERMEATION TRANSPORT CORE" apps/permeation-transport/index.html
           grep -q "FixedStepEngine" apps/permeation-transport/index.html
+      - name: Smoke-check geometry self-optimizer entrypoint
+        run: |
+          grep -q "DR MOAGI 3D GEOMETRY SELF-OPTIMIZER" apps/dr-moagi-geometry/index.html
+          grep -q "AUTO OPTIMIZE" apps/dr-moagi-geometry/index.html
+          grep -q "PROVISIONAL ≠ AUTHORITATIVE" apps/dr-moagi-geometry/index.html
 
   deploy:
     if: github.event_name != 'pull_request'
@@ -66,9 +75,10 @@ jobs:
       - name: Assemble shared static site
         run: |
           rm -rf dist
-          mkdir -p dist/permeation-transport
+          mkdir -p dist/permeation-transport dist/dr-moagi-geometry
           cp -a apps/dmvx-matrix/. dist/
           cp -a apps/permeation-transport/. dist/permeation-transport/
+          cp -a apps/dr-moagi-geometry/. dist/dr-moagi-geometry/
       - name: Upload static runtimes
         id: upload
         continue-on-error: true
@@ -106,6 +116,7 @@ jobs:
                 '',
                 `- root runtime: ${pageUrl}`,
                 `- permeation transport: ${pageUrl.replace(/\/$/, '')}/permeation-transport/`,
+                `- Dr Moagi geometry optimizer: ${pageUrl.replace(/\/$/, '')}/dr-moagi-geometry/`,
                 `- deployed commit: \`${context.sha}\``,
                 `- invariant test job: ${process.env.TEST_RESULT}`,
                 `- Pages deployment job: ${process.env.DEPLOY_RESULT}`,

--- a/apps/dr-moagi-geometry/README.md
+++ b/apps/dr-moagi-geometry/README.md
@@ -1,0 +1,104 @@
+# Dr Moagi 3D Geometry Self-Optimizer
+
+This runtime operationalizes the time-dependent Dr Moagi parametric geometry as a bounded, topology-preserving self-optimization loop.
+
+## Refined geometry
+
+The authoritative geometric state is
+
+```text
+θg = (R, Rmin, χ, ω, α, β, γ, δ, κ, λ)
+```
+
+with
+
+```text
+R(t) = Rmin + (R - Rmin) exp(-χ t)
+q    = γ v sin(u/2 + β t)
+r    = R(t) + v cos(u/2 + ω t)
+
+x = r cos(u + α t) - q sin(u + α t)
+y = v sin(u/2 + ω t) + δ sin(κ u + λ t)
+z = r sin(u + α t) + q cos(u + α t)
+```
+
+`κ` is restricted to integer spatial modes so the Möbius seam remains continuous:
+
+```text
+P(0, v, t) = P(2π, -v, t)
+```
+
+The secondary perturbation also uses a half-angle phase so it does not break the seam.
+
+## True inward motion
+
+The earlier time-dependent geometry rotated and twisted but did not necessarily move inward. The refined law introduces a monotone radius schedule:
+
+```text
+R(t) -> Rmin as t -> infinity
+```
+
+for `χ > 0`.
+
+## Geometry objective
+
+The optimizer measures the geometry rather than assigning a synthetic quality score. The objective combines:
+
+- seam RMS error;
+- local area-element non-degeneracy;
+- area coefficient of variation;
+- temporal speed RMS;
+- acceleration RMS;
+- bounded inward contraction;
+- bounded frequency cost;
+- an expressivity floor that discourages the trivial zero-motion solution.
+
+The score is an internal engineering objective, not an external SOTA benchmark.
+
+## Bounded self-optimization
+
+The parameter search is a 27-node local lattice:
+
+```text
+(shape, kinetics, inward) ∈ {-1, 0, +1}^3
+```
+
+The center is the incumbent and the remaining 26 nodes are counterfactual candidates.
+
+- **shape** changes perturbation/vertical-wave amplitudes;
+- **kinetics** changes twist/orbit/perturbation frequencies;
+- **inward** changes contraction rate and radius floor.
+
+Every candidate is measured in isolation. Promotion requires:
+
+1. lower objective than the incumbent by the configured minimum;
+2. seam RMS below the topology tolerance;
+3. no excessive regression of the minimum area element;
+4. a finite score.
+
+The invariant is:
+
+```text
+PROVISIONAL GEOMETRY != AUTHORITATIVE GEOMETRY
+```
+
+until `PI_GEOM` accepts the candidate.
+
+## Run tests
+
+```bash
+node --test apps/dr-moagi-geometry/test_core.mjs
+```
+
+## Browser runtime
+
+Open `index.html` from a static server. The app provides:
+
+- a live Three.js rendering of the authoritative manifold;
+- direct parameter controls;
+- measured geometric metrics;
+- a 27-node candidate evaluation view;
+- `AUTO OPTIMIZE` for one bounded geometry epoch;
+- explicit accept/hold transaction trace.
+
+The optimizer changes parameter values only. It does not rewrite source code, execute host commands, or infer that internal objective improvement is state-of-the-art performance.

--- a/apps/dr-moagi-geometry/core.mjs
+++ b/apps/dr-moagi-geometry/core.mjs
@@ -1,0 +1,281 @@
+export const TAU = Math.PI * 2;
+
+export const DEFAULT_GEOMETRY = Object.freeze({
+  R: 5.0,
+  Rmin: 3.6,
+  chi: 0.16,
+  omega: 0.50,
+  alpha: 0.30,
+  beta: 0.70,
+  gamma: 0.30,
+  delta: 0.50,
+  kappa: 2,
+  lambda: 0.50,
+});
+
+export const GEOMETRY_BOUNDS = Object.freeze({
+  R: [3.0, 8.0],
+  Rmin: [2.0, 7.5],
+  chi: [0.0, 0.8],
+  omega: [0.05, 1.5],
+  alpha: [0.05, 1.2],
+  beta: [0.05, 1.8],
+  gamma: [0.0, 0.8],
+  delta: [0.0, 1.2],
+  kappa: [1, 4],
+  lambda: [0.05, 1.5],
+});
+
+export function clamp(value, lo, hi) {
+  return Math.max(lo, Math.min(hi, value));
+}
+
+export function normalizeGeometry(params = {}) {
+  const p = { ...DEFAULT_GEOMETRY, ...params };
+  for (const [name, [lo, hi]] of Object.entries(GEOMETRY_BOUNDS)) {
+    p[name] = clamp(Number(p[name]), lo, hi);
+  }
+  p.kappa = Math.round(p.kappa);
+  p.Rmin = Math.min(p.R - 0.25, p.Rmin);
+  p.Rmin = Math.max(GEOMETRY_BOUNDS.Rmin[0], p.Rmin);
+  return p;
+}
+
+export function inwardRadius(t, params = DEFAULT_GEOMETRY) {
+  const p = normalizeGeometry(params);
+  return p.Rmin + (p.R - p.Rmin) * Math.exp(-p.chi * Math.max(0, t));
+}
+
+// Topology-preserving refinement of the Dr Moagi kinetic geometry.
+// The secondary perturbation uses a half-angle phase so the Möbius seam
+// P(0,v,t) == P(2π,-v,t) remains continuous for integer kappa.
+export function drMoagiPoint(u, v, t, params = DEFAULT_GEOMETRY) {
+  const p = normalizeGeometry(params);
+  const twist = 0.5 * u + p.omega * t;
+  const orbit = u + p.alpha * t;
+  const secondary = 0.5 * u + p.beta * t;
+  const baseRadius = inwardRadius(t, p) + v * Math.cos(twist);
+  const tangentPerturbation = p.gamma * v * Math.sin(secondary);
+  const tangentX = -Math.sin(orbit);
+  const tangentZ = Math.cos(orbit);
+
+  const x = baseRadius * Math.cos(orbit) + tangentPerturbation * tangentX;
+  const y = v * Math.sin(twist) + p.delta * Math.sin(p.kappa * u + p.lambda * t);
+  const z = baseRadius * Math.sin(orbit) + tangentPerturbation * tangentZ;
+  return { x, y, z };
+}
+
+function sub(a, b) {
+  return { x: a.x - b.x, y: a.y - b.y, z: a.z - b.z };
+}
+
+function norm2(a) {
+  return a.x * a.x + a.y * a.y + a.z * a.z;
+}
+
+function cross(a, b) {
+  return {
+    x: a.y * b.z - a.z * b.y,
+    y: a.z * b.x - a.x * b.z,
+    z: a.x * b.y - a.y * b.x,
+  };
+}
+
+function mean(values) {
+  if (!values.length) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function geometryMetrics(params = DEFAULT_GEOMETRY, options = {}) {
+  const p = normalizeGeometry(params);
+  const uSamples = options.uSamples ?? 36;
+  const vSamples = options.vSamples ?? 9;
+  const times = options.times ?? [0.0, 0.5, 1.0, 1.5];
+  const dt = options.dt ?? 1 / 60;
+  const du = TAU / uSamples;
+  const dv = 4 / Math.max(1, vSamples - 1);
+
+  const seamSq = [];
+  const speedSq = [];
+  const accelSq = [];
+  const areas = [];
+  const radii = [];
+
+  for (const t of times) {
+    for (let j = 0; j < vSamples; j += 1) {
+      const v = -2 + j * dv;
+      const a = drMoagiPoint(0, v, t, p);
+      const b = drMoagiPoint(TAU, -v, t, p);
+      seamSq.push(norm2(sub(a, b)));
+    }
+
+    for (let i = 0; i < uSamples; i += 1) {
+      const u = i * du;
+      for (let j = 0; j < vSamples; j += 1) {
+        const v = -2 + j * dv;
+        const now = drMoagiPoint(u, v, t, p);
+        const prev = drMoagiPoint(u, v, Math.max(0, t - dt), p);
+        const next = drMoagiPoint(u, v, t + dt, p);
+        const velocityDenom = Math.max(dt, t > 0 ? 2 * dt : dt);
+        const velocity = {
+          x: (next.x - prev.x) / velocityDenom,
+          y: (next.y - prev.y) / velocityDenom,
+          z: (next.z - prev.z) / velocityDenom,
+        };
+        const accel = {
+          x: (next.x - 2 * now.x + prev.x) / (dt * dt),
+          y: (next.y - 2 * now.y + prev.y) / (dt * dt),
+          z: (next.z - 2 * now.z + prev.z) / (dt * dt),
+        };
+        speedSq.push(norm2(velocity));
+        accelSq.push(norm2(accel));
+        radii.push(Math.sqrt(now.x * now.x + now.z * now.z));
+
+        const pu = drMoagiPoint(u + du * 0.5, v, t, p);
+        const vProbe = v >= 2 - 1e-12 ? v - dv * 0.5 : v + dv * 0.5;
+        const pv = drMoagiPoint(u, clamp(vProbe, -2, 2), t, p);
+        const tu = sub(pu, now);
+        const tv = sub(pv, now);
+        areas.push(Math.sqrt(norm2(cross(tu, tv))));
+      }
+    }
+  }
+
+  const meanArea = mean(areas);
+  const minArea = Math.min(...areas);
+  const areaVariance = mean(areas.map((x) => (x - meanArea) ** 2));
+  const areaCv = meanArea > 0 ? Math.sqrt(areaVariance) / meanArea : Infinity;
+  const speedRms = Math.sqrt(mean(speedSq));
+  const accelerationRms = Math.sqrt(mean(accelSq));
+  const seamRms = Math.sqrt(mean(seamSq));
+  const radialSpan = Math.max(...radii) - Math.min(...radii);
+  const contraction = p.R - inwardRadius(times[times.length - 1], p);
+
+  return {
+    seamRms,
+    minArea,
+    meanArea,
+    areaCv,
+    speedRms,
+    accelerationRms,
+    radialSpan,
+    contraction,
+  };
+}
+
+export function geometryObjective(params = DEFAULT_GEOMETRY, options = {}) {
+  const p = normalizeGeometry(params);
+  const m = geometryMetrics(p, options);
+  const collapsePenalty = m.minArea < 0.002 ? (0.002 - m.minArea) ** 2 * 1e6 : 0;
+  const motionLow = Math.max(0, 0.35 - m.speedRms);
+  const motionHigh = Math.max(0, m.speedRms - 3.0);
+  const contractionLow = Math.max(0, 0.15 - m.contraction);
+  const contractionHigh = Math.max(0, m.contraction - 1.8);
+  const frequencyCost = p.omega ** 2 + p.alpha ** 2 + p.beta ** 2 + p.lambda ** 2;
+  const expressivity = p.gamma ** 2 + p.delta ** 2;
+
+  const score =
+    1e6 * m.seamRms ** 2 +
+    8.0 * m.areaCv ** 2 +
+    collapsePenalty +
+    0.015 * m.accelerationRms ** 2 +
+    0.06 * motionHigh ** 2 +
+    3.0 * motionLow ** 2 +
+    2.5 * contractionLow ** 2 +
+    0.8 * contractionHigh ** 2 +
+    0.03 * frequencyCost +
+    0.30 * Math.max(0, 0.18 - expressivity) ** 2;
+
+  return { score, metrics: m };
+}
+
+export function geometryVectorLattice() {
+  const values = [-1, 0, 1];
+  const vectors = [];
+  for (const shape of values) {
+    for (const kinetics of values) {
+      for (const inward of values) {
+        if (shape || kinetics || inward) vectors.push({ shape, kinetics, inward });
+      }
+    }
+  }
+  vectors.sort((a, b) => {
+    const ma = Math.abs(a.shape) + Math.abs(a.kinetics) + Math.abs(a.inward);
+    const mb = Math.abs(b.shape) + Math.abs(b.kinetics) + Math.abs(b.inward);
+    if (ma !== mb) return ma - mb;
+    return a.shape - b.shape || a.kinetics - b.kinetics || a.inward - b.inward;
+  });
+  return vectors;
+}
+
+export function candidateGeometry(base, vector) {
+  const p = normalizeGeometry(base);
+  const q = { ...p };
+  if (vector.shape) {
+    const scale = vector.shape < 0 ? 0.88 : 1.12;
+    q.gamma *= scale;
+    q.delta *= scale;
+  }
+  if (vector.kinetics) {
+    const scale = vector.kinetics < 0 ? 0.90 : 1.10;
+    q.omega *= scale;
+    q.alpha *= scale;
+    q.beta *= scale;
+    q.lambda *= scale;
+  }
+  if (vector.inward) {
+    if (vector.inward < 0) {
+      q.chi *= 0.82;
+      q.Rmin += 0.18;
+    } else {
+      q.chi *= 1.18;
+      q.Rmin -= 0.18;
+    }
+  }
+  return normalizeGeometry(q);
+}
+
+export function optimizeGeometry(base = DEFAULT_GEOMETRY, options = {}) {
+  const incumbent = normalizeGeometry(base);
+  const baseline = geometryObjective(incumbent, options);
+  const maxCandidates = Math.min(26, options.maxCandidates ?? 26);
+  const minRelativeImprovement = options.minRelativeImprovement ?? 0.005;
+  const maxAreaRegression = options.maxAreaRegression ?? 0.05;
+  const seamTolerance = options.seamTolerance ?? 1e-9;
+
+  const evaluations = [{
+    vector: { shape: 0, kinetics: 0, inward: 0 },
+    params: incumbent,
+    ...baseline,
+    stage: 'baseline',
+  }];
+
+  for (const vector of geometryVectorLattice().slice(0, maxCandidates)) {
+    const params = candidateGeometry(incumbent, vector);
+    const result = geometryObjective(params, options);
+    evaluations.push({ vector, params, ...result, stage: 'candidate' });
+  }
+
+  const best = evaluations.reduce((a, b) => (b.score < a.score ? b : a));
+  const relativeImprovement = baseline.score > 0
+    ? Math.max(0, (baseline.score - best.score) / baseline.score)
+    : 0;
+  const areaFloor = baseline.metrics.minArea * (1 - maxAreaRegression);
+  const promoted =
+    best.stage !== 'baseline' &&
+    relativeImprovement >= minRelativeImprovement &&
+    best.metrics.seamRms <= seamTolerance &&
+    best.metrics.minArea >= areaFloor &&
+    Number.isFinite(best.score);
+
+  return {
+    baseline: evaluations[0],
+    best,
+    promoted,
+    relativeImprovement,
+    promotedParams: promoted ? best.params : null,
+    authoritativeParams: promoted ? best.params : incumbent,
+    evaluations,
+    claimStatus: 'internal_geometry_improvement_only',
+  };
+}

--- a/apps/dr-moagi-geometry/index.html
+++ b/apps/dr-moagi-geometry/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Dr Moagi 3D Geometry Self-Optimizer</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <style>
+    :root{color-scheme:dark;font-family:Inter,ui-sans-serif,system-ui,sans-serif;background:#020617;color:#e2e8f0}
+    *{box-sizing:border-box}html,body{margin:0;width:100%;height:100%;overflow:hidden}body{display:grid;grid-template-rows:56px 1fr 32px;background:radial-gradient(circle at 50% 20%,#111827 0,#020617 58%,#000 100%)}
+    header,footer{display:flex;align-items:center;justify-content:space-between;padding:0 16px;background:#020617e8;border-color:#164e63;backdrop-filter:blur(16px);z-index:10}header{border-bottom:1px solid #164e63}footer{border-top:1px solid #164e63;font:9px ui-monospace,monospace;color:#64748b}.brand b{display:block;color:#67e8f9;font-size:12px;letter-spacing:.1em}.brand small{font:9px ui-monospace,monospace;color:#64748b}.pills{display:flex;gap:8px;font:9px ui-monospace,monospace}.pill{padding:5px 8px;border:1px solid #1e3a4a;border-radius:99px;background:#07111dcc}.pill strong{color:#4ade80}
+    main{position:relative;min-height:0}.scene{position:absolute;inset:0}.panel{position:absolute;top:10px;bottom:10px;width:330px;background:#08101ee8;border:1px solid #164e63;border-radius:12px;backdrop-filter:blur(16px);padding:12px;overflow:auto;z-index:5}.left{left:10px}.right{right:10px}.title{font:700 10px ui-monospace,monospace;color:#67e8f9;letter-spacing:.12em;margin-bottom:10px;padding-bottom:7px;border-bottom:1px solid #172554}.control{margin:8px 0}.control label{display:flex;justify-content:space-between;font:9px ui-monospace,monospace;color:#94a3b8;margin-bottom:3px}.control input{width:100%;accent-color:#22d3ee}.buttons{display:grid;grid-template-columns:1fr 1fr;gap:7px;margin:10px 0}button{border:1px solid #155e75;background:#083344;color:#cffafe;border-radius:7px;padding:8px;font:700 9px ui-monospace,monospace;cursor:pointer}button.primary{background:#7c3aed;border-color:#a855f7;color:white}button.warn{background:#3f0a16;border-color:#881337;color:#fecdd3}.metric{display:flex;justify-content:space-between;font:10px ui-monospace,monospace;padding:7px 0;border-bottom:1px solid #172033}.metric b{color:#c4f1ff}.equation{font:9px ui-monospace,monospace;line-height:1.55;color:#a5b4fc;background:#020617cc;border:1px solid #1e293b;border-radius:8px;padding:9px;white-space:pre-wrap}.trace{max-height:180px;overflow:auto;background:#0008;border:1px solid #1e293b;border-radius:8px;padding:7px;font:8px ui-monospace,monospace;line-height:1.5}.ok{color:#4ade80}.bad{color:#fb7185}.candidate{display:grid;grid-template-columns:60px 1fr 58px;gap:6px;font:8px ui-monospace,monospace;padding:4px 0;border-bottom:1px solid #131c2a}.candidate b{color:#c4f1ff}.candidate .win{color:#4ade80}.candidate .loss{color:#fb7185}
+    .legend{position:absolute;left:350px;right:350px;bottom:14px;display:flex;justify-content:center;gap:6px;flex-wrap:wrap;z-index:3;pointer-events:none}.chip{font:8px ui-monospace,monospace;padding:4px 7px;border:1px solid #1e293b;border-radius:99px;background:#020617bb;color:#94a3b8}@media(max-width:1000px){.panel{width:285px}.legend{left:305px;right:305px}}@media(max-width:760px){.right{display:none}.panel.left{width:300px}.legend{left:315px;right:10px}.pills{display:none}}
+  </style>
+</head>
+<body>
+<header><div class="brand"><b>DR MOAGI 3D GEOMETRY SELF-OPTIMIZER</b><small>Topology-preserving kinetic manifold · bounded transactional parameter promotion</small></div><div class="pills"><span class="pill">mode: <strong id="mode">RUNNING</strong></span><span class="pill">epoch: <strong id="epoch">0</strong></span><span class="pill">claim: internal geometry improvement only</span></div></header>
+<main>
+  <div id="scene" class="scene"></div>
+  <section class="panel left">
+    <div class="title">AUTHORITATIVE GEOMETRY θg</div>
+    <div id="controls"></div>
+    <div class="buttons"><button id="optimize" class="primary">AUTO OPTIMIZE</button><button id="pause">PAUSE</button><button id="reset" class="warn">RESET</button><button id="camera">RESET CAMERA</button></div>
+    <div class="title">REFINED EQUATION</div>
+    <div class="equation">R(t)=Rmin+(R-Rmin)e^(-χt)
+q=γv sin(u/2+βt)
+r=R(t)+v cos(u/2+ωt)
+x=r cos(u+αt)-q sin(u+αt)
+y=v sin(u/2+ωt)+δ sin(κu+λt)
+z=r sin(u+αt)+q cos(u+αt)
+
+Seam invariant: P(0,v,t)=P(2π,-v,t)</div>
+  </section>
+  <section class="panel right">
+    <div class="title">MEASURED GEOMETRY METRICS</div>
+    <div class="metric"><span>Objective Jgeom</span><b id="score">—</b></div>
+    <div class="metric"><span>Seam RMS</span><b id="seam">—</b></div>
+    <div class="metric"><span>Minimum area element</span><b id="area">—</b></div>
+    <div class="metric"><span>Area CV</span><b id="areaCv">—</b></div>
+    <div class="metric"><span>Speed RMS</span><b id="speed">—</b></div>
+    <div class="metric"><span>Acceleration RMS</span><b id="accel">—</b></div>
+    <div class="metric"><span>Radial span</span><b id="span">—</b></div>
+    <div class="metric"><span>Inward contraction</span><b id="contract">—</b></div>
+    <div class="title" style="margin-top:12px">27-NODE GEOMETRY LATTICE</div>
+    <div id="candidates"></div>
+    <div class="title" style="margin-top:12px">TRANSACTION TRACE</div>
+    <div id="trace" class="trace"></div>
+  </section>
+  <div class="legend"><span class="chip">cyan = authoritative surface</span><span class="chip">purple = kinetic phase</span><span class="chip">green = promoted candidate</span><span class="chip">PROVISIONAL ≠ AUTHORITATIVE</span></div>
+</main>
+<footer><span>Geometry optimization changes parameters, not source code.</span><span id="footer">θg incumbent</span></footer>
+<script type="module">
+import {DEFAULT_GEOMETRY, GEOMETRY_BOUNDS, TAU, drMoagiPoint, geometryObjective, normalizeGeometry, optimizeGeometry} from './core.mjs';
+const $=id=>document.getElementById(id); let params=normalizeGeometry(DEFAULT_GEOMETRY), initial={...params}, running=true, epoch=0, t=0, last=performance.now();
+const defs=[['R','R outer radius',.05],['Rmin','Rmin inward floor',.05],['chi','χ inward rate',.01],['omega','ω twist rate',.01],['alpha','α orbit rate',.01],['beta','β perturb rate',.01],['gamma','γ perturb amplitude',.01],['delta','δ vertical amplitude',.01],['kappa','κ spatial mode',1],['lambda','λ vertical rate',.01]];
+const controls=$('controls');
+function buildControls(){controls.innerHTML='';for(const [key,label,step] of defs){const [lo,hi]=GEOMETRY_BOUNDS[key],row=document.createElement('div');row.className='control';row.innerHTML=`<label><span>${label}</span><b>${params[key].toFixed(step===1?0:2)}</b></label><input type="range" min="${lo}" max="${hi}" step="${step}" value="${params[key]}">`;const input=row.querySelector('input'),out=row.querySelector('b');input.oninput=()=>{params[key]=Number(input.value);params=normalizeGeometry(params);out.textContent=params[key].toFixed(step===1?0:2);refresh();};controls.append(row)}}
+const scene=new THREE.Scene();scene.background=new THREE.Color(0x020617);scene.fog=new THREE.FogExp2(0x020617,.035);const camera=new THREE.PerspectiveCamera(50,1,.1,100);camera.position.set(9,6,11);camera.lookAt(0,0,0);const renderer=new THREE.WebGLRenderer({antialias:true});renderer.setPixelRatio(Math.min(devicePixelRatio||1,2));$('scene').appendChild(renderer.domElement);scene.add(new THREE.AmbientLight(0x334155,1.5));const light=new THREE.PointLight(0x22d3ee,3,50);light.position.set(8,10,10);scene.add(light);const grid=new THREE.GridHelper(24,24,0x164e63,0x0f172a);grid.position.y=-3.6;scene.add(grid);
+let mesh=null,geom=null,mat=new THREE.MeshStandardMaterial({color:0x22d3ee,metalness:.35,roughness:.3,side:THREE.DoubleSide,transparent:true,opacity:.88});
+function buildSurface(){if(mesh){scene.remove(mesh);geom.dispose()}const nu=96,nv=24,verts=[],idx=[];for(let i=0;i<=nu;i++){const u=i/nu*TAU;for(let j=0;j<=nv;j++){const v=-2+j/nv*4;const p=drMoagiPoint(u,v,t,params);verts.push(p.x,p.y,p.z)}}for(let i=0;i<nu;i++)for(let j=0;j<nv;j++){const a=i*(nv+1)+j,b=a+nv+1,c=b+1,d=a+1;idx.push(a,b,d,b,c,d)}geom=new THREE.BufferGeometry();geom.setAttribute('position',new THREE.Float32BufferAttribute(verts,3));geom.setIndex(idx);geom.computeVertexNormals();mesh=new THREE.Mesh(geom,mat);scene.add(mesh)}
+function refresh(){buildSurface();const r=geometryObjective(params,{uSamples:24,vSamples:7,times:[0,.5,1]});const m=r.metrics;$('score').textContent=r.score.toFixed(5);$('seam').textContent=m.seamRms.toExponential(2);$('area').textContent=m.minArea.toFixed(5);$('areaCv').textContent=m.areaCv.toFixed(4);$('speed').textContent=m.speedRms.toFixed(4);$('accel').textContent=m.accelerationRms.toFixed(4);$('span').textContent=m.radialSpan.toFixed(4);$('contract').textContent=m.contraction.toFixed(4);$('footer').textContent=`R=${params.R.toFixed(2)} χ=${params.chi.toFixed(3)} ω=${params.omega.toFixed(2)} α=${params.alpha.toFixed(2)}`}
+function trace(msg,kind=''){const d=document.createElement('div');d.className=kind;d.textContent=`[${String($('trace').children.length+1).padStart(3,'0')}] ${msg}`;$('trace').append(d);$('trace').scrollTop=$('trace').scrollHeight}
+function showCandidates(report){$('candidates').innerHTML='';const base=report.baseline.score;for(const e of report.evaluations){const d=document.createElement('div');d.className='candidate';const v=e.vector;const cls=e.score<base?'win':e.score>base?'loss':'';d.innerHTML=`<span>${v.shape},${v.kinetics},${v.inward}</span><b>${e.stage}</b><span class="${cls}">${e.score.toFixed(3)}</span>`;$('candidates').append(d)}}
+$('optimize').onclick=()=>{trace('GEOMETRY_EPOCH begin · evaluating bounded 26-neighbour lattice');const report=optimizeGeometry(params,{uSamples:24,vSamples:7,times:[0,.5,1],maxCandidates:26});showCandidates(report);trace(`baseline=${report.baseline.score.toFixed(5)} best=${report.best.score.toFixed(5)} improvement=${(report.relativeImprovement*100).toFixed(2)}%`);if(report.promoted){params={...report.authoritativeParams};epoch++;$('epoch').textContent=epoch;trace(`PI_GEOM ACCEPT · promoted (${report.best.vector.shape},${report.best.vector.kinetics},${report.best.vector.inward})`,'ok')}else trace('PI_GEOM HOLD · incumbent remains authoritative','bad');buildControls();refresh()};
+$('pause').onclick=()=>{running=!running;$('mode').textContent=running?'RUNNING':'PAUSED';$('pause').textContent=running?'PAUSE':'PLAY'};$('reset').onclick=()=>{params={...initial};epoch=0;t=0;$('epoch').textContent='0';$('trace').innerHTML='';$('candidates').innerHTML='';buildControls();refresh();trace('RESET · restored canonical geometry')};$('camera').onclick=()=>{camera.position.set(9,6,11);camera.lookAt(0,0,0)};
+let drag=false,px=0,py=0;$('scene').onmousedown=e=>{drag=true;px=e.clientX;py=e.clientY};window.onmouseup=()=>drag=false;window.onmousemove=e=>{if(!drag)return;const dx=e.clientX-px,dy=e.clientY-py,r=camera.position.length();let th=Math.atan2(camera.position.x,camera.position.z),ph=Math.acos(Math.max(-1,Math.min(1,camera.position.y/r)));th-=dx*.005;ph=Math.max(.1,Math.min(Math.PI-.1,ph-dy*.005));camera.position.set(r*Math.sin(ph)*Math.sin(th),r*Math.cos(ph),r*Math.sin(ph)*Math.cos(th));camera.lookAt(0,0,0);px=e.clientX;py=e.clientY};$('scene').addEventListener('wheel',e=>{camera.position.multiplyScalar(e.deltaY>0?1.08:.92);e.preventDefault()},{passive:false});
+function resize(){const r=$('scene').getBoundingClientRect();camera.aspect=r.width/r.height;camera.updateProjectionMatrix();renderer.setSize(r.width,r.height)}window.onresize=resize;resize();buildControls();refresh();trace('BOOT · topology-preserving Dr Moagi geometry loaded','ok');
+function frame(now){const dt=Math.min(.05,(now-last)/1000);last=now;if(running){t+=dt;buildSurface()}renderer.render(scene,camera);requestAnimationFrame(frame)}requestAnimationFrame(frame);
+</script>
+</body>
+</html>

--- a/apps/dr-moagi-geometry/test_core.mjs
+++ b/apps/dr-moagi-geometry/test_core.mjs
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_GEOMETRY,
+  TAU,
+  candidateGeometry,
+  drMoagiPoint,
+  geometryMetrics,
+  geometryVectorLattice,
+  inwardRadius,
+  normalizeGeometry,
+  optimizeGeometry,
+} from './core.mjs';
+
+test('refined equation preserves the Möbius seam', () => {
+  for (const t of [0, 0.5, 1.2]) {
+    for (const v of [-2, -1, 0, 1, 2]) {
+      const a = drMoagiPoint(0, v, t, DEFAULT_GEOMETRY);
+      const b = drMoagiPoint(TAU, -v, t, DEFAULT_GEOMETRY);
+      assert.ok(Math.hypot(a.x - b.x, a.y - b.y, a.z - b.z) < 1e-10);
+    }
+  }
+});
+
+test('inward radius contracts monotonically toward Rmin', () => {
+  const p = normalizeGeometry(DEFAULT_GEOMETRY);
+  const values = [0, 0.5, 1, 2, 4].map((t) => inwardRadius(t, p));
+  for (let i = 1; i < values.length; i += 1) assert.ok(values[i] <= values[i - 1]);
+  assert.ok(values.at(-1) >= p.Rmin);
+});
+
+test('geometry metrics remain finite and non-degenerate', () => {
+  const m = geometryMetrics(DEFAULT_GEOMETRY, { uSamples: 18, vSamples: 7, times: [0, 0.5] });
+  for (const value of Object.values(m)) assert.ok(Number.isFinite(value));
+  assert.ok(m.seamRms < 1e-9);
+  assert.ok(m.minArea > 0);
+});
+
+test('geometry search is a 26-neighbour bounded lattice', () => {
+  const vectors = geometryVectorLattice();
+  assert.equal(vectors.length, 26);
+  for (const v of vectors) {
+    for (const x of [v.shape, v.kinetics, v.inward]) assert.ok([-1, 0, 1].includes(x));
+  }
+  const candidate = candidateGeometry(DEFAULT_GEOMETRY, { shape: 1, kinetics: -1, inward: 1 });
+  assert.ok(candidate.Rmin < candidate.R);
+});
+
+test('optimizer is deterministic and never worsens authoritative score', () => {
+  const options = { uSamples: 18, vSamples: 7, times: [0, 0.5, 1], maxCandidates: 8 };
+  const a = optimizeGeometry(DEFAULT_GEOMETRY, options);
+  const b = optimizeGeometry(DEFAULT_GEOMETRY, options);
+  assert.deepEqual(a, b);
+  assert.ok(a.best.score <= a.baseline.score + Number.EPSILON);
+  assert.deepEqual(
+    a.authoritativeParams,
+    a.promoted ? a.best.params : normalizeGeometry(DEFAULT_GEOMETRY),
+  );
+  assert.equal(a.claimStatus, 'internal_geometry_improvement_only');
+});


### PR DESCRIPTION
## Summary

Operationalizes the refined Dr Moagi parametric geometry as a bounded, topology-preserving self-optimization runtime.

### Geometry refinement

- Adds a true inward radius law: `R(t) = Rmin + (R - Rmin) exp(-chi t)`.
- Reworks the secondary perturbation to use a half-angle phase so the Möbius seam is preserved.
- Restricts `kappa` to integer spatial modes for seam continuity.
- Keeps the geometric state explicit as `theta_g = (R, Rmin, chi, omega, alpha, beta, gamma, delta, kappa, lambda)`.

### Measured objective

The optimizer evaluates:

- seam RMS error;
- minimum area element / non-degeneracy;
- area coefficient of variation;
- speed RMS;
- acceleration RMS;
- radial span;
- bounded inward contraction;
- bounded frequency cost;
- an expressivity floor to avoid the trivial zero-motion solution.

### Bounded 3D self-optimization

- Uses a 27-node local lattice over `(shape, kinetics, inward)`.
- Evaluates the 26 counterfactual neighbours without mutating the incumbent.
- Promotes only when the candidate beats the incumbent by the configured margin, preserves seam tolerance, avoids excessive area regression, and has a finite objective.
- Keeps the invariant `PROVISIONAL GEOMETRY != AUTHORITATIVE GEOMETRY` until `PI_GEOM` accepts.
- Reports `internal_geometry_improvement_only`; no external SOTA claim.

### Browser runtime

Adds `apps/dr-moagi-geometry/` with:

- a live Three.js surface driven directly by the refined equation;
- parameter controls;
- measured geometry telemetry;
- one-click `AUTO OPTIMIZE`;
- a 27-node candidate evaluation panel;
- explicit promotion/hold transaction trace.

### Validation and deployment

- Adds deterministic Node invariant tests for seam continuity, monotone inward contraction, non-degeneracy, bounded lattice search, deterministic evaluation, and fail-closed promotion.
- Extends the shared GitHub Pages workflow to test and deploy the geometry runtime at `/dr-moagi-geometry/` without clobbering existing runtimes.