### PR TITLE
Add DM-vOmegaXi+ inward 3D bit-matrix engine

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -38,6 +38,12 @@ add_executable(jarvisx-autoencoder3d
 jarvisx_include_runtime(jarvisx-autoencoder3d)
 jarvisx_harden(jarvisx-autoencoder3d)
 
+add_executable(jarvisx-bitmatrix3d
+    src/bitmatrix3d_main.cpp
+)
+jarvisx_include_runtime(jarvisx-bitmatrix3d)
+jarvisx_harden(jarvisx-bitmatrix3d)
+
 add_executable(jarvisx-multimedia4d
     src/multimedia4d_main.cpp
 )
@@ -98,6 +104,19 @@ add_test(
 set_tests_properties(inward-runtime-smoke PROPERTIES TIMEOUT 120)
 
 add_test(
+    NAME bitmatrix3d-runtime-smoke
+    COMMAND jarvisx-bitmatrix3d
+        --epochs 4
+        --edge 8
+        --channels 3
+        --threshold 0.25
+        --pattern sphere
+        --output-dir ${CMAKE_CURRENT_BINARY_DIR}/bitmatrix3d-smoke
+        --quiet
+)
+set_tests_properties(bitmatrix3d-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_test(
     NAME multimedia4d-runtime-smoke
     COMMAND jarvisx-multimedia4d
         --cycles 2
@@ -126,6 +145,15 @@ jarvisx_harden(jarvisx-autoencoder3d-tests)
 
 add_test(NAME autoencoder3d-regressions COMMAND jarvisx-autoencoder3d-tests)
 set_tests_properties(autoencoder3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-bitmatrix3d-tests
+    tests/bitmatrix3d_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-bitmatrix3d-tests)
+jarvisx_harden(jarvisx-bitmatrix3d-tests)
+
+add_test(NAME bitmatrix3d-regressions COMMAND jarvisx-bitmatrix3d-tests)
+set_tests_properties(bitmatrix3d-regressions PROPERTIES TIMEOUT 120)
 
 add_executable(jarvisx-multimedia4d-tests
     tests/multimedia4d_tests.cpp

--- a/cpp_runtime/include/jarvisx/bitmatrix3d.hpp
+++ b/cpp_runtime/include/jarvisx/bitmatrix3d.hpp
@@ -1,0 +1,574 @@
+#pragma once
+
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <random>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+struct BitMatrix3DConfig {
+    std::size_t input_edge{8U};
+    std::size_t latent_channels{4U};
+    float learning_rate{0.01F};
+    float l2_penalty{1.0e-4F};
+    float gradient_clip{1.0F};
+    float ternary_threshold{0.35F};
+    float ste_clip{1.0F};
+    float omega_decay{0.9F};
+    float omega_gain{0.15F};
+    float fixed_point_tolerance{1.0e-3F};
+    std::uint64_t seed{0x444D564249544D58ULL};
+
+    void validate() const {
+        if (input_edge < 4U || input_edge > 64U || input_edge % 2U != 0U) {
+            throw std::invalid_argument("input edge must be even and in [4, 64]");
+        }
+        if (latent_channels < 1U || latent_channels > 32U) {
+            throw std::invalid_argument("latent channels must be in [1, 32]");
+        }
+        auto finite_between = [](float value, float lo, float hi) {
+            return std::isfinite(value) && value >= lo && value <= hi;
+        };
+        if (!finite_between(learning_rate, 1.0e-7F, 1.0F))
+            throw std::invalid_argument("learning rate must be finite and in [1e-7, 1]");
+        if (!finite_between(l2_penalty, 0.0F, 1.0F))
+            throw std::invalid_argument("L2 penalty must be finite and in [0, 1]");
+        if (!finite_between(gradient_clip, 1.0e-6F, 100.0F))
+            throw std::invalid_argument("gradient clip must be finite and in [1e-6, 100]");
+        if (!finite_between(ternary_threshold, 0.0F, 1.0F))
+            throw std::invalid_argument("ternary threshold must be finite and in [0, 1]");
+        if (!finite_between(ste_clip, 1.0e-6F, 8.0F))
+            throw std::invalid_argument("STE clip must be finite and in [1e-6, 8]");
+        if (!finite_between(omega_decay, 0.0F, 1.0F))
+            throw std::invalid_argument("omega decay must be finite and in [0, 1]");
+        if (!finite_between(omega_gain, 0.0F, 4.0F))
+            throw std::invalid_argument("omega gain must be finite and in [0, 4]");
+        if (!finite_between(fixed_point_tolerance, 0.0F, 1.0F))
+            throw std::invalid_argument("fixed point tolerance must be finite and in [0, 1]");
+    }
+};
+
+inline std::uint32_t popcount64_portable(std::uint64_t value) noexcept {
+    std::uint32_t count = 0U;
+    while (value != 0U) {
+        value &= value - 1U;
+        ++count;
+    }
+    return count;
+}
+
+class PackedTernary {
+public:
+    PackedTernary() = default;
+
+    static PackedTernary pack(const std::vector<std::int8_t>& values) {
+        PackedTernary packed;
+        packed.count_ = values.size();
+        const std::size_t words = (values.size() + 63U) / 64U;
+        packed.sign_.assign(words, 0U);
+        packed.nonzero_.assign(words, 0U);
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            const std::int8_t value = values[i];
+            if (value < -1 || value > 1)
+                throw std::invalid_argument("ternary value must be -1, 0 or +1");
+            if (value == 0) continue;
+            const std::size_t word = i / 64U;
+            const std::uint64_t bit = std::uint64_t{1} << (i % 64U);
+            packed.nonzero_[word] |= bit;
+            if (value > 0) packed.sign_[word] |= bit;
+        }
+        packed.validate_padding();
+        return packed;
+    }
+
+    std::vector<std::int8_t> unpack() const {
+        validate_padding();
+        std::vector<std::int8_t> values(count_, 0);
+        for (std::size_t i = 0; i < count_; ++i) {
+            const std::size_t word = i / 64U;
+            const std::uint64_t bit = std::uint64_t{1} << (i % 64U);
+            if ((nonzero_[word] & bit) == 0U) continue;
+            values[i] = (sign_[word] & bit) != 0U ? std::int8_t{1} : std::int8_t{-1};
+        }
+        return values;
+    }
+
+    std::size_t size() const noexcept { return count_; }
+    std::size_t physical_bytes() const noexcept {
+        return (sign_.size() + nonzero_.size()) * sizeof(std::uint64_t);
+    }
+    std::size_t nonzero_count() const noexcept {
+        std::size_t count = 0U;
+        for (const auto word : nonzero_) count += popcount64_portable(word);
+        return count;
+    }
+    double density() const noexcept {
+        return count_ == 0U ? 0.0 : static_cast<double>(nonzero_count()) / static_cast<double>(count_);
+    }
+    const std::vector<std::uint64_t>& sign_words() const noexcept { return sign_; }
+    const std::vector<std::uint64_t>& nonzero_words() const noexcept { return nonzero_; }
+
+    static int binary_dot(std::uint64_t lhs, std::uint64_t rhs, std::size_t valid_bits = 64U) {
+        if (valid_bits > 64U) throw std::invalid_argument("valid_bits must be <= 64");
+        if (valid_bits == 0U) return 0;
+        const std::uint64_t mask = valid_bits == 64U
+            ? std::numeric_limits<std::uint64_t>::max()
+            : ((std::uint64_t{1} << valid_bits) - 1U);
+        const auto mismatches = popcount64_portable((lhs ^ rhs) & mask);
+        return static_cast<int>(valid_bits) - 2 * static_cast<int>(mismatches);
+    }
+
+    static int ternary_binary_dot(std::uint64_t binary_sign,
+                                  std::uint64_t ternary_sign,
+                                  std::uint64_t ternary_nonzero,
+                                  std::size_t valid_bits = 64U) {
+        if (valid_bits > 64U) throw std::invalid_argument("valid_bits must be <= 64");
+        if (valid_bits == 0U) return 0;
+        const std::uint64_t valid_mask = valid_bits == 64U
+            ? std::numeric_limits<std::uint64_t>::max()
+            : ((std::uint64_t{1} << valid_bits) - 1U);
+        const std::uint64_t mask = ternary_nonzero & valid_mask;
+        const auto active = popcount64_portable(mask);
+        const auto mismatches = popcount64_portable((binary_sign ^ ternary_sign) & mask);
+        return static_cast<int>(active) - 2 * static_cast<int>(mismatches);
+    }
+
+private:
+    std::size_t count_{};
+    std::vector<std::uint64_t> sign_;
+    std::vector<std::uint64_t> nonzero_;
+
+    void validate_padding() const {
+        if (sign_.size() != nonzero_.size())
+            throw std::logic_error("ternary planes have different word counts");
+        if (count_ == 0U) {
+            if (!sign_.empty() || !nonzero_.empty())
+                throw std::logic_error("empty ternary field has storage");
+            return;
+        }
+        const std::size_t expected = (count_ + 63U) / 64U;
+        if (sign_.size() != expected)
+            throw std::logic_error("ternary plane word count is not canonical");
+        if ((count_ & 63U) != 0U) {
+            const std::size_t used = count_ & 63U;
+            const std::uint64_t valid = (std::uint64_t{1} << used) - 1U;
+            if ((sign_.back() & ~valid) != 0U || (nonzero_.back() & ~valid) != 0U)
+                throw std::logic_error("ternary plane has non-zero padding bits");
+        }
+        for (std::size_t i = 0; i < sign_.size(); ++i) {
+            if ((sign_[i] & ~nonzero_[i]) != 0U)
+                throw std::logic_error("ternary sign bits must be zero where mask is zero");
+        }
+    }
+};
+
+struct QuantizedTernaryWeights {
+    float scale{1.0F};
+    std::vector<std::int8_t> values;
+    PackedTernary packed;
+};
+
+inline QuantizedTernaryWeights ternary_quantize_weights(const std::vector<float>& shadow) {
+    if (shadow.empty()) throw std::invalid_argument("shadow weights cannot be empty");
+    double abs_sum = 0.0;
+    for (const float value : shadow) {
+        if (!std::isfinite(value)) throw std::invalid_argument("shadow weights must be finite");
+        abs_sum += std::fabs(static_cast<double>(value));
+    }
+    float scale = static_cast<float>(abs_sum / static_cast<double>(shadow.size()));
+    if (scale < 1.0e-12F) scale = 1.0F;
+    std::vector<std::int8_t> values(shadow.size(), 0);
+    for (std::size_t i = 0; i < shadow.size(); ++i) {
+        const float normalized = shadow[i] / scale;
+        const float rounded = std::round(std::max(-1.0F, std::min(1.0F, normalized)));
+        values[i] = static_cast<std::int8_t>(rounded);
+    }
+    return {scale, values, PackedTernary::pack(values)};
+}
+
+struct QuantizedInt8 {
+    float scale{1.0F};
+    std::vector<std::int8_t> values;
+};
+
+inline QuantizedInt8 quantize_symmetric_int8(const std::vector<float>& input) {
+    if (input.empty()) throw std::invalid_argument("activation tensor cannot be empty");
+    float max_abs = 0.0F;
+    for (const float value : input) {
+        if (!std::isfinite(value)) throw std::invalid_argument("activation tensor must be finite");
+        max_abs = std::max(max_abs, std::fabs(value));
+    }
+    const float scale = max_abs < 1.0e-12F ? 1.0F : max_abs / 127.0F;
+    std::vector<std::int8_t> values(input.size(), 0);
+    for (std::size_t i = 0; i < input.size(); ++i) {
+        const float scaled = input[i] / scale;
+        const float clipped = std::max(-127.0F, std::min(127.0F, scaled));
+        values[i] = static_cast<std::int8_t>(std::lround(clipped));
+    }
+    return {scale, values};
+}
+
+struct BitMatrix3DMetrics {
+    std::uint64_t step{};
+    float mse{};
+    float mae{};
+    float max_abs_error{};
+    float fixed_point_residual{};
+    float encoder_weight_density{};
+    float decoder_weight_density{};
+    float latent_density{};
+    float gradient_l2{};
+    std::size_t shadow_weight_bytes{};
+    std::size_t packed_weight_bytes{};
+    std::size_t packed_latent_bytes{};
+    bool self_description_valid{};
+    bool fixed_point_converged{};
+};
+
+struct BitMatrix3DForward {
+    Tensor4D latent_shadow;
+    Tensor4D latent_ternary;
+    PackedTernary latent_packed;
+    Tensor4D reconstruction;
+    QuantizedTernaryWeights encoder_weights;
+    QuantizedTernaryWeights decoder_weights;
+};
+
+class BitMatrix3DEngine {
+public:
+    static constexpr std::size_t kKernelEdge = 3U;
+    static constexpr std::size_t kKernelVolume = 27U;
+
+    explicit BitMatrix3DEngine(BitMatrix3DConfig config)
+        : config_(config),
+          encoder_shadow_(config.latent_channels * kKernelVolume),
+          encoder_bias_(config.latent_channels, 0.0F),
+          decoder_shadow_(config.latent_channels * kKernelVolume),
+          omega_({1U, config.input_edge, config.input_edge, config.input_edge}) {
+        config_.validate();
+        initialize_weights();
+    }
+
+    const BitMatrix3DConfig& config() const noexcept { return config_; }
+    std::uint64_t steps() const noexcept { return steps_; }
+    const std::vector<float>& encoder_shadow_weights() const noexcept { return encoder_shadow_; }
+    const std::vector<float>& decoder_shadow_weights() const noexcept { return decoder_shadow_; }
+
+    BitMatrix3DForward forward(const Tensor4D& input) const {
+        validate_input(input);
+        const auto encoder_q = ternary_quantize_weights(encoder_shadow_);
+        const auto decoder_q = ternary_quantize_weights(decoder_shadow_);
+        const auto input_q = quantize_symmetric_int8(input.values());
+        const std::size_t latent_edge = config_.input_edge / 2U;
+        Tensor4D latent_shadow({config_.latent_channels, latent_edge, latent_edge, latent_edge});
+        Tensor4D latent_ternary({config_.latent_channels, latent_edge, latent_edge, latent_edge});
+        std::vector<std::int8_t> latent_codes(latent_ternary.size(), 0);
+
+        for (std::size_t channel = 0; channel < config_.latent_channels; ++channel) {
+            for (std::size_t z = 0; z < latent_edge; ++z) {
+                for (std::size_t y = 0; y < latent_edge; ++y) {
+                    for (std::size_t x = 0; x < latent_edge; ++x) {
+                        std::int32_t integer_sum = 0;
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t iz = wrap_index(static_cast<long long>(2U * z + kz) - 1LL, config_.input_edge);
+                                    const std::size_t iy = wrap_index(static_cast<long long>(2U * y + ky) - 1LL, config_.input_edge);
+                                    const std::size_t ix = wrap_index(static_cast<long long>(2U * x + kx) - 1LL, config_.input_edge);
+                                    const auto qx = input_q.values[input_index(iz, iy, ix)];
+                                    const auto qw = encoder_q.values[weight_index(channel, kernel)];
+                                    integer_sum += static_cast<std::int32_t>(qx) * static_cast<std::int32_t>(qw);
+                                }
+                            }
+                        }
+                        const float pre = encoder_bias_[channel] +
+                            static_cast<float>(integer_sum) * input_q.scale * encoder_q.scale;
+                        const float soft = std::tanh(pre);
+                        const std::int8_t code = ternary_activation(soft);
+                        latent_shadow(channel, z, y, x) = soft;
+                        latent_ternary(channel, z, y, x) = static_cast<float>(code);
+                        latent_codes[latent_index(channel, z, y, x)] = code;
+                    }
+                }
+            }
+        }
+
+        Tensor4D reconstruction({1U, config_.input_edge, config_.input_edge, config_.input_edge});
+        for (std::size_t z = 0; z < config_.input_edge; ++z) {
+            for (std::size_t y = 0; y < config_.input_edge; ++y) {
+                for (std::size_t x = 0; x < config_.input_edge; ++x) {
+                    std::int32_t integer_sum = 0;
+                    const std::size_t lz0 = z / 2U;
+                    const std::size_t ly0 = y / 2U;
+                    const std::size_t lx0 = x / 2U;
+                    for (std::size_t channel = 0; channel < config_.latent_channels; ++channel) {
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t lz = wrap_index(static_cast<long long>(lz0 + kz) - 1LL, latent_edge);
+                                    const std::size_t ly = wrap_index(static_cast<long long>(ly0 + ky) - 1LL, latent_edge);
+                                    const std::size_t lx = wrap_index(static_cast<long long>(lx0 + kx) - 1LL, latent_edge);
+                                    const auto qx = latent_codes[latent_index(channel, lz, ly, lx)];
+                                    const auto qw = decoder_q.values[weight_index(channel, kernel)];
+                                    integer_sum += static_cast<std::int32_t>(qx) * static_cast<std::int32_t>(qw);
+                                }
+                            }
+                        }
+                    }
+                    const float pre = decoder_bias_ + static_cast<float>(integer_sum) * decoder_q.scale;
+                    reconstruction(0U, z, y, x) = std::tanh(pre);
+                }
+            }
+        }
+
+        return {std::move(latent_shadow), std::move(latent_ternary),
+                PackedTernary::pack(latent_codes), std::move(reconstruction),
+                encoder_q, decoder_q};
+    }
+
+    Tensor4D reconstruct(const Tensor4D& input) const { return forward(input).reconstruction; }
+
+    BitMatrix3DMetrics train_step(const Tensor4D& input) {
+        validate_input(input);
+        const auto fwd = forward(input);
+        const std::size_t latent_edge = config_.input_edge / 2U;
+        Tensor4D output_delta(fwd.reconstruction.shape());
+        Tensor4D latent_gradient(fwd.latent_shadow.shape());
+        std::vector<float> decoder_gradient(decoder_shadow_.size(), 0.0F);
+        std::vector<float> encoder_gradient(encoder_shadow_.size(), 0.0F);
+        std::vector<float> encoder_bias_gradient(encoder_bias_.size(), 0.0F);
+        float decoder_bias_gradient = 0.0F;
+        double mse_sum = 0.0;
+        double mae_sum = 0.0;
+        float max_abs = 0.0F;
+        const float inverse_count = 1.0F / static_cast<float>(fwd.reconstruction.size());
+
+        for (std::size_t z = 0; z < config_.input_edge; ++z) {
+            for (std::size_t y = 0; y < config_.input_edge; ++y) {
+                for (std::size_t x = 0; x < config_.input_edge; ++x) {
+                    const float predicted = fwd.reconstruction(0U, z, y, x);
+                    const float error = predicted - input(0U, z, y, x);
+                    const float absolute = std::fabs(error);
+                    mse_sum += static_cast<double>(error) * error;
+                    mae_sum += absolute;
+                    max_abs = std::max(max_abs, absolute);
+                    const float delta = 2.0F * inverse_count * error * (1.0F - predicted * predicted);
+                    output_delta(0U, z, y, x) = delta;
+                    decoder_bias_gradient += delta;
+                    const std::size_t lz0 = z / 2U;
+                    const std::size_t ly0 = y / 2U;
+                    const std::size_t lx0 = x / 2U;
+                    for (std::size_t channel = 0; channel < config_.latent_channels; ++channel) {
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t lz = wrap_index(static_cast<long long>(lz0 + kz) - 1LL, latent_edge);
+                                    const std::size_t ly = wrap_index(static_cast<long long>(ly0 + ky) - 1LL, latent_edge);
+                                    const std::size_t lx = wrap_index(static_cast<long long>(lx0 + kx) - 1LL, latent_edge);
+                                    const std::size_t wi = weight_index(channel, kernel);
+                                    const float latent_value = fwd.latent_ternary(channel, lz, ly, lx);
+                                    decoder_gradient[wi] += delta * latent_value;
+                                    const float physical_weight = fwd.decoder_weights.scale *
+                                        static_cast<float>(fwd.decoder_weights.values[wi]);
+                                    latent_gradient(channel, lz, ly, lx) += delta * physical_weight;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        for (std::size_t channel = 0; channel < config_.latent_channels; ++channel) {
+            for (std::size_t z = 0; z < latent_edge; ++z) {
+                for (std::size_t y = 0; y < latent_edge; ++y) {
+                    for (std::size_t x = 0; x < latent_edge; ++x) {
+                        const float soft = fwd.latent_shadow(channel, z, y, x);
+                        const float ste = std::fabs(soft) <= config_.ste_clip ? 1.0F : 0.0F;
+                        const float delta = latent_gradient(channel, z, y, x) * ste * (1.0F - soft * soft);
+                        encoder_bias_gradient[channel] += delta;
+                        for (std::size_t kz = 0; kz < kKernelEdge; ++kz) {
+                            for (std::size_t ky = 0; ky < kKernelEdge; ++ky) {
+                                for (std::size_t kx = 0; kx < kKernelEdge; ++kx) {
+                                    const std::size_t kernel = kernel_index(kz, ky, kx);
+                                    const std::size_t iz = wrap_index(static_cast<long long>(2U * z + kz) - 1LL, config_.input_edge);
+                                    const std::size_t iy = wrap_index(static_cast<long long>(2U * y + ky) - 1LL, config_.input_edge);
+                                    const std::size_t ix = wrap_index(static_cast<long long>(2U * x + kx) - 1LL, config_.input_edge);
+                                    encoder_gradient[weight_index(channel, kernel)] += delta * input(0U, iz, iy, ix);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        double gradient_square_sum = 0.0;
+        apply_update(encoder_shadow_, encoder_gradient, gradient_square_sum);
+        apply_update(decoder_shadow_, decoder_gradient, gradient_square_sum);
+        for (std::size_t i = 0; i < encoder_bias_.size(); ++i) {
+            const float gradient = clip(encoder_bias_gradient[i]);
+            gradient_square_sum += static_cast<double>(gradient) * gradient;
+            encoder_bias_[i] -= config_.learning_rate * gradient;
+        }
+        decoder_bias_gradient = clip(decoder_bias_gradient);
+        gradient_square_sum += static_cast<double>(decoder_bias_gradient) * decoder_bias_gradient;
+        decoder_bias_ -= config_.learning_rate * decoder_bias_gradient;
+        ++steps_;
+
+        const auto inward = inward_metrics(input, fwd);
+        const double count = static_cast<double>(fwd.reconstruction.size());
+        return {
+            steps_,
+            static_cast<float>(mse_sum / count),
+            static_cast<float>(mae_sum / count),
+            max_abs,
+            inward.first,
+            static_cast<float>(fwd.encoder_weights.packed.density()),
+            static_cast<float>(fwd.decoder_weights.packed.density()),
+            static_cast<float>(fwd.latent_packed.density()),
+            static_cast<float>(std::sqrt(gradient_square_sum)),
+            (encoder_shadow_.size() + decoder_shadow_.size()) * sizeof(float),
+            fwd.encoder_weights.packed.physical_bytes() + fwd.decoder_weights.packed.physical_bytes(),
+            fwd.latent_packed.physical_bytes(),
+            verify_self_description(fwd),
+            inward.first <= config_.fixed_point_tolerance
+        };
+    }
+
+    BitMatrix3DMetrics evaluate_inward(const Tensor4D& input) {
+        const auto fwd = forward(input);
+        const auto inward = inward_metrics(input, fwd);
+        double mse_sum = 0.0;
+        double mae_sum = 0.0;
+        float max_abs = 0.0F;
+        for (std::size_t i = 0; i < input.size(); ++i) {
+            const float error = fwd.reconstruction.values()[i] - input.values()[i];
+            mse_sum += static_cast<double>(error) * error;
+            mae_sum += std::fabs(error);
+            max_abs = std::max(max_abs, std::fabs(error));
+        }
+        const double count = static_cast<double>(input.size());
+        return {
+            steps_, static_cast<float>(mse_sum / count), static_cast<float>(mae_sum / count), max_abs,
+            inward.first,
+            static_cast<float>(fwd.encoder_weights.packed.density()),
+            static_cast<float>(fwd.decoder_weights.packed.density()),
+            static_cast<float>(fwd.latent_packed.density()),
+            0.0F,
+            (encoder_shadow_.size() + decoder_shadow_.size()) * sizeof(float),
+            fwd.encoder_weights.packed.physical_bytes() + fwd.decoder_weights.packed.physical_bytes(),
+            fwd.latent_packed.physical_bytes(),
+            verify_self_description(fwd),
+            inward.first <= config_.fixed_point_tolerance
+        };
+    }
+
+    bool verify_self_description(const BitMatrix3DForward& fwd) const {
+        return fwd.encoder_weights.values == fwd.encoder_weights.packed.unpack() &&
+               fwd.decoder_weights.values == fwd.decoder_weights.packed.unpack() &&
+               latent_values(fwd.latent_ternary) == fwd.latent_packed.unpack();
+    }
+
+private:
+    BitMatrix3DConfig config_;
+    std::vector<float> encoder_shadow_;
+    std::vector<float> encoder_bias_;
+    std::vector<float> decoder_shadow_;
+    float decoder_bias_{0.0F};
+    Tensor4D omega_;
+    std::uint64_t steps_{};
+
+    static std::size_t kernel_index(std::size_t z, std::size_t y, std::size_t x) noexcept {
+        return x + kKernelEdge * (y + kKernelEdge * z);
+    }
+    std::size_t weight_index(std::size_t channel, std::size_t kernel) const noexcept {
+        return channel * kKernelVolume + kernel;
+    }
+    std::size_t input_index(std::size_t z, std::size_t y, std::size_t x) const noexcept {
+        return x + config_.input_edge * (y + config_.input_edge * z);
+    }
+    std::size_t latent_index(std::size_t channel, std::size_t z, std::size_t y, std::size_t x) const noexcept {
+        const std::size_t edge = config_.input_edge / 2U;
+        return x + edge * (y + edge * (z + edge * channel));
+    }
+    static std::size_t wrap_index(long long value, std::size_t extent) noexcept {
+        const long long size = static_cast<long long>(extent);
+        long long wrapped = value % size;
+        if (wrapped < 0) wrapped += size;
+        return static_cast<std::size_t>(wrapped);
+    }
+    std::int8_t ternary_activation(float value) const noexcept {
+        if (value > config_.ternary_threshold) return 1;
+        if (value < -config_.ternary_threshold) return -1;
+        return 0;
+    }
+    static std::vector<std::int8_t> latent_values(const Tensor4D& latent) {
+        std::vector<std::int8_t> values(latent.size(), 0);
+        for (std::size_t i = 0; i < latent.size(); ++i) {
+            const float value = latent.values()[i];
+            if (value > 0.5F) values[i] = 1;
+            else if (value < -0.5F) values[i] = -1;
+        }
+        return values;
+    }
+    void validate_input(const Tensor4D& input) const {
+        const auto& s = input.shape();
+        if (s.channels != 1U || s.depth != config_.input_edge ||
+            s.height != config_.input_edge || s.width != config_.input_edge)
+            throw std::invalid_argument("bit-matrix input shape mismatch");
+        for (const float value : input.values()) {
+            if (!std::isfinite(value)) throw std::invalid_argument("bit-matrix input must be finite");
+        }
+    }
+    void initialize_weights() {
+        std::mt19937_64 rng(config_.seed);
+        std::uniform_real_distribution<float> distribution(-0.35F, 0.35F);
+        for (auto& value : encoder_shadow_) value = distribution(rng);
+        for (auto& value : decoder_shadow_) value = distribution(rng);
+    }
+    float clip(float gradient) const noexcept {
+        return std::max(-config_.gradient_clip, std::min(config_.gradient_clip, gradient));
+    }
+    void apply_update(std::vector<float>& shadow, const std::vector<float>& gradient,
+                      double& gradient_square_sum) {
+        for (std::size_t i = 0; i < shadow.size(); ++i) {
+            float g = gradient[i] + config_.l2_penalty * shadow[i];
+            g = clip(g);
+            gradient_square_sum += static_cast<double>(g) * g;
+            shadow[i] -= config_.learning_rate * g;
+        }
+    }
+    std::pair<float, Tensor4D> inward_metrics(const Tensor4D& input, const BitMatrix3DForward& fwd) {
+        Tensor4D candidate(input.shape());
+        double numerator = 0.0;
+        double denominator = 0.0;
+        for (std::size_t i = 0; i < input.size(); ++i) {
+            const float residual = input.values()[i] - fwd.reconstruction.values()[i];
+            omega_.values()[i] = config_.omega_decay * omega_.values()[i] +
+                (1.0F - config_.omega_decay) * residual;
+            const float projected = std::max(-1.0F, std::min(1.0F,
+                fwd.reconstruction.values()[i] + config_.omega_gain * omega_.values()[i]));
+            candidate.values()[i] = projected;
+            const double difference = static_cast<double>(projected) - input.values()[i];
+            numerator += difference * difference;
+            denominator += static_cast<double>(input.values()[i]) * input.values()[i];
+        }
+        const float residual = static_cast<float>(std::sqrt(numerator) /
+            (std::sqrt(denominator) + 1.0e-12));
+        return {residual, std::move(candidate)};
+    }
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/src/bitmatrix3d_main.cpp
+++ b/cpp_runtime/src/bitmatrix3d_main.cpp
@@ -1,0 +1,142 @@
+#include "jarvisx/bitmatrix3d.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct Options {
+    std::size_t edge{8U};
+    std::size_t channels{4U};
+    std::size_t epochs{160U};
+    float learning_rate{0.01F};
+    float threshold{0.25F};
+    std::uint64_t seed{42U};
+    std::string pattern{"sphere"};
+    fs::path output_dir{".jarvisx-bitmatrix3d"};
+    bool quiet{false};
+};
+
+Options parse(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) throw std::invalid_argument(std::string(name) + " requires a value");
+            return argv[++i];
+        };
+        if (arg == "--edge") options.edge = static_cast<std::size_t>(std::stoull(require_value("--edge")));
+        else if (arg == "--channels") options.channels = static_cast<std::size_t>(std::stoull(require_value("--channels")));
+        else if (arg == "--epochs") options.epochs = static_cast<std::size_t>(std::stoull(require_value("--epochs")));
+        else if (arg == "--learning-rate") options.learning_rate = std::stof(require_value("--learning-rate"));
+        else if (arg == "--threshold") options.threshold = std::stof(require_value("--threshold"));
+        else if (arg == "--seed") options.seed = static_cast<std::uint64_t>(std::stoull(require_value("--seed")));
+        else if (arg == "--pattern") options.pattern = require_value("--pattern");
+        else if (arg == "--output-dir") options.output_dir = require_value("--output-dir");
+        else if (arg == "--quiet") options.quiet = true;
+        else if (arg == "--help") {
+            std::cout << "jarvisx-bitmatrix3d [--edge N] [--channels N] [--epochs N] "
+                         "[--learning-rate F] [--threshold F] [--seed N] "
+                         "[--pattern sphere|shell|checker|wave|noise] [--output-dir PATH] [--quiet]\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown argument: " + arg);
+        }
+    }
+    if (options.epochs == 0U || options.epochs > 100000U)
+        throw std::invalid_argument("epochs must be in [1, 100000]");
+    return options;
+}
+
+void write_words(std::ostream& out, const char* name, const std::vector<std::uint64_t>& words) {
+    out << name << "_count=" << words.size() << '\n';
+    for (std::size_t i = 0; i < words.size(); ++i) {
+        out << name << '[' << i << "]=0x" << std::hex << std::setw(16) << std::setfill('0')
+            << words[i] << std::dec << std::setfill(' ') << '\n';
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse(argc, argv);
+        jarvisx::BitMatrix3DConfig config;
+        config.input_edge = options.edge;
+        config.latent_channels = options.channels;
+        config.learning_rate = options.learning_rate;
+        config.ternary_threshold = options.threshold;
+        config.seed = options.seed;
+        jarvisx::BitMatrix3DEngine engine(config);
+        const auto input = jarvisx::make_volume(options.edge, options.pattern, options.seed);
+
+        fs::create_directories(options.output_dir);
+        std::ofstream metrics(options.output_dir / "metrics.csv", std::ios::trunc);
+        if (!metrics) throw std::runtime_error("cannot open metrics.csv");
+        metrics << "step,mse,mae,max_abs,fixed_point_residual,encoder_density,decoder_density,"
+                   "latent_density,gradient_l2,shadow_weight_bytes,packed_weight_bytes,"
+                   "packed_latent_bytes,self_description_valid,fixed_point_converged\n";
+
+        for (std::size_t epoch = 0; epoch < options.epochs; ++epoch) {
+            const auto m = engine.train_step(input);
+            metrics << m.step << ',' << m.mse << ',' << m.mae << ',' << m.max_abs_error << ','
+                    << m.fixed_point_residual << ',' << m.encoder_weight_density << ','
+                    << m.decoder_weight_density << ',' << m.latent_density << ',' << m.gradient_l2 << ','
+                    << m.shadow_weight_bytes << ',' << m.packed_weight_bytes << ',' << m.packed_latent_bytes << ','
+                    << (m.self_description_valid ? 1 : 0) << ',' << (m.fixed_point_converged ? 1 : 0) << '\n';
+            if (!options.quiet && (epoch == 0U || epoch + 1U == options.epochs || (epoch + 1U) % 25U == 0U)) {
+                std::cout << "step=" << m.step << " mse=" << m.mse
+                          << " fp_residual=" << m.fixed_point_residual
+                          << " latent_density=" << m.latent_density
+                          << " packed_weights=" << m.packed_weight_bytes << "B\n";
+            }
+        }
+
+        const auto final_forward = engine.forward(input);
+        const auto final_metrics = engine.evaluate_inward(input);
+        std::ofstream snapshot(options.output_dir / "bitplanes.txt", std::ios::trunc);
+        if (!snapshot) throw std::runtime_error("cannot open bitplanes.txt");
+        snapshot << "DMVX_BITMATRIX3D_V1\n";
+        snapshot << "steps=" << engine.steps() << '\n';
+        snapshot << "encoder_scale=" << final_forward.encoder_weights.scale << '\n';
+        snapshot << "decoder_scale=" << final_forward.decoder_weights.scale << '\n';
+        snapshot << "latent_elements=" << final_forward.latent_packed.size() << '\n';
+        snapshot << "latent_nonzero=" << final_forward.latent_packed.nonzero_count() << '\n';
+        write_words(snapshot, "encoder_sign", final_forward.encoder_weights.packed.sign_words());
+        write_words(snapshot, "encoder_mask", final_forward.encoder_weights.packed.nonzero_words());
+        write_words(snapshot, "decoder_sign", final_forward.decoder_weights.packed.sign_words());
+        write_words(snapshot, "decoder_mask", final_forward.decoder_weights.packed.nonzero_words());
+        write_words(snapshot, "latent_sign", final_forward.latent_packed.sign_words());
+        write_words(snapshot, "latent_mask", final_forward.latent_packed.nonzero_words());
+
+        std::ofstream report(options.output_dir / "report.txt", std::ios::trunc);
+        if (!report) throw std::runtime_error("cannot open report.txt");
+        report << "DM-vOmegaXi+ Bit-Matrix Engine reference report\n"
+               << "mse=" << final_metrics.mse << '\n'
+               << "fixed_point_residual=" << final_metrics.fixed_point_residual << '\n'
+               << "self_description_valid=" << (final_metrics.self_description_valid ? "true" : "false") << '\n'
+               << "shadow_weight_bytes=" << final_metrics.shadow_weight_bytes << '\n'
+               << "packed_weight_bytes=" << final_metrics.packed_weight_bytes << '\n'
+               << "packed_latent_bytes=" << final_metrics.packed_latent_bytes << '\n'
+               << "physical_weight_compression="
+               << (final_metrics.packed_weight_bytes == 0U ? 0.0 :
+                   static_cast<double>(final_metrics.shadow_weight_bytes) /
+                   static_cast<double>(final_metrics.packed_weight_bytes)) << "x\n"
+               << "note=reference scalar mixed-precision kernel; no AVX/CUDA speedup claim\n";
+
+        if (!final_metrics.self_description_valid)
+            throw std::runtime_error("packed bitplanes failed self-description verification");
+        if (!options.quiet)
+            std::cout << "artifacts=" << fs::absolute(options.output_dir).string() << '\n';
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "bit-matrix engine failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/bitmatrix3d_tests.cpp
+++ b/cpp_runtime/tests/bitmatrix3d_tests.cpp
@@ -1,0 +1,119 @@
+#include "jarvisx/bitmatrix3d.hpp"
+
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+jarvisx::Tensor4D fixture(std::size_t edge) {
+    jarvisx::Tensor4D tensor({1U, edge, edge, edge});
+    const float center = (static_cast<float>(edge) - 1.0F) * 0.5F;
+    const float denom = std::max(center, 1.0F);
+    for (std::size_t z = 0; z < edge; ++z) {
+        for (std::size_t y = 0; y < edge; ++y) {
+            for (std::size_t x = 0; x < edge; ++x) {
+                const float dx = (static_cast<float>(x) - center) / denom;
+                const float dy = (static_cast<float>(y) - center) / denom;
+                const float dz = (static_cast<float>(z) - center) / denom;
+                const float radius = std::sqrt(dx * dx + dy * dy + dz * dz);
+                tensor(0U, z, y, x) = radius < 0.7F ? 1.0F : -0.2F;
+            }
+        }
+    }
+    return tensor;
+}
+
+void ternary_round_trip() {
+    const std::vector<std::int8_t> values{1, 0, -1, 1, -1, 0, 0, 1, -1};
+    const auto packed = jarvisx::PackedTernary::pack(values);
+    require(packed.unpack() == values, "packed ternary planes must round-trip exactly");
+    require(packed.nonzero_count() == 6U, "packed ternary nonzero count mismatch");
+}
+
+void bitwise_dot_primitives() {
+    const std::uint64_t a = 0b1011U;
+    const std::uint64_t b = 0b1001U;
+    require(jarvisx::PackedTernary::binary_dot(a, b, 4U) == 2,
+            "binary XOR/popcount dot product mismatch");
+    const std::uint64_t ternary_sign = 0b1001U;
+    const std::uint64_t ternary_mask = 0b1101U;
+    require(jarvisx::PackedTernary::ternary_binary_dot(a, ternary_sign, ternary_mask, 4U) == 3,
+            "ternary masked dot product mismatch");
+}
+
+void deterministic_forward() {
+    jarvisx::BitMatrix3DConfig config;
+    config.seed = 99U;
+    config.ternary_threshold = 0.25F;
+    jarvisx::BitMatrix3DEngine first(config);
+    jarvisx::BitMatrix3DEngine second(config);
+    const auto input = fixture(config.input_edge);
+    const auto a = first.forward(input);
+    const auto b = second.forward(input);
+    require(a.reconstruction.values() == b.reconstruction.values(),
+            "same seed must produce deterministic reconstruction");
+    require(a.latent_packed.unpack() == b.latent_packed.unpack(),
+            "same seed must produce deterministic packed latent state");
+    require(first.verify_self_description(a), "first forward self-description failed");
+    require(second.verify_self_description(b), "second forward self-description failed");
+}
+
+void training_updates_shadow_and_reduces_error() {
+    jarvisx::BitMatrix3DConfig config;
+    config.learning_rate = 0.01F;
+    config.ternary_threshold = 0.25F;
+    config.seed = 42U;
+    jarvisx::BitMatrix3DEngine engine(config);
+    const auto input = fixture(config.input_edge);
+    const auto before_weights = engine.encoder_shadow_weights();
+    const auto before = engine.evaluate_inward(input).mse;
+    for (std::size_t step = 0; step < 220U; ++step) {
+        const auto metrics = engine.train_step(input);
+        require(std::isfinite(metrics.mse), "training MSE must remain finite");
+        require(std::isfinite(metrics.gradient_l2), "gradient norm must remain finite");
+        require(metrics.self_description_valid,
+                "packed self-description must remain valid during training");
+    }
+    const auto after = engine.evaluate_inward(input);
+    require(engine.encoder_shadow_weights() != before_weights,
+            "STE training must update continuous shadow weights");
+    require(after.mse < before * 0.85F,
+            "bit-matrix STE training must materially reduce fixture reconstruction error");
+    require(after.packed_weight_bytes < after.shadow_weight_bytes,
+            "packed ternary weight representation must be smaller than FP32 shadow weights");
+}
+
+void int8_activation_quantization_is_bounded() {
+    const std::vector<float> values{-2.0F, -1.0F, 0.0F, 0.5F, 2.0F};
+    const auto quantized = jarvisx::quantize_symmetric_int8(values);
+    require(quantized.values.size() == values.size(),
+            "INT8 quantized activation size mismatch");
+    require(quantized.scale > 0.0F && std::isfinite(quantized.scale),
+            "INT8 activation scale must be finite and positive");
+    for (const auto q : quantized.values)
+        require(q >= -127, "INT8 activation code entered the reserved -128 code");
+}
+
+} // namespace
+
+int main() {
+    try {
+        ternary_round_trip();
+        bitwise_dot_primitives();
+        deterministic_forward();
+        training_updates_shadow_and_reduces_error();
+        int8_activation_quantization_is_bounded();
+        std::cout << "DM-vOmegaXi+ bit-matrix 3D tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "bit-matrix 3D test failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/docs/DMVX_BITMATRIX3D_ENGINE.md
+++ b/docs/DMVX_BITMATRIX3D_ENGINE.md
@@ -1,0 +1,362 @@
+# DM-vOmegaXi+ Inward 3D Bit-Matrix Engine
+
+## Status
+
+**Executable bounded reference backend.**
+
+This subsystem turns the DM-vOmegaXi+ bit-scaffold formulation into a deterministic C++17 3D auto-encoding/decoding runtime. It preserves full-precision shadow weights for learning, projects them onto ternary execution weights, quantizes encoder activations to signed INT8, compresses the latent state into two bitplanes, reconstructs the 3D field through ternary decoder weights, accumulates residual memory, and measures a numerical inward fixed-point residual.
+
+It is an experimental backend beneath Jarvis-X authority and transaction layers. It does not make a state authoritative merely because the model generated it.
+
+---
+
+## 1. State
+
+The reference state is
+
+```text
+M_t = (X_t, W*_E,t, W*_D,t, Wq_E,t, Wq_D,t, Zq_t, Omega_t, Theta_t)
+```
+
+where:
+
+- `X_t` is the single-channel input 3D field;
+- `W*_E,t` and `W*_D,t` are continuous FP32 encoder/decoder shadow weights;
+- `Wq_E,t` and `Wq_D,t` are ternary projections in `{-1,0,+1}`;
+- `Zq_t` is the ternary latent field;
+- `Omega_t` is bounded residual memory;
+- `Theta_t` contains scales, thresholds and optimization parameters.
+
+The implementation deliberately separates learning state from execution state:
+
+```text
+continuous shadow weights != packed execution weights
+```
+
+---
+
+## 2. Ternary weight projection
+
+For a shadow tensor `W*`, the layer scale is
+
+```text
+alpha = mean(abs(W*))
+```
+
+and the execution weight is
+
+```text
+Wq_i = clip(round(W*_i / alpha), -1, +1)
+```
+
+with the zero-scale case mapped to a finite fallback scale.
+
+Therefore:
+
+```text
+Wq_i in {-1, 0, +1}
+```
+
+The reference stores each ternary field in two 64-bit planes:
+
+```text
+sign plane     S_i = 1 for +1, 0 otherwise
+nonzero plane  M_i = 1 for +/-1, 0 for zero
+```
+
+The sign plane is constrained to zero wherever the nonzero plane is zero.
+
+This is a physical **2-bit representation** before word-padding overhead. The phrase `1.58-bit` refers to the information content `log2(3) ~= 1.585` of three equally likely symbols; this reference implementation does not claim sub-2-bit entropy coding.
+
+---
+
+## 3. INT8 activation path
+
+The encoder input is symmetrically quantized:
+
+```text
+beta = max(abs(X)) / 127
+Xq_i = round(clamp(X_i / beta, -127, +127))
+```
+
+with a finite fallback scale for an all-zero tensor.
+
+The encoder accumulator is integer:
+
+```text
+A_E = sum(Xq_i * Wq_i)
+```
+
+and is rescaled before the nonlinearity:
+
+```text
+Y_E = tanh(b_E + alpha_E * beta * A_E)
+```
+
+This is a mixed-precision reference path: ternary weights, INT8 encoder activations, integer accumulation and FP32 rescaling/nonlinearity.
+
+---
+
+## 4. Ternary latent scaffold
+
+The continuous encoder shadow activation `Y_E` is projected onto
+
+```text
+Zq = +1  when Y_E > +tau
+Zq =  0  when -tau <= Y_E <= +tau
+Zq = -1  when Y_E < -tau
+```
+
+`Zq` is then packed into sign/nonzero bitplanes.
+
+The decoder consumes the ternary latent scaffold directly. Its core accumulation is therefore integer ternary-by-ternary arithmetic:
+
+```text
+A_D = sum(Zq_i * Wq_D,i)
+X_hat = tanh(b_D + alpha_D * A_D)
+```
+
+The current portable reference kernel uses scalar integer accumulators. Packed XOR/POPCNT primitives are implemented and tested separately, but the convolution loops are not yet replaced by AVX-512, NEON, CUDA or custom-silicon kernels.
+
+---
+
+## 5. Bitwise dot-product identities
+
+For binary sign bits representing `{-1,+1}`:
+
+```text
+dot(x,w) = N - 2 * popcount(X XOR W)
+```
+
+For ternary weights represented by sign plane `S` and nonzero mask `M` against binary activations `X`:
+
+```text
+dot(X,Wq) = popcount(M) - 2 * popcount((X XOR S) AND M)
+```
+
+The implementation contains portable 64-bit reference versions of both identities and regression tests them independently of the autoencoder.
+
+These identities do not imply that ternary-weight x INT8-activation convolution is reducible to POPCNT alone. The implemented INT8 encoder uses integer add/subtract accumulation through ternary multipliers.
+
+---
+
+## 6. STE learning
+
+Forward execution uses the quantized state, while parameter updates apply to the FP32 shadow weights.
+
+The latent ternary projection is treated with a bounded straight-through estimator:
+
+```text
+g_STE(y) = 1 if abs(y) <= ste_clip
+           0 otherwise
+```
+
+combined with the derivative of the encoder tanh:
+
+```text
+delta_E = delta_Z * g_STE(Y_E) * (1 - Y_E^2)
+```
+
+Shadow weights are updated by
+
+```text
+W*_(t+1) = W*_t - eta * clip(grad + lambda * W*_t)
+```
+
+where `lambda` is the configured L2 coefficient and gradient clipping is explicit.
+
+The derivative of the ternary scale itself is not modeled in this reference implementation. The STE therefore acts as a bounded quantization-aware approximation, not an exact derivative of the discrete projection.
+
+---
+
+## 7. Inward residual memory
+
+For reconstruction
+
+```text
+X_hat_t = D_bit(E_bit(X_t))
+```
+
+the reconstruction residual is
+
+```text
+e_t = X_t - X_hat_t
+```
+
+and the bounded memory state evolves as
+
+```text
+Omega_(t+1) = rho * Omega_t + (1-rho) * e_t
+```
+
+A projected inward candidate is
+
+```text
+Psi_candidate = clamp(X_hat_t + omega_gain * Omega_(t+1), -1, +1)
+```
+
+The reference fixed-point residual is
+
+```text
+r_t = ||Psi_candidate - X_t||_2 / (||X_t||_2 + epsilon)
+```
+
+and convergence is reported only when
+
+```text
+r_t <= fixed_point_tolerance
+```
+
+The engine **measures** this residual. It does not infer convergence merely from sparsity, entropy or a symbolic fixed-point equation.
+
+---
+
+## 8. Operational self-description check
+
+The reference self-description invariant is concrete and local:
+
+```text
+quantized encoder weights == unpack(pack(quantized encoder weights))
+quantized decoder weights == unpack(pack(quantized decoder weights))
+ternary latent tensor      == unpack(pack(ternary latent tensor))
+```
+
+If any of these equalities fail, `self_description_valid` is false.
+
+This is representational self-consistency, not a claim of consciousness or subjective self-awareness.
+
+---
+
+## 9. Storage metrics
+
+For `P` FP32 shadow parameters:
+
+```text
+shadow bytes = 4P
+```
+
+For a ternary field packed into two bitplanes:
+
+```text
+logical payload bits = 2P
+```
+
+or an ideal large-block ratio of
+
+```text
+32 / 2 = 16x
+```
+
+versus FP32 parameter storage, before 64-bit word padding and metadata.
+
+For small tensors the measured physical ratio is lower because each plane is padded to complete `uint64` words. The runtime reports measured bytes rather than assuming the ideal 16x value.
+
+The ideal ternary information limit is
+
+```text
+log2(3) ~= 1.585 bits/symbol
+```
+
+which corresponds to about `20.19x` relative to FP32 only if an appropriate sub-2-bit coding scheme is implemented. This reference does not make that claim.
+
+---
+
+## 10. Runtime target
+
+Build:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --config Release --parallel
+```
+
+Run:
+
+```bash
+./build/cpp-runtime/jarvisx-bitmatrix3d \
+  --edge 8 \
+  --channels 4 \
+  --epochs 220 \
+  --learning-rate 0.01 \
+  --threshold 0.25 \
+  --pattern sphere \
+  --output-dir .jarvisx-bitmatrix3d
+```
+
+Windows multi-config builds use the corresponding `Release` executable path.
+
+Generated artifacts:
+
+- `metrics.csv` — reconstruction, fixed-point, sparsity, gradient and byte metrics for every training step;
+- `bitplanes.txt` — deterministic sign/nonzero plane snapshot for encoder, decoder and latent scaffold;
+- `report.txt` — final measured reconstruction, fixed-point and physical-storage summary.
+
+---
+
+## 11. Regression invariants
+
+CTest verifies:
+
+1. exact ternary sign/mask pack -> unpack round trip;
+2. binary XOR/POPCNT dot-product identity;
+3. ternary masked XOR/POPCNT identity;
+4. deterministic same-seed forward execution;
+5. exact agreement between tensors and their packed self-description;
+6. finite STE training;
+7. actual continuous shadow-weight updates;
+8. material reconstruction-error reduction on a deterministic 3D fixture;
+9. packed weight bytes smaller than FP32 shadow bytes;
+10. symmetric INT8 activation quantization excludes the reserved `-128` code.
+
+The C++ runtime workflow executes GCC, Clang+ASan/UBSan and MSVC builds.
+
+---
+
+## 12. Governing executable recurrence
+
+The reference implementation corresponds to
+
+```text
+Wq_t       = Q_T(W*_t; alpha_t)
+Xq_t       = Q_8(X_t; beta_t)
+Zq_t       = Q_T(tanh(E_3D(Xq_t, Wq_E,t)); tau)
+X_hat_t    = tanh(D_3D(Zq_t, Wq_D,t))
+e_t        = X_t - X_hat_t
+Omega_t+1  = rho * Omega_t + (1-rho) * e_t
+W*_t+1     = W*_t - eta * STE(grad_t)
+Psi_t+1    = Pi_Lambda[X_hat_t + omega_gain * Omega_t+1]
+```
+
+The local C++ backend computes the candidate and diagnostics. The outer Jarvis-X authority layer remains responsible for any system-level `Pi_Lambda` commit/rollback decision.
+
+---
+
+## 13. Capability boundary
+
+Implemented now:
+
+- deterministic 3D convolutional autoencoder reference;
+- FP32 shadow tensors;
+- ternary abs-mean-style weight projection;
+- symmetric INT8 encoder activations;
+- ternary latent scaffold;
+- dual bitplane storage;
+- portable binary/ternary bitwise dot primitives;
+- bounded STE learning;
+- residual-memory update;
+- measured fixed-point residual;
+- self-description verification;
+- storage/reconstruction/gradient telemetry;
+- CLI, artifact export, CTest and cross-platform CI.
+
+Not implemented or claimed by this backend:
+
+- sub-2-bit entropy-coded physical ternary storage;
+- AVX-512/NEON/CUDA convolution acceleration;
+- measured hardware speedup or energy-per-operation superiority;
+- distributed training;
+- photorealistic rendering;
+- unrestricted self-modification;
+- external state-of-the-art performance.
+
+Those remain separate measurable backend milestones rather than assumptions embedded in the mathematical notation.


### PR DESCRIPTION
## Summary

Operationalizes the revised **DM-vOmegaXi+ Inward 3D Bit Auto-Encoding/Decoding Matrix Engine** as a bounded C++17 reference backend under the existing Jarvis-X authority model.

### Implemented
- FP32 continuous encoder/decoder shadow weights;
- abs-mean-style ternary projection into `{-1,0,+1}` execution weights;
- physical two-bit sign/nonzero bitplanes with exact pack/unpack verification;
- symmetric INT8 encoder activation quantization with integer accumulation;
- ternary latent scaffold and ternary decoder path;
- portable binary XOR+POPCNT and masked ternary dot-product primitives;
- bounded straight-through-estimator updates to the FP32 shadow tensors;
- residual-memory `Omega` update and measured normalized inward fixed-point residual;
- representational self-description check comparing quantized tensors with independently unpacked bitplanes;
- measured reconstruction, sparsity, gradient and physical-storage telemetry;
- `jarvisx-bitmatrix3d` CLI generating `metrics.csv`, `bitplanes.txt` and `report.txt`;
- deterministic regression suite and runtime smoke test wired into the existing cross-platform C++ workflow;
- formal capability and mathematical specification in `docs/DMVX_BITMATRIX3D_ENGINE.md`.

## Governing executable recurrence

```text
Wq_t       = Q_T(W*_t; alpha_t)
Xq_t       = Q_8(X_t; beta_t)
Zq_t       = Q_T(tanh(E_3D(Xq_t, Wq_E,t)); tau)
X_hat_t    = tanh(D_3D(Zq_t, Wq_D,t))
e_t        = X_t - X_hat_t
Omega_t+1  = rho * Omega_t + (1-rho) * e_t
W*_t+1     = W*_t - eta * STE(grad_t)
Psi_t+1    = Pi_Lambda[X_hat_t + omega_gain * Omega_t+1]
```

The local backend computes the candidate and diagnostics; Jarvis-X retains authority over any outer `Pi_Lambda` commit/rollback decision.

## Important precision boundaries

- `1.58-bit` is treated as the information content `log2(3)` of ternary symbols, not as the physical storage used by this reference.
- The implemented ternary representation uses two bitplanes (2 logical bits/element before uint64 padding).
- The mixed-precision encoder uses ternary weights plus INT8 activations; it does not claim POPCNT alone implements ternary x INT8 convolution.
- The convolution loops are portable scalar integer reference kernels. AVX-512/NEON/CUDA speedups are not claimed here.
- Fixed-point convergence is measured numerically and not declared from notation alone.
- No external SOTA or hardware energy-performance claim is made.

## Verification

The C++ workflow builds/tests with GCC, Clang + ASan/UBSan and MSVC. Regression tests cover exact ternary packing, binary/ternary bitwise identities, deterministic forward execution, packed-state self-description, finite STE training, shadow-weight mutation, material reconstruction-error reduction and INT8 activation bounds.