### PR TITLE
Operationalize QSOL 3D graphics auto-encoding/decoding codec

### DIFF
--- a/.github/workflows/qsol-graphics-codec.yml
+++ b/.github/workflows/qsol-graphics-codec.yml
@@ -1,0 +1,32 @@
+name: qsol-graphics-codec
+
+on:
+  push:
+    paths:
+      - 'apps/qsol-graphics-codec/**'
+      - '.github/workflows/qsol-graphics-codec.yml'
+  pull_request:
+    paths:
+      - 'apps/qsol-graphics-codec/**'
+      - '.github/workflows/qsol-graphics-codec.yml'
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Build
+        run: dotnet build apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release
+      - name: Round-trip self-test
+        run: dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release --no-build -- --self-test
+      - name: Generate smoke-test frames
+        run: dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release --no-build -- --frames 3 --target-error 0.0025 --output artifacts/qsol-graphics-codec
+      - name: Upload smoke-test artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: qsol-graphics-codec-smoke
+          path: artifacts/qsol-graphics-codec

--- a/apps/qsol-graphics-codec/Codec/BitPacking.cs
+++ b/apps/qsol-graphics-codec/Codec/BitPacking.cs
@@ -1,0 +1,97 @@
+namespace QSol.GraphicsCodec.Codec;
+
+internal sealed class BitWriter
+{
+    private readonly Stream _stream;
+    private ulong _buffer;
+    private int _bitCount;
+
+    public BitWriter(Stream stream) => _stream = stream;
+
+    public void Write(uint value, int bits)
+    {
+        if (bits is < 1 or > 32) throw new ArgumentOutOfRangeException(nameof(bits));
+        var mask = bits == 32 ? uint.MaxValue : (1u << bits) - 1u;
+        _buffer |= ((ulong)(value & mask)) << _bitCount;
+        _bitCount += bits;
+
+        while (_bitCount >= 8)
+        {
+            _stream.WriteByte((byte)_buffer);
+            _buffer >>= 8;
+            _bitCount -= 8;
+        }
+    }
+
+    public void AlignToByte()
+    {
+        if (_bitCount <= 0) return;
+        _stream.WriteByte((byte)_buffer);
+        _buffer = 0;
+        _bitCount = 0;
+    }
+}
+
+internal sealed class BitReader
+{
+    private readonly Stream _stream;
+    private ulong _buffer;
+    private int _bitCount;
+
+    public BitReader(Stream stream) => _stream = stream;
+
+    public uint Read(int bits)
+    {
+        if (bits is < 1 or > 32) throw new ArgumentOutOfRangeException(nameof(bits));
+        while (_bitCount < bits)
+        {
+            var next = _stream.ReadByte();
+            if (next < 0) throw new EndOfStreamException();
+            _buffer |= ((ulong)(byte)next) << _bitCount;
+            _bitCount += 8;
+        }
+
+        var mask = bits == 32 ? uint.MaxValue : (1u << bits) - 1u;
+        var value = (uint)_buffer & mask;
+        _buffer >>= bits;
+        _bitCount -= bits;
+        return value;
+    }
+
+    public void AlignToByte()
+    {
+        _buffer = 0;
+        _bitCount = 0;
+    }
+}
+
+internal static class VarInt
+{
+    public static void WriteUInt(Stream stream, uint value)
+    {
+        while (value >= 0x80)
+        {
+            stream.WriteByte((byte)(value | 0x80));
+            value >>= 7;
+        }
+        stream.WriteByte((byte)value);
+    }
+
+    public static uint ReadUInt(Stream stream)
+    {
+        uint value = 0;
+        var shift = 0;
+        while (shift < 35)
+        {
+            var next = stream.ReadByte();
+            if (next < 0) throw new EndOfStreamException();
+            value |= (uint)(next & 0x7F) << shift;
+            if ((next & 0x80) == 0) return value;
+            shift += 7;
+        }
+        throw new InvalidDataException("Invalid varint.");
+    }
+
+    public static uint ZigZagEncode(int value) => unchecked((uint)((value << 1) ^ (value >> 31)));
+    public static int ZigZagDecode(uint value) => (int)(value >> 1) ^ -((int)value & 1);
+}

--- a/apps/qsol-graphics-codec/Codec/SceneCodec.cs
+++ b/apps/qsol-graphics-codec/Codec/SceneCodec.cs
@@ -1,0 +1,249 @@
+using System.IO.Compression;
+using System.Numerics;
+using System.Text;
+using QSol.GraphicsCodec.Core;
+
+namespace QSol.GraphicsCodec.Codec;
+
+public sealed record EncodedScene(byte[] Data, int QuantizationBits, int RawBytes);
+public sealed record CodecCandidate(int Bits, int EncodedBytes, int RawBytes, float MaxVertexError, bool MeetsTolerance);
+public sealed record AutoEncodeResult(EncodedScene Encoded, Scene3D Decoded, float MaxVertexError, IReadOnlyList<CodecCandidate> Candidates);
+
+public static class SceneCodec
+{
+    private static readonly byte[] EnvelopeMagic = "QSC1"u8.ToArray();
+    private static readonly byte[] PayloadMagic = "Q3D1"u8.ToArray();
+    private const byte EnvelopeVersion = 1;
+    private const byte PayloadVersion = 1;
+
+    public static AutoEncodeResult AutoEncode(Scene3D scene, float targetMaxVertexError = 0.0025f, bool compress = true)
+    {
+        if (targetMaxVertexError <= 0f) throw new ArgumentOutOfRangeException(nameof(targetMaxVertexError));
+
+        var candidates = new List<CodecCandidate>();
+        EncodedScene? best = null;
+        Scene3D? bestDecoded = null;
+        var bestError = float.PositiveInfinity;
+
+        foreach (var bits in new[] { 8, 10, 12, 14, 16 })
+        {
+            var encoded = Encode(scene, bits, compress);
+            var decoded = Decode(encoded.Data);
+            var error = SceneMetrics.MaxVertexError(scene, decoded);
+            var meets = error <= targetMaxVertexError;
+            candidates.Add(new CodecCandidate(bits, encoded.Data.Length, encoded.RawBytes, error, meets));
+
+            if (meets && (best is null || encoded.Data.Length < best.Data.Length))
+            {
+                best = encoded;
+                bestDecoded = decoded;
+                bestError = error;
+            }
+        }
+
+        if (best is null)
+        {
+            best = Encode(scene, 16, compress);
+            bestDecoded = Decode(best.Data);
+            bestError = SceneMetrics.MaxVertexError(scene, bestDecoded);
+        }
+
+        return new AutoEncodeResult(best, bestDecoded!, bestError, candidates);
+    }
+
+    public static EncodedScene Encode(Scene3D scene, int quantizationBits = 14, bool compress = true)
+    {
+        if (quantizationBits is < 8 or > 16)
+            throw new ArgumentOutOfRangeException(nameof(quantizationBits), "Quantization must be 8..16 bits per axis.");
+
+        var raw = EncodePayload(scene, quantizationBits);
+        using var output = new MemoryStream();
+        using var writer = new BinaryWriter(output, Encoding.UTF8, leaveOpen: true);
+        writer.Write(EnvelopeMagic);
+        writer.Write(EnvelopeVersion);
+        writer.Write((byte)(compress ? 1 : 0));
+        writer.Write(raw.Length);
+        writer.Flush();
+
+        if (compress)
+        {
+            using var brotli = new BrotliStream(output, CompressionLevel.SmallestSize, leaveOpen: true);
+            brotli.Write(raw);
+        }
+        else
+        {
+            output.Write(raw);
+        }
+
+        return new EncodedScene(output.ToArray(), quantizationBits, raw.Length);
+    }
+
+    public static Scene3D Decode(ReadOnlySpan<byte> encoded)
+    {
+        using var input = new MemoryStream(encoded.ToArray(), writable: false);
+        using var reader = new BinaryReader(input, Encoding.UTF8, leaveOpen: true);
+
+        RequireMagic(reader.ReadBytes(4), EnvelopeMagic, "QSC envelope");
+        if (reader.ReadByte() != EnvelopeVersion) throw new InvalidDataException("Unsupported QSC envelope version.");
+        var compressed = reader.ReadByte() != 0;
+        var rawLength = reader.ReadInt32();
+        if (rawLength is < 0 or > 1_073_741_824) throw new InvalidDataException("Invalid payload length.");
+
+        byte[] raw;
+        if (compressed)
+        {
+            using var brotli = new BrotliStream(input, CompressionMode.Decompress, leaveOpen: true);
+            using var rawStream = new MemoryStream(rawLength > 0 ? rawLength : 0);
+            brotli.CopyTo(rawStream);
+            raw = rawStream.ToArray();
+        }
+        else
+        {
+            raw = reader.ReadBytes(rawLength);
+        }
+
+        if (raw.Length != rawLength) throw new InvalidDataException("Payload length mismatch.");
+        return DecodePayload(raw);
+    }
+
+    private static byte[] EncodePayload(Scene3D scene, int bits)
+    {
+        var bounds = scene.ComputeLocalGeometryBounds();
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+        writer.Write(PayloadMagic);
+        writer.Write(PayloadVersion);
+        writer.Write((byte)bits);
+        WriteVector3(writer, bounds.Min);
+        WriteVector3(writer, bounds.Max);
+        writer.Flush();
+        VarInt.WriteUInt(stream, checked((uint)scene.Entities.Count));
+
+        foreach (var entity in scene.Entities)
+        {
+            writer.Write(entity.Name ?? string.Empty);
+            WriteVector3(writer, entity.Transform.Position);
+            WriteQuaternion(writer, entity.Transform.Rotation);
+            WriteVector3(writer, entity.Transform.Scale);
+            WriteVector3(writer, entity.LinearVelocity);
+            WriteVector3(writer, entity.AngularVelocity);
+            WriteVector4(writer, entity.Material.BaseColor);
+            writer.Write(entity.Material.Metallic);
+            writer.Write(entity.Material.Roughness);
+            writer.Flush();
+
+            VarInt.WriteUInt(stream, checked((uint)entity.Mesh.Vertices.Length));
+            VarInt.WriteUInt(stream, checked((uint)entity.Mesh.Indices.Length));
+
+            var bitWriter = new BitWriter(stream);
+            foreach (var vertex in entity.Mesh.Vertices)
+            {
+                bitWriter.Write(Quantize(vertex.X, bounds.Min.X, bounds.Max.X, bits), bits);
+                bitWriter.Write(Quantize(vertex.Y, bounds.Min.Y, bounds.Max.Y, bits), bits);
+                bitWriter.Write(Quantize(vertex.Z, bounds.Min.Z, bounds.Max.Z, bits), bits);
+            }
+            bitWriter.AlignToByte();
+
+            var previous = 0;
+            foreach (var index in entity.Mesh.Indices)
+            {
+                if ((uint)index >= (uint)entity.Mesh.Vertices.Length)
+                    throw new InvalidDataException($"Entity '{entity.Name}' contains an out-of-range mesh index.");
+                var delta = index - previous;
+                VarInt.WriteUInt(stream, VarInt.ZigZagEncode(delta));
+                previous = index;
+            }
+        }
+
+        writer.Flush();
+        return stream.ToArray();
+    }
+
+    private static Scene3D DecodePayload(byte[] raw)
+    {
+        using var stream = new MemoryStream(raw, writable: false);
+        using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+        RequireMagic(reader.ReadBytes(4), PayloadMagic, "Q3D payload");
+        if (reader.ReadByte() != PayloadVersion) throw new InvalidDataException("Unsupported Q3D payload version.");
+        var bits = reader.ReadByte();
+        if (bits is < 8 or > 16) throw new InvalidDataException("Invalid quantization depth.");
+
+        var min = ReadVector3(reader);
+        var max = ReadVector3(reader);
+        var entityCount = checked((int)VarInt.ReadUInt(stream));
+        if (entityCount > 1_000_000) throw new InvalidDataException("Entity count exceeds decoder limit.");
+
+        var scene = new Scene3D();
+        for (var e = 0; e < entityCount; e++)
+        {
+            var name = reader.ReadString();
+            var transform = new Transform3D(ReadVector3(reader), ReadQuaternion(reader), ReadVector3(reader));
+            var linearVelocity = ReadVector3(reader);
+            var angularVelocity = ReadVector3(reader);
+            var material = new MaterialPbr(ReadVector4(reader), reader.ReadSingle(), reader.ReadSingle());
+            var vertexCount = checked((int)VarInt.ReadUInt(stream));
+            var indexCount = checked((int)VarInt.ReadUInt(stream));
+            if (vertexCount > 50_000_000 || indexCount > 150_000_000)
+                throw new InvalidDataException("Mesh exceeds decoder limits.");
+
+            var vertices = new Vector3[vertexCount];
+            var bitReader = new BitReader(stream);
+            for (var i = 0; i < vertexCount; i++)
+            {
+                vertices[i] = new Vector3(
+                    Dequantize(bitReader.Read(bits), min.X, max.X, bits),
+                    Dequantize(bitReader.Read(bits), min.Y, max.Y, bits),
+                    Dequantize(bitReader.Read(bits), min.Z, max.Z, bits));
+            }
+            bitReader.AlignToByte();
+
+            var indices = new int[indexCount];
+            var previous = 0;
+            for (var i = 0; i < indexCount; i++)
+            {
+                var delta = VarInt.ZigZagDecode(VarInt.ReadUInt(stream));
+                var index = checked(previous + delta);
+                if ((uint)index >= (uint)vertexCount) throw new InvalidDataException("Decoded mesh index is out of range.");
+                indices[i] = index;
+                previous = index;
+            }
+
+            scene.Entities.Add(new Entity3D
+            {
+                Name = name,
+                Mesh = new MeshData { Vertices = vertices, Indices = indices },
+                Material = material,
+                Transform = transform,
+                LinearVelocity = linearVelocity,
+                AngularVelocity = angularVelocity
+            });
+        }
+
+        return scene;
+    }
+
+    private static uint Quantize(float value, float min, float max, int bits)
+    {
+        var levels = (1u << bits) - 1u;
+        var t = Math.Clamp((value - min) / (max - min), 0f, 1f);
+        return (uint)MathF.Round(t * levels);
+    }
+
+    private static float Dequantize(uint value, float min, float max, int bits)
+    {
+        var levels = (1u << bits) - 1u;
+        return min + (value / (float)levels) * (max - min);
+    }
+
+    private static void WriteVector3(BinaryWriter w, Vector3 v) { w.Write(v.X); w.Write(v.Y); w.Write(v.Z); }
+    private static Vector3 ReadVector3(BinaryReader r) => new(r.ReadSingle(), r.ReadSingle(), r.ReadSingle());
+    private static void WriteVector4(BinaryWriter w, Vector4 v) { w.Write(v.X); w.Write(v.Y); w.Write(v.Z); w.Write(v.W); }
+    private static Vector4 ReadVector4(BinaryReader r) => new(r.ReadSingle(), r.ReadSingle(), r.ReadSingle(), r.ReadSingle());
+    private static void WriteQuaternion(BinaryWriter w, Quaternion q) { w.Write(q.X); w.Write(q.Y); w.Write(q.Z); w.Write(q.W); }
+    private static Quaternion ReadQuaternion(BinaryReader r) => new(r.ReadSingle(), r.ReadSingle(), r.ReadSingle(), r.ReadSingle());
+
+    private static void RequireMagic(byte[] actual, byte[] expected, string label)
+    {
+        if (!actual.AsSpan().SequenceEqual(expected)) throw new InvalidDataException($"Invalid {label} magic.");
+    }
+}

--- a/apps/qsol-graphics-codec/Core/KineticIntegrator.cs
+++ b/apps/qsol-graphics-codec/Core/KineticIntegrator.cs
@@ -1,0 +1,28 @@
+using System.Numerics;
+
+namespace QSol.GraphicsCodec.Core;
+
+public static class KineticIntegrator
+{
+    public static void Step(Scene3D scene, float dt)
+    {
+        if (dt <= 0f) return;
+
+        foreach (var entity in scene.Entities)
+        {
+            var transform = entity.Transform;
+            var position = transform.Position + entity.LinearVelocity * dt;
+            var rotation = transform.Rotation;
+
+            var speed = entity.AngularVelocity.Length();
+            if (speed > 1e-8f)
+            {
+                var axis = entity.AngularVelocity / speed;
+                var delta = Quaternion.CreateFromAxisAngle(axis, speed * dt);
+                rotation = Quaternion.Normalize(delta * rotation);
+            }
+
+            entity.Transform = new Transform3D(position, rotation, transform.Scale);
+        }
+    }
+}

--- a/apps/qsol-graphics-codec/Core/Scene.cs
+++ b/apps/qsol-graphics-codec/Core/Scene.cs
@@ -1,0 +1,85 @@
+using System.Numerics;
+
+namespace QSol.GraphicsCodec.Core;
+
+public readonly record struct Transform3D(Vector3 Position, Quaternion Rotation, Vector3 Scale)
+{
+    public static Transform3D Identity => new(Vector3.Zero, Quaternion.Identity, Vector3.One);
+}
+
+public sealed record MaterialPbr(Vector4 BaseColor, float Metallic, float Roughness);
+
+public sealed class MeshData
+{
+    public required Vector3[] Vertices { get; init; }
+    public required int[] Indices { get; init; }
+}
+
+public sealed class Entity3D
+{
+    public required string Name { get; init; }
+    public required MeshData Mesh { get; init; }
+    public required MaterialPbr Material { get; init; }
+    public Transform3D Transform { get; set; } = Transform3D.Identity;
+    public Vector3 LinearVelocity { get; set; }
+    public Vector3 AngularVelocity { get; set; }
+}
+
+public sealed class Scene3D
+{
+    public List<Entity3D> Entities { get; } = new();
+
+    public Bounds3D ComputeLocalGeometryBounds()
+    {
+        var hasPoint = false;
+        var min = new Vector3(float.PositiveInfinity);
+        var max = new Vector3(float.NegativeInfinity);
+
+        foreach (var entity in Entities)
+        {
+            foreach (var v in entity.Mesh.Vertices)
+            {
+                hasPoint = true;
+                min = Vector3.Min(min, v);
+                max = Vector3.Max(max, v);
+            }
+        }
+
+        if (!hasPoint)
+            return new Bounds3D(Vector3.Zero, Vector3.One);
+
+        var size = max - min;
+        if (MathF.Abs(size.X) < 1e-12f) max.X = min.X + 1f;
+        if (MathF.Abs(size.Y) < 1e-12f) max.Y = min.Y + 1f;
+        if (MathF.Abs(size.Z) < 1e-12f) max.Z = min.Z + 1f;
+        return new Bounds3D(min, max);
+    }
+}
+
+public readonly record struct Bounds3D(Vector3 Min, Vector3 Max)
+{
+    public Vector3 Size => Max - Min;
+}
+
+public static class SceneMetrics
+{
+    public static float MaxVertexError(Scene3D a, Scene3D b)
+    {
+        if (a.Entities.Count != b.Entities.Count)
+            return float.PositiveInfinity;
+
+        var max = 0f;
+        for (var e = 0; e < a.Entities.Count; e++)
+        {
+            var av = a.Entities[e].Mesh.Vertices;
+            var bv = b.Entities[e].Mesh.Vertices;
+            if (av.Length != bv.Length)
+                return float.PositiveInfinity;
+
+            for (var i = 0; i < av.Length; i++)
+                max = MathF.Max(max, Vector3.Distance(av[i], bv[i]));
+        }
+
+        return max;
+    }
+}

--- a/apps/qsol-graphics-codec/Export/ObjExporter.cs
+++ b/apps/qsol-graphics-codec/Export/ObjExporter.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using System.Numerics;
+using QSol.GraphicsCodec.Core;
+
+namespace QSol.GraphicsCodec.Export;
+
+public static class ObjExporter
+{
+    public static void Export(Scene3D scene, string path)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path))!);
+        using var writer = new StreamWriter(path, false);
+        writer.WriteLine("# QSOL Graphics Codec decoded scene");
+        var vertexOffset = 1;
+
+        foreach (var entity in scene.Entities)
+        {
+            writer.WriteLine($"o {Sanitize(entity.Name)}");
+            writer.WriteLine(FormattableString.Invariant($"# PBR baseColor={entity.Material.BaseColor.X:F4},{entity.Material.BaseColor.Y:F4},{entity.Material.BaseColor.Z:F4},{entity.Material.BaseColor.W:F4} metallic={entity.Material.Metallic:F4} roughness={entity.Material.Roughness:F4}"));
+
+            foreach (var local in entity.Mesh.Vertices)
+            {
+                var scaled = local * entity.Transform.Scale;
+                var rotated = Vector3.Transform(scaled, entity.Transform.Rotation);
+                var world = rotated + entity.Transform.Position;
+                writer.WriteLine(string.Create(CultureInfo.InvariantCulture, $"v {world.X:R} {world.Y:R} {world.Z:R}"));
+            }
+
+            var indices = entity.Mesh.Indices;
+            for (var i = 0; i + 2 < indices.Length; i += 3)
+            {
+                var a = indices[i] + vertexOffset;
+                var b = indices[i + 1] + vertexOffset;
+                var c = indices[i + 2] + vertexOffset;
+                writer.WriteLine($"f {a} {b} {c}");
+            }
+
+            vertexOffset += entity.Mesh.Vertices.Length;
+        }
+    }
+
+    private static string Sanitize(string value) => value.Replace(' ', '_').Replace('\t', '_');
+}

--- a/apps/qsol-graphics-codec/Procedural/DemoSceneFactory.cs
+++ b/apps/qsol-graphics-codec/Procedural/DemoSceneFactory.cs
@@ -1,0 +1,69 @@
+using System.Numerics;
+using QSol.GraphicsCodec.Core;
+
+namespace QSol.GraphicsCodec.Procedural;
+
+public static class DemoSceneFactory
+{
+    public static Scene3D Create()
+    {
+        var scene = new Scene3D();
+        scene.Entities.Add(CreateEntity("kinetic-ring-a", new Vector3(-2.4f, 0f, 0f), new Vector3(0.05f, 0.10f, 0.02f), new Vector3(0.3f, 0.7f, 0.2f), new Vector4(0.82f, 0.22f, 0.12f, 1f), 0.65f, 0.22f));
+        scene.Entities.Add(CreateEntity("kinetic-ring-b", new Vector3(2.4f, 0.2f, 0f), new Vector3(-0.04f, 0.02f, 0.06f), new Vector3(0.8f, 0.25f, 0.45f), new Vector4(0.08f, 0.42f, 0.92f, 1f), 0.25f, 0.12f));
+        scene.Entities.Add(CreateEntity("kinetic-ring-c", new Vector3(0f, 2.2f, -0.6f), new Vector3(0.02f, -0.05f, 0.03f), new Vector3(0.35f, 0.3f, 0.9f), new Vector4(0.15f, 0.85f, 0.48f, 1f), 0.45f, 0.3f));
+        return scene;
+    }
+
+    private static Entity3D CreateEntity(string name, Vector3 position, Vector3 velocity, Vector3 angularVelocity, Vector4 color, float metallic, float roughness)
+    {
+        return new Entity3D
+        {
+            Name = name,
+            Mesh = CreateTorus(48, 18, 1.2f, 0.34f),
+            Material = new MaterialPbr(color, metallic, roughness),
+            Transform = new Transform3D(position, Quaternion.Identity, Vector3.One),
+            LinearVelocity = velocity,
+            AngularVelocity = angularVelocity
+        };
+    }
+
+    public static MeshData CreateTorus(int majorSegments, int minorSegments, float majorRadius, float minorRadius)
+    {
+        if (majorSegments < 3 || minorSegments < 3) throw new ArgumentOutOfRangeException(nameof(majorSegments));
+        var vertices = new Vector3[majorSegments * minorSegments];
+        var indices = new int[majorSegments * minorSegments * 6];
+
+        for (var i = 0; i < majorSegments; i++)
+        {
+            var u = 2f * MathF.PI * i / majorSegments;
+            var cu = MathF.Cos(u);
+            var su = MathF.Sin(u);
+            for (var j = 0; j < minorSegments; j++)
+            {
+                var v = 2f * MathF.PI * j / minorSegments;
+                var cv = MathF.Cos(v);
+                var sv = MathF.Sin(v);
+                var radius = majorRadius + minorRadius * cv;
+                vertices[i * minorSegments + j] = new Vector3(radius * cu, minorRadius * sv, radius * su);
+            }
+        }
+
+        var k = 0;
+        for (var i = 0; i < majorSegments; i++)
+        {
+            var ni = (i + 1) % majorSegments;
+            for (var j = 0; j < minorSegments; j++)
+            {
+                var nj = (j + 1) % minorSegments;
+                var a = i * minorSegments + j;
+                var b = ni * minorSegments + j;
+                var c = ni * minorSegments + nj;
+                var d = i * minorSegments + nj;
+                indices[k++] = a; indices[k++] = b; indices[k++] = c;
+                indices[k++] = a; indices[k++] = c; indices[k++] = d;
+            }
+        }
+
+        return new MeshData { Vertices = vertices, Indices = indices };
+    }
+}

--- a/apps/qsol-graphics-codec/Program.cs
+++ b/apps/qsol-graphics-codec/Program.cs
@@ -1,0 +1,119 @@
+using System.Globalization;
+using QSol.GraphicsCodec.Codec;
+using QSol.GraphicsCodec.Core;
+using QSol.GraphicsCodec.Export;
+using QSol.GraphicsCodec.Procedural;
+
+namespace QSol.GraphicsCodec;
+
+internal static class Program
+{
+    public static int Main(string[] args)
+    {
+        try
+        {
+            if (args.Contains("--self-test", StringComparer.OrdinalIgnoreCase))
+                return SelfTest();
+
+            var decodePath = GetOption(args, "--decode");
+            if (decodePath is not null)
+            {
+                var decoded = SceneCodec.Decode(File.ReadAllBytes(decodePath));
+                var objPath = GetOption(args, "--obj") ?? Path.ChangeExtension(decodePath, ".obj");
+                ObjExporter.Export(decoded, objPath);
+                Console.WriteLine($"Decoded {decoded.Entities.Count} entities -> {objPath}");
+                return 0;
+            }
+
+            var frames = ParseInt(GetOption(args, "--frames"), 24, 1, 10_000);
+            var targetError = ParseFloat(GetOption(args, "--target-error"), 0.0025f, 1e-7f, 1f);
+            var output = GetOption(args, "--output") ?? Path.Combine("artifacts", "qsol-graphics-codec");
+            Directory.CreateDirectory(output);
+
+            var scene = DemoSceneFactory.Create();
+            var metrics = new List<string> { "frame,bits,encoded_bytes,raw_bytes,max_vertex_error" };
+            Console.WriteLine($"QSOL Graphics Codec | frames={frames} targetError={targetError:R}");
+
+            for (var frame = 0; frame < frames; frame++)
+            {
+                var result = SceneCodec.AutoEncode(scene, targetError, compress: true);
+                var framePath = Path.Combine(output, $"frame-{frame:D4}.q3d");
+                File.WriteAllBytes(framePath, result.Encoded.Data);
+                metrics.Add(FormattableString.Invariant($"{frame},{result.Encoded.QuantizationBits},{result.Encoded.Data.Length},{result.Encoded.RawBytes},{result.MaxVertexError:R}"));
+
+                if (frame == 0 || frame == frames - 1)
+                    ObjExporter.Export(result.Decoded, Path.Combine(output, $"frame-{frame:D4}.obj"));
+
+                Console.WriteLine(FormattableString.Invariant($"frame={frame:D4} bits={result.Encoded.QuantizationBits} encoded={result.Encoded.Data.Length}B raw={result.Encoded.RawBytes}B maxError={result.MaxVertexError:G6}"));
+                KineticIntegrator.Step(scene, 1f / 60f);
+            }
+
+            File.WriteAllLines(Path.Combine(output, "metrics.csv"), metrics);
+            Console.WriteLine($"Wrote encoded animation stream and decoded OBJ checkpoints to {Path.GetFullPath(output)}");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"QSOL Graphics Codec failed: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static int SelfTest()
+    {
+        const float tolerance = 0.0025f;
+        var scene = DemoSceneFactory.Create();
+        var before = scene.Entities[0].Transform.Position;
+        KineticIntegrator.Step(scene, 1f / 60f);
+        if (scene.Entities[0].Transform.Position == before)
+            throw new InvalidOperationException("Kinetic integrator did not advance entity state.");
+
+        var result = SceneCodec.AutoEncode(scene, tolerance, compress: true);
+        if (result.Decoded.Entities.Count != scene.Entities.Count)
+            throw new InvalidOperationException("Entity count changed during round trip.");
+        if (result.MaxVertexError > tolerance)
+            throw new InvalidOperationException($"Round-trip error {result.MaxVertexError} exceeds {tolerance}.");
+
+        for (var i = 0; i < scene.Entities.Count; i++)
+        {
+            if (!scene.Entities[i].Mesh.Indices.SequenceEqual(result.Decoded.Entities[i].Mesh.Indices))
+                throw new InvalidOperationException($"Index topology mismatch for entity {i}.");
+        }
+
+        var secondDecode = SceneCodec.Decode(result.Encoded.Data);
+        if (secondDecode.Entities.Count != scene.Entities.Count)
+            throw new InvalidOperationException("Persisted binary stream did not decode deterministically.");
+
+        Console.WriteLine("QSOL Graphics Codec self-test PASS");
+        foreach (var candidate in result.Candidates)
+        {
+            Console.WriteLine(FormattableString.Invariant($"bits={candidate.Bits} encoded={candidate.EncodedBytes}B raw={candidate.RawBytes}B error={candidate.MaxVertexError:G6} meets={candidate.MeetsTolerance}"));
+        }
+        Console.WriteLine(FormattableString.Invariant($"selected={result.Encoded.QuantizationBits} bits maxError={result.MaxVertexError:G6}"));
+        return 0;
+    }
+
+    private static string? GetOption(string[] args, string name)
+    {
+        for (var i = 0; i < args.Length - 1; i++)
+            if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase))
+                return args[i + 1];
+        return null;
+    }
+
+    private static int ParseInt(string? value, int fallback, int min, int max)
+    {
+        if (value is null) return fallback;
+        if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) || parsed < min || parsed > max)
+            throw new ArgumentException($"Expected integer in range {min}..{max}, got '{value}'.");
+        return parsed;
+    }
+
+    private static float ParseFloat(string? value, float fallback, float min, float max)
+    {
+        if (value is null) return fallback;
+        if (!float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) || parsed < min || parsed > max)
+            throw new ArgumentException($"Expected number in range {min}..{max}, got '{value}'.");
+        return parsed;
+    }
+}

--- a/apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj
+++ b/apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+</Project>

--- a/apps/qsol-graphics-codec/README.md
+++ b/apps/qsol-graphics-codec/README.md
@@ -1,0 +1,114 @@
+# QSOL 3D Graphics Auto-Encoder / Decoder
+
+Executable .NET 8 reference implementation of the inward kinetic encoding model for 3D graphics state.
+
+## What is operational
+
+- Procedural animated 3D scene generation (three toroidal meshes).
+- Kinetic state update using linear and angular velocity.
+- Binary scene encoder and decoder with an explicit versioned container.
+- Variable-bit (8/10/12/14/16) XYZ quantization packed at bit level.
+- Delta + ZigZag + varint topology/index compaction.
+- Brotli payload compaction using only the .NET runtime.
+- Automatic codec search: the encoder tries each quantization depth, decodes each candidate, measures geometric reconstruction error, and selects the smallest stream that satisfies the requested error bound.
+- PBR material parameters (base color, metallic, roughness) preserved in the stream.
+- Transform and kinetic velocity state preserved in the stream.
+- OBJ export from the decoded state for inspection in Blender, Unity, Unreal import pipelines, MeshLab, etc.
+- Deterministic self-test suitable for CI.
+
+## Operational loop
+
+```text
+Scene(t)
+  -> kinetic update
+  -> encode candidates {8,10,12,14,16 bits/axis}
+  -> compact topology + Brotli
+  -> decode every candidate
+  -> measure max vertex reconstruction error
+  -> select smallest valid representation
+  -> persist .q3d
+  -> decode
+  -> verify topology + geometry
+  -> export OBJ checkpoint
+  -> Scene(t+1)
+```
+
+The implemented inward selection criterion is:
+
+```text
+Z* = argmin |Z_b|
+     over b in {8,10,12,14,16}
+     subject to max_vertex_error(decode(Z_b), X) <= epsilon
+```
+
+This makes compaction measurable rather than symbolic: a lower-bit representation is promoted only if its decoded geometry remains inside the declared error tolerance.
+
+## Build
+
+```bash
+dotnet build apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release
+```
+
+No NuGet packages are required.
+
+## Verify the codec
+
+```bash
+dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- --self-test
+```
+
+The self-test verifies:
+
+1. kinetic state advances;
+2. encode -> decode preserves entity count;
+3. decoded index topology is exact;
+4. geometric reconstruction error is within tolerance;
+5. persisted binary bytes decode deterministically.
+
+## Generate an encoded 3D animation sequence
+
+```bash
+dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- \
+  --frames 120 \
+  --target-error 0.0025 \
+  --output artifacts/qsol-graphics-codec
+```
+
+Outputs:
+
+```text
+artifacts/qsol-graphics-codec/
+  frame-0000.q3d
+  frame-0000.obj
+  frame-0001.q3d
+  ...
+  frame-0119.q3d
+  frame-0119.obj
+  metrics.csv
+```
+
+`metrics.csv` records the selected bit depth, encoded bytes, pre-Brotli bytes, and measured reconstruction error for every frame.
+
+## Decode an existing stream
+
+```bash
+dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- \
+  --decode artifacts/qsol-graphics-codec/frame-0000.q3d \
+  --obj artifacts/qsol-graphics-codec/reconstructed.obj
+```
+
+## Binary pipeline
+
+The `.q3d` stream contains:
+
+- QSC envelope/version/flags/raw length;
+- Q3D payload/version/quantization depth;
+- global local-geometry bounds;
+- per-entity name, transform, linear/angular velocity and PBR material state;
+- bit-packed quantized vertices;
+- exact delta-coded triangle indices;
+- optional Brotli compression.
+
+## Scope
+
+This is a fully executable **graphics-state codec and kinetic animation reference core**. It does not claim that the codec itself performs photorealistic rasterization or path tracing. The decoded scene state is deliberately renderer-agnostic so GPU backends (Direct3D 12, Vulkan, WebGPU, Unity/Unreal adapters, ray/path tracers, neural renderers) can be attached without changing the Q3D encode/decode invariant.


### PR DESCRIPTION
## Summary

Adds an executable .NET 8 3D graphics-state auto-encoder/decoder that operationalizes the inward kinetic encoding model as a bounded, verifiable codec loop.

## Implemented

- versioned `.q3d` binary envelope/payload
- 8/10/12/14/16-bit XYZ quantization with bit packing
- delta + ZigZag + varint triangle index compaction
- Brotli payload compaction
- automatic candidate search and promotion of the smallest representation meeting a declared max-vertex-error tolerance
- kinetic 3D scene integration (linear + angular velocity)
- procedural torus animation generator
- preserved transforms, velocities and PBR material state
- deterministic decode + topology verification
- decoded OBJ export for inspection in standard 3D tools
- CLI for animation generation and `.q3d` decoding
- GitHub Actions build, round-trip self-test and smoke artifact generation

## Verification invariant

`Z* = argmin |Z_b|` over supported bit depths subject to `max_vertex_error(decode(Z_b), X) <= epsilon`.

This keeps the self-optimization loop bounded: candidates are measured and promoted only when reconstruction constraints pass.

## Commands

```bash
dotnet build apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release
dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- --self-test
dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- --frames 120 --target-error 0.0025
```
