### PR TITLE
Add 1 GiB operational 3D bit-stream benchmark

### DIFF
--- a/.github/workflows/bitmatrix-1gib.yml
+++ b/.github/workflows/bitmatrix-1gib.yml
@@ -66,13 +66,13 @@ jobs:
           --chunk-mib 4
           --pattern sparse3d
           --window-ms 100
-          --output-dir .jarvisx-bitmatrix1gib-ci
+          --output-dir bitmatrix1gib-ci
 
       - name: Upload smoke telemetry
         uses: actions/upload-artifact@v6
         with:
           name: bitmatrix-1gib-smoke-telemetry
-          path: .jarvisx-bitmatrix1gib-ci/
+          path: bitmatrix1gib-ci/
 
   full-1gib:
     if: github.event_name == 'workflow_dispatch'
@@ -94,10 +94,10 @@ jobs:
           --chunk-mib ${{ inputs.chunk_mib }}
           --pattern ${{ inputs.pattern }}
           --window-ms ${{ inputs.window_ms }}
-          --output-dir .jarvisx-bitmatrix1gib-full
+          --output-dir bitmatrix1gib-full
 
       - name: Upload full telemetry
         uses: actions/upload-artifact@v6
         with:
           name: bitmatrix-1gib-full-telemetry
-          path: .jarvisx-bitmatrix1gib-full/
+          path: bitmatrix1gib-full/

--- a/.github/workflows/bitmatrix-1gib.yml
+++ b/.github/workflows/bitmatrix-1gib.yml
@@ -1,0 +1,103 @@
+name: BitMatrix 1GiB Stream
+
+on:
+  workflow_dispatch:
+    inputs:
+      pattern:
+        description: Deterministic stream pattern
+        required: false
+        default: sparse3d
+        type: choice
+        options:
+          - sparse3d
+          - checker3d
+          - zero
+          - random
+      chunk_mib:
+        description: Reusable chunk size in MiB
+        required: false
+        default: "8"
+        type: string
+      window_ms:
+        description: Telemetry burst window in milliseconds
+        required: false
+        default: "100"
+        type: string
+  push:
+    paths:
+      - "cpp_runtime/include/jarvisx/bitmatrix1gib.hpp"
+      - "cpp_runtime/src/bitmatrix1gib_main.cpp"
+      - "cpp_runtime/tests/bitmatrix1gib_tests.cpp"
+      - "docs/DMVX_BITMATRIX_1GIB_STREAM.md"
+      - ".github/workflows/bitmatrix-1gib.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/include/jarvisx/bitmatrix1gib.hpp"
+      - "cpp_runtime/src/bitmatrix1gib_main.cpp"
+      - "cpp_runtime/tests/bitmatrix1gib_tests.cpp"
+      - "docs/DMVX_BITMATRIX_1GIB_STREAM.md"
+      - ".github/workflows/bitmatrix-1gib.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bitmatrix-1gib-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: github.event_name != 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure
+        run: cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release -DJARVISX_BUILD_GL_VISUALIZER=OFF
+
+      - name: Build 1GiB stream target
+        run: cmake --build build/cpp-runtime --config Release --target jarvisx-bitmatrix1gib --parallel 2
+
+      - name: Run 64 MiB measured smoke benchmark
+        run: >-
+          ./build/cpp-runtime/jarvisx-bitmatrix1gib
+          --bytes 67108864
+          --chunk-mib 4
+          --pattern sparse3d
+          --window-ms 100
+          --output-dir .jarvisx-bitmatrix1gib-ci
+
+      - name: Upload smoke telemetry
+        uses: actions/upload-artifact@v6
+        with:
+          name: bitmatrix-1gib-smoke-telemetry
+          path: .jarvisx-bitmatrix1gib-ci/
+
+  full-1gib:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure
+        run: cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release -DJARVISX_BUILD_GL_VISUALIZER=OFF
+
+      - name: Build 1GiB stream target
+        run: cmake --build build/cpp-runtime --config Release --target jarvisx-bitmatrix1gib --parallel 2
+
+      - name: Run full 1 GiB benchmark
+        run: >-
+          ./build/cpp-runtime/jarvisx-bitmatrix1gib
+          --bytes 1073741824
+          --chunk-mib ${{ inputs.chunk_mib }}
+          --pattern ${{ inputs.pattern }}
+          --window-ms ${{ inputs.window_ms }}
+          --output-dir .jarvisx-bitmatrix1gib-full
+
+      - name: Upload full telemetry
+        uses: actions/upload-artifact@v6
+        with:
+          name: bitmatrix-1gib-full-telemetry
+          path: .jarvisx-bitmatrix1gib-full/

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -44,6 +44,12 @@ add_executable(jarvisx-bitmatrix3d
 jarvisx_include_runtime(jarvisx-bitmatrix3d)
 jarvisx_harden(jarvisx-bitmatrix3d)
 
+add_executable(jarvisx-bitmatrix1gib
+    src/bitmatrix1gib_main.cpp
+)
+jarvisx_include_runtime(jarvisx-bitmatrix1gib)
+jarvisx_harden(jarvisx-bitmatrix1gib)
+
 add_executable(jarvisx-multimedia4d
     src/multimedia4d_main.cpp
 )
@@ -117,6 +123,18 @@ add_test(
 set_tests_properties(bitmatrix3d-runtime-smoke PROPERTIES TIMEOUT 120)
 
 add_test(
+    NAME bitmatrix1gib-runtime-smoke
+    COMMAND jarvisx-bitmatrix1gib
+        --bytes 8388608
+        --chunk-mib 1
+        --pattern sparse3d
+        --window-ms 20
+        --output-dir ${CMAKE_CURRENT_BINARY_DIR}/bitmatrix1gib-smoke
+        --quiet
+)
+set_tests_properties(bitmatrix1gib-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_test(
     NAME multimedia4d-runtime-smoke
     COMMAND jarvisx-multimedia4d
         --cycles 2
@@ -154,6 +172,15 @@ jarvisx_harden(jarvisx-bitmatrix3d-tests)
 
 add_test(NAME bitmatrix3d-regressions COMMAND jarvisx-bitmatrix3d-tests)
 set_tests_properties(bitmatrix3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-bitmatrix1gib-tests
+    tests/bitmatrix1gib_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-bitmatrix1gib-tests)
+jarvisx_harden(jarvisx-bitmatrix1gib-tests)
+
+add_test(NAME bitmatrix1gib-regressions COMMAND jarvisx-bitmatrix1gib-tests)
+set_tests_properties(bitmatrix1gib-regressions PROPERTIES TIMEOUT 120)
 
 add_executable(jarvisx-multimedia4d-tests
     tests/multimedia4d_tests.cpp

--- a/cpp_runtime/include/jarvisx/bitmatrix1gib.hpp
+++ b/cpp_runtime/include/jarvisx/bitmatrix1gib.hpp
@@ -1,0 +1,437 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace jarvisx {
+
+constexpr std::uint64_t kOneGiBBytes = std::uint64_t{1} << 30U;
+constexpr std::uint64_t kOneGiBBits = kOneGiBBytes * 8U;
+constexpr std::uint32_t kCanonicalBitCubeEdge = 2048U;
+constexpr std::uint64_t kLogicalVectorBits = 512U;
+
+struct BitCoordinate3D {
+    std::uint32_t x{};
+    std::uint32_t y{};
+    std::uint32_t z{};
+};
+
+inline BitCoordinate3D bit_coordinate_2048(std::uint64_t bit_index) {
+    if (bit_index >= kOneGiBBits) {
+        throw std::out_of_range("bit index is outside the canonical 2048^3-bit volume");
+    }
+    constexpr std::uint64_t plane =
+        static_cast<std::uint64_t>(kCanonicalBitCubeEdge) *
+        static_cast<std::uint64_t>(kCanonicalBitCubeEdge);
+    const std::uint64_t z = bit_index / plane;
+    const std::uint64_t rem = bit_index % plane;
+    const std::uint64_t y = rem / kCanonicalBitCubeEdge;
+    const std::uint64_t x = rem % kCanonicalBitCubeEdge;
+    return {
+        static_cast<std::uint32_t>(x),
+        static_cast<std::uint32_t>(y),
+        static_cast<std::uint32_t>(z)
+    };
+}
+
+inline std::uint64_t bit_index_2048(BitCoordinate3D coordinate) {
+    if (coordinate.x >= kCanonicalBitCubeEdge ||
+        coordinate.y >= kCanonicalBitCubeEdge ||
+        coordinate.z >= kCanonicalBitCubeEdge) {
+        throw std::out_of_range("3D coordinate is outside the canonical 2048^3-bit volume");
+    }
+    return static_cast<std::uint64_t>(coordinate.z) *
+               static_cast<std::uint64_t>(kCanonicalBitCubeEdge) *
+               static_cast<std::uint64_t>(kCanonicalBitCubeEdge) +
+           static_cast<std::uint64_t>(coordinate.y) *
+               static_cast<std::uint64_t>(kCanonicalBitCubeEdge) +
+           static_cast<std::uint64_t>(coordinate.x);
+}
+
+enum class StreamPattern {
+    Sparse3D,
+    Checker3D,
+    Zero,
+    Random
+};
+
+inline const char* stream_pattern_name(StreamPattern pattern) noexcept {
+    switch (pattern) {
+        case StreamPattern::Sparse3D: return "sparse3d";
+        case StreamPattern::Checker3D: return "checker3d";
+        case StreamPattern::Zero: return "zero";
+        case StreamPattern::Random: return "random";
+    }
+    return "unknown";
+}
+
+inline StreamPattern parse_stream_pattern(const std::string& value) {
+    if (value == "sparse3d") return StreamPattern::Sparse3D;
+    if (value == "checker3d") return StreamPattern::Checker3D;
+    if (value == "zero") return StreamPattern::Zero;
+    if (value == "random") return StreamPattern::Random;
+    throw std::invalid_argument("pattern must be sparse3d, checker3d, zero or random");
+}
+
+struct Stream1GiBConfig {
+    std::uint64_t target_bytes{kOneGiBBytes};
+    std::size_t chunk_bytes{8U * 1024U * 1024U};
+    StreamPattern pattern{StreamPattern::Sparse3D};
+    std::uint64_t seed{0x444D315342535452ULL};
+    std::uint32_t window_ms{100U};
+    std::uint64_t configured_l3_bytes{0U};
+
+    void validate() const {
+        if (target_bytes == 0U || target_bytes > kOneGiBBytes) {
+            throw std::invalid_argument("target bytes must be in (0, 1 GiB]");
+        }
+        if ((target_bytes & 7U) != 0U) {
+            throw std::invalid_argument("target bytes must be divisible by 8");
+        }
+        if (chunk_bytes < 64U || (chunk_bytes & 7U) != 0U) {
+            throw std::invalid_argument("chunk bytes must be >=64 and divisible by 8");
+        }
+        if (static_cast<std::uint64_t>(chunk_bytes) > target_bytes) {
+            throw std::invalid_argument("chunk bytes cannot exceed target bytes");
+        }
+        if (window_ms == 0U || window_ms > 60000U) {
+            throw std::invalid_argument("window ms must be in [1, 60000]");
+        }
+    }
+};
+
+struct StreamChunkMetrics {
+    std::uint64_t offset_bytes{};
+    std::size_t raw_bytes{};
+    std::size_t encoded_bytes{};
+    bool raw_passthrough{};
+    double ingest_ms{};
+    double encode_ms{};
+    double core_verify_ms{};
+    double decode_ms{};
+};
+
+struct Stream1GiBMetrics {
+    std::uint64_t target_bytes{};
+    std::uint64_t processed_bytes{};
+    std::uint64_t encoded_bytes{};
+    std::uint64_t logical_vectors_512{};
+    std::uint64_t first_window_bytes{};
+    double first_window_elapsed_ms{};
+    double ingest_seconds{};
+    double encode_seconds{};
+    double core_verify_seconds{};
+    double decode_seconds{};
+    double total_seconds{};
+    double compression_ratio{};
+    double throughput_gbps{};
+    double first_window_gbps{};
+    std::size_t reusable_working_set_bytes{};
+    std::size_t hot_path_reallocations{};
+    bool exact_round_trip{};
+    bool codec_fixed_point{};
+    bool fits_configured_l3{};
+    std::vector<StreamChunkMetrics> chunks;
+};
+
+inline std::uint64_t splitmix64(std::uint64_t value) noexcept {
+    value += 0x9E3779B97F4A7C15ULL;
+    value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31U);
+}
+
+inline void generate_stream_words(std::vector<std::uint64_t>& words,
+                                  std::uint64_t global_word_offset,
+                                  StreamPattern pattern,
+                                  std::uint64_t seed) {
+    for (std::size_t i = 0; i < words.size(); ++i) {
+        const std::uint64_t global_word =
+            global_word_offset + static_cast<std::uint64_t>(i);
+        switch (pattern) {
+            case StreamPattern::Zero:
+                words[i] = 0U;
+                break;
+            case StreamPattern::Random:
+                words[i] = splitmix64(seed ^ global_word);
+                break;
+            case StreamPattern::Checker3D: {
+                const auto c = bit_coordinate_2048((global_word * 64U) % kOneGiBBits);
+                const std::uint32_t cell =
+                    (c.x / 64U) + (c.y / 32U) + (c.z / 16U);
+                words[i] = (cell & 1U) == 0U
+                    ? std::uint64_t{0}
+                    : std::numeric_limits<std::uint64_t>::max();
+                break;
+            }
+            case StreamPattern::Sparse3D: {
+                const auto c = bit_coordinate_2048((global_word * 64U) % kOneGiBBits);
+                const std::uint32_t gate =
+                    ((c.x / 64U) + (c.y / 64U) * 3U + (c.z / 64U) * 5U) & 63U;
+                if (gate == 0U) {
+                    const std::uint64_t mixed = splitmix64(seed ^ global_word);
+                    words[i] = std::uint64_t{1} << (mixed & 63U);
+                } else {
+                    words[i] = 0U;
+                }
+                break;
+            }
+        }
+    }
+}
+
+inline void append_u32_le(std::vector<std::uint8_t>& output, std::uint32_t value) {
+    output.push_back(static_cast<std::uint8_t>(value & 0xFFU));
+    output.push_back(static_cast<std::uint8_t>((value >> 8U) & 0xFFU));
+    output.push_back(static_cast<std::uint8_t>((value >> 16U) & 0xFFU));
+    output.push_back(static_cast<std::uint8_t>((value >> 24U) & 0xFFU));
+}
+
+inline void append_u64_le(std::vector<std::uint8_t>& output, std::uint64_t value) {
+    for (unsigned shift = 0U; shift < 64U; shift += 8U) {
+        output.push_back(static_cast<std::uint8_t>((value >> shift) & 0xFFU));
+    }
+}
+
+inline std::uint32_t read_u32_le(const std::vector<std::uint8_t>& input,
+                                 std::size_t& cursor) {
+    if (cursor + 4U > input.size()) throw std::runtime_error("truncated RLE count");
+    std::uint32_t value = 0U;
+    for (unsigned shift = 0U; shift < 32U; shift += 8U) {
+        value |= static_cast<std::uint32_t>(input[cursor++]) << shift;
+    }
+    return value;
+}
+
+inline std::uint64_t read_u64_le(const std::vector<std::uint8_t>& input,
+                                 std::size_t& cursor) {
+    if (cursor + 8U > input.size()) throw std::runtime_error("truncated literal word");
+    std::uint64_t value = 0U;
+    for (unsigned shift = 0U; shift < 64U; shift += 8U) {
+        value |= static_cast<std::uint64_t>(input[cursor++]) << shift;
+    }
+    return value;
+}
+
+class AdaptiveWordCodec {
+public:
+    static bool encode(const std::vector<std::uint64_t>& input,
+                       std::vector<std::uint8_t>& output) {
+        if (input.empty()) throw std::invalid_argument("codec input cannot be empty");
+        output.clear();
+        output.push_back(1U); // RLE mode
+        std::size_t i = 0U;
+        while (i < input.size()) {
+            if (input[i] == 0U || input[i] == std::numeric_limits<std::uint64_t>::max()) {
+                const std::uint64_t repeated = input[i];
+                std::size_t end = i + 1U;
+                while (end < input.size() && input[end] == repeated &&
+                       (end - i) < static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max())) {
+                    ++end;
+                }
+                output.push_back(repeated == 0U ? 0U : 1U);
+                append_u32_le(output, static_cast<std::uint32_t>(end - i));
+                i = end;
+            } else {
+                const std::size_t begin = i;
+                ++i;
+                while (i < input.size() && input[i] != 0U &&
+                       input[i] != std::numeric_limits<std::uint64_t>::max() &&
+                       (i - begin) < static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max())) {
+                    ++i;
+                }
+                output.push_back(2U);
+                append_u32_le(output, static_cast<std::uint32_t>(i - begin));
+                for (std::size_t j = begin; j < i; ++j) append_u64_le(output, input[j]);
+            }
+        }
+
+        const std::size_t raw_size = 1U + input.size() * sizeof(std::uint64_t);
+        if (output.size() < raw_size) return false;
+
+        output.clear();
+        output.reserve(raw_size);
+        output.push_back(0U); // raw mode
+        for (const auto word : input) append_u64_le(output, word);
+        return true;
+    }
+
+    static void decode(const std::vector<std::uint8_t>& encoded,
+                       std::size_t expected_words,
+                       std::vector<std::uint64_t>& output) {
+        if (encoded.empty()) throw std::runtime_error("encoded chunk is empty");
+        output.clear();
+        if (output.capacity() < expected_words) output.reserve(expected_words);
+        std::size_t cursor = 1U;
+        const std::uint8_t mode = encoded[0];
+        if (mode == 0U) {
+            const std::size_t expected_bytes = 1U + expected_words * sizeof(std::uint64_t);
+            if (encoded.size() != expected_bytes) throw std::runtime_error("raw chunk size mismatch");
+            for (std::size_t i = 0U; i < expected_words; ++i) {
+                output.push_back(read_u64_le(encoded, cursor));
+            }
+        } else if (mode == 1U) {
+            while (cursor < encoded.size() && output.size() < expected_words) {
+                const std::uint8_t tag = encoded[cursor++];
+                const std::uint32_t count = read_u32_le(encoded, cursor);
+                if (count == 0U ||
+                    static_cast<std::uint64_t>(output.size()) + count > expected_words) {
+                    throw std::runtime_error("invalid RLE run length");
+                }
+                if (tag == 0U || tag == 1U) {
+                    const std::uint64_t word = tag == 0U
+                        ? std::uint64_t{0}
+                        : std::numeric_limits<std::uint64_t>::max();
+                    output.insert(output.end(), count, word);
+                } else if (tag == 2U) {
+                    for (std::uint32_t i = 0U; i < count; ++i) {
+                        output.push_back(read_u64_le(encoded, cursor));
+                    }
+                } else {
+                    throw std::runtime_error("unknown RLE token");
+                }
+            }
+            if (output.size() != expected_words || cursor != encoded.size()) {
+                throw std::runtime_error("RLE chunk did not decode canonically");
+            }
+        } else {
+            throw std::runtime_error("unknown chunk codec mode");
+        }
+    }
+};
+
+inline double milliseconds_since(const std::chrono::steady_clock::time_point& begin,
+                                 const std::chrono::steady_clock::time_point& end) {
+    return std::chrono::duration<double, std::milli>(end - begin).count();
+}
+
+inline Stream1GiBMetrics run_stream_1gib(const Stream1GiBConfig& config) {
+    config.validate();
+    const std::size_t max_words = config.chunk_bytes / sizeof(std::uint64_t);
+    std::vector<std::uint64_t> input(max_words, 0U);
+    std::vector<std::uint64_t> decoded;
+    decoded.reserve(max_words);
+    std::vector<std::uint8_t> encoded;
+    const std::size_t reserve_encoded =
+        config.chunk_bytes > (std::numeric_limits<std::size_t>::max() - 64U) / 2U
+            ? throw std::overflow_error("chunk reserve overflow")
+            : config.chunk_bytes * 2U + 64U;
+    encoded.reserve(reserve_encoded);
+
+    const std::size_t input_capacity0 = input.capacity();
+    const std::size_t decoded_capacity0 = decoded.capacity();
+    const std::size_t encoded_capacity0 = encoded.capacity();
+
+    Stream1GiBMetrics metrics;
+    metrics.target_bytes = config.target_bytes;
+    metrics.logical_vectors_512 =
+        (config.target_bytes * 8U + kLogicalVectorBits - 1U) / kLogicalVectorBits;
+    metrics.exact_round_trip = true;
+    metrics.codec_fixed_point = true;
+    metrics.chunks.reserve(static_cast<std::size_t>(
+        (config.target_bytes + static_cast<std::uint64_t>(config.chunk_bytes) - 1U) /
+        static_cast<std::uint64_t>(config.chunk_bytes)));
+
+    const auto all_begin = std::chrono::steady_clock::now();
+    bool window_closed = false;
+    std::uint64_t offset_bytes = 0U;
+    while (offset_bytes < config.target_bytes) {
+        const std::uint64_t remaining = config.target_bytes - offset_bytes;
+        const std::size_t raw_bytes = static_cast<std::size_t>(std::min<std::uint64_t>(
+            remaining, static_cast<std::uint64_t>(config.chunk_bytes)));
+        const std::size_t words = raw_bytes / sizeof(std::uint64_t);
+        input.resize(words);
+
+        const auto ingest_begin = std::chrono::steady_clock::now();
+        generate_stream_words(input, offset_bytes / sizeof(std::uint64_t),
+                              config.pattern, config.seed);
+        const auto ingest_end = std::chrono::steady_clock::now();
+
+        const auto encode_begin = ingest_end;
+        const bool raw_mode = AdaptiveWordCodec::encode(input, encoded);
+        const auto encode_end = std::chrono::steady_clock::now();
+
+        const auto decode_begin = encode_end;
+        AdaptiveWordCodec::decode(encoded, words, decoded);
+        const auto decode_end = std::chrono::steady_clock::now();
+
+        const auto verify_begin = decode_end;
+        const bool equal = input == decoded;
+        const auto verify_end = std::chrono::steady_clock::now();
+        if (!equal) {
+            metrics.exact_round_trip = false;
+            metrics.codec_fixed_point = false;
+            throw std::runtime_error("stream codec round-trip mismatch");
+        }
+
+        StreamChunkMetrics chunk;
+        chunk.offset_bytes = offset_bytes;
+        chunk.raw_bytes = raw_bytes;
+        chunk.encoded_bytes = encoded.size();
+        chunk.raw_passthrough = raw_mode;
+        chunk.ingest_ms = milliseconds_since(ingest_begin, ingest_end);
+        chunk.encode_ms = milliseconds_since(encode_begin, encode_end);
+        chunk.decode_ms = milliseconds_since(decode_begin, decode_end);
+        chunk.core_verify_ms = milliseconds_since(verify_begin, verify_end);
+        metrics.chunks.push_back(chunk);
+
+        metrics.ingest_seconds += chunk.ingest_ms / 1000.0;
+        metrics.encode_seconds += chunk.encode_ms / 1000.0;
+        metrics.decode_seconds += chunk.decode_ms / 1000.0;
+        metrics.core_verify_seconds += chunk.core_verify_ms / 1000.0;
+        metrics.processed_bytes += raw_bytes;
+        metrics.encoded_bytes += encoded.size();
+        offset_bytes += raw_bytes;
+
+        if (input.capacity() != input_capacity0) {
+            ++metrics.hot_path_reallocations;
+        }
+        if (decoded.capacity() != decoded_capacity0) {
+            ++metrics.hot_path_reallocations;
+        }
+        if (encoded.capacity() != encoded_capacity0) {
+            ++metrics.hot_path_reallocations;
+        }
+
+        const auto now = std::chrono::steady_clock::now();
+        const double elapsed_ms = milliseconds_since(all_begin, now);
+        if (!window_closed) {
+            metrics.first_window_bytes = metrics.processed_bytes;
+            metrics.first_window_elapsed_ms = elapsed_ms;
+            if (elapsed_ms >= static_cast<double>(config.window_ms)) window_closed = true;
+        }
+    }
+    const auto all_end = std::chrono::steady_clock::now();
+    metrics.total_seconds =
+        std::chrono::duration<double>(all_end - all_begin).count();
+    metrics.compression_ratio = metrics.encoded_bytes == 0U
+        ? 0.0
+        : static_cast<double>(metrics.processed_bytes) /
+          static_cast<double>(metrics.encoded_bytes);
+    metrics.throughput_gbps = metrics.total_seconds <= 0.0
+        ? 0.0
+        : static_cast<double>(metrics.processed_bytes) * 8.0 /
+          metrics.total_seconds / 1.0e9;
+    metrics.first_window_gbps = metrics.first_window_elapsed_ms <= 0.0
+        ? 0.0
+        : static_cast<double>(metrics.first_window_bytes) * 8.0 /
+          (metrics.first_window_elapsed_ms / 1000.0) / 1.0e9;
+    metrics.reusable_working_set_bytes =
+        input_capacity0 * sizeof(std::uint64_t) +
+        decoded_capacity0 * sizeof(std::uint64_t) +
+        encoded_capacity0 * sizeof(std::uint8_t);
+    metrics.fits_configured_l3 =
+        config.configured_l3_bytes != 0U &&
+        static_cast<std::uint64_t>(metrics.reusable_working_set_bytes) <=
+            config.configured_l3_bytes;
+    return metrics;
+}
+
+} // namespace jarvisx

--- a/cpp_runtime/src/bitmatrix1gib_main.cpp
+++ b/cpp_runtime/src/bitmatrix1gib_main.cpp
@@ -1,0 +1,167 @@
+#include "jarvisx/bitmatrix1gib.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+struct Options {
+    jarvisx::Stream1GiBConfig config;
+    fs::path output_dir{".jarvisx-bitmatrix1gib"};
+    bool quiet{false};
+};
+
+std::uint64_t parse_u64(const std::string& text, const char* name) {
+    std::size_t consumed = 0U;
+    const auto value = std::stoull(text, &consumed, 10);
+    if (consumed != text.size()) throw std::invalid_argument(std::string("invalid ") + name);
+    return value;
+}
+
+Options parse_args(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) throw std::invalid_argument(std::string(name) + " requires a value");
+            return argv[++i];
+        };
+        if (arg == "--bytes") {
+            options.config.target_bytes = parse_u64(require_value("--bytes"), "byte count");
+        } else if (arg == "--chunk-mib") {
+            const auto mib = parse_u64(require_value("--chunk-mib"), "chunk MiB");
+            if (mib == 0U || mib > 256U) throw std::invalid_argument("chunk MiB must be in [1, 256]");
+            options.config.chunk_bytes = static_cast<std::size_t>(mib * 1024U * 1024U);
+        } else if (arg == "--pattern") {
+            options.config.pattern = jarvisx::parse_stream_pattern(require_value("--pattern"));
+        } else if (arg == "--window-ms") {
+            const auto ms = parse_u64(require_value("--window-ms"), "window ms");
+            if (ms > std::numeric_limits<std::uint32_t>::max()) throw std::invalid_argument("window ms is too large");
+            options.config.window_ms = static_cast<std::uint32_t>(ms);
+        } else if (arg == "--l3-mib") {
+            const auto mib = parse_u64(require_value("--l3-mib"), "L3 MiB");
+            options.config.configured_l3_bytes = mib * 1024U * 1024U;
+        } else if (arg == "--seed") {
+            options.config.seed = parse_u64(require_value("--seed"), "seed");
+        } else if (arg == "--output-dir") {
+            options.output_dir = require_value("--output-dir");
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout
+                << "jarvisx-bitmatrix1gib [options]\n"
+                << "  --bytes N          bytes to process (default 1073741824 = 1 GiB)\n"
+                << "  --chunk-mib N      reusable chunk size in MiB (default 8)\n"
+                << "  --pattern P        sparse3d|checker3d|zero|random\n"
+                << "  --window-ms N      telemetry burst window (default 100)\n"
+                << "  --l3-mib N         optional configured L3 size for fit comparison\n"
+                << "  --seed N           deterministic generator seed\n"
+                << "  --output-dir PATH  artifact directory\n"
+                << "  --quiet             suppress console telemetry\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown argument: " + arg);
+        }
+    }
+    options.config.validate();
+    return options;
+}
+
+void write_metrics_csv(const fs::path& path, const jarvisx::Stream1GiBMetrics& metrics) {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) throw std::runtime_error("cannot write metrics.csv");
+    out << "offset_bytes,raw_bytes,encoded_bytes,mode,ingest_ms,encode_ms,core_verify_ms,decode_ms\n";
+    out << std::setprecision(10);
+    for (const auto& chunk : metrics.chunks) {
+        out << chunk.offset_bytes << ','
+            << chunk.raw_bytes << ','
+            << chunk.encoded_bytes << ','
+            << (chunk.raw_passthrough ? "raw" : "rle") << ','
+            << chunk.ingest_ms << ','
+            << chunk.encode_ms << ','
+            << chunk.core_verify_ms << ','
+            << chunk.decode_ms << '\n';
+    }
+}
+
+void write_report(const fs::path& path,
+                  const Options& options,
+                  const jarvisx::Stream1GiBMetrics& metrics) {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) throw std::runtime_error("cannot write report.txt");
+    out << std::setprecision(12);
+    out << "DM-vOmegaXi+ 1 GiB Operational Bit-Wise 3D Stream Report\n";
+    out << "target_bytes=" << metrics.target_bytes << '\n';
+    out << "canonical_full_volume_bits=" << jarvisx::kOneGiBBits << '\n';
+    out << "canonical_full_volume_shape_bits=2048x2048x2048\n";
+    out << "processed_bytes=" << metrics.processed_bytes << '\n';
+    out << "pattern=" << jarvisx::stream_pattern_name(options.config.pattern) << '\n';
+    out << "chunk_bytes=" << options.config.chunk_bytes << '\n';
+    out << "logical_vector_width_bits=512\n";
+    out << "logical_vector_count_512=" << metrics.logical_vectors_512 << '\n';
+    out << "execution_backend=portable_u64_reference\n";
+    out << "avx512_execution_claimed=false\n";
+    out << "encoded_bytes=" << metrics.encoded_bytes << '\n';
+    out << "compression_ratio=" << metrics.compression_ratio << '\n';
+    out << "total_seconds=" << metrics.total_seconds << '\n';
+    out << "throughput_gbps=" << metrics.throughput_gbps << '\n';
+    out << "first_window_requested_ms=" << options.config.window_ms << '\n';
+    out << "first_window_observed_ms=" << metrics.first_window_elapsed_ms << '\n';
+    out << "first_window_bytes=" << metrics.first_window_bytes << '\n';
+    out << "first_window_gbps=" << metrics.first_window_gbps << '\n';
+    out << "ingest_seconds=" << metrics.ingest_seconds << '\n';
+    out << "encode_seconds=" << metrics.encode_seconds << '\n';
+    out << "core_verify_seconds=" << metrics.core_verify_seconds << '\n';
+    out << "decode_seconds=" << metrics.decode_seconds << '\n';
+    out << "reusable_working_set_bytes=" << metrics.reusable_working_set_bytes << '\n';
+    out << "hot_path_reallocations=" << metrics.hot_path_reallocations << '\n';
+    out << "exact_round_trip=" << (metrics.exact_round_trip ? "true" : "false") << '\n';
+    out << "codec_fixed_point=" << (metrics.codec_fixed_point ? "true" : "false") << '\n';
+    out << "configured_l3_bytes=" << options.config.configured_l3_bytes << '\n';
+    out << "working_set_fits_configured_l3=" << (metrics.fits_configured_l3 ? "true" : "false") << '\n';
+    out << "zero_dram_latency_claimed=false\n";
+    out << "zero_gc_claimed=false\n";
+    out << "semantic_loss_claimed=false\n";
+    out << "lossless_bit_identity_verified=true\n";
+    out << "reality_gap_gamma=conceptual_boundary_not_hardware_metric\n";
+    out << "kinetic_visual_radii=12.5->8.0->2.0->0.8->1.3->7.5\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_args(argc, argv);
+        fs::create_directories(options.output_dir);
+        const auto metrics = jarvisx::run_stream_1gib(options.config);
+        write_metrics_csv(options.output_dir / "metrics.csv", metrics);
+        write_report(options.output_dir / "report.txt", options, metrics);
+
+        if (!options.quiet) {
+            std::cout << std::fixed << std::setprecision(3)
+                      << "DM-vOmegaXi+ 3D stream processed "
+                      << (static_cast<double>(metrics.processed_bytes) / 1073741824.0)
+                      << " GiB\n"
+                      << "pattern: " << jarvisx::stream_pattern_name(options.config.pattern) << '\n'
+                      << "compression: " << metrics.compression_ratio << "x\n"
+                      << "throughput: " << metrics.throughput_gbps << " Gbps\n"
+                      << "100ms-window-equivalent: " << metrics.first_window_gbps << " Gbps\n"
+                      << "logical 512-bit vectors: " << metrics.logical_vectors_512 << '\n'
+                      << "working set: "
+                      << (static_cast<double>(metrics.reusable_working_set_bytes) / 1048576.0)
+                      << " MiB\n"
+                      << "hot-path reallocations: " << metrics.hot_path_reallocations << '\n'
+                      << "exact round-trip: " << (metrics.exact_round_trip ? "PASS" : "FAIL") << '\n';
+        }
+        return metrics.exact_round_trip && metrics.codec_fixed_point ? 0 : 2;
+    } catch (const std::exception& error) {
+        std::cerr << "bitmatrix1gib failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/bitmatrix1gib_tests.cpp
+++ b/cpp_runtime/tests/bitmatrix1gib_tests.cpp
@@ -1,0 +1,100 @@
+#include "jarvisx/bitmatrix1gib.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void canonical_volume_mapping() {
+    require(jarvisx::kOneGiBBits ==
+                static_cast<std::uint64_t>(jarvisx::kCanonicalBitCubeEdge) *
+                jarvisx::kCanonicalBitCubeEdge * jarvisx::kCanonicalBitCubeEdge,
+            "1 GiB must equal the 2048^3-bit canonical volume");
+    const auto origin = jarvisx::bit_coordinate_2048(0U);
+    require(origin.x == 0U && origin.y == 0U && origin.z == 0U,
+            "origin coordinate mismatch");
+    const auto last = jarvisx::bit_coordinate_2048(jarvisx::kOneGiBBits - 1U);
+    require(last.x == 2047U && last.y == 2047U && last.z == 2047U,
+            "last coordinate mismatch");
+    require(jarvisx::bit_index_2048(last) == jarvisx::kOneGiBBits - 1U,
+            "coordinate inverse mismatch");
+    require(jarvisx::kOneGiBBytes / 64U == 16777216U,
+            "1 GiB must contain exactly 16,777,216 logical 512-bit vectors");
+}
+
+void codec_round_trip_and_fallback() {
+    std::vector<std::uint64_t> sparse(4096U, 0U);
+    sparse[0] = 1U;
+    sparse[2048] = 2U;
+    std::vector<std::uint8_t> encoded;
+    encoded.reserve(16384U);
+    const bool sparse_raw = jarvisx::AdaptiveWordCodec::encode(sparse, encoded);
+    require(!sparse_raw, "sparse data should select RLE mode");
+    require(encoded.size() < sparse.size() * sizeof(std::uint64_t),
+            "sparse encoding should be smaller than raw words");
+    std::vector<std::uint64_t> decoded;
+    jarvisx::AdaptiveWordCodec::decode(encoded, sparse.size(), decoded);
+    require(decoded == sparse, "sparse codec round-trip failed");
+
+    std::vector<std::uint64_t> random(4096U, 0U);
+    jarvisx::generate_stream_words(random, 0U, jarvisx::StreamPattern::Random, 42U);
+    const bool random_raw = jarvisx::AdaptiveWordCodec::encode(random, encoded);
+    require(random_raw, "incompressible deterministic random data should fall back to raw");
+    jarvisx::AdaptiveWordCodec::decode(encoded, random.size(), decoded);
+    require(decoded == random, "raw fallback round-trip failed");
+}
+
+void bounded_stream_smoke() {
+    jarvisx::Stream1GiBConfig config;
+    config.target_bytes = 8U * 1024U * 1024U;
+    config.chunk_bytes = 1U * 1024U * 1024U;
+    config.pattern = jarvisx::StreamPattern::Sparse3D;
+    config.window_ms = 20U;
+    config.configured_l3_bytes = 16U * 1024U * 1024U;
+    const auto metrics = jarvisx::run_stream_1gib(config);
+    require(metrics.processed_bytes == config.target_bytes, "smoke target byte count mismatch");
+    require(metrics.exact_round_trip, "smoke exact round-trip failed");
+    require(metrics.codec_fixed_point, "smoke codec fixed point failed");
+    require(metrics.compression_ratio > 1.0, "sparse smoke stream should compress");
+    require(metrics.logical_vectors_512 == config.target_bytes / 64U,
+            "logical 512-bit vector count mismatch");
+    require(metrics.hot_path_reallocations == 0U,
+            "reusable hot path should not reallocate after warm-up reservation");
+    require(metrics.reusable_working_set_bytes > 0U, "working set telemetry missing");
+    require(metrics.throughput_gbps > 0.0 && std::isfinite(metrics.throughput_gbps),
+            "throughput telemetry must be finite and positive");
+}
+
+void zero_stream_is_highly_compressible() {
+    jarvisx::Stream1GiBConfig config;
+    config.target_bytes = 1U * 1024U * 1024U;
+    config.chunk_bytes = 1U * 1024U * 1024U;
+    config.pattern = jarvisx::StreamPattern::Zero;
+    config.window_ms = 10U;
+    const auto metrics = jarvisx::run_stream_1gib(config);
+    require(metrics.compression_ratio > 1000.0,
+            "all-zero stream should compress by more than three orders of magnitude");
+    require(metrics.exact_round_trip, "zero stream round-trip failed");
+}
+
+} // namespace
+
+int main() {
+    try {
+        canonical_volume_mapping();
+        codec_round_trip_and_fallback();
+        bounded_stream_smoke();
+        zero_stream_is_highly_compressible();
+        std::cout << "1 GiB 3D stream tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "1 GiB 3D stream test failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/docs/DMVX_BITMATRIX_1GIB_STREAM.md
+++ b/docs/DMVX_BITMATRIX_1GIB_STREAM.md
@@ -1,0 +1,264 @@
+# DM-vOmegaXi+ 1 GiB Operational Bit-Wise 3D Stream
+
+## Status
+
+**Executable bounded streaming benchmark and lossless bit-transport reference.**
+
+This subsystem operationalizes the 1 GiB kinetic processing proposal without treating illustrative performance numbers as facts. It measures the actual rate, compression ratio, reusable working set, chunk-mode decisions and exact reconstruction behavior on the machine that runs it.
+
+It is a transport/benchmark layer beneath the existing DM-vOmegaXi+ Bit-Matrix autoencoder. It does not replace the learned ternary autoencoder and does not make a candidate state authoritative.
+
+---
+
+## 1. Exact 3D target volume
+
+One GiB is
+
+```text
+1 GiB = 2^30 bytes = 2^33 bits = 8,589,934,592 bits
+```
+
+and
+
+```text
+2048^3 = 8,589,934,592.
+```
+
+Therefore the canonical full stream has an exact virtual geometry
+
+```text
+2048 x 2048 x 2048 bits.
+```
+
+The mapping is X-fastest:
+
+```text
+bit_index = z * 2048 * 2048 + y * 2048 + x
+```
+
+The runtime streams this virtual volume through reusable bounded chunks. It never needs to allocate a resident 1 GiB input buffer.
+
+---
+
+## 2. Five-phase operational interpretation
+
+The kinetic radii remain a visualization mapping rather than physical distances inside CPU hardware:
+
+```text
+Ingestion      12.5 -> 8.0
+Compression     8.0 -> 2.0
+Core verify     2.0 -> 0.8
+Buffer ring     0.8 -> 1.3
+Reconstruction  1.3 -> 7.5
+```
+
+The executable phases are:
+
+1. **Spatial ingestion** — deterministically materialize the current prefix/chunk of the 2048^3-bit field.
+2. **Adaptive compression** — scan 64-bit words and encode zero/all-one runs; retain literal runs; fall back to raw mode when compression would expand the chunk.
+3. **Fixed-point verification** — enforce exact `Decode(Encode(B)) == B` for every chunk.
+4. **Reusable buffer ring** — reuse pre-reserved input, encoded and decoded buffers and report any hot-path capacity change as a reallocation.
+5. **Outward reconstruction** — decode the chunk and compare every 64-bit word with the source before the stream advances.
+
+This benchmark is deliberately lossless. The learned Bit-Matrix autoencoder remains a separate bounded-distortion subsystem.
+
+---
+
+## 3. Adaptive word codec
+
+For each 64-bit word the codec classifies the stream into three token types:
+
+```text
+ZERO_RUN     repeated 0x0000000000000000
+ONE_RUN      repeated 0xFFFFFFFFFFFFFFFF
+LITERAL_RUN  all other words
+```
+
+Each run carries a 32-bit count. Literal runs carry their 64-bit words in little-endian order.
+
+The encoder computes the candidate RLE form and compares its final byte count with a raw packet. If RLE is not smaller, the chunk is emitted in raw mode.
+
+Therefore compression is data dependent:
+
+```text
+compression_ratio = raw_bytes / encoded_bytes
+```
+
+No fixed ratio such as 128x is assumed.
+
+---
+
+## 4. Codec fixed point
+
+For each streamed chunk `B_k` the mandatory invariant is
+
+```text
+D(E(B_k)) = B_k.
+```
+
+The benchmark fails immediately on a mismatch. For the whole stream:
+
+```text
+codec_fixed_point = AND_k [D(E(B_k)) == B_k].
+```
+
+This is exact bit identity. It is not a claim that a lossy neural latent representation preserves all source bits.
+
+---
+
+## 5. 512-bit vector telemetry
+
+A 512-bit vector contains 64 bytes. Therefore the full 1 GiB target contains exactly
+
+```text
+1,073,741,824 / 64 = 16,777,216
+```
+
+logical 512-bit vectors.
+
+The reference backend currently executes portable 64-bit C++ operations. The number `16,777,216` is reported as a logical vector count only. It does not prove AVX-512 was selected by the compiler or executed by the CPU.
+
+Architecture-specific AVX-512, AVX2, NEON and CUDA kernels remain separate optimization milestones.
+
+---
+
+## 6. 100 ms execution window
+
+The runtime records the amount of raw source data completed by the first chunk boundary at or beyond the requested window:
+
+```text
+window_gbps = window_bytes * 8 / elapsed_window_seconds / 1e9.
+```
+
+The default requested window is 100 ms.
+
+This is measured telemetry. The runtime does not hard-code `85.899 Gbps` or any other target throughput.
+
+---
+
+## 7. Reusable working set and allocation semantics
+
+The hot loop owns three reusable buffers:
+
+```text
+input words
+encoded bytes
+decoded words
+```
+
+They are allocated/reserved before timed chunk processing. Capacity changes are counted as `hot_path_reallocations`.
+
+A zero count means the benchmark's reusable vector capacities did not grow during the hot loop. It does **not** prove that the entire process, C++ runtime, operating system or allocator performed zero allocations.
+
+The runtime reports
+
+```text
+reusable_working_set_bytes
+```
+
+from those reserved capacities.
+
+---
+
+## 8. L3 cache claim boundary
+
+An optional `--l3-mib N` argument compares the reusable benchmark working set with a user-supplied L3 capacity:
+
+```text
+working_set_fits_configured_l3 = reusable_working_set_bytes <= configured_l3_bytes.
+```
+
+Even when true, the report does not claim zero DRAM traffic or zero memory latency. Cache placement, replacement, other processes, code/data footprints and hardware policy remain physical runtime effects.
+
+---
+
+## 9. Patterns
+
+The deterministic generator supports:
+
+- `sparse3d` — mostly zero words with coordinate-dependent sparse set bits;
+- `checker3d` — structured zero/all-one regions;
+- `zero` — all-zero upper-bound compression fixture;
+- `random` — deterministic incompressible fixture expected to select raw passthrough.
+
+This makes rate behavior falsifiable across very different source statistics.
+
+---
+
+## 10. Build and run
+
+Build:
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --config Release --parallel
+```
+
+Run the canonical full target:
+
+```bash
+./build/cpp-runtime/jarvisx-bitmatrix1gib \
+  --bytes 1073741824 \
+  --chunk-mib 8 \
+  --pattern sparse3d \
+  --window-ms 100 \
+  --output-dir .jarvisx-bitmatrix1gib
+```
+
+Optionally compare the reusable working set with a known cache size:
+
+```bash
+./build/cpp-runtime/jarvisx-bitmatrix1gib \
+  --bytes 1073741824 \
+  --chunk-mib 8 \
+  --pattern sparse3d \
+  --window-ms 100 \
+  --l3-mib 32
+```
+
+Generated artifacts:
+
+- `metrics.csv` — per-chunk ingestion, compression, verification and decode timing;
+- `report.txt` — aggregate rate, throughput, 100 ms window, working-set and invariant telemetry.
+
+---
+
+## 11. CI strategy
+
+Normal C++ CI runs a bounded smoke workload so pull requests remain portable across GCC, Clang+ASan/UBSan and MSVC.
+
+The dedicated `bitmatrix-1gib.yml` workflow runs a larger automated smoke benchmark on pushes/pull requests and exposes a manual `workflow_dispatch` path for the full 1 GiB target.
+
+The full benchmark result is therefore an artifact to measure, not a number embedded in the framework definition.
+
+---
+
+## 12. Capability boundary
+
+Implemented now:
+
+- exact 2048^3-bit virtual addressing for a full 1 GiB stream;
+- bounded chunked processing with no resident 1 GiB source allocation;
+- deterministic structured/random 3D bit generation;
+- adaptive zero/one-run + literal lossless encoding;
+- raw fallback for incompressible data;
+- exact codec fixed-point verification;
+- logical 512-bit vector accounting;
+- measured 100 ms-window telemetry;
+- reusable working-set and hot-path reallocation telemetry;
+- optional configured-L3 fit comparison;
+- CLI, reports, CTest and cross-platform build integration.
+
+Not claimed by this reference:
+
+- actual AVX-512 execution;
+- a fixed 8.362 MiB latent footprint;
+- a fixed 85.899 Gbps transfer rate;
+- a fixed 38.5x speedup;
+- zero DRAM traffic;
+- process-wide zero allocations;
+- semantic equivalence inferred from bit identity;
+- gamma=infinity as a measured hardware property;
+- external state-of-the-art performance.
+
+Those are either benchmark outcomes, future acceleration targets, or conceptual boundaries and must be reported separately.


### PR DESCRIPTION
## Summary

Operationalizes the **1 GiB Bit-Wise 3D Kinetic Processing** proposal as a measured, lossless streaming benchmark beneath the existing DM-vOmegaXi+ Bit-Matrix engine.

### Canonical target

`1 GiB = 2^33 bits = 2048^3 bits`, so the full target is represented as an exact virtual `2048 x 2048 x 2048` bit lattice with X-fastest addressing.

### Implemented
- bounded chunk streaming: no resident 1 GiB input allocation;
- deterministic `sparse3d`, `checker3d`, `zero`, and `random` source patterns;
- adaptive 64-bit word codec using zero runs, all-one runs and literal runs;
- raw passthrough when compression would expand a chunk;
- exact per-chunk `Decode(Encode(B)) == B` fixed-point verification;
- reusable pre-reserved input/encoded/decoded buffers with hot-path capacity-change telemetry;
- exact logical 512-bit vector count (`16,777,216` for 1 GiB) without claiming AVX-512 execution;
- measured full-stream and requested-window throughput rather than hard-coded Gbps values;
- optional configured-L3 working-set comparison without claiming zero DRAM traffic;
- per-chunk `metrics.csv` and aggregate `report.txt` artifacts;
- CMake/CTest integration and portable regression coverage;
- dedicated `bitmatrix-1gib.yml` workflow: 64 MiB PR/push smoke, manual full 1 GiB benchmark artifact.

## Claim boundaries

This PR deliberately does **not** hard-code or claim:
- an 8.362 MiB latent footprint;
- 85.899 Gbps throughput;
- 38.5x speedup;
- actual AVX-512 execution;
- zero DRAM latency;
- process-wide zero allocations;
- gamma=infinity as a hardware measurement;
- external SOTA performance.

Those become measured outputs or future architecture-specific backend milestones.

## Governing transport invariant

```text
B_k -> Encode -> CandidatePacket -> Decode -> B'_k
accept iff B'_k == B_k
```

The learned ternary autoencoder remains a separate bounded-distortion layer; this benchmark is exact bit transport and hardware-throughput telemetry.