### PR TITLE
Build verified 1 GiB Dr Moagi firmware container end to end

### DIFF
--- a/.github/workflows/dr-moagi-os.yml
+++ b/.github/workflows/dr-moagi-os.yml
@@ -7,10 +7,12 @@ on:
       - "src/jarvisx/dr_moagi_os*.py"
       - "src/jarvisx/dr_moagi_meta_optimizer.py"
       - "src/jarvisx/dr_moagi_system_*.py"
+      - "src/jarvisx/dr_moagi_firmware*.py"
       - "src/jarvisx/dr_moagi_bitplane.py"
       - "tests/test_dr_moagi_os.py"
       - "tests/test_dr_moagi_meta_optimizer.py"
       - "tests/test_dr_moagi_system_evolution.py"
+      - "tests/test_dr_moagi_firmware.py"
       - "deploy/dr_moagi_os/**"
       - "compose.dr-moagi-os.yml"
       - "pyproject.toml"
@@ -21,10 +23,12 @@ on:
       - "src/jarvisx/dr_moagi_os*.py"
       - "src/jarvisx/dr_moagi_meta_optimizer.py"
       - "src/jarvisx/dr_moagi_system_*.py"
+      - "src/jarvisx/dr_moagi_firmware*.py"
       - "src/jarvisx/dr_moagi_bitplane.py"
       - "tests/test_dr_moagi_os.py"
       - "tests/test_dr_moagi_meta_optimizer.py"
       - "tests/test_dr_moagi_system_evolution.py"
+      - "tests/test_dr_moagi_firmware.py"
       - "deploy/dr_moagi_os/**"
       - "compose.dr-moagi-os.yml"
       - "pyproject.toml"
@@ -45,7 +49,7 @@ jobs:
       - name: Install
         run: python -m pip install -e ".[test]"
       - name: Unit and integration tests
-        run: pytest tests/test_dr_moagi_os.py tests/test_dr_moagi_meta_optimizer.py tests/test_dr_moagi_system_evolution.py
+        run: pytest tests/test_dr_moagi_os.py tests/test_dr_moagi_meta_optimizer.py tests/test_dr_moagi_system_evolution.py tests/test_dr_moagi_firmware.py
       - name: OS CLI smoke
         run: jarvisx-dr-moagi-os demo --side 16 --cycles 2 --state-dir /tmp/dr-moagi-os
       - name: Four-scale system CLI smoke
@@ -58,6 +62,22 @@ jobs:
             --meta-candidates 1 \
             --architecture-candidates 1 \
             --max-eval-cells 16
+      - name: Firmware build verify boot smoke
+        run: |
+          jarvisx-dr-moagi-firmware keygen /tmp/dm-fw-key
+          jarvisx-dr-moagi-firmware build-demo /tmp/dr-moagi-1g.img \
+            --side 8 \
+            --signing-private-key /tmp/dm-fw-key.ed25519.private \
+            --encryption-key /tmp/dm-fw-key.aes256
+          test "$(stat -c %s /tmp/dr-moagi-1g.img)" = "1073741824"
+          jarvisx-dr-moagi-firmware verify /tmp/dr-moagi-1g.img \
+            --public-key /tmp/dm-fw-key.ed25519.public \
+            --encryption-key /tmp/dm-fw-key.aes256
+          jarvisx-dr-moagi-firmware run /tmp/dr-moagi-1g.img \
+            --cycles 1 \
+            --max-active-cells 512 \
+            --public-key /tmp/dm-fw-key.ed25519.public \
+            --encryption-key /tmp/dm-fw-key.aes256
 
   container:
     runs-on: ubuntu-latest

--- a/docs/DR_MOAGI_FIRMWARE_CONTAINER.md
+++ b/docs/DR_MOAGI_FIRMWARE_CONTAINER.md
@@ -1,0 +1,167 @@
+# Dr Moagi DMLAMBDA 1 GiB Firmware Container
+
+`DMLAMBDA-1G` is the executable container boundary for the bounded Dr Moagi system. It turns the earlier conceptual byte map into an exact **1 GiB logical image** while preserving sparse residency and verified state transitions.
+
+## Exact memory map
+
+| Region | Start | End (inclusive) | Capacity |
+|---|---:|---:|---:|
+| Genesis / manifest | `0x00000000` | `0x000FFFFF` | 1 MiB |
+| QSOL sparse state | `0x00100000` | `0x17FFFFFF` | 383 MiB |
+| Sparse SPD metric field | `0x18000000` | `0x2BFFFFFF` | 320 MiB |
+| Immutable RISC-V kernel | `0x2C000000` | `0x37FFFFFF` | 192 MiB |
+| Trace / audit reserve | `0x38000000` | `0x3FFFFFFF` | 128 MiB |
+
+The exclusive end is `0x40000000`, exactly `1,073,741,824` bytes. `FirmwareBuilder` creates the file with `truncate()` and writes only used section payloads, so supporting filesystems represent the unused reservations as sparse holes rather than physically writing a gigabyte of zeros.
+
+## Trust and boot chain
+
+```text
+external Ed25519 public trust anchor
+  -> verify 512-byte DMLAMBDA header
+  -> SHA-256 verify canonical manifest
+  -> Ed25519 verify manifest signature
+  -> verify stored section SHA-256 values
+  -> AES-256-GCM authenticate/decrypt QSOL + metric sections
+  -> verify plaintext SHA-256 values
+  -> DMOS2 exact sparse-state decode
+  -> DMMET1 sparse SPD metric decode
+  -> validate ELF64 RISC-V e_machine = 243 and executable PT_LOAD
+  -> verify SHA3-256 trace anchor
+  -> boot DrMoagiOSKernel
+  -> wrap SelfOptimizing3DSystem
+  -> wrap SelfEvolving3DArchitecture
+  -> execute bounded autonomic cycles
+```
+
+A signed image requires the public key to be supplied externally at verify/boot time. The image does not treat an embedded public key as its own root of trust.
+
+## Section semantics
+
+### Genesis
+
+The first 512 bytes are the DMLAMBDA header. The canonical JSON manifest begins at offset 512 and contains the exact region map, per-section used byte counts, hashes, codecs, encryption metadata, signer fingerprint, kernel metadata, and capability boundaries.
+
+### QSOL sparse state
+
+QSOL stores the existing exact `DMOS2` Morton-delta/float64 state packet. The logical lattice may be much larger than its resident state; only active coordinates are encoded.
+
+### Metric field
+
+`DMMET1` stores sparse symmetric 3x3 metric tensors as six float32 components:
+
+```text
+(gxx, gyy, gzz, gxy, gxz, gyz)
+```
+
+Every stored tensor must satisfy Sylvester positive-definiteness checks. Coordinates not explicitly present are interpreted by the runtime as the Euclidean identity metric where needed. The reference dynamic step is **SPD-preserving metric relaxation**, not a claim of Ricci-flow integration.
+
+### Kernel
+
+The default image contains a minimal valid ELF64 little-endian RISC-V executable monitor stub with `EM_RISCV = 243`, one executable `PT_LOAD` segment, and entry `0x80000000`. It is deliberately a reference monitor, not board-specific startup firmware. A real board supervisor can be injected with `--supervisor` and must pass the same ELF validation.
+
+The executable region is immutable under the runtime. Self-optimization changes bounded state/model/configuration/architecture parameters, not executable instructions.
+
+### Trace
+
+The genesis trace anchor is SHA3-256 over the initial QSOL, metric, and kernel content digests. A boot session advances the trace head with canonical run events. A hash chain is tamper-evident only when the expected head is anchored outside an attacker-controlled image; the manifest states that boundary explicitly.
+
+## Cryptography
+
+- Manifest authentication: Ed25519.
+- Section confidentiality/integrity: AES-256-GCM.
+- Per-section key derivation: HKDF-SHA256 with a random image salt and section-specific context.
+- Section and manifest digests: SHA-256.
+- Runtime trace chain: SHA3-256.
+
+No key is derived from geometry, holonomy, state values, or other public deterministic data. Private signing and AES master keys must remain outside source control and firmware images.
+
+## CLI
+
+Generate external keys:
+
+```bash
+jarvisx-dr-moagi-firmware keygen /secure/dm-fw
+```
+
+Build an exact-size signed/encrypted demo image:
+
+```bash
+jarvisx-dr-moagi-firmware build-demo dr-moagi-1g.img \
+  --side 64 \
+  --signing-private-key /secure/dm-fw.ed25519.private \
+  --encryption-key /secure/dm-fw.aes256
+```
+
+Verify it:
+
+```bash
+jarvisx-dr-moagi-firmware verify dr-moagi-1g.img \
+  --public-key /secure/dm-fw.ed25519.public \
+  --encryption-key /secure/dm-fw.aes256 \
+  --pretty
+```
+
+Verified boot and run:
+
+```bash
+jarvisx-dr-moagi-firmware run dr-moagi-1g.img \
+  --cycles 8 \
+  --public-key /secure/dm-fw.ed25519.public \
+  --encryption-key /secure/dm-fw.aes256 \
+  --pretty
+```
+
+Serve the firmware control plane:
+
+```bash
+jarvisx-dr-moagi-firmware serve dr-moagi-1g.img \
+  --public-key /secure/dm-fw.ed25519.public \
+  --encryption-key /secure/dm-fw.aes256 \
+  --host 0.0.0.0 --port 10002
+```
+
+Service routes:
+
+```text
+GET  /healthz
+GET  /v1/firmware/status
+GET  /v1/firmware/manifest
+POST /v1/firmware/verify
+POST /v1/firmware/boot
+POST /v1/firmware/run
+```
+
+## Capability boundary
+
+Implemented:
+
+- exact 1 GiB logical image layout;
+- sparse physical file allocation where the host filesystem supports it;
+- exact DMOS2 state persistence;
+- sparse SPD metric storage and bounded relaxation;
+- valid reference RV64 ELF payload and ELF validation;
+- Ed25519 authenticated manifest;
+- AES-256-GCM encrypted state/metric sections;
+- verified boot into the existing state/model/configuration/architecture loops;
+- hash-chain runtime trace;
+- CLI and FastAPI control planes;
+- fail-closed verification before execution.
+
+Not claimed:
+
+- a board-specific bare-metal bootloader;
+- native execution of RISC-V instructions by a generic GPU;
+- an integrated Ricci-flow numerical solver;
+- arbitrary lossless compression of dense `1000^3` tensor data into the reserved regions;
+- self-modifying executable code;
+- secret-key derivation from public geometry;
+- external SOTA superiority without matched benchmarks.
+
+The system invariant remains:
+
+```text
+PROVISIONAL != AUTHORITATIVE
+```
+
+A firmware image is trusted only after the external trust anchor, manifest, encrypted sections, exact sparse-state transport, metric invariants, kernel ELF contract, and trace anchor all verify.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = [
     "uvicorn>=0.23.0",
     "fastapi>=0.100.0",
+    "cryptography>=43.0",
 ]
 
 [project.optional-dependencies]
@@ -65,6 +66,7 @@ jarvisx-hyperion = "jarvisx.hyperion_cli:main"
 jarvisx-dr-moagi = "jarvisx.dr_moagi_autoexec_cli:main"
 jarvisx-dr-moagi-os = "jarvisx.dr_moagi_os_cli:main"
 jarvisx-dr-moagi-system = "jarvisx.dr_moagi_system_cli:main"
+jarvisx-dr-moagi-firmware = "jarvisx.dr_moagi_firmware_cli:main"
 jarvisx-dr-moagi-frontier = "jarvisx.dr_moagi_frontier_cli:main"
 jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
 jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"

--- a/src/jarvisx/dr_moagi_firmware.py
+++ b/src/jarvisx/dr_moagi_firmware.py
@@ -1,20 +1,15 @@
 """Verified 1 GiB firmware-container runtime for the Dr Moagi architecture.
 
-This module turns the earlier conceptual byte map into a concrete, deterministic
-container format with an exact 1 GiB *logical* image size.  The image is sparse
-on filesystems that support sparse files: only the used payload bytes are
-written; the large reserved regions remain holes.
+The container is exactly one GiB logically but is written as a sparse file where
+supported.  It separates immutable executable material from sparse state, metric
+state, and audit data.  A canonical manifest can be authenticated with Ed25519;
+QSOL and metric sections can be protected with AES-256-GCM using HKDF-derived
+per-section keys.
 
-The container deliberately separates immutable executable material from mutable
-state.  It embeds a valid minimal RV64 ELF monitor stub (or a caller-provided
-RISC-V ELF), exact DMOS2 sparse state, a sparse symmetric-positive-definite 3D
-metric packet, and a hash-chain trace anchor.  The manifest may be authenticated
-with Ed25519 and the state/metric payloads may be encrypted with AES-256-GCM.
-
-This is a reference firmware/runtime layer.  It does not claim that the Python
-host is bare metal or that a generic GPU executes RISC-V instructions directly.
-Board-specific startup code and accelerator binaries can replace the reference
-ELF payload while retaining the verified container contract.
+The default RISC-V payload is a valid minimal RV64 ELF monitor stub, not a
+board-specific bare-metal supervisor.  The verified boot path executes the
+existing bounded Dr Moagi OS/meta/architecture runtime on the host after all
+container invariants pass.
 """
 
 from __future__ import annotations
@@ -29,7 +24,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Mapping, Sequence, cast
 
-from cryptography.exceptions import InvalidSignature
+from cryptography.exceptions import InvalidSignature, InvalidTag
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
@@ -43,7 +38,7 @@ from .dr_moagi_os_store import SparseStateCodec3D
 from .dr_moagi_system_evolution import AutonomicRunReport, SelfEvolving3DArchitecture
 
 MIB = 1 << 20
-IMAGE_SIZE = 1 << 30  # exactly 1 GiB / 1,073,741,824 bytes
+IMAGE_SIZE = 1 << 30
 HEADER_SIZE = 512
 MANIFEST_OFFSET = HEADER_SIZE
 
@@ -52,7 +47,6 @@ _CONTAINER_VERSION = 1
 _HEADER_STRUCT = struct.Struct("<8sIIQII32s64s")
 _FLAG_SIGNED = 1 << 0
 _FLAG_ENCRYPTED = 1 << 1
-
 _METRIC_MAGIC = b"DMMET1"
 _TRACE_MAGIC = b"DMTRC1"
 _RISCV_MACHINE = 243
@@ -83,6 +77,17 @@ _REGION_BY_NAME = {region.name: region for region in FIRMWARE_LAYOUT}
 
 MetricComponents = tuple[float, float, float, float, float, float]
 MetricField3D = dict[Coordinate, MetricComponents]
+
+
+@dataclass(frozen=True)
+class FirmwareHeader:
+    version: int
+    header_size: int
+    image_size: int
+    manifest_length: int
+    flags: int
+    manifest_sha256: bytes
+    signature: bytes
 
 
 @dataclass(frozen=True)
@@ -122,8 +127,6 @@ class FirmwareRunReport:
 
 
 def validate_layout() -> None:
-    """Assert that the firmware map is contiguous and closes at exactly 1 GiB."""
-
     cursor = 0
     for region in FIRMWARE_LAYOUT:
         if region.offset != cursor:
@@ -138,8 +141,6 @@ def validate_layout() -> None:
 
 
 def generate_ed25519_keypair() -> tuple[bytes, bytes]:
-    """Return raw 32-byte Ed25519 private and public keys."""
-
     private = Ed25519PrivateKey.generate()
     private_raw = private.private_bytes(
         serialization.Encoding.Raw,
@@ -158,26 +159,21 @@ def generate_aes256_key() -> bytes:
 
 
 def build_reference_riscv_elf() -> bytes:
-    """Build a minimal valid ELF64 little-endian RISC-V executable.
-
-    The payload is a monitor stub, not a board-specific supervisor.  It contains
-    ``addi a0, x0, 0`` followed by ``jal x0, 0`` (an intentional idle loop).
-    Production boards should replace this payload with their signed supervisor.
-    """
+    """Return a valid ELF64 RISC-V monitor stub with one executable segment."""
 
     entry = 0x80000000
     ident = bytearray(16)
     ident[0:4] = b"\x7fELF"
-    ident[4] = 2  # ELFCLASS64
-    ident[5] = 1  # little endian
-    ident[6] = 1  # ELF version
+    ident[4] = 2
+    ident[5] = 1
+    ident[6] = 1
     header = bytes(ident) + struct.pack(
         "<HHIQQQIHHHHHH",
-        2,  # ET_EXEC
+        2,
         _RISCV_MACHINE,
         1,
         entry,
-        64,  # program header table immediately after ELF header
+        64,
         0,
         0,
         64,
@@ -189,8 +185,8 @@ def build_reference_riscv_elf() -> bytes:
     )
     program = struct.pack(
         "<IIQQQQQQ",
-        1,  # PT_LOAD
-        5,  # PF_R | PF_X
+        1,
+        5,
         0x1000,
         entry,
         entry,
@@ -219,19 +215,19 @@ def inspect_riscv_elf(payload: bytes) -> dict[str, int]:
         raise ValueError("kernel ELF has invalid program-header metadata")
     if phoff + phentsize * phnum > len(payload):
         raise ValueError("kernel ELF program headers are truncated")
-    loadable = False
+    executable = False
     for index in range(phnum):
         p_type, p_flags = struct.unpack_from("<II", payload, phoff + index * phentsize)
         if p_type == 1 and p_flags & 1:
-            loadable = True
+            executable = True
             break
-    if not loadable:
+    if not executable:
         raise ValueError("kernel ELF has no executable PT_LOAD segment")
     return {"machine": machine, "entry": entry, "program_headers": phnum}
 
 
 class SparseMetricCodec3D:
-    """Lossless-for-float32 sparse packet for symmetric positive-definite 3D metrics."""
+    """Sparse float32 codec for symmetric positive-definite 3D metrics."""
 
     _record = struct.Struct("<Q6f")
 
@@ -264,8 +260,7 @@ class SparseMetricCodec3D:
         side, count = struct.unpack_from("<II", raw, len(_METRIC_MAGIC))
         _validate_side(side)
         cursor = len(_METRIC_MAGIC) + 8
-        expected = cursor + count * self._record.size
-        if expected != len(raw):
+        if cursor + count * self._record.size != len(raw):
             raise ValueError("metric packet size/count mismatch")
         field: MetricField3D = {}
         previous = -1
@@ -290,27 +285,19 @@ def identity_metric_for_state(field: Mapping[Coordinate, float]) -> MetricField3
 
 
 def relax_metric_field(
-    field: Mapping[Coordinate, Sequence[float]],
-    *,
-    side: int,
-    alpha: float = 0.05,
+    field: Mapping[Coordinate, Sequence[float]], *, side: int, alpha: float = 0.05
 ) -> MetricField3D:
-    """Perform a bounded SPD-preserving metric diffusion step.
-
-    This is intentionally described as metric relaxation, not Ricci flow.  Every
-    candidate is a convex combination of SPD tensors (explicit neighbours or
-    identity), so the SPD invariant is preserved for ``alpha in [0, 1]``.
-    """
+    """Apply an SPD-preserving local diffusion step; this is not Ricci flow."""
 
     _validate_side(side)
     if not math.isfinite(float(alpha)) or not 0.0 <= float(alpha) <= 1.0:
         raise ValueError("alpha must be finite and in [0, 1]")
     current: MetricField3D = {}
-    for coordinate, metric in field.items():
+    for coordinate, raw in field.items():
         coord = _validate_coordinate(coordinate, side)
-        parsed = _metric_tuple(metric)
-        _validate_spd(parsed)
-        current[coord] = parsed
+        metric = _metric_tuple(raw)
+        _validate_spd(metric)
+        current[coord] = metric
     identity: MetricComponents = (1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
     offsets = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
     result: MetricField3D = {}
@@ -318,17 +305,24 @@ def relax_metric_field(
         neighbours: list[MetricComponents] = []
         x, y, z = coordinate
         for dx, dy, dz in offsets:
-            candidate = x + dx, y + dy, z + dz
+            candidate = (x + dx, y + dy, z + dz)
             if all(0 <= axis < side for axis in candidate):
                 neighbours.append(current.get(candidate, identity))
         if not neighbours:
             neighbours = [identity]
-        average = tuple(
+        averages = [
             sum(item[index] for item in neighbours) / len(neighbours) for index in range(6)
-        )
-        blended = cast(
-            MetricComponents,
-            tuple((1.0 - alpha) * metric[index] + alpha * average[index] for index in range(6)),
+        ]
+        values = [
+            (1.0 - alpha) * metric[index] + alpha * averages[index] for index in range(6)
+        ]
+        blended: MetricComponents = (
+            values[0],
+            values[1],
+            values[2],
+            values[3],
+            values[4],
+            values[5],
         )
         _validate_spd(blended)
         result[coordinate] = blended
@@ -336,8 +330,6 @@ def relax_metric_field(
 
 
 class FirmwareBuilder:
-    """Build exact-size sparse firmware images."""
-
     def __init__(self) -> None:
         validate_layout()
         self.state_codec = SparseStateCodec3D()
@@ -357,9 +349,9 @@ class FirmwareBuilder:
         _validate_side(side)
         if not state:
             raise ValueError("firmware state must be non-empty")
-        state_packet = self.state_codec.encode(state, side=side)
-        qsol_plain = state_packet.payload
-        metric_field = identity_metric_for_state(state) if metric is None else dict(metric)
+        qsol_plain = self.state_codec.encode(state, side=side).payload
+        metric_field: Mapping[Coordinate, Sequence[float]]
+        metric_field = identity_metric_for_state(state) if metric is None else metric
         metric_plain = self.metric_codec.encode(metric_field, side=side)
         kernel_plain = build_reference_riscv_elf() if supervisor_elf is None else supervisor_elf
         kernel_info = inspect_riscv_elf(kernel_plain)
@@ -375,18 +367,19 @@ class FirmwareBuilder:
         if encryption_key is not None and len(encryption_key) != 32:
             raise ValueError("encryption key must contain exactly 32 bytes")
         salt = os.urandom(16) if encrypted else b""
-        sections: dict[str, bytes] = {}
+        stored_sections: dict[str, bytes] = {}
         section_meta: dict[str, dict[str, object]] = {}
-        for name, plaintext, codec, encryptable in (
+        section_inputs = (
             ("qsol", qsol_plain, "DMOS2", True),
             ("metric", metric_plain, "DMMET1+DEFLATE", True),
             ("kernel", kernel_plain, "ELF64-RISCV", False),
             ("trace", trace_plain, "DMTRC1", False),
-        ):
+        )
+        for name, plaintext, codec, encryptable in section_inputs:
             stored = plaintext
             nonce = b""
-            is_encrypted = encrypted and encryptable
-            if is_encrypted:
+            section_encrypted = encrypted and encryptable
+            if section_encrypted:
                 assert encryption_key is not None
                 nonce = os.urandom(12)
                 stored = _encrypt_section(name, plaintext, encryption_key, salt, nonce)
@@ -395,20 +388,20 @@ class FirmwareBuilder:
                 raise ValueError(
                     f"{name} payload uses {len(stored)} bytes but region capacity is {region.capacity}"
                 )
-            sections[name] = stored
+            stored_sections[name] = stored
             section_meta[name] = {
                 "offset": region.offset,
                 "capacity": region.capacity,
                 "used_bytes": len(stored),
                 "codec": codec,
-                "encrypted": is_encrypted,
+                "encrypted": section_encrypted,
                 "nonce": nonce.hex(),
                 "stored_sha256": hashlib.sha256(stored).hexdigest(),
                 "content_sha256": hashlib.sha256(plaintext).hexdigest(),
             }
 
-        signer_fingerprint = ""
         private: Ed25519PrivateKey | None = None
+        signer_fingerprint = ""
         if signing_private_key is not None:
             if len(signing_private_key) != 32:
                 raise ValueError("Ed25519 private key must contain exactly 32 raw bytes")
@@ -419,7 +412,7 @@ class FirmwareBuilder:
             )
             signer_fingerprint = hashlib.sha256(public_raw).hexdigest()
 
-        manifest = {
+        manifest: dict[str, object] = {
             "format": "DMLAMBDA-1G",
             "version": _CONTAINER_VERSION,
             "image_size": IMAGE_SIZE,
@@ -458,13 +451,10 @@ class FirmwareBuilder:
             },
         }
         manifest_bytes = _canonical_json(manifest)
-        genesis_capacity = _REGION_BY_NAME["genesis"].capacity
-        if MANIFEST_OFFSET + len(manifest_bytes) > genesis_capacity:
+        if MANIFEST_OFFSET + len(manifest_bytes) > _REGION_BY_NAME["genesis"].end:
             raise ValueError("manifest does not fit genesis region")
         manifest_digest = hashlib.sha256(manifest_bytes).digest()
-        signature = (
-            private.sign(_signature_message(manifest_bytes)) if private is not None else bytes(64)
-        )
+        signature = private.sign(_signature_message(manifest_bytes)) if private else bytes(64)
         flags = (_FLAG_SIGNED if signed else 0) | (_FLAG_ENCRYPTED if encrypted else 0)
         header_core = _HEADER_STRUCT.pack(
             _CONTAINER_MAGIC,
@@ -484,7 +474,7 @@ class FirmwareBuilder:
             handle.write(header)
             handle.seek(MANIFEST_OFFSET)
             handle.write(manifest_bytes)
-            for name, stored in sections.items():
+            for name, stored in stored_sections.items():
                 handle.seek(_REGION_BY_NAME[name].offset)
                 handle.write(stored)
             handle.flush()
@@ -501,19 +491,17 @@ class FirmwareBuilder:
 
 
 class FirmwareImage:
-    """Read, verify, decrypt and boot a DMLAMBDA firmware image."""
-
     def __init__(self, path: Path) -> None:
         self.path = path
-        self._header, self.manifest, self.manifest_bytes = self._read_header_manifest()
+        self.header, self.manifest, self.manifest_bytes = self._read_header_manifest()
 
     @property
     def signed(self) -> bool:
-        return bool(self._header[5] & _FLAG_SIGNED)
+        return bool(self.header.flags & _FLAG_SIGNED)
 
     @property
     def encrypted(self) -> bool:
-        return bool(self._header[5] & _FLAG_ENCRYPTED)
+        return bool(self.header.flags & _FLAG_ENCRYPTED)
 
     def verify(
         self,
@@ -524,19 +512,21 @@ class FirmwareImage:
         if self.path.stat().st_size != IMAGE_SIZE:
             raise ValueError("firmware image is not exactly 1 GiB")
         manifest_digest = hashlib.sha256(self.manifest_bytes).digest()
-        if manifest_digest != self._header[6]:
+        if manifest_digest != self.header.manifest_sha256:
             raise ValueError("firmware manifest checksum mismatch")
         signature_valid = not self.signed
         if self.signed:
             if public_key is None or len(public_key) != 32:
                 raise ValueError("a 32-byte Ed25519 public trust anchor is required")
-            fingerprint = hashlib.sha256(public_key).hexdigest()
-            expected = str(self.manifest["crypto"]["signer_public_key_sha256"])
-            if fingerprint != expected:
+            crypto = self._manifest_mapping("crypto")
+            expected = crypto.get("signer_public_key_sha256")
+            if not isinstance(expected, str):
+                raise ValueError("firmware signer fingerprint metadata is invalid")
+            if hashlib.sha256(public_key).hexdigest() != expected:
                 raise ValueError("firmware signer fingerprint does not match trust anchor")
             try:
                 Ed25519PublicKey.from_public_bytes(public_key).verify(
-                    self._header[7], _signature_message(self.manifest_bytes)
+                    self.header.signature, _signature_message(self.manifest_bytes)
                 )
             except InvalidSignature as exc:
                 raise ValueError("firmware manifest signature is invalid") from exc
@@ -547,13 +537,16 @@ class FirmwareImage:
         decoded = self._decoded_sections(encryption_key=encryption_key)
         state_packet, state = SparseStateCodec3D().decode_payload(decoded["qsol"])
         metric_side, metric = SparseMetricCodec3D().decode(decoded["metric"])
-        side = int(self.manifest["side"])
+        side = self._manifest_integer("side")
         if state_packet.side != side or metric_side != side:
             raise ValueError("firmware section logical-side mismatch")
         kernel = inspect_riscv_elf(decoded["kernel"])
         trace_head = _decode_trace(decoded["trace"])
-        if trace_head != str(self.manifest["trace"]["anchor"]):
+        trace = self._manifest_mapping("trace")
+        anchor = trace.get("anchor")
+        if not isinstance(anchor, str) or trace_head != anchor:
             raise ValueError("firmware trace anchor mismatch")
+        sections = {name: dict(self._section_metadata(name)) for name in ("qsol", "metric", "kernel", "trace")}
         return FirmwareVerificationReport(
             image_size=IMAGE_SIZE,
             signed=self.signed,
@@ -565,7 +558,7 @@ class FirmwareImage:
             kernel_entry=kernel["entry"],
             trace_head=trace_head,
             manifest_sha256=manifest_digest.hex(),
-            sections=cast(dict[str, dict[str, object]], self.manifest["sections"]),
+            sections=sections,
         )
 
     def boot(
@@ -581,17 +574,17 @@ class FirmwareImage:
         metric_side, metric = SparseMetricCodec3D().decode(decoded["metric"])
         if metric_side != state_packet.side:
             raise ValueError("firmware metric/state side mismatch")
+        active_budget = max(max_active_cells, len(state))
         config = DrMoagiOSConfig(
             side=state_packet.side,
-            max_active_cells=max(max_active_cells, len(state)),
-            deep_distiller_max_latent_cells=max(1, min(25_000, max(max_active_cells, len(state)))),
+            max_active_cells=active_budget,
+            deep_distiller_max_latent_cells=max(1, min(25_000, active_budget)),
             state_dir=None,
         )
         kernel = DrMoagiOSKernel(config)
         kernel.boot(restore=False)
         kernel.load(state)
-        system = SelfOptimizing3DSystem(kernel)
-        architecture = SelfEvolving3DArchitecture(system)
+        architecture = SelfEvolving3DArchitecture(SelfOptimizing3DSystem(kernel))
         return FirmwareBootSession(
             verification=verification,
             architecture=architecture,
@@ -600,7 +593,7 @@ class FirmwareImage:
             trace_head=bytes.fromhex(verification.trace_head),
         )
 
-    def _read_header_manifest(self) -> tuple[tuple[object, ...], dict[str, object], bytes]:
+    def _read_header_manifest(self) -> tuple[FirmwareHeader, dict[str, object], bytes]:
         if not self.path.exists():
             raise FileNotFoundError(self.path)
         with self.path.open("rb") as handle:
@@ -608,75 +601,103 @@ class FirmwareImage:
             if len(raw_header) != HEADER_SIZE:
                 raise ValueError("truncated firmware header")
             unpacked = _HEADER_STRUCT.unpack_from(raw_header)
-            magic, version, header_size, image_size, manifest_length = unpacked[:5]
-            if magic != _CONTAINER_MAGIC or version != _CONTAINER_VERSION:
+            magic = cast(bytes, unpacked[0])
+            header = FirmwareHeader(
+                version=int(unpacked[1]),
+                header_size=int(unpacked[2]),
+                image_size=int(unpacked[3]),
+                manifest_length=int(unpacked[4]),
+                flags=int(unpacked[5]),
+                manifest_sha256=cast(bytes, unpacked[6]),
+                signature=cast(bytes, unpacked[7]),
+            )
+            if magic != _CONTAINER_MAGIC or header.version != _CONTAINER_VERSION:
                 raise ValueError("unsupported firmware container")
-            if header_size != HEADER_SIZE or image_size != IMAGE_SIZE:
+            if header.header_size != HEADER_SIZE or header.image_size != IMAGE_SIZE:
                 raise ValueError("firmware header size contract mismatch")
-            if manifest_length <= 0 or MANIFEST_OFFSET + manifest_length > MIB:
+            if header.manifest_length <= 0 or MANIFEST_OFFSET + header.manifest_length > MIB:
                 raise ValueError("firmware manifest length is invalid")
             handle.seek(MANIFEST_OFFSET)
-            manifest_bytes = handle.read(manifest_length)
+            manifest_bytes = handle.read(header.manifest_length)
         try:
             parsed = json.loads(manifest_bytes.decode("utf-8"))
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError("firmware manifest is not canonical JSON") from exc
+            raise ValueError("firmware manifest is not valid JSON") from exc
         if not isinstance(parsed, dict):
             raise ValueError("firmware manifest must be an object")
-        return cast(tuple[object, ...], unpacked), cast(dict[str, object], parsed), manifest_bytes
+        manifest = cast(dict[str, object], parsed)
+        if _canonical_json(manifest) != manifest_bytes:
+            raise ValueError("firmware manifest is not canonical JSON")
+        return header, manifest, manifest_bytes
+
+    def _manifest_mapping(self, key: str) -> dict[str, object]:
+        value = self.manifest.get(key)
+        if not isinstance(value, dict):
+            raise ValueError(f"firmware manifest field {key!r} must be an object")
+        return cast(dict[str, object], value)
+
+    def _manifest_integer(self, key: str) -> int:
+        value = self.manifest.get(key)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f"firmware manifest field {key!r} must be an integer")
+        return value
+
+    def _section_metadata(self, name: str) -> dict[str, object]:
+        sections = self._manifest_mapping("sections")
+        value = sections.get(name)
+        if not isinstance(value, dict):
+            raise ValueError(f"missing firmware section metadata: {name}")
+        return cast(dict[str, object], value)
 
     def _decoded_sections(self, *, encryption_key: bytes | None) -> dict[str, bytes]:
-        result: dict[str, bytes] = {}
-        sections = self.manifest.get("sections")
-        if not isinstance(sections, dict):
-            raise ValueError("firmware manifest sections are invalid")
-        crypto = self.manifest.get("crypto")
-        if not isinstance(crypto, dict):
-            raise ValueError("firmware crypto metadata is invalid")
-        salt_hex = crypto.get("salt", "")
-        if not isinstance(salt_hex, str):
+        crypto = self._manifest_mapping("crypto")
+        salt_raw = crypto.get("salt", "")
+        if not isinstance(salt_raw, str):
             raise ValueError("firmware salt metadata is invalid")
-        salt = bytes.fromhex(salt_hex) if salt_hex else b""
+        try:
+            salt = bytes.fromhex(salt_raw) if salt_raw else b""
+        except ValueError as exc:
+            raise ValueError("firmware salt is not hexadecimal") from exc
+        result: dict[str, bytes] = {}
         with self.path.open("rb") as handle:
             for name in ("qsol", "metric", "kernel", "trace"):
-                raw_meta = sections.get(name)
-                if not isinstance(raw_meta, dict):
-                    raise ValueError(f"missing firmware section metadata: {name}")
+                metadata = self._section_metadata(name)
                 region = _REGION_BY_NAME[name]
-                offset = int(raw_meta.get("offset", -1))
-                capacity = int(raw_meta.get("capacity", -1))
-                used = int(raw_meta.get("used_bytes", -1))
+                offset = _metadata_int(metadata, "offset", name)
+                capacity = _metadata_int(metadata, "capacity", name)
+                used = _metadata_int(metadata, "used_bytes", name)
                 if offset != region.offset or capacity != region.capacity or not 0 <= used <= capacity:
                     raise ValueError(f"firmware section layout mismatch: {name}")
                 handle.seek(offset)
                 stored = handle.read(used)
                 if len(stored) != used:
                     raise ValueError(f"truncated firmware section: {name}")
-                if hashlib.sha256(stored).hexdigest() != raw_meta.get("stored_sha256"):
+                stored_hash = metadata.get("stored_sha256")
+                if not isinstance(stored_hash, str) or hashlib.sha256(stored).hexdigest() != stored_hash:
                     raise ValueError(f"firmware section checksum mismatch: {name}")
                 plaintext = stored
-                if bool(raw_meta.get("encrypted")):
+                encrypted = metadata.get("encrypted")
+                if not isinstance(encrypted, bool):
+                    raise ValueError(f"firmware encrypted flag is invalid: {name}")
+                if encrypted:
                     if encryption_key is None or len(encryption_key) != 32:
                         raise ValueError("firmware encrypted section requires AES key")
-                    nonce_hex = raw_meta.get("nonce")
-                    if not isinstance(nonce_hex, str):
+                    nonce_raw = metadata.get("nonce")
+                    if not isinstance(nonce_raw, str):
                         raise ValueError(f"invalid nonce metadata: {name}")
-                    plaintext = _decrypt_section(
-                        name,
-                        stored,
-                        encryption_key,
-                        salt,
-                        bytes.fromhex(nonce_hex),
-                    )
-                if hashlib.sha256(plaintext).hexdigest() != raw_meta.get("content_sha256"):
+                    try:
+                        nonce = bytes.fromhex(nonce_raw)
+                    except ValueError as exc:
+                        raise ValueError(f"invalid nonce encoding: {name}") from exc
+                    plaintext = _decrypt_section(name, stored, encryption_key, salt, nonce)
+                content_hash = metadata.get("content_sha256")
+                if not isinstance(content_hash, str) or hashlib.sha256(plaintext).hexdigest() != content_hash:
                     raise ValueError(f"firmware plaintext checksum mismatch: {name}")
                 result[name] = plaintext
         return result
 
 
 class FirmwareBootSession:
-    """Verified runtime session created only after firmware verification succeeds."""
-
     def __init__(
         self,
         *,
@@ -703,8 +724,6 @@ class FirmwareBootSession:
         if autonomic.state_reports and all(item.committed for item in autonomic.state_reports):
             try:
                 candidate = relax_metric_field(self.metric, side=self.side, alpha=0.05)
-                for value in candidate.values():
-                    _validate_spd(value)
                 self.metric = candidate
                 metric_committed = True
             except (TypeError, ValueError):
@@ -731,15 +750,17 @@ class FirmwareBootSession:
 
 
 def _encrypt_section(name: str, plaintext: bytes, master: bytes, salt: bytes, nonce: bytes) -> bytes:
-    key = _derive_section_key(master, salt, name)
-    return AESGCM(key).encrypt(nonce, plaintext, _section_aad(name))
+    return AESGCM(_derive_section_key(master, salt, name)).encrypt(
+        nonce, plaintext, _section_aad(name)
+    )
 
 
 def _decrypt_section(name: str, ciphertext: bytes, master: bytes, salt: bytes, nonce: bytes) -> bytes:
-    key = _derive_section_key(master, salt, name)
     try:
-        return AESGCM(key).decrypt(nonce, ciphertext, _section_aad(name))
-    except Exception as exc:  # cryptography deliberately normalizes auth failures
+        return AESGCM(_derive_section_key(master, salt, name)).decrypt(
+            nonce, ciphertext, _section_aad(name)
+        )
+    except InvalidTag as exc:
         raise ValueError(f"firmware section authentication failed: {name}") from exc
 
 
@@ -763,7 +784,8 @@ def _signature_message(manifest_bytes: bytes) -> bytes:
 
 
 def _decode_trace(payload: bytes) -> str:
-    if len(payload) != len(_TRACE_MAGIC) + 32 + 8 or not payload.startswith(_TRACE_MAGIC):
+    expected = len(_TRACE_MAGIC) + 32 + 8
+    if len(payload) != expected or not payload.startswith(_TRACE_MAGIC):
         raise ValueError("invalid firmware trace payload")
     count = struct.unpack_from("<Q", payload, len(_TRACE_MAGIC) + 32)[0]
     if count != 0:
@@ -775,6 +797,13 @@ def _canonical_json(payload: object) -> bytes:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
         "utf-8"
     )
+
+
+def _metadata_int(metadata: Mapping[str, object], key: str, section: str) -> int:
+    value = metadata.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"firmware section {section} field {key} must be an integer")
+    return value
 
 
 def _validate_side(side: int) -> None:
@@ -799,10 +828,10 @@ def _validate_coordinate(coordinate: Coordinate, side: int) -> Coordinate:
 def _metric_tuple(raw: Sequence[float]) -> MetricComponents:
     if len(raw) != 6:
         raise ValueError("metric must contain six symmetric 3D components")
-    values = tuple(float(item) for item in raw)
+    values = [float(item) for item in raw]
     if any(not math.isfinite(item) for item in values):
         raise ValueError("metric contains non-finite component")
-    return cast(MetricComponents, values)
+    return (values[0], values[1], values[2], values[3], values[4], values[5])
 
 
 def _validate_spd(metric: MetricComponents) -> None:

--- a/src/jarvisx/dr_moagi_firmware.py
+++ b/src/jarvisx/dr_moagi_firmware.py
@@ -1,0 +1,840 @@
+"""Verified 1 GiB firmware-container runtime for the Dr Moagi architecture.
+
+This module turns the earlier conceptual byte map into a concrete, deterministic
+container format with an exact 1 GiB *logical* image size.  The image is sparse
+on filesystems that support sparse files: only the used payload bytes are
+written; the large reserved regions remain holes.
+
+The container deliberately separates immutable executable material from mutable
+state.  It embeds a valid minimal RV64 ELF monitor stub (or a caller-provided
+RISC-V ELF), exact DMOS2 sparse state, a sparse symmetric-positive-definite 3D
+metric packet, and a hash-chain trace anchor.  The manifest may be authenticated
+with Ed25519 and the state/metric payloads may be encrypted with AES-256-GCM.
+
+This is a reference firmware/runtime layer.  It does not claim that the Python
+host is bare metal or that a generic GPU executes RISC-V instructions directly.
+Board-specific startup code and accelerator binaries can replace the reference
+ELF payload while retaining the verified container contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import struct
+import zlib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Mapping, Sequence, cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from .dr_moagi_field_runtime import Coordinate, SparseField
+from .dr_moagi_frontier import morton3_decode, morton3_encode
+from .dr_moagi_meta_optimizer import SelfOptimizing3DSystem
+from .dr_moagi_os import DrMoagiOSConfig, DrMoagiOSKernel
+from .dr_moagi_os_store import SparseStateCodec3D
+from .dr_moagi_system_evolution import AutonomicRunReport, SelfEvolving3DArchitecture
+
+MIB = 1 << 20
+IMAGE_SIZE = 1 << 30  # exactly 1 GiB / 1,073,741,824 bytes
+HEADER_SIZE = 512
+MANIFEST_OFFSET = HEADER_SIZE
+
+_CONTAINER_MAGIC = b"DMLAMBDA"
+_CONTAINER_VERSION = 1
+_HEADER_STRUCT = struct.Struct("<8sIIQII32s64s")
+_FLAG_SIGNED = 1 << 0
+_FLAG_ENCRYPTED = 1 << 1
+
+_METRIC_MAGIC = b"DMMET1"
+_TRACE_MAGIC = b"DMTRC1"
+_RISCV_MACHINE = 243
+
+
+@dataclass(frozen=True)
+class FirmwareRegion:
+    name: str
+    offset: int
+    capacity: int
+
+    @property
+    def end(self) -> int:
+        return self.offset + self.capacity
+
+    def as_dict(self) -> dict[str, object]:
+        return {"name": self.name, "offset": self.offset, "capacity": self.capacity}
+
+
+FIRMWARE_LAYOUT: tuple[FirmwareRegion, ...] = (
+    FirmwareRegion("genesis", 0x00000000, 1 * MIB),
+    FirmwareRegion("qsol", 0x00100000, 383 * MIB),
+    FirmwareRegion("metric", 0x18000000, 320 * MIB),
+    FirmwareRegion("kernel", 0x2C000000, 192 * MIB),
+    FirmwareRegion("trace", 0x38000000, 128 * MIB),
+)
+_REGION_BY_NAME = {region.name: region for region in FIRMWARE_LAYOUT}
+
+MetricComponents = tuple[float, float, float, float, float, float]
+MetricField3D = dict[Coordinate, MetricComponents]
+
+
+@dataclass(frozen=True)
+class FirmwareVerificationReport:
+    image_size: int
+    signed: bool
+    encrypted: bool
+    signature_valid: bool
+    qsol_cells: int
+    metric_cells: int
+    kernel_machine: int
+    kernel_entry: int
+    trace_head: str
+    manifest_sha256: str
+    sections: dict[str, dict[str, object]]
+
+    def as_dict(self) -> dict[str, object]:
+        return cast(dict[str, object], asdict(self))
+
+
+@dataclass(frozen=True)
+class FirmwareRunReport:
+    verification: FirmwareVerificationReport
+    autonomic: AutonomicRunReport
+    metric_cells: int
+    metric_relaxation_committed: bool
+    trace_head: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "verification": self.verification.as_dict(),
+            "autonomic": self.autonomic.as_dict(),
+            "metric_cells": self.metric_cells,
+            "metric_relaxation_committed": self.metric_relaxation_committed,
+            "trace_head": self.trace_head,
+        }
+
+
+def validate_layout() -> None:
+    """Assert that the firmware map is contiguous and closes at exactly 1 GiB."""
+
+    cursor = 0
+    for region in FIRMWARE_LAYOUT:
+        if region.offset != cursor:
+            raise RuntimeError(f"firmware region {region.name} is not contiguous")
+        if region.capacity <= 0:
+            raise RuntimeError(f"firmware region {region.name} has invalid capacity")
+        cursor = region.end
+    if cursor != IMAGE_SIZE:
+        raise RuntimeError("firmware layout does not close at exactly 1 GiB")
+    if MANIFEST_OFFSET >= _REGION_BY_NAME["genesis"].end:
+        raise RuntimeError("manifest offset lies outside genesis region")
+
+
+def generate_ed25519_keypair() -> tuple[bytes, bytes]:
+    """Return raw 32-byte Ed25519 private and public keys."""
+
+    private = Ed25519PrivateKey.generate()
+    private_raw = private.private_bytes(
+        serialization.Encoding.Raw,
+        serialization.PrivateFormat.Raw,
+        serialization.NoEncryption(),
+    )
+    public_raw = private.public_key().public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw,
+    )
+    return private_raw, public_raw
+
+
+def generate_aes256_key() -> bytes:
+    return os.urandom(32)
+
+
+def build_reference_riscv_elf() -> bytes:
+    """Build a minimal valid ELF64 little-endian RISC-V executable.
+
+    The payload is a monitor stub, not a board-specific supervisor.  It contains
+    ``addi a0, x0, 0`` followed by ``jal x0, 0`` (an intentional idle loop).
+    Production boards should replace this payload with their signed supervisor.
+    """
+
+    entry = 0x80000000
+    ident = bytearray(16)
+    ident[0:4] = b"\x7fELF"
+    ident[4] = 2  # ELFCLASS64
+    ident[5] = 1  # little endian
+    ident[6] = 1  # ELF version
+    header = bytes(ident) + struct.pack(
+        "<HHIQQQIHHHHHH",
+        2,  # ET_EXEC
+        _RISCV_MACHINE,
+        1,
+        entry,
+        64,  # program header table immediately after ELF header
+        0,
+        0,
+        64,
+        56,
+        1,
+        0,
+        0,
+        0,
+    )
+    program = struct.pack(
+        "<IIQQQQQQ",
+        1,  # PT_LOAD
+        5,  # PF_R | PF_X
+        0x1000,
+        entry,
+        entry,
+        8,
+        8,
+        0x1000,
+    )
+    payload = bytearray(header + program)
+    payload.extend(b"\x00" * (0x1000 - len(payload)))
+    payload.extend(struct.pack("<II", 0x00000513, 0x0000006F))
+    return bytes(payload)
+
+
+def inspect_riscv_elf(payload: bytes) -> dict[str, int]:
+    if len(payload) < 64 or payload[:4] != b"\x7fELF":
+        raise ValueError("kernel payload is not an ELF file")
+    if payload[4] != 2 or payload[5] != 1 or payload[6] != 1:
+        raise ValueError("kernel must be ELF64 little-endian version 1")
+    e_type, machine, version = struct.unpack_from("<HHI", payload, 16)
+    entry = struct.unpack_from("<Q", payload, 24)[0]
+    phoff = struct.unpack_from("<Q", payload, 32)[0]
+    ehsize, phentsize, phnum = struct.unpack_from("<HHH", payload, 52)
+    if e_type != 2 or machine != _RISCV_MACHINE or version != 1:
+        raise ValueError("kernel must be an executable RISC-V ELF")
+    if ehsize != 64 or phentsize != 56 or phnum < 1:
+        raise ValueError("kernel ELF has invalid program-header metadata")
+    if phoff + phentsize * phnum > len(payload):
+        raise ValueError("kernel ELF program headers are truncated")
+    loadable = False
+    for index in range(phnum):
+        p_type, p_flags = struct.unpack_from("<II", payload, phoff + index * phentsize)
+        if p_type == 1 and p_flags & 1:
+            loadable = True
+            break
+    if not loadable:
+        raise ValueError("kernel ELF has no executable PT_LOAD segment")
+    return {"machine": machine, "entry": entry, "program_headers": phnum}
+
+
+class SparseMetricCodec3D:
+    """Lossless-for-float32 sparse packet for symmetric positive-definite 3D metrics."""
+
+    _record = struct.Struct("<Q6f")
+
+    def encode(self, field: Mapping[Coordinate, Sequence[float]], *, side: int) -> bytes:
+        _validate_side(side)
+        rows: list[tuple[int, MetricComponents]] = []
+        for coordinate, raw in field.items():
+            coord = _validate_coordinate(coordinate, side)
+            metric = _metric_tuple(raw)
+            _validate_spd(metric)
+            rows.append((morton3_encode(*coord), metric))
+        rows.sort(key=lambda item: item[0])
+        raw = bytearray(_METRIC_MAGIC)
+        raw.extend(struct.pack("<II", side, len(rows)))
+        previous = -1
+        for code, metric in rows:
+            if code <= previous:
+                raise ValueError("metric coordinates must be unique")
+            raw.extend(self._record.pack(code, *metric))
+            previous = code
+        return zlib.compress(bytes(raw), level=9)
+
+    def decode(self, payload: bytes) -> tuple[int, MetricField3D]:
+        try:
+            raw = zlib.decompress(payload)
+        except zlib.error as exc:
+            raise ValueError("invalid compressed metric packet") from exc
+        if not raw.startswith(_METRIC_MAGIC) or len(raw) < len(_METRIC_MAGIC) + 8:
+            raise ValueError("invalid metric packet magic")
+        side, count = struct.unpack_from("<II", raw, len(_METRIC_MAGIC))
+        _validate_side(side)
+        cursor = len(_METRIC_MAGIC) + 8
+        expected = cursor + count * self._record.size
+        if expected != len(raw):
+            raise ValueError("metric packet size/count mismatch")
+        field: MetricField3D = {}
+        previous = -1
+        for _ in range(count):
+            unpacked = self._record.unpack_from(raw, cursor)
+            cursor += self._record.size
+            code = int(unpacked[0])
+            if code <= previous:
+                raise ValueError("metric Morton stream is not strictly ordered")
+            coordinate = morton3_decode(code)
+            _validate_coordinate(coordinate, side)
+            metric = _metric_tuple(unpacked[1:])
+            _validate_spd(metric)
+            field[coordinate] = metric
+            previous = code
+        return side, field
+
+
+def identity_metric_for_state(field: Mapping[Coordinate, float]) -> MetricField3D:
+    identity: MetricComponents = (1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+    return {coordinate: identity for coordinate in field}
+
+
+def relax_metric_field(
+    field: Mapping[Coordinate, Sequence[float]],
+    *,
+    side: int,
+    alpha: float = 0.05,
+) -> MetricField3D:
+    """Perform a bounded SPD-preserving metric diffusion step.
+
+    This is intentionally described as metric relaxation, not Ricci flow.  Every
+    candidate is a convex combination of SPD tensors (explicit neighbours or
+    identity), so the SPD invariant is preserved for ``alpha in [0, 1]``.
+    """
+
+    _validate_side(side)
+    if not math.isfinite(float(alpha)) or not 0.0 <= float(alpha) <= 1.0:
+        raise ValueError("alpha must be finite and in [0, 1]")
+    current: MetricField3D = {}
+    for coordinate, metric in field.items():
+        coord = _validate_coordinate(coordinate, side)
+        parsed = _metric_tuple(metric)
+        _validate_spd(parsed)
+        current[coord] = parsed
+    identity: MetricComponents = (1.0, 1.0, 1.0, 0.0, 0.0, 0.0)
+    offsets = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+    result: MetricField3D = {}
+    for coordinate, metric in current.items():
+        neighbours: list[MetricComponents] = []
+        x, y, z = coordinate
+        for dx, dy, dz in offsets:
+            candidate = x + dx, y + dy, z + dz
+            if all(0 <= axis < side for axis in candidate):
+                neighbours.append(current.get(candidate, identity))
+        if not neighbours:
+            neighbours = [identity]
+        average = tuple(
+            sum(item[index] for item in neighbours) / len(neighbours) for index in range(6)
+        )
+        blended = cast(
+            MetricComponents,
+            tuple((1.0 - alpha) * metric[index] + alpha * average[index] for index in range(6)),
+        )
+        _validate_spd(blended)
+        result[coordinate] = blended
+    return result
+
+
+class FirmwareBuilder:
+    """Build exact-size sparse firmware images."""
+
+    def __init__(self) -> None:
+        validate_layout()
+        self.state_codec = SparseStateCodec3D()
+        self.metric_codec = SparseMetricCodec3D()
+
+    def build(
+        self,
+        path: Path,
+        *,
+        state: Mapping[Coordinate, float],
+        side: int,
+        metric: Mapping[Coordinate, Sequence[float]] | None = None,
+        supervisor_elf: bytes | None = None,
+        signing_private_key: bytes | None = None,
+        encryption_key: bytes | None = None,
+    ) -> dict[str, object]:
+        _validate_side(side)
+        if not state:
+            raise ValueError("firmware state must be non-empty")
+        state_packet = self.state_codec.encode(state, side=side)
+        qsol_plain = state_packet.payload
+        metric_field = identity_metric_for_state(state) if metric is None else dict(metric)
+        metric_plain = self.metric_codec.encode(metric_field, side=side)
+        kernel_plain = build_reference_riscv_elf() if supervisor_elf is None else supervisor_elf
+        kernel_info = inspect_riscv_elf(kernel_plain)
+        trace_anchor = hashlib.sha3_256(
+            hashlib.sha256(qsol_plain).digest()
+            + hashlib.sha256(metric_plain).digest()
+            + hashlib.sha256(kernel_plain).digest()
+        ).digest()
+        trace_plain = _TRACE_MAGIC + trace_anchor + struct.pack("<Q", 0)
+
+        signed = signing_private_key is not None
+        encrypted = encryption_key is not None
+        if encryption_key is not None and len(encryption_key) != 32:
+            raise ValueError("encryption key must contain exactly 32 bytes")
+        salt = os.urandom(16) if encrypted else b""
+        sections: dict[str, bytes] = {}
+        section_meta: dict[str, dict[str, object]] = {}
+        for name, plaintext, codec, encryptable in (
+            ("qsol", qsol_plain, "DMOS2", True),
+            ("metric", metric_plain, "DMMET1+DEFLATE", True),
+            ("kernel", kernel_plain, "ELF64-RISCV", False),
+            ("trace", trace_plain, "DMTRC1", False),
+        ):
+            stored = plaintext
+            nonce = b""
+            is_encrypted = encrypted and encryptable
+            if is_encrypted:
+                assert encryption_key is not None
+                nonce = os.urandom(12)
+                stored = _encrypt_section(name, plaintext, encryption_key, salt, nonce)
+            region = _REGION_BY_NAME[name]
+            if len(stored) > region.capacity:
+                raise ValueError(
+                    f"{name} payload uses {len(stored)} bytes but region capacity is {region.capacity}"
+                )
+            sections[name] = stored
+            section_meta[name] = {
+                "offset": region.offset,
+                "capacity": region.capacity,
+                "used_bytes": len(stored),
+                "codec": codec,
+                "encrypted": is_encrypted,
+                "nonce": nonce.hex(),
+                "stored_sha256": hashlib.sha256(stored).hexdigest(),
+                "content_sha256": hashlib.sha256(plaintext).hexdigest(),
+            }
+
+        signer_fingerprint = ""
+        private: Ed25519PrivateKey | None = None
+        if signing_private_key is not None:
+            if len(signing_private_key) != 32:
+                raise ValueError("Ed25519 private key must contain exactly 32 raw bytes")
+            private = Ed25519PrivateKey.from_private_bytes(signing_private_key)
+            public_raw = private.public_key().public_bytes(
+                serialization.Encoding.Raw,
+                serialization.PublicFormat.Raw,
+            )
+            signer_fingerprint = hashlib.sha256(public_raw).hexdigest()
+
+        manifest = {
+            "format": "DMLAMBDA-1G",
+            "version": _CONTAINER_VERSION,
+            "image_size": IMAGE_SIZE,
+            "side": side,
+            "logical_cells": side**3,
+            "state_active_cells": len(state),
+            "metric_cells": len(metric_field),
+            "layout": [region.as_dict() for region in FIRMWARE_LAYOUT],
+            "sections": section_meta,
+            "kernel": {
+                "architecture": "RISC-V",
+                "elf_class": 64,
+                "machine": kernel_info["machine"],
+                "entry": kernel_info["entry"],
+                "reference_stub": supervisor_elf is None,
+            },
+            "crypto": {
+                "signature": "Ed25519" if signed else "none",
+                "signer_public_key_sha256": signer_fingerprint,
+                "section_encryption": "AES-256-GCM" if encrypted else "none",
+                "kdf": "HKDF-SHA256" if encrypted else "none",
+                "salt": salt.hex(),
+            },
+            "trace": {
+                "algorithm": "SHA3-256 hash chain",
+                "anchor": trace_anchor.hex(),
+                "externally_anchored_head_required_for_strong_tamper_evidence": True,
+            },
+            "capability_boundary": {
+                "bare_metal_board_support": "board-specific supervisor required",
+                "gpu_native_riscv": False,
+                "ricci_flow": False,
+                "metric_relaxation": True,
+                "arbitrary_host_commands": False,
+                "self_modifying_executable_code": False,
+            },
+        }
+        manifest_bytes = _canonical_json(manifest)
+        genesis_capacity = _REGION_BY_NAME["genesis"].capacity
+        if MANIFEST_OFFSET + len(manifest_bytes) > genesis_capacity:
+            raise ValueError("manifest does not fit genesis region")
+        manifest_digest = hashlib.sha256(manifest_bytes).digest()
+        signature = (
+            private.sign(_signature_message(manifest_bytes)) if private is not None else bytes(64)
+        )
+        flags = (_FLAG_SIGNED if signed else 0) | (_FLAG_ENCRYPTED if encrypted else 0)
+        header_core = _HEADER_STRUCT.pack(
+            _CONTAINER_MAGIC,
+            _CONTAINER_VERSION,
+            HEADER_SIZE,
+            IMAGE_SIZE,
+            len(manifest_bytes),
+            flags,
+            manifest_digest,
+            signature,
+        )
+        header = header_core + bytes(HEADER_SIZE - len(header_core))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("wb") as handle:
+            handle.truncate(IMAGE_SIZE)
+            handle.seek(0)
+            handle.write(header)
+            handle.seek(MANIFEST_OFFSET)
+            handle.write(manifest_bytes)
+            for name, stored in sections.items():
+                handle.seek(_REGION_BY_NAME[name].offset)
+                handle.write(stored)
+            handle.flush()
+            os.fsync(handle.fileno())
+        return {
+            "path": str(path),
+            "image_size": path.stat().st_size,
+            "signed": signed,
+            "encrypted": encrypted,
+            "manifest_sha256": manifest_digest.hex(),
+            "trace_anchor": trace_anchor.hex(),
+            "sections": section_meta,
+        }
+
+
+class FirmwareImage:
+    """Read, verify, decrypt and boot a DMLAMBDA firmware image."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._header, self.manifest, self.manifest_bytes = self._read_header_manifest()
+
+    @property
+    def signed(self) -> bool:
+        return bool(self._header[5] & _FLAG_SIGNED)
+
+    @property
+    def encrypted(self) -> bool:
+        return bool(self._header[5] & _FLAG_ENCRYPTED)
+
+    def verify(
+        self,
+        *,
+        public_key: bytes | None = None,
+        encryption_key: bytes | None = None,
+    ) -> FirmwareVerificationReport:
+        if self.path.stat().st_size != IMAGE_SIZE:
+            raise ValueError("firmware image is not exactly 1 GiB")
+        manifest_digest = hashlib.sha256(self.manifest_bytes).digest()
+        if manifest_digest != self._header[6]:
+            raise ValueError("firmware manifest checksum mismatch")
+        signature_valid = not self.signed
+        if self.signed:
+            if public_key is None or len(public_key) != 32:
+                raise ValueError("a 32-byte Ed25519 public trust anchor is required")
+            fingerprint = hashlib.sha256(public_key).hexdigest()
+            expected = str(self.manifest["crypto"]["signer_public_key_sha256"])
+            if fingerprint != expected:
+                raise ValueError("firmware signer fingerprint does not match trust anchor")
+            try:
+                Ed25519PublicKey.from_public_bytes(public_key).verify(
+                    self._header[7], _signature_message(self.manifest_bytes)
+                )
+            except InvalidSignature as exc:
+                raise ValueError("firmware manifest signature is invalid") from exc
+            signature_valid = True
+        if self.encrypted and (encryption_key is None or len(encryption_key) != 32):
+            raise ValueError("a 32-byte AES master key is required for encrypted firmware")
+
+        decoded = self._decoded_sections(encryption_key=encryption_key)
+        state_packet, state = SparseStateCodec3D().decode_payload(decoded["qsol"])
+        metric_side, metric = SparseMetricCodec3D().decode(decoded["metric"])
+        side = int(self.manifest["side"])
+        if state_packet.side != side or metric_side != side:
+            raise ValueError("firmware section logical-side mismatch")
+        kernel = inspect_riscv_elf(decoded["kernel"])
+        trace_head = _decode_trace(decoded["trace"])
+        if trace_head != str(self.manifest["trace"]["anchor"]):
+            raise ValueError("firmware trace anchor mismatch")
+        return FirmwareVerificationReport(
+            image_size=IMAGE_SIZE,
+            signed=self.signed,
+            encrypted=self.encrypted,
+            signature_valid=signature_valid,
+            qsol_cells=len(state),
+            metric_cells=len(metric),
+            kernel_machine=kernel["machine"],
+            kernel_entry=kernel["entry"],
+            trace_head=trace_head,
+            manifest_sha256=manifest_digest.hex(),
+            sections=cast(dict[str, dict[str, object]], self.manifest["sections"]),
+        )
+
+    def boot(
+        self,
+        *,
+        public_key: bytes | None = None,
+        encryption_key: bytes | None = None,
+        max_active_cells: int = 50_000,
+    ) -> "FirmwareBootSession":
+        verification = self.verify(public_key=public_key, encryption_key=encryption_key)
+        decoded = self._decoded_sections(encryption_key=encryption_key)
+        state_packet, state = SparseStateCodec3D().decode_payload(decoded["qsol"])
+        metric_side, metric = SparseMetricCodec3D().decode(decoded["metric"])
+        if metric_side != state_packet.side:
+            raise ValueError("firmware metric/state side mismatch")
+        config = DrMoagiOSConfig(
+            side=state_packet.side,
+            max_active_cells=max(max_active_cells, len(state)),
+            deep_distiller_max_latent_cells=max(1, min(25_000, max(max_active_cells, len(state)))),
+            state_dir=None,
+        )
+        kernel = DrMoagiOSKernel(config)
+        kernel.boot(restore=False)
+        kernel.load(state)
+        system = SelfOptimizing3DSystem(kernel)
+        architecture = SelfEvolving3DArchitecture(system)
+        return FirmwareBootSession(
+            verification=verification,
+            architecture=architecture,
+            metric=metric,
+            side=state_packet.side,
+            trace_head=bytes.fromhex(verification.trace_head),
+        )
+
+    def _read_header_manifest(self) -> tuple[tuple[object, ...], dict[str, object], bytes]:
+        if not self.path.exists():
+            raise FileNotFoundError(self.path)
+        with self.path.open("rb") as handle:
+            raw_header = handle.read(HEADER_SIZE)
+            if len(raw_header) != HEADER_SIZE:
+                raise ValueError("truncated firmware header")
+            unpacked = _HEADER_STRUCT.unpack_from(raw_header)
+            magic, version, header_size, image_size, manifest_length = unpacked[:5]
+            if magic != _CONTAINER_MAGIC or version != _CONTAINER_VERSION:
+                raise ValueError("unsupported firmware container")
+            if header_size != HEADER_SIZE or image_size != IMAGE_SIZE:
+                raise ValueError("firmware header size contract mismatch")
+            if manifest_length <= 0 or MANIFEST_OFFSET + manifest_length > MIB:
+                raise ValueError("firmware manifest length is invalid")
+            handle.seek(MANIFEST_OFFSET)
+            manifest_bytes = handle.read(manifest_length)
+        try:
+            parsed = json.loads(manifest_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("firmware manifest is not canonical JSON") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("firmware manifest must be an object")
+        return cast(tuple[object, ...], unpacked), cast(dict[str, object], parsed), manifest_bytes
+
+    def _decoded_sections(self, *, encryption_key: bytes | None) -> dict[str, bytes]:
+        result: dict[str, bytes] = {}
+        sections = self.manifest.get("sections")
+        if not isinstance(sections, dict):
+            raise ValueError("firmware manifest sections are invalid")
+        crypto = self.manifest.get("crypto")
+        if not isinstance(crypto, dict):
+            raise ValueError("firmware crypto metadata is invalid")
+        salt_hex = crypto.get("salt", "")
+        if not isinstance(salt_hex, str):
+            raise ValueError("firmware salt metadata is invalid")
+        salt = bytes.fromhex(salt_hex) if salt_hex else b""
+        with self.path.open("rb") as handle:
+            for name in ("qsol", "metric", "kernel", "trace"):
+                raw_meta = sections.get(name)
+                if not isinstance(raw_meta, dict):
+                    raise ValueError(f"missing firmware section metadata: {name}")
+                region = _REGION_BY_NAME[name]
+                offset = int(raw_meta.get("offset", -1))
+                capacity = int(raw_meta.get("capacity", -1))
+                used = int(raw_meta.get("used_bytes", -1))
+                if offset != region.offset or capacity != region.capacity or not 0 <= used <= capacity:
+                    raise ValueError(f"firmware section layout mismatch: {name}")
+                handle.seek(offset)
+                stored = handle.read(used)
+                if len(stored) != used:
+                    raise ValueError(f"truncated firmware section: {name}")
+                if hashlib.sha256(stored).hexdigest() != raw_meta.get("stored_sha256"):
+                    raise ValueError(f"firmware section checksum mismatch: {name}")
+                plaintext = stored
+                if bool(raw_meta.get("encrypted")):
+                    if encryption_key is None or len(encryption_key) != 32:
+                        raise ValueError("firmware encrypted section requires AES key")
+                    nonce_hex = raw_meta.get("nonce")
+                    if not isinstance(nonce_hex, str):
+                        raise ValueError(f"invalid nonce metadata: {name}")
+                    plaintext = _decrypt_section(
+                        name,
+                        stored,
+                        encryption_key,
+                        salt,
+                        bytes.fromhex(nonce_hex),
+                    )
+                if hashlib.sha256(plaintext).hexdigest() != raw_meta.get("content_sha256"):
+                    raise ValueError(f"firmware plaintext checksum mismatch: {name}")
+                result[name] = plaintext
+        return result
+
+
+class FirmwareBootSession:
+    """Verified runtime session created only after firmware verification succeeds."""
+
+    def __init__(
+        self,
+        *,
+        verification: FirmwareVerificationReport,
+        architecture: SelfEvolving3DArchitecture,
+        metric: MetricField3D,
+        side: int,
+        trace_head: bytes,
+    ) -> None:
+        self.verification = verification
+        self.architecture = architecture
+        self.metric = dict(metric)
+        self.side = side
+        self._trace_head = trace_head
+
+    @property
+    def trace_head(self) -> str:
+        return self._trace_head.hex()
+
+    def run(self, cycles: int) -> FirmwareRunReport:
+        autonomic = self.architecture.run_autonomic(cycles)
+        before_metric = dict(self.metric)
+        metric_committed = False
+        if autonomic.state_reports and all(item.committed for item in autonomic.state_reports):
+            try:
+                candidate = relax_metric_field(self.metric, side=self.side, alpha=0.05)
+                for value in candidate.values():
+                    _validate_spd(value)
+                self.metric = candidate
+                metric_committed = True
+            except (TypeError, ValueError):
+                self.metric = before_metric
+        event = {
+            "cycles": cycles,
+            "state_reports": len(autonomic.state_reports),
+            "state_committed": all(item.committed for item in autonomic.state_reports),
+            "metric_committed": metric_committed,
+            "state_hash": self.architecture.kernel.status()["state_hash"],
+        }
+        self._trace_head = hashlib.sha3_256(self._trace_head + _canonical_json(event)).digest()
+        return FirmwareRunReport(
+            verification=self.verification,
+            autonomic=autonomic,
+            metric_cells=len(self.metric),
+            metric_relaxation_committed=metric_committed,
+            trace_head=self.trace_head,
+        )
+
+    def export_state(self) -> SparseField:
+        packet = self.architecture.kernel.export_state_packet()
+        return SparseStateCodec3D().decode(packet)
+
+
+def _encrypt_section(name: str, plaintext: bytes, master: bytes, salt: bytes, nonce: bytes) -> bytes:
+    key = _derive_section_key(master, salt, name)
+    return AESGCM(key).encrypt(nonce, plaintext, _section_aad(name))
+
+
+def _decrypt_section(name: str, ciphertext: bytes, master: bytes, salt: bytes, nonce: bytes) -> bytes:
+    key = _derive_section_key(master, salt, name)
+    try:
+        return AESGCM(key).decrypt(nonce, ciphertext, _section_aad(name))
+    except Exception as exc:  # cryptography deliberately normalizes auth failures
+        raise ValueError(f"firmware section authentication failed: {name}") from exc
+
+
+def _derive_section_key(master: bytes, salt: bytes, name: str) -> bytes:
+    if len(master) != 32:
+        raise ValueError("AES master key must contain exactly 32 bytes")
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        info=("DMLAMBDA-SECTION:" + name).encode("ascii"),
+    ).derive(master)
+
+
+def _section_aad(name: str) -> bytes:
+    return ("DMLAMBDA:v1:" + name).encode("ascii")
+
+
+def _signature_message(manifest_bytes: bytes) -> bytes:
+    return b"DMLAMBDA-SIGN-v1\x00" + manifest_bytes
+
+
+def _decode_trace(payload: bytes) -> str:
+    if len(payload) != len(_TRACE_MAGIC) + 32 + 8 or not payload.startswith(_TRACE_MAGIC):
+        raise ValueError("invalid firmware trace payload")
+    count = struct.unpack_from("<Q", payload, len(_TRACE_MAGIC) + 32)[0]
+    if count != 0:
+        raise ValueError("initial firmware trace record count must be zero")
+    return payload[len(_TRACE_MAGIC) : len(_TRACE_MAGIC) + 32].hex()
+
+
+def _canonical_json(payload: object) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode(
+        "utf-8"
+    )
+
+
+def _validate_side(side: int) -> None:
+    if isinstance(side, bool) or not isinstance(side, int) or side <= 0:
+        raise ValueError("side must be a positive integer")
+    if side > 1_048_576:
+        raise ValueError("side exceeds the 20-bit Morton coordinate contract")
+
+
+def _validate_coordinate(coordinate: Coordinate, side: int) -> Coordinate:
+    if (
+        not isinstance(coordinate, tuple)
+        or len(coordinate) != 3
+        or any(isinstance(axis, bool) or not isinstance(axis, int) for axis in coordinate)
+    ):
+        raise TypeError("coordinates must be integer (x, y, z) tuples")
+    if any(axis < 0 or axis >= side for axis in coordinate):
+        raise ValueError("coordinate outside logical lattice")
+    return coordinate
+
+
+def _metric_tuple(raw: Sequence[float]) -> MetricComponents:
+    if len(raw) != 6:
+        raise ValueError("metric must contain six symmetric 3D components")
+    values = tuple(float(item) for item in raw)
+    if any(not math.isfinite(item) for item in values):
+        raise ValueError("metric contains non-finite component")
+    return cast(MetricComponents, values)
+
+
+def _validate_spd(metric: MetricComponents) -> None:
+    gxx, gyy, gzz, gxy, gxz, gyz = metric
+    minor1 = gxx
+    minor2 = gxx * gyy - gxy * gxy
+    determinant = (
+        gxx * (gyy * gzz - gyz * gyz)
+        - gxy * (gxy * gzz - gyz * gxz)
+        + gxz * (gxy * gyz - gyy * gxz)
+    )
+    epsilon = 1.0e-8
+    if minor1 <= epsilon or minor2 <= epsilon or determinant <= epsilon:
+        raise ValueError("metric tensor is not symmetric positive definite")
+
+
+__all__ = [
+    "FIRMWARE_LAYOUT",
+    "FirmwareBootSession",
+    "FirmwareBuilder",
+    "FirmwareImage",
+    "FirmwareRunReport",
+    "FirmwareVerificationReport",
+    "IMAGE_SIZE",
+    "MetricComponents",
+    "MetricField3D",
+    "SparseMetricCodec3D",
+    "build_reference_riscv_elf",
+    "generate_aes256_key",
+    "generate_ed25519_keypair",
+    "identity_metric_for_state",
+    "inspect_riscv_elf",
+    "relax_metric_field",
+    "validate_layout",
+]

--- a/src/jarvisx/dr_moagi_firmware_api.py
+++ b/src/jarvisx/dr_moagi_firmware_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import cast
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
@@ -46,7 +47,8 @@ class FirmwareService:
 
     def verify(self) -> dict[str, object]:
         public, encryption = self._keys()
-        return self.image().verify(public_key=public, encryption_key=encryption).as_dict()
+        payload = self.image().verify(public_key=public, encryption_key=encryption).as_dict()
+        return cast(dict[str, object], payload)
 
     def boot(self) -> dict[str, object]:
         public, encryption = self._keys()
@@ -119,7 +121,7 @@ def status() -> dict[str, object]:
 
 @app.get("/v1/firmware/manifest")
 def manifest() -> dict[str, object]:
-    return _get_service().image().manifest
+    return dict(_get_service().image().manifest)
 
 
 @app.post("/v1/firmware/verify")

--- a/src/jarvisx/dr_moagi_firmware_api.py
+++ b/src/jarvisx/dr_moagi_firmware_api.py
@@ -1,0 +1,146 @@
+"""FastAPI control plane for verified Dr Moagi firmware images."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .dr_moagi_firmware import FirmwareBootSession, FirmwareImage
+
+app = FastAPI(
+    title="Dr Moagi DMLAMBDA Firmware Service",
+    version="1.0.0",
+    description="Verified boot and bounded autonomic execution for 1 GiB firmware containers.",
+)
+
+
+class RunRequest(BaseModel):
+    cycles: int = Field(default=1, ge=1, le=10_000)
+
+
+class FirmwareService:
+    def __init__(
+        self,
+        image_path: Path,
+        *,
+        public_key_path: Path | None = None,
+        encryption_key_path: Path | None = None,
+    ) -> None:
+        self.image_path = image_path
+        self.public_key_path = public_key_path
+        self.encryption_key_path = encryption_key_path
+        self.session: FirmwareBootSession | None = None
+
+    def _keys(self) -> tuple[bytes | None, bytes | None]:
+        public = self.public_key_path.read_bytes() if self.public_key_path is not None else None
+        encryption = (
+            self.encryption_key_path.read_bytes() if self.encryption_key_path is not None else None
+        )
+        return public, encryption
+
+    def image(self) -> FirmwareImage:
+        return FirmwareImage(self.image_path)
+
+    def verify(self) -> dict[str, object]:
+        public, encryption = self._keys()
+        return self.image().verify(public_key=public, encryption_key=encryption).as_dict()
+
+    def boot(self) -> dict[str, object]:
+        public, encryption = self._keys()
+        self.session = self.image().boot(public_key=public, encryption_key=encryption)
+        return self.status()
+
+    def run(self, cycles: int) -> dict[str, object]:
+        if self.session is None:
+            self.boot()
+        assert self.session is not None
+        report = self.session.run(cycles)
+        return {"report": report.as_dict(), "status": self.status()}
+
+    def status(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "image": str(self.image_path),
+            "image_exists": self.image_path.exists(),
+            "booted": self.session is not None,
+        }
+        if self.session is not None:
+            payload.update(
+                {
+                    "trace_head": self.session.trace_head,
+                    "metric_cells": len(self.session.metric),
+                    "system": self.session.architecture.status(),
+                }
+            )
+        return payload
+
+
+def _service_from_env() -> FirmwareService:
+    image = os.getenv("JARVISX_FIRMWARE_IMAGE")
+    if not image:
+        raise RuntimeError("JARVISX_FIRMWARE_IMAGE is not configured")
+    public = os.getenv("JARVISX_FIRMWARE_PUBLIC_KEY")
+    encryption = os.getenv("JARVISX_FIRMWARE_ENCRYPTION_KEY")
+    return FirmwareService(
+        Path(image),
+        public_key_path=Path(public) if public else None,
+        encryption_key_path=Path(encryption) if encryption else None,
+    )
+
+
+_service: FirmwareService | None = None
+
+
+def _get_service() -> FirmwareService:
+    global _service
+    if _service is None:
+        try:
+            _service = _service_from_env()
+        except RuntimeError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return _service
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, object]:
+    try:
+        service = _get_service()
+    except HTTPException:
+        return {"status": "unconfigured", "booted": False}
+    return {"status": "ok", **service.status()}
+
+
+@app.get("/v1/firmware/status")
+def status() -> dict[str, object]:
+    return _get_service().status()
+
+
+@app.get("/v1/firmware/manifest")
+def manifest() -> dict[str, object]:
+    return _get_service().image().manifest
+
+
+@app.post("/v1/firmware/verify")
+def verify() -> dict[str, object]:
+    try:
+        return _get_service().verify()
+    except (OSError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/v1/firmware/boot")
+def boot() -> dict[str, object]:
+    try:
+        return _get_service().boot()
+    except (OSError, TypeError, ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@app.post("/v1/firmware/run")
+def run(request: RunRequest) -> dict[str, object]:
+    try:
+        return _get_service().run(request.cycles)
+    except (OSError, TypeError, ValueError, RuntimeError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/src/jarvisx/dr_moagi_firmware_cli.py
+++ b/src/jarvisx/dr_moagi_firmware_cli.py
@@ -1,0 +1,218 @@
+"""CLI for the Dr Moagi verified 1 GiB firmware container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from .dr_moagi_firmware import (
+    FirmwareBuilder,
+    FirmwareImage,
+    build_reference_riscv_elf,
+    generate_aes256_key,
+    generate_ed25519_keypair,
+    inspect_riscv_elf,
+)
+from .dr_moagi_os import demo_field
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx-dr-moagi-firmware",
+        description=(
+            "Build, inspect, verify and boot the exact-size DMLAMBDA 1 GiB firmware container."
+        ),
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    keys = sub.add_parser("keygen", help="Generate Ed25519 signing and AES-256 encryption keys")
+    keys.add_argument("prefix", type=Path)
+    keys.add_argument("--pretty", action="store_true")
+
+    build_demo = sub.add_parser("build-demo", help="Build a signed/encrypted demo firmware image")
+    build_demo.add_argument("output", type=Path)
+    build_demo.add_argument("--side", type=int, default=16)
+    _add_build_keys(build_demo)
+    build_demo.add_argument("--supervisor", type=Path)
+    build_demo.add_argument("--pretty", action="store_true")
+
+    build = sub.add_parser("build", help="Build firmware from a sparse state JSON file")
+    build.add_argument("state", type=Path)
+    build.add_argument("output", type=Path)
+    build.add_argument("--side", type=int, required=True)
+    build.add_argument("--metric", type=Path)
+    build.add_argument("--supervisor", type=Path)
+    _add_build_keys(build)
+    build.add_argument("--pretty", action="store_true")
+
+    inspect = sub.add_parser("inspect", help="Inspect container metadata without booting it")
+    inspect.add_argument("image", type=Path)
+    inspect.add_argument("--pretty", action="store_true")
+
+    verify = sub.add_parser("verify", help="Verify manifest, signature, encryption and sections")
+    verify.add_argument("image", type=Path)
+    _add_verify_keys(verify)
+    verify.add_argument("--pretty", action="store_true")
+
+    run = sub.add_parser("run", help="Verified-boot the image and execute bounded autonomic cycles")
+    run.add_argument("image", type=Path)
+    run.add_argument("--cycles", type=int, default=1)
+    run.add_argument("--max-active-cells", type=int, default=50_000)
+    _add_verify_keys(run)
+    run.add_argument("--pretty", action="store_true")
+
+    elf = sub.add_parser("reference-elf", help="Write the valid RV64 reference monitor ELF")
+    elf.add_argument("output", type=Path)
+    elf.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def _add_build_keys(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--signing-private-key", type=Path)
+    parser.add_argument("--encryption-key", type=Path)
+
+
+def _add_verify_keys(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--public-key", type=Path)
+    parser.add_argument("--encryption-key", type=Path)
+
+
+def _read_optional(path: Path | None) -> bytes | None:
+    return None if path is None else path.read_bytes()
+
+
+def _load_field(path: Path) -> dict[tuple[int, int, int], float]:
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    rows = raw.get("field") if isinstance(raw, dict) else raw
+    if not isinstance(rows, list) or not rows:
+        raise ValueError("state JSON must contain a non-empty list or {'field': [...]} object")
+    result: dict[tuple[int, int, int], float] = {}
+    for row in rows:
+        if isinstance(row, dict):
+            coordinate = int(row["x"]), int(row["y"]), int(row["z"])
+            value = float(row["value"])
+        elif isinstance(row, list) and len(row) == 4:
+            coordinate = int(row[0]), int(row[1]), int(row[2])
+            value = float(row[3])
+        else:
+            raise ValueError("state rows must be {x,y,z,value} or [x,y,z,value]")
+        if coordinate in result:
+            raise ValueError(f"duplicate state coordinate: {coordinate}")
+        result[coordinate] = value
+    return result
+
+
+def _load_metric(path: Path) -> dict[tuple[int, int, int], tuple[float, ...]]:
+    raw: Any = json.loads(path.read_text(encoding="utf-8"))
+    rows = raw.get("metric") if isinstance(raw, dict) else raw
+    if not isinstance(rows, list):
+        raise ValueError("metric JSON must contain a list or {'metric': [...]} object")
+    result: dict[tuple[int, int, int], tuple[float, ...]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("metric rows must be objects")
+        coordinate = int(row["x"]), int(row["y"]), int(row["z"])
+        components = tuple(
+            float(row[name]) for name in ("gxx", "gyy", "gzz", "gxy", "gxz", "gyz")
+        )
+        if coordinate in result:
+            raise ValueError(f"duplicate metric coordinate: {coordinate}")
+        result[coordinate] = components
+    return result
+
+
+def _print(payload: object, pretty: bool) -> None:
+    print(json.dumps(payload, indent=2 if pretty else None, sort_keys=True))
+
+
+def main() -> int:
+    args = _parser().parse_args()
+
+    if args.command == "keygen":
+        private, public = generate_ed25519_keypair()
+        aes = generate_aes256_key()
+        args.prefix.parent.mkdir(parents=True, exist_ok=True)
+        private_path = Path(str(args.prefix) + ".ed25519.private")
+        public_path = Path(str(args.prefix) + ".ed25519.public")
+        aes_path = Path(str(args.prefix) + ".aes256")
+        private_path.write_bytes(private)
+        public_path.write_bytes(public)
+        aes_path.write_bytes(aes)
+        _print(
+            {
+                "private_key": str(private_path),
+                "public_key": str(public_path),
+                "encryption_key": str(aes_path),
+                "warning": "keep private and AES keys outside firmware images and source control",
+            },
+            args.pretty,
+        )
+        return 0
+
+    if args.command == "reference-elf":
+        payload = build_reference_riscv_elf()
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_bytes(payload)
+        _print({"path": str(args.output), "bytes": len(payload), **inspect_riscv_elf(payload)}, args.pretty)
+        return 0
+
+    if args.command in ("build", "build-demo"):
+        state = demo_field(args.side) if args.command == "build-demo" else _load_field(args.state)
+        metric = None
+        if args.command == "build" and args.metric is not None:
+            metric = _load_metric(args.metric)
+        supervisor = _read_optional(args.supervisor)
+        report = FirmwareBuilder().build(
+            args.output,
+            state=state,
+            side=args.side,
+            metric=metric,
+            supervisor_elf=supervisor,
+            signing_private_key=_read_optional(args.signing_private_key),
+            encryption_key=_read_optional(args.encryption_key),
+        )
+        _print(report, args.pretty)
+        return 0
+
+    image = FirmwareImage(args.image)
+    if args.command == "inspect":
+        _print(
+            {
+                "path": str(args.image),
+                "logical_size_bytes": args.image.stat().st_size,
+                "signed": image.signed,
+                "encrypted": image.encrypted,
+                "manifest": image.manifest,
+            },
+            args.pretty,
+        )
+        return 0
+
+    public = _read_optional(args.public_key)
+    encryption = _read_optional(args.encryption_key)
+    if args.command == "verify":
+        _print(image.verify(public_key=public, encryption_key=encryption).as_dict(), args.pretty)
+        return 0
+    if args.command == "run":
+        session = image.boot(
+            public_key=public,
+            encryption_key=encryption,
+            max_active_cells=args.max_active_cells,
+        )
+        report = session.run(args.cycles)
+        _print(
+            {
+                "run": report.as_dict(),
+                "status": session.architecture.status(),
+                "trace_head": session.trace_head,
+            },
+            args.pretty,
+        )
+        return 0
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_firmware_cli.py
+++ b/src/jarvisx/dr_moagi_firmware_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -62,6 +63,13 @@ def _parser() -> argparse.ArgumentParser:
     run.add_argument("--max-active-cells", type=int, default=50_000)
     _add_verify_keys(run)
     run.add_argument("--pretty", action="store_true")
+
+    serve = sub.add_parser("serve", help="Serve a verified firmware image through FastAPI")
+    serve.add_argument("image", type=Path)
+    serve.add_argument("--public-key", type=Path)
+    serve.add_argument("--encryption-key", type=Path)
+    serve.add_argument("--host", default="127.0.0.1")
+    serve.add_argument("--port", type=int, default=10002)
 
     elf = sub.add_parser("reference-elf", help="Write the valid RV64 reference monitor ELF")
     elf.add_argument("output", type=Path)
@@ -155,7 +163,10 @@ def main() -> int:
         payload = build_reference_riscv_elf()
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_bytes(payload)
-        _print({"path": str(args.output), "bytes": len(payload), **inspect_riscv_elf(payload)}, args.pretty)
+        _print(
+            {"path": str(args.output), "bytes": len(payload), **inspect_riscv_elf(payload)},
+            args.pretty,
+        )
         return 0
 
     if args.command in ("build", "build-demo"):
@@ -174,6 +185,17 @@ def main() -> int:
             encryption_key=_read_optional(args.encryption_key),
         )
         _print(report, args.pretty)
+        return 0
+
+    if args.command == "serve":
+        os.environ["JARVISX_FIRMWARE_IMAGE"] = str(args.image)
+        if args.public_key is not None:
+            os.environ["JARVISX_FIRMWARE_PUBLIC_KEY"] = str(args.public_key)
+        if args.encryption_key is not None:
+            os.environ["JARVISX_FIRMWARE_ENCRYPTION_KEY"] = str(args.encryption_key)
+        import uvicorn
+
+        uvicorn.run("jarvisx.dr_moagi_firmware_api:app", host=args.host, port=args.port)
         return 0
 
     image = FirmwareImage(args.image)

--- a/tests/test_dr_moagi_firmware.py
+++ b/tests/test_dr_moagi_firmware.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jarvisx.dr_moagi_firmware import (
+    FIRMWARE_LAYOUT,
+    IMAGE_SIZE,
+    FirmwareBuilder,
+    FirmwareImage,
+    SparseMetricCodec3D,
+    build_reference_riscv_elf,
+    generate_aes256_key,
+    generate_ed25519_keypair,
+    identity_metric_for_state,
+    inspect_riscv_elf,
+    relax_metric_field,
+    validate_layout,
+)
+from jarvisx.dr_moagi_os import demo_field
+
+
+def test_firmware_layout_is_exact_contiguous_one_gib() -> None:
+    validate_layout()
+    assert FIRMWARE_LAYOUT[0].offset == 0
+    assert FIRMWARE_LAYOUT[-1].end == IMAGE_SIZE == 1_073_741_824
+    assert [region.capacity >> 20 for region in FIRMWARE_LAYOUT] == [1, 383, 320, 192, 128]
+
+
+def test_reference_kernel_is_valid_riscv_elf64() -> None:
+    payload = build_reference_riscv_elf()
+    info = inspect_riscv_elf(payload)
+    assert payload[:4] == b"\x7fELF"
+    assert info["machine"] == 243
+    assert info["entry"] == 0x80000000
+    assert info["program_headers"] == 1
+
+
+def test_sparse_metric_roundtrip_and_spd_relaxation() -> None:
+    field = {
+        (1, 1, 1): (1.2, 1.1, 1.0, 0.05, 0.02, 0.01),
+        (2, 1, 1): (1.1, 1.0, 1.3, 0.02, 0.01, 0.03),
+    }
+    codec = SparseMetricCodec3D()
+    payload = codec.encode(field, side=8)
+    side, decoded = codec.decode(payload)
+    assert side == 8
+    assert set(decoded) == set(field)
+    relaxed = relax_metric_field(decoded, side=8, alpha=0.1)
+    assert set(relaxed) == set(field)
+    codec.encode(relaxed, side=8)  # validation succeeds
+
+    with pytest.raises(ValueError, match="positive definite"):
+        codec.encode({(1, 1, 1): (-1, 1, 1, 0, 0, 0)}, side=8)
+
+
+def test_signed_encrypted_image_verifies_and_is_logically_one_gib(tmp_path: Path) -> None:
+    private, public = generate_ed25519_keypair()
+    aes = generate_aes256_key()
+    state = demo_field(8)
+    image_path = tmp_path / "dr-moagi.img"
+    build = FirmwareBuilder().build(
+        image_path,
+        state=state,
+        side=8,
+        signing_private_key=private,
+        encryption_key=aes,
+    )
+    assert build["image_size"] == IMAGE_SIZE
+    assert image_path.stat().st_size == IMAGE_SIZE
+
+    image = FirmwareImage(image_path)
+    report = image.verify(public_key=public, encryption_key=aes)
+    assert report.signed is True
+    assert report.encrypted is True
+    assert report.signature_valid is True
+    assert report.qsol_cells == len(state)
+    assert report.metric_cells == len(state)
+    assert report.kernel_machine == 243
+
+
+def test_wrong_crypto_keys_fail_closed(tmp_path: Path) -> None:
+    private, public = generate_ed25519_keypair()
+    _, wrong_public = generate_ed25519_keypair()
+    aes = generate_aes256_key()
+    wrong_aes = generate_aes256_key()
+    image_path = tmp_path / "secure.img"
+    FirmwareBuilder().build(
+        image_path,
+        state=demo_field(8),
+        side=8,
+        signing_private_key=private,
+        encryption_key=aes,
+    )
+    image = FirmwareImage(image_path)
+    with pytest.raises(ValueError, match="trust anchor"):
+        image.verify(public_key=wrong_public, encryption_key=aes)
+    with pytest.raises(ValueError, match="authentication failed"):
+        image.verify(public_key=public, encryption_key=wrong_aes)
+
+
+def test_section_tampering_is_detected_before_boot(tmp_path: Path) -> None:
+    state = demo_field(8)
+    image_path = tmp_path / "tampered.img"
+    FirmwareBuilder().build(image_path, state=state, side=8)
+    qsol = next(region for region in FIRMWARE_LAYOUT if region.name == "qsol")
+    with image_path.open("r+b") as handle:
+        handle.seek(qsol.offset)
+        first = handle.read(1)
+        handle.seek(qsol.offset)
+        handle.write(bytes([first[0] ^ 0x01]))
+    with pytest.raises(ValueError, match="section checksum mismatch"):
+        FirmwareImage(image_path).verify()
+
+
+def test_verified_boot_runs_existing_autonomic_system_and_metric_transaction(tmp_path: Path) -> None:
+    state = demo_field(8)
+    image_path = tmp_path / "boot.img"
+    FirmwareBuilder().build(
+        image_path,
+        state=state,
+        side=8,
+        metric=identity_metric_for_state(state),
+    )
+    session = FirmwareImage(image_path).boot(max_active_cells=512)
+    report = session.run(1)
+    assert report.verification.qsol_cells == len(state)
+    assert len(report.autonomic.state_reports) == 1
+    assert len(session.trace_head) == 64
+    assert session.export_state()


### PR DESCRIPTION
## Summary

Operationalizes the corrected 1 GiB Dr Moagi firmware concept as a real sparse firmware-container runtime rather than a synthetic hex dump.

### Exact 1 GiB container

- Adds an exact contiguous 1 GiB logical map:
  - 1 MiB genesis/manifest
  - 383 MiB sparse QSOL state
  - 320 MiB sparse SPD metric field
  - 192 MiB immutable RISC-V kernel region
  - 128 MiB trace/audit reserve
- Builds sparse files with `truncate()` and writes only used section payloads.

### Verified boot and cryptography

- Canonical JSON manifest in the genesis block.
- SHA-256 manifest and section digests.
- Ed25519 manifest authentication with an external public-key trust anchor.
- AES-256-GCM encryption/authentication for QSOL and metric sections.
- HKDF-SHA256 per-section key derivation.
- SHA3-256 trace anchor/head.

### Executable boundary

- Adds a valid minimal ELF64 little-endian RISC-V monitor stub (`EM_RISCV=243`, executable `PT_LOAD`, entry `0x80000000`).
- Supports caller-supplied RISC-V supervisor ELF images through the same validation contract.
- Keeps executable code immutable; self-optimization remains in bounded state/model/configuration/architecture parameters.

### State and metric runtime

- Reuses exact DMOS2 sparse Morton state transport.
- Adds DMMET1 sparse symmetric-positive-definite 3D metric packets with six float32 components.
- Adds SPD-preserving metric relaxation as the reference metric dynamic; explicitly does not mislabel it as Ricci flow.
- Verified boot instantiates the existing `DrMoagiOSKernel -> SelfOptimizing3DSystem -> SelfEvolving3DArchitecture` stack.

### Operational surfaces

Adds `jarvisx-dr-moagi-firmware` with:

- `keygen`
- `reference-elf`
- `build-demo`
- `build`
- `inspect`
- `verify`
- `run`
- `serve`

FastAPI routes:

- `GET /healthz`
- `GET /v1/firmware/status`
- `GET /v1/firmware/manifest`
- `POST /v1/firmware/verify`
- `POST /v1/firmware/boot`
- `POST /v1/firmware/run`

### Validation

- Adds firmware layout, RISC-V ELF, SPD metric, signed/encrypted image, wrong-key, tamper-detection, and verified-boot integration tests.
- Extends Dr Moagi OS CI with a real 1 GiB sparse build -> verify -> boot/run CLI smoke path.
- Adds `cryptography` for standard Ed25519/AES-GCM/HKDF primitives.

### Boundaries

- Reference monitor is not a board-specific bare-metal bootloader.
- Generic GPUs do not natively execute RISC-V code.
- No arbitrary lossless compression claim for dense `1000^3` data.
- No self-modifying executable code.
- No key derivation from public geometry/holonomy.
- No Ricci-flow claim until a verified numerical Ricci solver is integrated.

The invariant remains: `PROVISIONAL != AUTHORITATIVE`; firmware execution begins only after the external trust anchor, manifest, sections, state codec, metric invariants, RISC-V ELF contract, and trace anchor verify.