### PR TITLE
Add DMKB-1 kinetic bytecode lowering profile

### DIFF
--- a/apps/qsol-graphics-codec/Dmkb1/BitStream.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/BitStream.cs
@@ -1,0 +1,201 @@
+using System.Runtime.CompilerServices;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public ref struct BitWriter
+{
+    private Span<byte> _buffer;
+    private int _bitPosition;
+
+    public BitWriter(Span<byte> buffer)
+    {
+        _buffer = buffer;
+        _buffer.Clear();
+        _bitPosition = 0;
+    }
+
+    public readonly int BitLength => _bitPosition;
+    public readonly int ByteLength => (_bitPosition + 7) >> 3;
+    public readonly int CapacityBits => checked(_buffer.Length * 8);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteBits(uint value, int bitCount)
+    {
+        ValidateBitCount(bitCount);
+        EnsureWritable(bitCount);
+
+        var consumed = 0;
+        while (consumed < bitCount)
+        {
+            var byteIndex = _bitPosition >> 3;
+            var bitOffset = _bitPosition & 7;
+            var take = Math.Min(8 - bitOffset, bitCount - consumed);
+            var mask = take == 8 ? 0xFFu : (1u << take) - 1u;
+            var chunk = (byte)(((value >> consumed) & mask) << bitOffset);
+            _buffer[byteIndex] |= chunk;
+            _bitPosition += take;
+            consumed += take;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteFloat32(float value)
+    {
+        if (!float.IsFinite(value))
+            throw new InvalidDataException("DMKB-1 does not permit NaN or Infinity in float payloads.");
+        WriteBits(BitConverter.SingleToUInt32Bits(value), 32);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteQuantizedFloat(float value, float min, float max, int bits)
+    {
+        Quantization.Validate(value, min, max, bits);
+        if (min == max)
+        {
+            WriteBits(0, bits);
+            return;
+        }
+
+        var clamped = Math.Clamp(value, min, max);
+        var normalized = (clamped - min) / (max - min);
+        var maxQuant = Quantization.MaxCode(bits);
+        var quantized = (uint)Math.Round(normalized * maxQuant, MidpointRounding.AwayFromZero);
+        if (quantized > maxQuant)
+            quantized = maxQuant;
+        WriteBits(quantized, bits);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void WriteSignedInt(int value, int bits)
+    {
+        ValidateBitCount(bits);
+        var zigZag = unchecked((uint)((value << 1) ^ (value >> 31)));
+        if (bits < 32 && zigZag > ((1u << bits) - 1u))
+            throw new ArgumentOutOfRangeException(nameof(value), "Signed value does not fit the declared DMKB-1 bit width.");
+        WriteBits(zigZag, bits);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly void EnsureWritable(int bitCount)
+    {
+        if (_bitPosition > CapacityBits - bitCount)
+            throw new InvalidDataException("DMKB-1 bitstream capacity exceeded.");
+    }
+
+    private static void ValidateBitCount(int bitCount)
+    {
+        if (bitCount is < 1 or > 32)
+            throw new ArgumentOutOfRangeException(nameof(bitCount), "Bit count must be in the range 1..32.");
+    }
+}
+
+public ref struct BitReader
+{
+    private readonly ReadOnlySpan<byte> _buffer;
+    private int _bitPosition;
+
+    public BitReader(ReadOnlySpan<byte> buffer)
+    {
+        _buffer = buffer;
+        _bitPosition = 0;
+    }
+
+    public readonly int BitPosition => _bitPosition;
+    public readonly int CapacityBits => checked(_buffer.Length * 8);
+    public readonly int RemainingBits => CapacityBits - _bitPosition;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public uint ReadBits(int bitCount)
+    {
+        ValidateBitCount(bitCount);
+        EnsureReadable(bitCount);
+
+        uint value = 0;
+        var produced = 0;
+        while (produced < bitCount)
+        {
+            var byteIndex = _bitPosition >> 3;
+            var bitOffset = _bitPosition & 7;
+            var take = Math.Min(8 - bitOffset, bitCount - produced);
+            var mask = take == 8 ? 0xFFu : (1u << take) - 1u;
+            var chunk = ((uint)_buffer[byteIndex] >> bitOffset) & mask;
+            value |= chunk << produced;
+            _bitPosition += take;
+            produced += take;
+        }
+        return value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float ReadFloat32()
+    {
+        var value = BitConverter.UInt32BitsToSingle(ReadBits(32));
+        if (!float.IsFinite(value))
+            throw new InvalidDataException("DMKB-1 float payload contains NaN or Infinity.");
+        return value;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public float ReadQuantizedFloat(float min, float max, int bits)
+    {
+        Quantization.ValidateRange(min, max, bits);
+        var quantized = ReadBits(bits);
+        if (min == max)
+            return min;
+        var normalized = (float)quantized / Quantization.MaxCode(bits);
+        return min + (normalized * (max - min));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public int ReadSignedInt(int bits)
+    {
+        var zigZag = ReadBits(bits);
+        return (int)(zigZag >> 1) ^ -(int)(zigZag & 1u);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private readonly void EnsureReadable(int bitCount)
+    {
+        if (_bitPosition > CapacityBits - bitCount)
+            throw new InvalidDataException("Truncated DMKB-1 bitstream.");
+    }
+
+    private static void ValidateBitCount(int bitCount)
+    {
+        if (bitCount is < 1 or > 32)
+            throw new ArgumentOutOfRangeException(nameof(bitCount), "Bit count must be in the range 1..32.");
+    }
+}
+
+internal static class Quantization
+{
+    public const int MinBits = 1;
+    public const int MaxFloatBits = 24;
+
+    public static uint MaxCode(int bits)
+    {
+        if (bits is < MinBits or > MaxFloatBits)
+            throw new ArgumentOutOfRangeException(nameof(bits), $"Float quantization bits must be in the range {MinBits}..{MaxFloatBits}.");
+        return (1u << bits) - 1u;
+    }
+
+    public static void Validate(float value, float min, float max, int bits)
+    {
+        ValidateRange(min, max, bits);
+        if (!float.IsFinite(value))
+            throw new ArgumentOutOfRangeException(nameof(value), "Quantized values must be finite.");
+    }
+
+    public static void ValidateRange(float min, float max, int bits)
+    {
+        _ = MaxCode(bits);
+        if (!float.IsFinite(min) || !float.IsFinite(max) || max < min)
+            throw new ArgumentOutOfRangeException(nameof(max), "Quantization range must be finite and max >= min.");
+    }
+
+    public static float Step(float min, float max, int bits)
+    {
+        ValidateRange(min, max, bits);
+        return min == max ? 0f : (max - min) / MaxCode(bits);
+    }
+}

--- a/apps/qsol-graphics-codec/Dmkb1/DmkbContainer.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/DmkbContainer.cs
@@ -1,0 +1,76 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public enum DmkbPacketKind : byte
+{
+    Meshlet = 1,
+    LatentVector = 2,
+    InstructionStream = 3
+}
+
+public readonly record struct DmkbEnvelope(DmkbPacketKind Kind, ushort Flags, byte[] Payload);
+
+public static class DmkbContainer
+{
+    private static ReadOnlySpan<byte> Magic => "DMKB"u8;
+    public const byte Version = 1;
+    public const int HeaderSize = 12;
+    public const int DigestSize = 32;
+    public const int MaxPayloadBytes = 256 * 1024 * 1024;
+
+    public static byte[] Wrap(DmkbPacketKind kind, ReadOnlySpan<byte> payload, ushort flags = 0)
+    {
+        if (!Enum.IsDefined(kind))
+            throw new ArgumentOutOfRangeException(nameof(kind));
+        if (payload.Length > MaxPayloadBytes)
+            throw new ArgumentOutOfRangeException(nameof(payload), "DMKB-1 payload exceeds the bounded container limit.");
+
+        var total = checked(HeaderSize + payload.Length + DigestSize);
+        var output = new byte[total];
+        Magic.CopyTo(output);
+        output[4] = Version;
+        output[5] = (byte)kind;
+        BinaryPrimitives.WriteUInt16LittleEndian(output.AsSpan(6, 2), flags);
+        BinaryPrimitives.WriteUInt32LittleEndian(output.AsSpan(8, 4), (uint)payload.Length);
+        payload.CopyTo(output.AsSpan(HeaderSize));
+
+        var authenticatedLength = HeaderSize + payload.Length;
+        SHA256.HashData(output.AsSpan(0, authenticatedLength), output.AsSpan(authenticatedLength, DigestSize));
+        return output;
+    }
+
+    public static DmkbEnvelope Unwrap(ReadOnlySpan<byte> encoded, DmkbPacketKind? expectedKind = null)
+    {
+        if (encoded.Length < HeaderSize + DigestSize)
+            throw new InvalidDataException("Truncated DMKB-1 container.");
+        if (!encoded[..4].SequenceEqual(Magic))
+            throw new InvalidDataException("Invalid DMKB-1 magic.");
+        if (encoded[4] != Version)
+            throw new InvalidDataException($"Unsupported DMKB version {encoded[4]}.");
+
+        var kind = (DmkbPacketKind)encoded[5];
+        if (!Enum.IsDefined(kind))
+            throw new InvalidDataException("Unknown DMKB-1 packet kind.");
+        if (expectedKind is not null && kind != expectedKind.Value)
+            throw new InvalidDataException($"Expected {expectedKind.Value} packet, received {kind}.");
+
+        var flags = BinaryPrimitives.ReadUInt16LittleEndian(encoded.Slice(6, 2));
+        var payloadLength = BinaryPrimitives.ReadUInt32LittleEndian(encoded.Slice(8, 4));
+        if (payloadLength > MaxPayloadBytes)
+            throw new InvalidDataException("DMKB-1 declared payload exceeds the bounded container limit.");
+
+        var expectedLength = checked(HeaderSize + (int)payloadLength + DigestSize);
+        if (encoded.Length != expectedLength)
+            throw new InvalidDataException("DMKB-1 container length does not match its declared payload length.");
+
+        var authenticatedLength = HeaderSize + (int)payloadLength;
+        Span<byte> digest = stackalloc byte[DigestSize];
+        SHA256.HashData(encoded[..authenticatedLength], digest);
+        if (!CryptographicOperations.FixedTimeEquals(digest, encoded.Slice(authenticatedLength, DigestSize)))
+            throw new InvalidDataException("DMKB-1 SHA-256 integrity verification failed.");
+
+        return new DmkbEnvelope(kind, flags, encoded.Slice(HeaderSize, (int)payloadLength).ToArray());
+    }
+}

--- a/apps/qsol-graphics-codec/Dmkb1/DmkbSelfTest.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/DmkbSelfTest.cs
@@ -1,0 +1,144 @@
+using System.Numerics;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public static class DmkbSelfTest
+{
+    public static void Run()
+    {
+        TestBitStream();
+        TestInstructions();
+        TestMeshlet();
+        TestLatentVector();
+        Console.WriteLine("DMKB-1 kinetic bytecode self-test PASS");
+    }
+
+    private static void TestBitStream()
+    {
+        Span<byte> bytes = stackalloc byte[8];
+        var writer = new BitWriter(bytes);
+        writer.WriteBits(0b10_1101u, 6);
+        writer.WriteBits(0xDEADBEEFu, 32);
+        writer.WriteSignedInt(-17, 8);
+
+        var reader = new BitReader(bytes[..writer.ByteLength]);
+        Require(reader.ReadBits(6) == 0b10_1101u, "Variable-width bit prefix did not round-trip.");
+        Require(reader.ReadBits(32) == 0xDEADBEEFu, "32-bit field did not round-trip across byte boundaries.");
+        Require(reader.ReadSignedInt(8) == -17, "Signed ZigZag value did not round-trip.");
+        Require(reader.BitPosition == writer.BitLength, "Bit reader/writer positions diverged.");
+
+        ExpectThrows<InvalidDataException>(() =>
+        {
+            var shortReader = new BitReader(new byte[1]);
+            _ = shortReader.ReadBits(16);
+        });
+    }
+
+    private static void TestInstructions()
+    {
+        var instruction = new CompactInstruction(GraphicsOpcode.RotAxis, 1, 2, 3, 7, 42);
+        var unpacked = CompactInstruction.Unpack32(instruction.Pack32());
+        Require(unpacked == instruction, "Compact 32-bit graphics instruction lost a field during round-trip.");
+
+        var program = new[]
+        {
+            instruction,
+            new CompactInstruction(GraphicsOpcode.BindMeshlet, 4, 0, 0, 0, 11),
+            new CompactInstruction(GraphicsOpcode.DrawIndexed, 0, 4, 0, 1, 63)
+        };
+        var encoded = InstructionPacket.Encode(program);
+        var decoded = InstructionPacket.Decode(encoded);
+        Require(program.SequenceEqual(decoded), "DMKB-1 instruction stream did not round-trip exactly.");
+        ExpectThrows<ArgumentOutOfRangeException>(() =>
+            _ = new CompactInstruction(GraphicsOpcode.Nop, 32, 0, 0, 0, 0));
+    }
+
+    private static void TestMeshlet()
+    {
+        const int bits = 10;
+        var meshlet = new MeshletPacketData
+        {
+            Anchor = new Vector3(100f, 50f, -25f),
+            Vertices =
+            [
+                new Vector3(131.2f, 42.4f, -4.1f),
+                new Vector3(89.1f, 78.3f, -56.5f),
+                new Vector3(104.6f, 61.0f, -19.75f)
+            ],
+            Indices = [0, 1, 2, 2, 1, 0]
+        };
+
+        var encoded = MeshletPacket.Encode(meshlet, bits);
+        var decoded = MeshletPacket.Decode(encoded);
+        Require(meshlet.Indices.SequenceEqual(decoded.Indices), "DMKB-1 meshlet topology changed during decode.");
+        Require(decoded.Anchor == meshlet.Anchor, "DMKB-1 meshlet anchor was not preserved exactly.");
+
+        var actualError = MaxVertexError(meshlet.Vertices, decoded.Vertices);
+        var bound = MeshletPacket.TheoreticalMaxVertexError(meshlet, bits);
+        Require(actualError <= bound + 1e-5f, $"Meshlet error {actualError} exceeded deterministic bound {bound}.");
+
+        var corrupt = encoded.ToArray();
+        corrupt[Math.Min(20, corrupt.Length - 33)] ^= 0x40;
+        ExpectThrows<InvalidDataException>(() => _ = MeshletPacket.Decode(corrupt));
+        ExpectThrows<InvalidDataException>(() => _ = MeshletPacket.Decode(encoded.AsSpan(0, encoded.Length - 1)));
+
+        Console.WriteLine(FormattableString.Invariant(
+            $"DMKB meshlet: bytes={encoded.Length} vertices={meshlet.Vertices.Length} indices={meshlet.Indices.Length} maxError={actualError:G6} bound={bound:G6}"));
+    }
+
+    private static void TestLatentVector()
+    {
+        const int quantBits = 4;
+        var random = new Random(42);
+        var latent = new float[128];
+        for (var i = 0; i < latent.Length; i++)
+            latent[i] = (float)((random.NextDouble() * 2.0) - 1.0);
+
+        var encoded = LatentPacket.Encode(latent, quantBits);
+        var decoded = LatentPacket.Decode(encoded);
+        var metrics = LatentPacket.Measure(latent, decoded, encoded.Length);
+        var bound = LatentPacket.TheoreticalMaxAbsError(latent, quantBits);
+        Require(metrics.MaxAbsError <= bound + 1e-5f, $"Latent max error {metrics.MaxAbsError} exceeded bound {bound}.");
+
+        var constant = Enumerable.Repeat(0.5f, 17).ToArray();
+        var constantDecoded = LatentPacket.Decode(LatentPacket.Encode(constant, 4));
+        Require(constant.SequenceEqual(constantDecoded), "Constant latent range did not round-trip exactly.");
+
+        var corrupt = encoded.ToArray();
+        corrupt[^1] ^= 0x01;
+        ExpectThrows<InvalidDataException>(() => _ = LatentPacket.Decode(corrupt));
+        ExpectThrows<ArgumentOutOfRangeException>(() => _ = LatentPacket.Encode(latent, 0));
+        ExpectThrows<ArgumentOutOfRangeException>(() => _ = LatentPacket.Encode(latent, 25));
+
+        Console.WriteLine(FormattableString.Invariant(
+            $"DMKB latent: raw={metrics.RawBytes}B encoded={metrics.EncodedBytes}B ratio={metrics.CompressionRatio:F2}x mse={metrics.Mse:G6} maxError={metrics.MaxAbsError:G6} bound={bound:G6}"));
+    }
+
+    private static float MaxVertexError(Vector3[] a, Vector3[] b)
+    {
+        Require(a.Length == b.Length, "Vertex arrays have different lengths.");
+        var max = 0f;
+        for (var i = 0; i < a.Length; i++)
+            max = MathF.Max(max, Vector3.Distance(a[i], b[i]));
+        return max;
+    }
+
+    private static void Require(bool condition, string message)
+    {
+        if (!condition)
+            throw new InvalidOperationException(message);
+    }
+
+    private static void ExpectThrows<T>(Action action) where T : Exception
+    {
+        try
+        {
+            action();
+        }
+        catch (T)
+        {
+            return;
+        }
+        throw new InvalidOperationException($"Expected {typeof(T).Name} was not thrown.");
+    }
+}

--- a/apps/qsol-graphics-codec/Dmkb1/GraphicsIr.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/GraphicsIr.cs
@@ -1,0 +1,77 @@
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public enum GraphicsOpcode : byte
+{
+    Nop = 0x00,
+    LoadVec3 = 0x01,
+    LoadVec4 = 0x02,
+    StoreVec3 = 0x03,
+    AddVec3 = 0x04,
+    MulScalar = 0x05,
+    RotAxis = 0x06,
+    BindMeshlet = 0x07,
+    BindShader = 0x08,
+    DrawIndexed = 0x09,
+    ReflectEval = 0x0A
+}
+
+public readonly record struct CompactInstruction
+{
+    public GraphicsOpcode Opcode { get; }
+    public byte Dst { get; }
+    public byte Src1 { get; }
+    public byte Src2 { get; }
+    public byte Flags { get; }
+    public byte Immediate { get; }
+
+    public CompactInstruction(
+        GraphicsOpcode opcode,
+        byte dst,
+        byte src1,
+        byte src2,
+        byte flags,
+        byte immediate)
+    {
+        if (!Enum.IsDefined(opcode))
+            throw new ArgumentOutOfRangeException(nameof(opcode), "Unknown DMKB-1 graphics opcode.");
+        if (dst > 31) throw new ArgumentOutOfRangeException(nameof(dst), "Destination register must be 0..31.");
+        if (src1 > 31) throw new ArgumentOutOfRangeException(nameof(src1), "Source register 1 must be 0..31.");
+        if (src2 > 31) throw new ArgumentOutOfRangeException(nameof(src2), "Source register 2 must be 0..31.");
+        if (flags > 7) throw new ArgumentOutOfRangeException(nameof(flags), "Flags must be 0..7.");
+        if (immediate > 63) throw new ArgumentOutOfRangeException(nameof(immediate), "Immediate must be 0..63.");
+
+        Opcode = opcode;
+        Dst = dst;
+        Src1 = src1;
+        Src2 = src2;
+        Flags = flags;
+        Immediate = immediate;
+    }
+
+    public uint Pack32()
+    {
+        uint packed = 0;
+        packed |= (uint)Opcode;
+        packed |= (uint)Dst << 8;
+        packed |= (uint)Src1 << 13;
+        packed |= (uint)Src2 << 18;
+        packed |= (uint)Flags << 23;
+        packed |= (uint)Immediate << 26;
+        return packed;
+    }
+
+    public static CompactInstruction Unpack32(uint packed)
+    {
+        var opcode = (GraphicsOpcode)(packed & 0xFFu);
+        return new CompactInstruction(
+            opcode,
+            (byte)((packed >> 8) & 0x1Fu),
+            (byte)((packed >> 13) & 0x1Fu),
+            (byte)((packed >> 18) & 0x1Fu),
+            (byte)((packed >> 23) & 0x07u),
+            (byte)((packed >> 26) & 0x3Fu));
+    }
+
+    public override string ToString() =>
+        $"[{Opcode}] Dst:r{Dst}, Src1:r{Src1}, Src2:r{Src2}, Flags:{Flags}, Imm:{Immediate}";
+}

--- a/apps/qsol-graphics-codec/Dmkb1/InstructionPacket.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/InstructionPacket.cs
@@ -1,0 +1,43 @@
+using System.Buffers.Binary;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public static class InstructionPacket
+{
+    private const int MaxInstructions = 1_000_000;
+
+    public static byte[] Encode(ReadOnlySpan<CompactInstruction> instructions)
+    {
+        if (instructions.Length > MaxInstructions)
+            throw new ArgumentOutOfRangeException(nameof(instructions), $"DMKB-1 instruction streams support at most {MaxInstructions} words.");
+
+        var payload = new byte[checked(4 + (instructions.Length * 4))];
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(0, 4), checked((uint)instructions.Length));
+        for (var i = 0; i < instructions.Length; i++)
+            BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(4 + (i * 4), 4), instructions[i].Pack32());
+        return DmkbContainer.Wrap(DmkbPacketKind.InstructionStream, payload);
+    }
+
+    public static CompactInstruction[] Decode(ReadOnlySpan<byte> encoded)
+    {
+        var envelope = DmkbContainer.Unwrap(encoded, DmkbPacketKind.InstructionStream);
+        var payload = envelope.Payload.AsSpan();
+        if (payload.Length < 4)
+            throw new InvalidDataException("Truncated DMKB-1 instruction stream header.");
+
+        var count = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(0, 4));
+        if (count > MaxInstructions)
+            throw new InvalidDataException("DMKB-1 instruction count exceeds the implementation limit.");
+        var expected = checked(4 + (checked((int)count) * 4));
+        if (payload.Length != expected)
+            throw new InvalidDataException("DMKB-1 instruction payload length is not canonical.");
+
+        var instructions = new CompactInstruction[checked((int)count)];
+        for (var i = 0; i < instructions.Length; i++)
+        {
+            var word = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(4 + (i * 4), 4));
+            instructions[i] = CompactInstruction.Unpack32(word);
+        }
+        return instructions;
+    }
+}

--- a/apps/qsol-graphics-codec/Dmkb1/LatentPacket.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/LatentPacket.cs
@@ -1,0 +1,150 @@
+using System.Buffers.Binary;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public readonly record struct LatentPacketMetrics(
+    int EncodedBytes,
+    int RawBytes,
+    float Mse,
+    float MaxAbsError,
+    double CompressionRatio);
+
+public static class LatentPacket
+{
+    private const int HeaderSize = 20;
+    private const int MaxElements = 1_000_000;
+
+    public static byte[] Encode(ReadOnlySpan<float> values, int quantizationBits = 4)
+    {
+        _ = Quantization.MaxCode(quantizationBits);
+        if (values.Length is < 1 or > MaxElements)
+            throw new ArgumentOutOfRangeException(nameof(values), $"DMKB-1 latent vectors require 1..{MaxElements} elements.");
+
+        var min = float.PositiveInfinity;
+        var max = float.NegativeInfinity;
+        foreach (var value in values)
+        {
+            if (!float.IsFinite(value))
+                throw new InvalidDataException("DMKB-1 latent vector contains NaN or Infinity.");
+            min = MathF.Min(min, value);
+            max = MathF.Max(max, value);
+        }
+
+        var bitLengthLong = checked((long)values.Length * quantizationBits);
+        if (bitLengthLong > int.MaxValue)
+            throw new InvalidDataException("DMKB-1 latent bit payload exceeds the implementation limit.");
+        var bitLength = (int)bitLengthLong;
+        var bitBytes = (bitLength + 7) >> 3;
+        var bitPayload = new byte[bitBytes];
+        var writer = new BitWriter(bitPayload);
+        foreach (var value in values)
+            writer.WriteQuantizedFloat(value, min, max, quantizationBits);
+        if (writer.BitLength != bitLength)
+            throw new InvalidOperationException("DMKB-1 latent bit accounting mismatch.");
+
+        var payload = new byte[checked(HeaderSize + bitBytes)];
+        payload[0] = checked((byte)quantizationBits);
+        payload[1] = 0;
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(2, 2), 0);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(4, 4), checked((uint)values.Length));
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(8, 4), BitConverter.SingleToUInt32Bits(min));
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(12, 4), BitConverter.SingleToUInt32Bits(max));
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(16, 4), checked((uint)bitLength));
+        bitPayload.CopyTo(payload.AsSpan(HeaderSize));
+        return DmkbContainer.Wrap(DmkbPacketKind.LatentVector, payload);
+    }
+
+    public static float[] Decode(ReadOnlySpan<byte> encoded)
+    {
+        var envelope = DmkbContainer.Unwrap(encoded, DmkbPacketKind.LatentVector);
+        var payload = envelope.Payload.AsSpan();
+        if (payload.Length < HeaderSize)
+            throw new InvalidDataException("Truncated DMKB-1 latent header.");
+
+        var quantBits = payload[0];
+        _ = Quantization.MaxCode(quantBits);
+        if (payload[1] != 0 || BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(2, 2)) != 0)
+            throw new InvalidDataException("DMKB-1 latent reserved header bits must be zero.");
+
+        var length = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(4, 4));
+        if (length is 0 or > MaxElements)
+            throw new InvalidDataException("DMKB-1 latent element count is outside the implementation limit.");
+
+        var min = BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(8, 4)));
+        var max = BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(12, 4)));
+        Quantization.ValidateRange(min, max, quantBits);
+
+        var declaredBits = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(16, 4));
+        var expectedBits = checked((long)length * quantBits);
+        if (declaredBits != expectedBits)
+            throw new InvalidDataException("DMKB-1 latent declared bit length does not match its element count.");
+        if (declaredBits > int.MaxValue)
+            throw new InvalidDataException("DMKB-1 latent bit payload exceeds the implementation limit.");
+
+        var bitLength = checked((int)declaredBits);
+        var bitBytes = (bitLength + 7) >> 3;
+        if (payload.Length != HeaderSize + bitBytes)
+            throw new InvalidDataException("DMKB-1 latent payload byte length is not canonical.");
+
+        var bitSpan = payload.Slice(HeaderSize, bitBytes);
+        ValidateZeroPadding(bitSpan, bitLength);
+        var reader = new BitReader(bitSpan);
+        var decoded = new float[checked((int)length)];
+        for (var i = 0; i < decoded.Length; i++)
+            decoded[i] = reader.ReadQuantizedFloat(min, max, quantBits);
+        if (reader.BitPosition != declaredBits)
+            throw new InvalidDataException("DMKB-1 latent decoder did not consume the declared bit payload exactly.");
+        return decoded;
+    }
+
+    public static LatentPacketMetrics Measure(ReadOnlySpan<float> original, ReadOnlySpan<float> decoded, int encodedBytes)
+    {
+        if (original.Length != decoded.Length || original.Length == 0)
+            throw new ArgumentException("Latent metric inputs must be non-empty and have matching lengths.");
+        if (encodedBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(encodedBytes));
+
+        double squared = 0;
+        var maxError = 0f;
+        for (var i = 0; i < original.Length; i++)
+        {
+            var error = MathF.Abs(original[i] - decoded[i]);
+            squared += (double)error * error;
+            maxError = MathF.Max(maxError, error);
+        }
+
+        var rawBytes = checked(original.Length * sizeof(float));
+        return new LatentPacketMetrics(
+            encodedBytes,
+            rawBytes,
+            (float)(squared / original.Length),
+            maxError,
+            (double)rawBytes / encodedBytes);
+    }
+
+    public static float TheoreticalMaxAbsError(ReadOnlySpan<float> values, int quantizationBits)
+    {
+        if (values.Length == 0)
+            return 0f;
+        var min = float.PositiveInfinity;
+        var max = float.NegativeInfinity;
+        foreach (var value in values)
+        {
+            if (!float.IsFinite(value))
+                throw new InvalidDataException("Latent vector contains NaN or Infinity.");
+            min = MathF.Min(min, value);
+            max = MathF.Max(max, value);
+        }
+        return Quantization.Step(min, max, quantizationBits) * 0.5f;
+    }
+
+    private static void ValidateZeroPadding(ReadOnlySpan<byte> payload, int bitLength)
+    {
+        if (payload.Length == 0 || (bitLength & 7) == 0)
+            return;
+        var used = bitLength & 7;
+        var unusedMask = (byte)~((1 << used) - 1);
+        if ((payload[^1] & unusedMask) != 0)
+            throw new InvalidDataException("DMKB-1 latent packet has non-zero padding bits.");
+    }
+}

--- a/apps/qsol-graphics-codec/Dmkb1/MeshletPacket.cs
+++ b/apps/qsol-graphics-codec/Dmkb1/MeshletPacket.cs
@@ -1,0 +1,217 @@
+using System.Buffers.Binary;
+using System.Numerics;
+
+namespace QSol.GraphicsCodec.Dmkb1;
+
+public sealed class MeshletPacketData
+{
+    public required Vector3 Anchor { get; init; }
+    public required Vector3[] Vertices { get; init; }
+    public required ushort[] Indices { get; init; }
+}
+
+public static class MeshletPacket
+{
+    private const int HeaderSize = 48;
+
+    public static byte[] Encode(MeshletPacketData meshlet, int bitsPerComponent = 10)
+    {
+        ArgumentNullException.ThrowIfNull(meshlet);
+        _ = Quantization.MaxCode(bitsPerComponent);
+        ValidateVector(meshlet.Anchor, nameof(meshlet.Anchor));
+
+        if (meshlet.Vertices.Length is < 1 or > ushort.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(meshlet), "DMKB-1 meshlets require 1..65535 vertices.");
+        if (meshlet.Indices.Length > ushort.MaxValue)
+            throw new ArgumentOutOfRangeException(nameof(meshlet), "DMKB-1 meshlets support at most 65535 local indices.");
+
+        var minDelta = new Vector3(float.PositiveInfinity);
+        var maxDelta = new Vector3(float.NegativeInfinity);
+        foreach (var vertex in meshlet.Vertices)
+        {
+            ValidateVector(vertex, nameof(meshlet.Vertices));
+            var delta = vertex - meshlet.Anchor;
+            minDelta = Vector3.Min(minDelta, delta);
+            maxDelta = Vector3.Max(maxDelta, delta);
+        }
+
+        var indexBits = IndexBitWidth(meshlet.Vertices.Length);
+        foreach (var index in meshlet.Indices)
+        {
+            if (index >= meshlet.Vertices.Length)
+                throw new InvalidDataException($"Meshlet index {index} is outside the local vertex range.");
+        }
+
+        var bitLengthLong = checked(
+            ((long)meshlet.Vertices.Length * 3L * bitsPerComponent) +
+            ((long)meshlet.Indices.Length * indexBits));
+        if (bitLengthLong > int.MaxValue)
+            throw new InvalidDataException("DMKB-1 meshlet bit payload exceeds the implementation limit.");
+
+        var bitLength = (int)bitLengthLong;
+        var bitBytes = (bitLength + 7) >> 3;
+        var bitPayload = new byte[bitBytes];
+        var writer = new BitWriter(bitPayload);
+
+        foreach (var vertex in meshlet.Vertices)
+        {
+            var delta = vertex - meshlet.Anchor;
+            writer.WriteQuantizedFloat(delta.X, minDelta.X, maxDelta.X, bitsPerComponent);
+            writer.WriteQuantizedFloat(delta.Y, minDelta.Y, maxDelta.Y, bitsPerComponent);
+            writer.WriteQuantizedFloat(delta.Z, minDelta.Z, maxDelta.Z, bitsPerComponent);
+        }
+        foreach (var index in meshlet.Indices)
+            writer.WriteBits(index, indexBits);
+
+        if (writer.BitLength != bitLength)
+            throw new InvalidOperationException("DMKB-1 meshlet bit accounting mismatch.");
+
+        var payload = new byte[checked(HeaderSize + bitBytes)];
+        payload[0] = checked((byte)bitsPerComponent);
+        payload[1] = checked((byte)indexBits);
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(2, 2), 0);
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(4, 2), checked((ushort)meshlet.Vertices.Length));
+        BinaryPrimitives.WriteUInt16LittleEndian(payload.AsSpan(6, 2), checked((ushort)meshlet.Indices.Length));
+        WriteVector3(payload.AsSpan(8, 12), meshlet.Anchor);
+        WriteVector3(payload.AsSpan(20, 12), minDelta);
+        WriteVector3(payload.AsSpan(32, 12), maxDelta);
+        BinaryPrimitives.WriteUInt32LittleEndian(payload.AsSpan(44, 4), checked((uint)bitLength));
+        bitPayload.CopyTo(payload.AsSpan(HeaderSize));
+
+        return DmkbContainer.Wrap(DmkbPacketKind.Meshlet, payload);
+    }
+
+    public static MeshletPacketData Decode(ReadOnlySpan<byte> encoded)
+    {
+        var envelope = DmkbContainer.Unwrap(encoded, DmkbPacketKind.Meshlet);
+        var payload = envelope.Payload.AsSpan();
+        if (payload.Length < HeaderSize)
+            throw new InvalidDataException("Truncated DMKB-1 meshlet header.");
+
+        var quantBits = payload[0];
+        _ = Quantization.MaxCode(quantBits);
+        var indexBits = payload[1];
+        if (indexBits is < 1 or > 16)
+            throw new InvalidDataException("DMKB-1 meshlet index width must be 1..16 bits.");
+        if (BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(2, 2)) != 0)
+            throw new InvalidDataException("DMKB-1 meshlet reserved header bits must be zero.");
+
+        var vertexCount = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(4, 2));
+        var indexCount = BinaryPrimitives.ReadUInt16LittleEndian(payload.Slice(6, 2));
+        if (vertexCount == 0)
+            throw new InvalidDataException("DMKB-1 meshlet must contain at least one vertex.");
+        if (indexBits != IndexBitWidth(vertexCount))
+            throw new InvalidDataException("DMKB-1 meshlet index width is not canonical for its vertex count.");
+
+        var anchor = ReadVector3(payload.Slice(8, 12));
+        var minDelta = ReadVector3(payload.Slice(20, 12));
+        var maxDelta = ReadVector3(payload.Slice(32, 12));
+        ValidateVector(anchor, nameof(anchor));
+        ValidateVector(minDelta, nameof(minDelta));
+        ValidateVector(maxDelta, nameof(maxDelta));
+        if (maxDelta.X < minDelta.X || maxDelta.Y < minDelta.Y || maxDelta.Z < minDelta.Z)
+            throw new InvalidDataException("DMKB-1 meshlet delta bounds are invalid.");
+
+        var declaredBits = BinaryPrimitives.ReadUInt32LittleEndian(payload.Slice(44, 4));
+        var expectedBits = checked(
+            ((long)vertexCount * 3L * quantBits) +
+            ((long)indexCount * indexBits));
+        if (declaredBits != expectedBits)
+            throw new InvalidDataException("DMKB-1 meshlet declared bit length does not match its header counts.");
+        if (declaredBits > int.MaxValue)
+            throw new InvalidDataException("DMKB-1 meshlet bit payload exceeds the implementation limit.");
+
+        var bitBytes = (checked((int)declaredBits) + 7) >> 3;
+        if (payload.Length != HeaderSize + bitBytes)
+            throw new InvalidDataException("DMKB-1 meshlet payload byte length is not canonical.");
+
+        var bitSpan = payload.Slice(HeaderSize, bitBytes);
+        ValidateZeroPadding(bitSpan, checked((int)declaredBits));
+        var reader = new BitReader(bitSpan);
+        var vertices = new Vector3[vertexCount];
+        for (var i = 0; i < vertices.Length; i++)
+        {
+            var delta = new Vector3(
+                reader.ReadQuantizedFloat(minDelta.X, maxDelta.X, quantBits),
+                reader.ReadQuantizedFloat(minDelta.Y, maxDelta.Y, quantBits),
+                reader.ReadQuantizedFloat(minDelta.Z, maxDelta.Z, quantBits));
+            vertices[i] = anchor + delta;
+        }
+
+        var indices = new ushort[indexCount];
+        for (var i = 0; i < indices.Length; i++)
+        {
+            var index = reader.ReadBits(indexBits);
+            if (index >= vertexCount)
+                throw new InvalidDataException("Decoded DMKB-1 meshlet index is outside the local vertex range.");
+            indices[i] = checked((ushort)index);
+        }
+
+        if (reader.BitPosition != declaredBits)
+            throw new InvalidDataException("DMKB-1 meshlet decoder did not consume the declared bit payload exactly.");
+
+        return new MeshletPacketData
+        {
+            Anchor = anchor,
+            Vertices = vertices,
+            Indices = indices
+        };
+    }
+
+    public static float TheoreticalMaxVertexError(MeshletPacketData meshlet, int bitsPerComponent)
+    {
+        ArgumentNullException.ThrowIfNull(meshlet);
+        if (meshlet.Vertices.Length == 0)
+            return 0f;
+
+        var minDelta = new Vector3(float.PositiveInfinity);
+        var maxDelta = new Vector3(float.NegativeInfinity);
+        foreach (var vertex in meshlet.Vertices)
+        {
+            var delta = vertex - meshlet.Anchor;
+            minDelta = Vector3.Min(minDelta, delta);
+            maxDelta = Vector3.Max(maxDelta, delta);
+        }
+
+        var halfStep = new Vector3(
+            Quantization.Step(minDelta.X, maxDelta.X, bitsPerComponent) * 0.5f,
+            Quantization.Step(minDelta.Y, maxDelta.Y, bitsPerComponent) * 0.5f,
+            Quantization.Step(minDelta.Z, maxDelta.Z, bitsPerComponent) * 0.5f);
+        return halfStep.Length();
+    }
+
+    private static int IndexBitWidth(int vertexCount)
+    {
+        if (vertexCount <= 1)
+            return 1;
+        return BitOperations.Log2(checked((uint)(vertexCount - 1))) + 1;
+    }
+
+    private static void ValidateVector(Vector3 value, string name)
+    {
+        if (!float.IsFinite(value.X) || !float.IsFinite(value.Y) || !float.IsFinite(value.Z))
+            throw new InvalidDataException($"{name} contains NaN or Infinity.");
+    }
+
+    private static void WriteVector3(Span<byte> target, Vector3 value)
+    {
+        BinaryPrimitives.WriteUInt32LittleEndian(target.Slice(0, 4), BitConverter.SingleToUInt32Bits(value.X));
+        BinaryPrimitives.WriteUInt32LittleEndian(target.Slice(4, 4), BitConverter.SingleToUInt32Bits(value.Y));
+        BinaryPrimitives.WriteUInt32LittleEndian(target.Slice(8, 4), BitConverter.SingleToUInt32Bits(value.Z));
+    }
+
+    private static Vector3 ReadVector3(ReadOnlySpan<byte> source) => new(
+        BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(0, 4))),
+        BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(4, 4))),
+        BitConverter.UInt32BitsToSingle(BinaryPrimitives.ReadUInt32LittleEndian(source.Slice(8, 4))));
+
+    private static void ValidateZeroPadding(ReadOnlySpan<byte> payload, int bitLength)
+    {
+        if (payload.Length == 0 || (bitLength & 7) == 0)
+            return;
+        var used = bitLength & 7;
+        var unusedMask = (byte)~((1 << used) - 1);
+        if ((payload[^1] & unusedMask) != 0)
+            throw new InvalidDataException("DMKB-1 meshlet has non-zero padding bits.");
+    }
+}

--- a/apps/qsol-graphics-codec/Program.cs
+++ b/apps/qsol-graphics-codec/Program.cs
@@ -90,6 +90,8 @@ internal static class Program
             Console.WriteLine(FormattableString.Invariant($"bits={candidate.Bits} encoded={candidate.EncodedBytes}B raw={candidate.RawBytes}B error={candidate.MaxVertexError:G6} meets={candidate.MeetsTolerance}"));
         }
         Console.WriteLine(FormattableString.Invariant($"selected={result.Encoded.QuantizationBits} bits maxError={result.MaxVertexError:G6}"));
+
+        Dmkb1.DmkbSelfTest.Run();
         return 0;
     }
 

--- a/docs/DMKB1_KINETIC_BYTECODE.md
+++ b/docs/DMKB1_KINETIC_BYTECODE.md
@@ -1,0 +1,283 @@
+# DMKB-1 — Dr Moagi Kinetic Bytecode Binary Profile
+
+## Status
+
+DMKB-1 is a bounded binary lowering and transport profile for the QSOL 3D graphics codec. It is **not** a replacement for the canonical Jarvis-X authority VM and it is not a second top-level bytecode architecture.
+
+Its role is:
+
+```text
+application / geometry / latent state
+        -> typed graphics IR
+        -> DMKB-1 instruction + data packets
+        -> verified binary transport
+        -> CPU / GPU / WebGPU / native backend adapter
+```
+
+The outer Jarvis-X rule remains candidate-first: decoding or executing a DMKB-1 packet does not make the resulting state authoritative. The enclosing runtime still applies its ordinary validation and commit/rollback gate.
+
+## 1. Core objects
+
+DMKB-1 defines four objects:
+
+- `I32`: one validated 32-bit graphics operational instruction;
+- `M_Q`: a self-contained quantized meshlet packet;
+- `Z_Q`: a self-contained quantized latent-vector packet;
+- `C`: a versioned integrity-protected DMKB container.
+
+The lowering path is:
+
+```text
+X -> E(X) -> Z -> Q(Z) -> C -> verify -> decode/execute -> X_hat
+```
+
+## 2. Common container
+
+Every persistent packet uses the following outer envelope:
+
+```text
+offset  bytes  field
+0       4      magic = "DMKB"
+4       1      version = 1
+5       1      packet kind
+6       2      flags, little-endian
+8       4      payload length, little-endian
+12      N      payload
+12+N    32     SHA-256(header || payload)
+```
+
+Packet kinds are:
+
+```text
+1  Meshlet
+2  LatentVector
+3  InstructionStream
+```
+
+The decoder rejects:
+
+- invalid magic;
+- unsupported version;
+- unknown packet kind;
+- a declared payload above the implementation ceiling;
+- length mismatch or trailing bytes;
+- SHA-256 mismatch.
+
+The digest establishes packet integrity. It is not an encryption mechanism and is not treated as an invertible latent representation.
+
+## 3. Bit ordering
+
+Variable-width fields use LSB-first packing within the byte stream. Sequential writes consume the least-significant available bits of the current byte before continuing into subsequent bytes.
+
+The bit reader and writer are fail-closed:
+
+```text
+requested bits > remaining bits  -> reject
+invalid bit width                -> reject
+NaN / Infinity                   -> reject
+invalid quantization range       -> reject
+```
+
+Generic integer fields support widths `1..32`. Float quantization uses `1..24` bits because `float32` has 24 bits of significand precision including the implicit leading bit.
+
+## 4. Graphics instruction word
+
+The 32-bit word is:
+
+```text
+bits       width  field
+0..7       8      opcode
+8..12      5      dst
+13..17     5      src1
+18..22     5      src2
+23..25     3      flags
+26..31     6      immediate
+```
+
+Therefore:
+
+```text
+8 + 5 + 5 + 5 + 3 + 6 = 32 bits
+```
+
+Registers must be `0..31`, flags `0..7`, and the immediate `0..63`. Invalid host values are rejected rather than silently masked.
+
+The C# `CompactInstruction` object is a host representation. `Pack32()` is the authoritative 4-byte word representation.
+
+Current opcode surface:
+
+```text
+0x00 NOP
+0x01 LOAD_VEC3
+0x02 LOAD_VEC4
+0x03 STORE_VEC3
+0x04 ADD_VEC3
+0x05 MUL_SCALAR
+0x06 ROT_AXIS
+0x07 BIND_MESHLET
+0x08 BIND_SHADER
+0x09 DRAW_INDEXED
+0x0A REFLECT_EVAL
+```
+
+An instruction stream stores a 32-bit word count followed by exactly that many little-endian `I32` words.
+
+## 5. Quantization law
+
+For a scalar `x` in declared range `[xmin,xmax]`, nearest quantization is:
+
+```text
+q = round((x-xmin)/(xmax-xmin) * (2^b-1))
+```
+
+and reconstruction is:
+
+```text
+x_hat = xmin + q/(2^b-1) * (xmax-xmin).
+```
+
+The quantization step is:
+
+```text
+Delta_b = (xmax-xmin)/(2^b-1)
+```
+
+and, under nearest rounding,
+
+```text
+|x-x_hat| <= Delta_b/2
+```
+
+apart from ordinary finite `float32` arithmetic tolerance.
+
+For a constant range `xmin == xmax`, the canonical quantized code is zero and decoding returns the constant exactly. This avoids `0/0` normalization.
+
+## 6. Meshlet packet
+
+A meshlet payload contains:
+
+```text
+offset  bytes  field
+0       1      quantization bits
+1       1      canonical local-index bit width
+2       2      reserved = 0
+4       2      vertex count
+6       2      index count
+8       12     anchor xyz float32
+20      12     delta minimum xyz float32
+32      12     delta maximum xyz float32
+44      4      exact bit-payload length
+48      N      packed vertices followed by packed indices
+```
+
+The encoder derives bounds from the actual anchor-relative geometry:
+
+```text
+d_i = v_i - anchor
+min_k = min_i d_i,k
+max_k = max_i d_i,k
+```
+
+No out-of-band `[-10,+10]` window is required.
+
+The local topology width is:
+
+```text
+b_i = max(1, ceil(log2(vertex_count))).
+```
+
+Every index must be less than `vertex_count`. The decoder verifies the canonical width, counts, exact bit length, zero padding bits and topology bounds.
+
+For three independently quantized coordinates, the deterministic Euclidean error envelope is:
+
+```text
+E_vertex <= sqrt((Delta_x/2)^2 + (Delta_y/2)^2 + (Delta_z/2)^2).
+```
+
+## 7. Latent-vector packet
+
+A latent payload contains:
+
+```text
+offset  bytes  field
+0       1      quantization bits
+1       1      reserved = 0
+2       2      reserved = 0
+4       4      vector length
+8       4      minimum float32
+12      4      maximum float32
+16      4      exact bit-payload length
+20      N      packed scalar codes
+```
+
+The current implementation permits `1..1,000,000` float elements and `1..24` quantization bits.
+
+Rate-distortion telemetry should report at least:
+
+```text
+encoded bytes
+raw float32 bytes
+compression ratio
+mean squared error
+maximum absolute error
+```
+
+A compression ratio without distortion is not sufficient evidence for a lossy representation.
+
+## 8. Verification invariants
+
+The executable self-test verifies:
+
+1. variable-width fields across byte boundaries;
+2. exact `Pack32 -> Unpack32` equality for every instruction field;
+3. exact instruction-stream round trip;
+4. rejection of invalid register fields;
+5. meshlet decode without out-of-band bounds;
+6. exact meshlet topology preservation;
+7. measured mesh vertex error within the deterministic quantization envelope;
+8. SHA-256 corruption rejection;
+9. truncation rejection;
+10. latent max error within its deterministic quantization envelope;
+11. exact constant-latent round trip;
+12. rejection of invalid float quantization depths.
+
+These checks run through the existing QSOL graphics codec `--self-test` path and therefore participate in its GitHub Actions build-and-verify workflow.
+
+## 9. Authority boundary
+
+DMKB-1 verifies binary structure and reconstruction semantics. It does not grant side-effect authority.
+
+The system hierarchy remains:
+
+```text
+semantic state
+ -> candidate graphics/latent state
+ -> DMKB-1 lowering
+ -> binary verification
+ -> backend decode/execute
+ -> measured result
+ -> outer Pi_Lambda validation
+ -> COMMIT or ROLLBACK
+```
+
+Accordingly:
+
+```text
+VALID DMKB PACKET != AUTHORITATIVE JARVIS-X STATE
+```
+
+## 10. Follow-on lowering targets
+
+The profile is designed to support later adapters without redefining its semantic contracts:
+
+- direct C# interpreter for the current graphics opcode family;
+- WebGPU compute/raster lowering;
+- Direct3D 12 or Vulkan command generation;
+- meshlet GPU upload records;
+- PBR material and texture packets;
+- animation/motion packets;
+- bounded shader identifiers and resource tables;
+- cross-language Python/C++/C# golden vectors;
+- rate-distortion selection across quantization candidates.
+
+Any accelerator backend remains subordinate to the same packet validation, reconstruction bounds and outer transaction gate.


### PR DESCRIPTION
## Summary

Operationalizes the audited C# kinetic-bitstream prototype as **DMKB-1**, a bounded binary lowering/transport profile beneath the existing QSOL graphics codec rather than a competing top-level Jarvis-X bytecode.

### Added
- fail-closed variable-width `BitWriter` / `BitReader` with capacity and truncation checks;
- finite-only scalar encoding and explicit `1..24`-bit float quantization;
- constant-range quantization handling (`min == max`) without `0/0` normalization;
- validated 32-bit graphics IR word (`8+5+5+5+3+6` bits) that rejects out-of-range host fields instead of silently masking them;
- exact instruction-stream packet round trips;
- common `DMKB` v1 container with packet kind, flags, declared payload length and SHA-256 integrity verification;
- self-contained meshlet packets carrying anchor, derived delta bounds, quantization depth, adaptive local-index width, counts and exact bit length;
- topology validation, zero-padding validation and deterministic mesh vertex error envelope;
- self-contained latent-vector packets with dynamic range, quantization depth, exact bit length, constant-vector support and rate-distortion telemetry;
- corruption/truncation and invalid-width rejection tests integrated into the existing QSOL `--self-test` path;
- `docs/DMKB1_KINETIC_BYTECODE.md` wire and authority specification.

## Architecture

```text
semantic / geometry / latent state
  -> typed graphics IR
  -> DMKB-1 instruction + data packets
  -> structural + SHA-256 verification
  -> CPU / GPU / WebGPU / native lowering
  -> measured result
  -> outer Jarvis-X Pi_Lambda
  -> COMMIT / ROLLBACK
```

DMKB-1 deliberately remains below the canonical Jarvis-X authority VM. A structurally valid packet is not authoritative state.

## Correctness fixes relative to the supplied prototype

1. Meshlet bounds and quantization depth are serialized; decode no longer assumes hidden `[-10,+10]` bounds.
2. Index width is derived from local vertex count and indices outside the meshlet fail closed.
3. Writer overrun and reader truncation reject instead of reading/writing beyond the declared stream.
4. Constant latent vectors encode deterministically.
5. Invalid quantization widths, NaN/Infinity and malformed ranges reject.
6. All 32-bit instruction fields participate in round-trip equality.
7. Packet integrity, declared lengths, reserved bits and padding are validated.
8. Lossy codecs report error bounds/metrics alongside encoded size.

## Verification

The existing `.github/workflows/qsol-graphics-codec.yml` builds the .NET 8 project with warnings as errors and executes `--self-test`; DMKB-1 invariants are now invoked by that same test path.

## Capability boundary

This PR defines binary representation, reconstruction and integrity semantics. It does not yet implement a full graphics opcode interpreter, Direct3D/Vulkan/WebGPU execution backend, photorealistic renderer, neural encoder training, encryption, hostile-code sandboxing, or external SOTA performance claims.