### PR TITLE
feat(dm): operationalize DM-vOmegaXi+ consideration loop

### DIFF
--- a/docs/dm-vomegaxi-consideration-loop.md
+++ b/docs/dm-vomegaxi-consideration-loop.md
@@ -1,0 +1,292 @@
+# DM–vOmegaXi+ Operational Consideration Loop
+
+## Status
+
+This document is an executable reference interpretation of the Dr Moagi Master Equation (DM–vOmegaXi+) for the Jarvis-X runtime.
+
+The user-specified symbolic roles are preserved:
+
+- `Phi_in`: internal description operator.
+- `Psi_t`: active time-dependent state.
+- `Lambda_in^-1(div_Theta Omega_t)`: bounded holographic-memory constraint.
+- `U_attn(t)`: attentional control field.
+- `-i*hbar*Gamma_in`: dissipative entropy/noise term.
+- `Theta_in`: execution/stability boundary.
+- `Omega_t`: historical/holographic memory state.
+- `H_MMM`: equilibrium field used to assess stabilization.
+
+The numerical runtime below is an implementation mapping of those symbols. It does not assert that the operators are literal quantum-mechanical observables or that an internal fixed point is identical to external reality.
+
+## 1. Consideration-loop recurrence
+
+Let the sparse materialized state at cycle `t` be `Psi_t` over active coordinates in a logical domain as large as `10^6 x 10^6 x 10^6 = 10^18` voxels.
+
+### Attention contraction
+
+The first operator contracts the active search support:
+
+```text
+A_t = U_attn(t)[Psi_t]
+```
+
+The reference runtime ranks active coordinates by absolute amplitude and deterministically retains a configurable fraction of them. No dense `10^18` array is allocated.
+
+For amplitudes `a_i = |Psi_t(i)|`, define
+
+```text
+p_i = a_i / sum_j a_j
+H(Psi_t) = -sum_i p_i log p_i
+```
+
+The measurable entropy-contraction statistic is
+
+```text
+Delta_H_t = max(0, H(Psi_t) - H(A_t)).
+```
+
+### Description operator
+
+The attended field is encoded into a sparse latent representation and decoded back onto active support:
+
+```text
+(Z_t, Phi_t) = Phi_in(A_t).
+```
+
+In the reference implementation `Phi_in` is backed by the existing sparse block codec. `Z_t` is explicitly bounded by `latent_bound`.
+
+### Holographic-memory constraint
+
+The symbolic memory term is made executable as a bounded discrete divergence:
+
+```text
+C_t = Lambda_in^-1(div_Theta Omega_t).
+```
+
+For active coordinate `x`, the runtime uses the six-neighbour graph Laplacian
+
+```text
+div_Theta Omega_t(x)
+    = mean_{n in N6(x)} [Omega_t(n) - Omega_t(x)]
+```
+
+and the inverse-boundary map
+
+```text
+C_t(x)
+    = g_omega * d(x) / (1 + theta_constraint * |d(x)|).
+```
+
+This is bounded and therefore prevents an unconstrained memory correction from growing linearly with local disagreement.
+
+### Theta projection
+
+The structural target is
+
+```text
+T_t = Phi_t + C_t.
+```
+
+The next provisional state is a bounded projection
+
+```text
+Psi_tilde_{t+1}
+    = Pi_Theta[
+        Psi_t + eta * (T_t - Psi_t)
+      ],
+```
+
+where both amplitude and per-cycle state delta are capped.
+
+### Dissipative entropy/noise term
+
+The source notation includes
+
+```text
+-i * hbar * Gamma_in.
+```
+
+Because the current Jarvis-X field runtime is real-valued rather than a complex Hilbert-space simulator, the executable reference model does not pretend that the factor `i` has physical quantum meaning. Instead, `Gamma_in` acts on the residual not explained by the current description:
+
+```text
+R_t = Psi_tilde_{t+1} - Phi_t
+```
+
+and
+
+```text
+Psi_{t+1}
+    = Phi_t + (1 - hbar_semantic * gamma) * R_t,
+```
+
+with the contraction factor clamped to `[0,1]`.
+
+Thus described signal is retained while unexplained innovation/noise is dissipated.
+
+### Omega memory update
+
+Historical state is updated recurrently:
+
+```text
+Omega_{t+1}
+    = rho * Omega_t + (1-rho) * Psi_{t+1},
+```
+
+with `0 <= rho < 1`.
+
+## 2. Master operational map
+
+The complete executable operator is
+
+```text
+Psi_{t+1} = F_DM(Psi_t, Omega_t)
+```
+
+with the ordered mechanics
+
+```text
+Raw / stochastic sparse field
+        |
+        v
+U_attn(t)                    entropy/support contraction
+        |
+        v
+Phi_in                       structural description + latent code
+        |
+        +----------------------------+
+        |                            |
+        v                            v
+Theta target             Lambda^-1(div_Theta Omega_t)
+        |                            |
+        +-------------+--------------+
+                      v
+                 Pi_Theta
+                      |
+                      v
+                 Gamma_in
+                      |
+          +-----------+-----------+
+          |                       |
+          v                       v
+      Psi_{t+1}              Omega_{t+1}
+          |                       |
+          +-----------+-----------+
+                      v
+                  H_MMM
+                      |
+                      v
+             fixed-point test
+```
+
+## 3. Fixed-point criterion
+
+The operational fixed point is internal self-consistency:
+
+```text
+Psi* = F_DM(Psi*, Omega*)
+Omega* = Psi*.
+```
+
+The implementation computes
+
+```text
+r_state  = RMS(Psi_{t+1} - Psi_t)
+r_memory = RMS(Omega_{t+1} - Omega_t)
+r_fixed  = max(r_state, r_memory).
+```
+
+It also defines a non-negative Lyapunov-like equilibrium energy
+
+```text
+H_MMM(t)
+    = r_state^2
+    + r_memory^2
+    + RMS(Psi_{t+1} - Phi_t)^2.
+```
+
+Convergence requires both
+
+```text
+r_fixed <= fixed_point_tolerance
+```
+
+and
+
+```text
+|H_MMM(t) - H_MMM(t-1)| <= equilibrium_tolerance.
+```
+
+This distinguishes a numerically stable fixed point from a single low-residual step.
+
+## 4. Sparse `10^18`-voxel domain
+
+For a million cells on each axis,
+
+```text
+N = 1,000,000^3 = 10^18 logical voxels.
+```
+
+The runtime treats this as an address space. Storage is proportional to active sparse support and latent representation, not to `10^18`.
+
+The implementation reports
+
+```text
+logical_domain      = 1000000^3
+logical_voxels      = 1000000000000000000
+materialization     = sparse-active-support-only
+```
+
+and has a regression test loading only two active coordinates at opposite regions of the logical domain.
+
+## 5. Runtime implementation
+
+Source:
+
+```text
+src/jarvisx/dm_vomegaxi_consideration.py
+```
+
+Tests:
+
+```text
+tests/test_dm_vomegaxi_consideration.py
+```
+
+Key implementation classes:
+
+```python
+DMvOmegaXiConsiderationConfig
+DMvOmegaXiConsiderationLoop
+ConsiderationReport
+```
+
+A typical use is:
+
+```python
+from jarvisx.dm_vomegaxi_consideration import DMvOmegaXiConsiderationLoop
+
+engine = DMvOmegaXiConsiderationLoop()
+engine.load({
+    (1, 2, 3): 0.8,
+    (5, 8, 13): -0.4,
+})
+reports = engine.run_until_fixed_point()
+print(reports[-1])
+print(engine.status())
+```
+
+Each iteration is appended to the existing hash-chained journal, producing a deterministic audit trail of entropy contraction, dissipation, memory correction, fixed-point residual, and `H_MMM` equilibrium.
+
+## 6. Verification contract
+
+The regression suite verifies that:
+
+1. `U_attn(t)` reduces active support and Shannon entropy for a high-entropy uniform sparse field.
+2. `Gamma_in` executes as measurable residual damping.
+3. The loop converges to an internal fixed point under a lossy sparse description.
+4. `Lambda_in^-1(div_Theta Omega_t)` has the expected sign and remains bounded.
+5. A `1,000,000^3` logical domain remains sparse rather than densely materialized.
+6. The consideration history remains verifiable through the existing hash-chain journal.
+
+## 7. Interpretation boundary
+
+`State of Understanding` in this runtime means a converged internal computational state under the declared operators and tolerances. It must not be interpreted as proof that the internal state is factually identical to the external world. External correctness still requires observation, evaluation, and task-specific verification outside the fixed-point recurrence.

--- a/src/jarvisx/dm_vomegaxi_consideration.py
+++ b/src/jarvisx/dm_vomegaxi_consideration.py
@@ -1,0 +1,480 @@
+"""Operational consideration loop for the Dr Moagi DM-vOmegaXi+ formulation.
+
+This module adds two first-class mechanics to the existing fixed-point runtime:
+
+* U_attn(t): deterministic salience contraction over sparse active support.
+* Gamma_in: dissipative damping of innovation/noise residuals.
+
+The implementation is a bounded numerical reference model.  It does not claim
+that the symbolic operators are physical quantum operators.  In particular,
+the symbolic ``-i*hbar*Gamma_in`` term is represented here by a real-valued
+contractive damping operator acting on the residual that is not explained by
+Phi_in.
+
+The logical spatial domain may be extremely large, but only active sparse
+coordinates are materialized.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass, field, replace
+from pathlib import Path
+from typing import Mapping
+
+from .dr_moagi_autoexec import (
+    AutoExecPolicy,
+    HashChainJournal,
+    SparseBlockCodec3D,
+    SparseLatent3D,
+    SparseParser3D,
+)
+from .dr_moagi_field_runtime import Coordinate, SparseField
+
+
+@dataclass(frozen=True)
+class DMvOmegaXiConsiderationConfig:
+    """Configuration for a bounded sparse consideration loop."""
+
+    side: int = 64
+    max_active_cells: int = 50_000
+    value_min: float = -1.0
+    value_max: float = 1.0
+    policy: AutoExecPolicy = field(default_factory=AutoExecPolicy)
+
+    # U_attn(t)
+    attention_keep_ratio: float = 0.5
+    attention_min_cells: int = 1
+
+    # Lambda^-1(div_Theta Omega_t)
+    latent_bound: float = 1.0
+    memory_retention: float = 0.75
+    memory_constraint_gain: float = 0.10
+    theta_constraint: float = 1.0
+
+    # Theta_in projection
+    state_gain: float = 0.5
+    max_state_delta: float = 0.25
+
+    # -i*hbar*Gamma_in -> real-valued residual damping
+    semantic_hbar: float = 1.0
+    dissipation_rate: float = 0.10
+
+    fixed_point_tolerance: float = 1.0e-6
+    equilibrium_tolerance: float = 1.0e-8
+    max_iterations: int = 128
+    logical_side: int = 1_000_000
+
+    def __post_init__(self) -> None:
+        for name in ("side", "max_active_cells", "attention_min_cells", "max_iterations", "logical_side"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+        for name in (
+            "value_min",
+            "value_max",
+            "attention_keep_ratio",
+            "latent_bound",
+            "memory_retention",
+            "memory_constraint_gain",
+            "theta_constraint",
+            "state_gain",
+            "max_state_delta",
+            "semantic_hbar",
+            "dissipation_rate",
+            "fixed_point_tolerance",
+            "equilibrium_tolerance",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+        if not 0.0 < self.attention_keep_ratio <= 1.0:
+            raise ValueError("attention_keep_ratio must be in (0, 1]")
+        if self.latent_bound <= 0.0:
+            raise ValueError("latent_bound must be positive")
+        if not 0.0 <= self.memory_retention < 1.0:
+            raise ValueError("memory_retention must be in [0, 1)")
+        if self.memory_constraint_gain < 0.0:
+            raise ValueError("memory_constraint_gain must be non-negative")
+        if self.theta_constraint < 0.0:
+            raise ValueError("theta_constraint must be non-negative")
+        if not 0.0 < self.state_gain <= 1.0:
+            raise ValueError("state_gain must be in (0, 1]")
+        if self.max_state_delta <= 0.0:
+            raise ValueError("max_state_delta must be positive")
+        if self.semantic_hbar < 0.0:
+            raise ValueError("semantic_hbar must be non-negative")
+        if not 0.0 <= self.dissipation_rate <= 1.0:
+            raise ValueError("dissipation_rate must be in [0, 1]")
+        if self.fixed_point_tolerance < 0.0:
+            raise ValueError("fixed_point_tolerance must be non-negative")
+        if self.equilibrium_tolerance < 0.0:
+            raise ValueError("equilibrium_tolerance must be non-negative")
+
+
+@dataclass(frozen=True)
+class ConsiderationReport:
+    iteration: int
+    input_entropy: float
+    attended_entropy: float
+    entropy_contraction: float
+    active_cells_before_attention: int
+    active_cells_after_attention: int
+    latent_cells: int
+    description_rms: float
+    memory_constraint_rms: float
+    state_delta_rms: float
+    memory_delta_rms: float
+    dissipated_rms: float
+    fixed_point_residual: float
+    h_mmm: float
+    h_mmm_delta: float
+    converged: bool
+    state_hash: str
+    journal_hash: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class DMvOmegaXiConsiderationLoop:
+    """Sparse deterministic consideration loop.
+
+    One step operationalizes the stack as::
+
+        Psi_t
+          -> U_attn(t)[Psi_t]                  salience contraction
+          -> Phi_in                            structural description
+          -> Lambda^-1(div_Theta Omega_t)      bounded memory correction
+          -> Theta_in                          bounded state projection
+          -> Gamma_in                          residual dissipation
+          -> Psi_{t+1}
+          -> Omega_{t+1}                       recurrent memory update
+
+    The accepted fixed point is an internal numerical equilibrium:
+
+        Psi* = F_DM(Psi*, Omega*)
+        Omega* = Psi*
+
+    subject to a bounded residual and a stabilized H_MMM Lyapunov-like energy.
+    """
+
+    LAW_ID = "DM-vOmegaXi+"
+    OPERATOR_STACK = (
+        "U_attn(t)",
+        "Psi_t",
+        "Phi_in",
+        "Lambda_in^-1(div_Theta Omega_t)",
+        "Theta_in",
+        "Gamma_in",
+        "Omega_t",
+        "H_MMM",
+    )
+
+    def __init__(
+        self,
+        config: DMvOmegaXiConsiderationConfig | None = None,
+        *,
+        journal_path: str | Path | None = None,
+    ) -> None:
+        self.config = config or DMvOmegaXiConsiderationConfig()
+        self.parser = SparseParser3D(
+            side=self.config.side,
+            max_active_cells=self.config.max_active_cells,
+            value_min=self.config.value_min,
+            value_max=self.config.value_max,
+            prune_epsilon=self.config.policy.prune_epsilon,
+        )
+        self.codec = SparseBlockCodec3D(self.config.policy)
+        self.journal = HashChainJournal(journal_path)
+        self._state: SparseField = {}
+        self._memory: SparseField = {}
+        self._iteration = 0
+        self._loaded = False
+        self._last_h_mmm: float | None = None
+        self.reports: list[ConsiderationReport] = []
+
+    def load(self, source: Mapping[Coordinate, float]) -> SparseField:
+        state = self.parser.parse(source)
+        self._state = dict(state)
+        self._memory = dict(state)
+        self._iteration = 0
+        self._last_h_mmm = None
+        self.reports.clear()
+        self._loaded = True
+        return self.snapshot()
+
+    def snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._state)
+
+    def memory_snapshot(self) -> SparseField:
+        self._require_loaded()
+        return dict(self._memory)
+
+    def attention(self, field: Mapping[Coordinate, float]) -> SparseField:
+        """U_attn(t): retain the most salient active coordinates.
+
+        Salience is absolute amplitude with deterministic coordinate tie-breaking.
+        The operator contracts support without allocating the logical dense domain.
+        """
+        if not field:
+            return {}
+        count = max(
+            self.config.attention_min_cells,
+            int(math.ceil(len(field) * self.config.attention_keep_ratio)),
+        )
+        count = min(count, len(field))
+        ranked = sorted(field.items(), key=lambda item: (-abs(float(item[1])), item[0]))
+        return {coordinate: float(value) for coordinate, value in ranked[:count]}
+
+    def phi_in(self, field: Mapping[Coordinate, float]) -> tuple[SparseLatent3D, SparseField]:
+        """Phi_in: compress and reconstruct the current structural description."""
+        latent = self.codec.encode(field)
+        bound = self.config.latent_bound
+        bounded_cells = tuple(
+            replace(cell, value=max(-bound, min(bound, float(cell.value))))
+            for cell in latent.cells
+        )
+        bounded = replace(latent, cells=bounded_cells)
+        support = tuple(sorted(field))
+        decoded = self.codec.decode(bounded, support)
+        return bounded, decoded
+
+    def memory_constraint(self, support: set[Coordinate]) -> SparseField:
+        """Lambda^-1(div_Theta Omega_t): bounded discrete memory correction.
+
+        The divergence term is represented by a six-neighbour graph Laplacian over
+        materialized memory support.  Lambda^-1 is a saturating inverse-boundary
+        map, preventing the correction from growing linearly without bound.
+        """
+        gain = self.config.memory_constraint_gain
+        theta = self.config.theta_constraint
+        correction: SparseField = {}
+        for coordinate in sorted(support):
+            center = float(self._memory.get(coordinate, 0.0))
+            x, y, z = coordinate
+            neighbours = (
+                (x - 1, y, z),
+                (x + 1, y, z),
+                (x, y - 1, z),
+                (x, y + 1, z),
+                (x, y, z - 1),
+                (x, y, z + 1),
+            )
+            present = [float(self._memory[n]) for n in neighbours if n in self._memory]
+            if not present or gain == 0.0:
+                continue
+            divergence = sum(value - center for value in present) / len(present)
+            bounded = gain * divergence / (1.0 + theta * abs(divergence))
+            if bounded != 0.0:
+                correction[coordinate] = bounded
+        return correction
+
+    def theta_project(
+        self,
+        current: Mapping[Coordinate, float],
+        target: Mapping[Coordinate, float],
+    ) -> SparseField:
+        """Theta_in: bounded state-space projection toward the current target."""
+        gain = self.config.state_gain
+        cap = self.config.max_state_delta
+        eps = self.config.policy.prune_epsilon
+        result: SparseField = {}
+        for coordinate in sorted(set(current) | set(target)):
+            value = float(current.get(coordinate, 0.0))
+            desired = float(target.get(coordinate, 0.0))
+            delta = max(-cap, min(cap, gain * (desired - value)))
+            projected = max(self.config.value_min, min(self.config.value_max, value + delta))
+            if abs(projected) > eps:
+                result[coordinate] = projected
+        return result
+
+    def gamma_dissipate(
+        self,
+        candidate: Mapping[Coordinate, float],
+        description: Mapping[Coordinate, float],
+    ) -> tuple[SparseField, float]:
+        """Gamma_in: damp unexplained residual while preserving described signal.
+
+        For a real-valued runtime the symbolic ``-i*hbar*Gamma`` term is mapped to
+        a contraction of r = candidate - description:
+
+            r' = (1 - hbar_semantic * gamma) r
+
+        with the contraction factor clamped to [0, 1].
+        """
+        damping = min(1.0, max(0.0, self.config.semantic_hbar * self.config.dissipation_rate))
+        eps = self.config.policy.prune_epsilon
+        result: SparseField = {}
+        removed_sq = 0.0
+        support = set(candidate) | set(description)
+        for coordinate in sorted(support):
+            value = float(candidate.get(coordinate, 0.0))
+            base = float(description.get(coordinate, 0.0))
+            residual = value - base
+            removed = damping * residual
+            stabilized = value - removed
+            removed_sq += removed * removed
+            if abs(stabilized) > eps:
+                result[coordinate] = stabilized
+        removed_rms = math.sqrt(removed_sq / len(support)) if support else 0.0
+        return result, removed_rms
+
+    def omega_update(self, state: Mapping[Coordinate, float]) -> SparseField:
+        retain = self.config.memory_retention
+        inject = 1.0 - retain
+        result: SparseField = {}
+        for coordinate in sorted(set(self._memory) | set(state)):
+            value = retain * float(self._memory.get(coordinate, 0.0)) + inject * float(
+                state.get(coordinate, 0.0)
+            )
+            if abs(value) > self.config.policy.prune_epsilon:
+                result[coordinate] = value
+        return result
+
+    def step(self) -> ConsiderationReport:
+        self._require_loaded()
+        current = dict(self._state)
+        before_entropy = self._entropy(current)
+
+        attended = self.attention(current)
+        attended_entropy = self._entropy(attended)
+        latent, description = self.phi_in(attended)
+
+        support = set(current) | set(description) | set(self._memory)
+        correction = self.memory_constraint(support)
+        target = {
+            coordinate: float(description.get(coordinate, 0.0)) + float(correction.get(coordinate, 0.0))
+            for coordinate in sorted(set(description) | set(correction))
+        }
+
+        projected = self.theta_project(current, target)
+        candidate, dissipated_rms = self.gamma_dissipate(projected, description)
+        next_memory = self.omega_update(candidate)
+
+        description_rms = self._rms(candidate, description)
+        memory_constraint_rms = self._rms(correction, {})
+        state_delta_rms = self._rms(candidate, current)
+        memory_delta_rms = self._rms(next_memory, self._memory)
+        residual = max(state_delta_rms, memory_delta_rms)
+
+        # A non-negative Lyapunov-like equilibrium energy for the executable model.
+        h_mmm = (
+            state_delta_rms * state_delta_rms
+            + memory_delta_rms * memory_delta_rms
+            + description_rms * description_rms
+        )
+        h_delta = 0.0 if self._last_h_mmm is None else abs(h_mmm - self._last_h_mmm)
+
+        self._state = candidate
+        self._memory = next_memory
+        self._iteration += 1
+        self._last_h_mmm = h_mmm
+
+        converged = bool(
+            residual <= self.config.fixed_point_tolerance
+            and h_delta <= self.config.equilibrium_tolerance
+        )
+
+        provisional = ConsiderationReport(
+            iteration=self._iteration,
+            input_entropy=before_entropy,
+            attended_entropy=attended_entropy,
+            entropy_contraction=max(0.0, before_entropy - attended_entropy),
+            active_cells_before_attention=len(current),
+            active_cells_after_attention=len(attended),
+            latent_cells=latent.latent_cells,
+            description_rms=description_rms,
+            memory_constraint_rms=memory_constraint_rms,
+            state_delta_rms=state_delta_rms,
+            memory_delta_rms=memory_delta_rms,
+            dissipated_rms=dissipated_rms,
+            fixed_point_residual=residual,
+            h_mmm=h_mmm,
+            h_mmm_delta=h_delta,
+            converged=converged,
+            state_hash=self._state_hash(candidate),
+        )
+        record = provisional.as_dict()
+        record.pop("journal_hash", None)
+        digest = self.journal.append(record)
+        report = replace(provisional, journal_hash=digest)
+        self.reports.append(report)
+        return report
+
+    def run_until_fixed_point(self, max_iterations: int | None = None) -> tuple[ConsiderationReport, ...]:
+        self._require_loaded()
+        limit = self.config.max_iterations if max_iterations is None else max_iterations
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("max_iterations must be a positive integer")
+        for _ in range(limit):
+            report = self.step()
+            if report.converged:
+                break
+        return tuple(self.reports)
+
+    def status(self) -> dict[str, object]:
+        self._require_loaded()
+        latest = self.reports[-1] if self.reports else None
+        return {
+            "law": self.LAW_ID,
+            "operator_stack": list(self.OPERATOR_STACK),
+            "fixed_point_equation": "Psi* = F_DM(Psi*, Omega*), Omega* = Psi*",
+            "logical_domain": f"{self.config.logical_side}^3",
+            "logical_voxels": str(self.config.logical_side**3),
+            "materialization": "sparse-active-support-only",
+            "iteration": self._iteration,
+            "active_cells": len(self._state),
+            "fixed_point_residual": latest.fixed_point_residual if latest else None,
+            "h_mmm": latest.h_mmm if latest else None,
+            "h_mmm_delta": latest.h_mmm_delta if latest else None,
+            "entropy_contraction": latest.entropy_contraction if latest else None,
+            "converged": latest.converged if latest else False,
+            "journal_head": self.journal.head,
+            "journal_valid": self.journal.verify(),
+        }
+
+    @staticmethod
+    def _entropy(field: Mapping[Coordinate, float]) -> float:
+        weights = [abs(float(value)) for value in field.values() if abs(float(value)) > 0.0]
+        total = sum(weights)
+        if total <= 0.0:
+            return 0.0
+        entropy = 0.0
+        for weight in weights:
+            p = weight / total
+            entropy -= p * math.log(p)
+        return entropy
+
+    @staticmethod
+    def _rms(left: Mapping[Coordinate, float], right: Mapping[Coordinate, float]) -> float:
+        support = set(left) | set(right)
+        if not support:
+            return 0.0
+        mse = sum(
+            (float(left.get(coordinate, 0.0)) - float(right.get(coordinate, 0.0))) ** 2
+            for coordinate in support
+        ) / len(support)
+        return math.sqrt(mse)
+
+    @staticmethod
+    def _state_hash(field: Mapping[Coordinate, float]) -> str:
+        canonical = [
+            [coordinate[0], coordinate[1], coordinate[2], float(field[coordinate])]
+            for coordinate in sorted(field)
+        ]
+        payload = json.dumps(canonical, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def _require_loaded(self) -> None:
+        if not self._loaded:
+            raise RuntimeError("load a sparse 3D field before consideration-loop execution")

--- a/tests/test_dm_vomegaxi_consideration.py
+++ b/tests/test_dm_vomegaxi_consideration.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dm_vomegaxi_consideration import (
+    DMvOmegaXiConsiderationConfig,
+    DMvOmegaXiConsiderationLoop,
+)
+from jarvisx.dr_moagi_autoexec import AutoExecPolicy
+
+
+def _config(**overrides):
+    values = dict(
+        side=32,
+        max_active_cells=256,
+        value_min=-2.0,
+        value_max=2.0,
+        policy=AutoExecPolicy(block_size=2, quantization=0.001, prune_epsilon=0.0),
+        attention_keep_ratio=1.0,
+        attention_min_cells=1,
+        latent_bound=2.0,
+        memory_retention=0.5,
+        memory_constraint_gain=0.0,
+        theta_constraint=1.0,
+        state_gain=0.5,
+        max_state_delta=0.5,
+        semantic_hbar=1.0,
+        dissipation_rate=0.1,
+        fixed_point_tolerance=1.0e-6,
+        equilibrium_tolerance=1.0e-8,
+        max_iterations=256,
+        logical_side=1_000_000,
+    )
+    values.update(overrides)
+    return DMvOmegaXiConsiderationConfig(**values)
+
+
+def test_attention_contracts_high_entropy_sparse_support():
+    engine = DMvOmegaXiConsiderationLoop(_config(attention_keep_ratio=0.5))
+    field = {(i, 0, 0): 1.0 for i in range(8)}
+    engine.load(field)
+
+    report = engine.step()
+
+    assert report.active_cells_before_attention == 8
+    assert report.active_cells_after_attention == 4
+    assert report.attended_entropy < report.input_entropy
+    assert report.entropy_contraction > 0.0
+
+
+def test_gamma_term_is_executable_as_real_residual_damping():
+    engine = DMvOmegaXiConsiderationLoop(
+        _config(state_gain=0.25, dissipation_rate=0.5, semantic_hbar=1.0)
+    )
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): 0.5})
+
+    report = engine.step()
+
+    assert report.dissipated_rms > 0.0
+    assert report.description_rms >= 0.0
+    assert report.fixed_point_residual >= 0.0
+
+
+def test_consideration_loop_converges_to_internal_fixed_point():
+    engine = DMvOmegaXiConsiderationLoop(_config())
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): 0.5})
+
+    reports = engine.run_until_fixed_point()
+
+    assert reports[-1].converged
+    assert reports[-1].fixed_point_residual <= engine.config.fixed_point_tolerance
+    assert reports[-1].h_mmm_delta <= engine.config.equilibrium_tolerance
+    state = engine.snapshot()
+    assert state[(2, 2, 2)] == pytest.approx(0.75, abs=2.0e-4)
+    assert state[(3, 2, 2)] == pytest.approx(0.75, abs=2.0e-4)
+
+
+def test_memory_constraint_uses_bounded_spatial_divergence():
+    engine = DMvOmegaXiConsiderationLoop(
+        _config(memory_constraint_gain=0.5, theta_constraint=2.0)
+    )
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): -1.0})
+
+    correction = engine.memory_constraint(set(engine.snapshot()))
+
+    assert correction[(2, 2, 2)] < 0.0
+    assert correction[(3, 2, 2)] > 0.0
+    assert all(abs(value) <= 0.25 for value in correction.values())
+
+
+def test_million_cubed_domain_is_logical_not_dense_materialization():
+    engine = DMvOmegaXiConsiderationLoop(
+        _config(side=1_000_000, logical_side=1_000_000)
+    )
+    engine.load({(1, 2, 3): 0.8, (999_999, 999_999, 999_999): 0.6})
+
+    status = engine.status()
+
+    assert status["logical_domain"] == "1000000^3"
+    assert status["logical_voxels"] == str(10**18)
+    assert status["materialization"] == "sparse-active-support-only"
+    assert status["active_cells"] == 2
+
+
+def test_consideration_journal_is_hash_chained(tmp_path):
+    path = tmp_path / "dm-vomegaxi-consideration.jsonl"
+    engine = DMvOmegaXiConsiderationLoop(_config(), journal_path=path)
+    engine.load({(2, 2, 2): 1.0, (3, 2, 2): 0.5})
+
+    engine.run_until_fixed_point()
+
+    assert path.exists()
+    assert engine.journal.verify()
+    assert len(engine.journal.head) == 64


### PR DESCRIPTION
## Summary

Operationalizes the DM-vOmegaXi+ consideration loop as a bounded sparse fixed-point runtime over the existing Jarvis-X field/codec stack.

### Added
- `U_attn(t)` deterministic salience/support contraction with measurable Shannon-entropy contraction.
- `Phi_in` structural description via the existing sparse block codec.
- `Lambda_in^-1(div_Theta Omega_t)` as a bounded six-neighbour discrete memory-divergence correction.
- `Theta_in` bounded state projection.
- `Gamma_in` as an executable real-valued residual damping operator corresponding to the symbolic `-i*hbar*Gamma_in` term without claiming literal quantum dynamics.
- `Omega_t` recurrent memory update.
- `H_MMM` Lyapunov-like equilibrium metric plus fixed-point residual criteria.
- Sparse `1,000,000^3 = 10^18` logical-domain reporting without dense materialization.
- Hash-chained per-iteration audit records.

## Files

- `src/jarvisx/dm_vomegaxi_consideration.py`
- `tests/test_dm_vomegaxi_consideration.py`
- `docs/dm-vomegaxi-consideration-loop.md`

## Fixed-point contract

`Psi* = F_DM(Psi*, Omega*)`, with `Omega* = Psi*`, accepted only when both the state/memory residual and the `H_MMM` equilibrium delta fall below configured tolerances.

## Verification

Regression tests cover attention entropy contraction, dissipative damping, bounded memory divergence, convergence, sparse million-cubed addressing, and journal integrity.

## Interpretation boundary

The implementation treats "State of Understanding" as an internally converged computational state. It does not equate internal fixed-point stability with external-world truth; external correctness still requires task-specific verification.