### PR TITLE
Implement DMVANN Chat runtime and register Manus deployment

### DIFF
--- a/.github/workflows/dmvx-matrix-pages.yml
+++ b/.github/workflows/dmvx-matrix-pages.yml
@@ -10,6 +10,7 @@ on:
       - "apps/permeation-transport/**"
       - "apps/dr-moagi-geometry/**"
       - "apps/dr-moagi-cognitive/**"
+      - "apps/dmvann-chat/**"
       - ".github/workflows/dmvx-matrix-pages.yml"
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - "apps/permeation-transport/**"
       - "apps/dr-moagi-geometry/**"
       - "apps/dr-moagi-cognitive/**"
+      - "apps/dmvann-chat/**"
       - ".github/workflows/dmvx-matrix-pages.yml"
   workflow_dispatch:
 
@@ -48,11 +50,18 @@ jobs:
         run: node --test apps/dr-moagi-geometry/test_core.mjs
       - name: Run cognitive web-application invariants
         run: node --test apps/dr-moagi-cognitive/test_core.mjs
+      - name: Run DMVANN Chat invariants
+        run: node --test apps/dmvann-chat/test_core.mjs
       - name: Syntax-check cognitive browser modules
         run: |
           node --check apps/dr-moagi-cognitive/core.mjs
           node --check apps/dr-moagi-cognitive/app.mjs
           node --check apps/dr-moagi-cognitive/sw.js
+      - name: Syntax-check DMVANN Chat modules
+        run: |
+          node --check apps/dmvann-chat/core.mjs
+          node --check apps/dmvann-chat/app.mjs
+          node --check apps/dmvann-chat/server.mjs
       - name: Smoke-check permeation browser entrypoint
         run: |
           grep -q "DM-vΩΞ⁺ PERMEATION TRANSPORT CORE" apps/permeation-transport/index.html
@@ -72,6 +81,14 @@ jobs:
           grep -q "PROVISIONAL != AUTHORITATIVE" apps/dr-moagi-cognitive/README.md
           test -s apps/dr-moagi-cognitive/sw.js
           test -s apps/dr-moagi-cognitive/icon.svg
+      - name: Smoke-check DMVANN Chat web application
+        run: |
+          grep -q "DM–vΩΞ⁺ Neural Interface" apps/dmvann-chat/index.html
+          grep -q "PROVISIONAL ≠ AUTHORITATIVE" apps/dmvann-chat/index.html
+          grep -q "app.mjs" apps/dmvann-chat/index.html
+          grep -q "UPSTREAM_NOT_CONFIGURED" apps/dmvann-chat/server.mjs
+          grep -q "no remote model response was used" apps/dmvann-chat/core.mjs
+          test -s apps/dmvann-chat/Dockerfile
 
   deploy:
     if: github.event_name != 'pull_request'
@@ -94,11 +111,12 @@ jobs:
       - name: Assemble shared static site
         run: |
           rm -rf dist
-          mkdir -p dist/permeation-transport dist/dr-moagi-geometry dist/dr-moagi-cognitive
+          mkdir -p dist/permeation-transport dist/dr-moagi-geometry dist/dr-moagi-cognitive dist/dmvann-chat
           cp -a apps/dmvx-matrix/. dist/
           cp -a apps/permeation-transport/. dist/permeation-transport/
           cp -a apps/dr-moagi-geometry/. dist/dr-moagi-geometry/
           cp -a apps/dr-moagi-cognitive/. dist/dr-moagi-cognitive/
+          cp -a apps/dmvann-chat/. dist/dmvann-chat/
       - name: Upload static runtimes
         id: upload
         continue-on-error: true
@@ -138,6 +156,7 @@ jobs:
                 `- permeation transport: ${pageUrl.replace(/\/$/, '')}/permeation-transport/`,
                 `- Dr Moagi geometry optimizer: ${pageUrl.replace(/\/$/, '')}/dr-moagi-geometry/`,
                 `- Dr Moagi cognitive 3D web app: ${pageUrl.replace(/\/$/, '')}/dr-moagi-cognitive/`,
+                `- DMVANN Chat: ${pageUrl.replace(/\/$/, '')}/dmvann-chat/`,
                 `- deployed commit: \`${context.sha}\``,
                 `- invariant test job: ${process.env.TEST_RESULT}`,
                 `- Pages deployment job: ${process.env.DEPLOY_RESULT}`,

--- a/apps/dmvann-chat/Dockerfile
+++ b/apps/dmvann-chat/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY . .
+ENV NODE_ENV=production PORT=8787
+EXPOSE 8787
+USER node
+CMD ["node", "server.mjs"]

--- a/apps/dmvann-chat/README.md
+++ b/apps/dmvann-chat/README.md
@@ -1,0 +1,52 @@
+# DMVANN Chat — DM-vΩΞ⁺ Neural Interface
+
+This directory registers the externally deployed DMVANN Chat interface with the Jarvis-X application tree.
+
+## Live deployment
+
+- URL: https://dmvannchat-utfg9t9j.manus.space/
+- Observed page title: `DM–vΩΞ⁺ Neural Interface`
+- Registered: 2026-08-25
+- Deployment host: Manus
+
+## Relationship to Jarvis-X
+
+Jarvis-X already contains `apps/dr-moagi-cognitive`, the production-oriented DM-vΩΞ⁺ browser control plane. DMVANN Chat is tracked separately here until its deployable source tree, build configuration, and runtime contract are imported and verified.
+
+This registration intentionally does **not** claim that the current Manus deployment is byte-for-byte identical to `apps/dr-moagi-cognitive`.
+
+## Integration boundary
+
+Before treating this deployment as a first-class Jarvis-X runtime, verify and import:
+
+1. application source and dependency lockfile;
+2. build/start commands and environment variables;
+3. client/server API contract;
+4. model/provider configuration with secrets kept server-side;
+5. deterministic health endpoint and readiness semantics;
+6. CSP, CORS, authentication, rate limiting, and input-boundary controls;
+7. test suite covering chat state, failure recovery, and any DM-vΩΞ⁺ numerical transforms;
+8. CI build/test/deploy workflow;
+9. provenance/version metadata tying a deployment to a Git commit;
+10. deployment rollback procedure.
+
+## Verification status
+
+The public endpoint is reachable through the browsing layer and identifies itself as `DM–vΩΞ⁺ Neural Interface`. The dynamic deployment source was not recoverable from the public page during this registration, so no source equivalence or backend-capability claim is made here.
+
+## Target repository layout
+
+When source is available, converge on:
+
+```text
+apps/dmvann-chat/
+├── README.md
+├── package.json
+├── package-lock.json
+├── src/
+├── public/
+├── tests/
+└── deployment/
+```
+
+The acceptance criterion is **working → robust → portable → elegant → advanced**: first reproduce the deployed behavior locally, then harden, test, containerize, and optimize it.

--- a/apps/dmvann-chat/README.md
+++ b/apps/dmvann-chat/README.md
@@ -18,7 +18,7 @@ The repository implementation is **not** asserted to be source-equivalent to the
 This directory contains an independently verifiable implementation with two execution modes:
 
 1. **Static / GitHub Pages mode** — renders the DMVANN neural-field interface and executes deterministic local field transforms. No model credentials or generative inference are used.
-2. **Node runtime mode** — serves the same UI, exposes health/runtime endpoints, and can proxy an OpenAI-compatible chat backend using server-side environment variables.
+2. **Node runtime mode** — serves the same UI, exposes health/runtime endpoints, and can proxy an OpenAI-compatible chat backend using server-side environment variables after an explicit operator opt-in.
 
 The interface always distinguishes deterministic local control-plane output from remote model output.
 
@@ -51,7 +51,7 @@ apps/dmvann-chat/
 ├── app.mjs          # browser state, rendering and runtime selection
 ├── core.mjs         # deterministic Ψ–Φ–Λ–Ω–Θ transforms and validation
 ├── server.mjs       # Node static server + server-side chat proxy
-├── test_core.mjs    # invariant tests
+├── test_core.mjs    # invariant + endpoint tests
 ├── package.json     # Node 22 scripts
 ├── Dockerfile       # portable runtime image
 ├── deployment.json  # external/reference deployment metadata
@@ -93,18 +93,19 @@ POST /api/chat
 
 ## Configure generative chat
 
-The Node runtime expects an OpenAI-compatible upstream at `/v1/chat/completions`.
+The Node runtime expects an OpenAI-compatible upstream at `/v1/chat/completions`. Remote inference is disabled unless `DMVANN_ENABLE_REMOTE=1` is explicitly set.
 
 ```bash
 export DMVANN_UPSTREAM_URL="https://your-trusted-model-gateway.example"
 export DMVANN_UPSTREAM_API_KEY="server-side-secret"
 export DMVANN_MODEL="your-model-id"
+export DMVANN_ENABLE_REMOTE="1"
 node server.mjs
 ```
 
-`DMVANN_UPSTREAM_API_KEY` is read only by the Node process and is never emitted by `/healthz`, `/api/runtime`, or browser code.
+`DMVANN_UPSTREAM_API_KEY` is read only by the Node process and is never emitted by `/healthz`, `/api/runtime`, or browser code. Client requests cannot override `DMVANN_MODEL`.
 
-If no upstream is configured, `/api/chat` fails closed with `503 UPSTREAM_NOT_CONFIGURED` and the browser uses a clearly labelled deterministic local fallback.
+If no upstream is configured, `/api/chat` fails closed with `503 UPSTREAM_NOT_CONFIGURED`. If an upstream URL exists but remote inference has not been explicitly enabled, it fails closed with `503 REMOTE_MODEL_DISABLED`. In both cases the browser uses a clearly labelled deterministic local fallback.
 
 ## Container
 
@@ -116,6 +117,7 @@ docker run --rm -p 8787:8787 \
   -e DMVANN_UPSTREAM_URL \
   -e DMVANN_UPSTREAM_API_KEY \
   -e DMVANN_MODEL \
+  -e DMVANN_ENABLE_REMOTE=1 \
   dmvann-chat
 ```
 
@@ -126,10 +128,15 @@ docker run --rm -p 8787:8787 \
 - upstream request timeout enforced;
 - unsupported message roles normalized;
 - API keys remain server-side;
+- upstream model selection is server-controlled;
+- remote inference requires explicit operator enablement;
+- upstream error bodies are not reflected to browser clients;
 - same-origin browser API surface by default;
-- CSP, no-sniff, referrer and permissions headers emitted by the Node server;
+- CSP, frame denial, no-sniff, referrer and permissions headers emitted by the Node server;
 - remote failure degrades to disclosed deterministic local mode instead of fabricating a model response;
 - no claim of byte-for-byte identity with the Manus deployment.
+
+A public Node deployment should still sit behind authentication/rate limiting before attaching a billable or sensitive upstream model service.
 
 ## Verification
 
@@ -140,7 +147,7 @@ node --check apps/dmvann-chat/app.mjs
 node --check apps/dmvann-chat/server.mjs
 ```
 
-The invariant suite covers bounded message normalization, deterministic field evolution, state bounds, fingerprints, chat request validation and disclosure of local fallback behavior.
+The current suite contains seven tests covering bounded message normalization, deterministic field evolution, state bounds, fingerprints, chat request validation, disclosure of local fallback behavior, health endpoint semantics, and fail-closed remote inference behavior.
 
 ## Release criterion
 
@@ -150,4 +157,4 @@ The integration follows the Jarvis-X progression:
 working → robust → portable → elegant → advanced
 ```
 
-The current GitHub implementation reaches **portable**: it is runnable locally, testable, static-hostable, containerizable, and can attach to a server-side model gateway without exposing secrets. Further advancement should benchmark latency, add authenticated multi-user sessions, persistence, streaming inference, model-routing policy, observability and deployment provenance before stronger production claims are made.
+The current GitHub implementation reaches **portable**: it is runnable locally, testable, static-hostable, containerizable, and can attach to a server-side model gateway without exposing provider credentials. Further advancement should benchmark latency, add authenticated multi-user sessions, persistence, streaming inference, model-routing policy, observability and deployment provenance before stronger production claims are made.

--- a/apps/dmvann-chat/README.md
+++ b/apps/dmvann-chat/README.md
@@ -1,52 +1,153 @@
 # DMVANN Chat — DM-vΩΞ⁺ Neural Interface
 
-This directory registers the externally deployed DMVANN Chat interface with the Jarvis-X application tree.
+DMVANN Chat is a first-class Jarvis-X application that separates a deterministic local Ψ–Φ–Λ–Ω–Θ control field from optional generative-model inference.
 
-## Live deployment
+The repository implementation is **not** asserted to be source-equivalent to the externally hosted Manus deployment. The external endpoint remains registered for provenance and comparison only.
+
+## Deployments
+
+### External reference
 
 - URL: https://dmvannchat-utfg9t9j.manus.space/
-- Observed page title: `DM–vΩΞ⁺ Neural Interface`
-- Registered: 2026-08-25
-- Deployment host: Manus
+- Observed interface name: `DM–vΩΞ⁺ Neural Interface`
+- Provider: Manus
+- Source equivalence with this repository: **unverified**
 
-## Relationship to Jarvis-X
+### Jarvis-X implementation
 
-Jarvis-X already contains `apps/dr-moagi-cognitive`, the production-oriented DM-vΩΞ⁺ browser control plane. DMVANN Chat is tracked separately here until its deployable source tree, build configuration, and runtime contract are imported and verified.
+This directory contains an independently verifiable implementation with two execution modes:
 
-This registration intentionally does **not** claim that the current Manus deployment is byte-for-byte identical to `apps/dr-moagi-cognitive`.
+1. **Static / GitHub Pages mode** — renders the DMVANN neural-field interface and executes deterministic local field transforms. No model credentials or generative inference are used.
+2. **Node runtime mode** — serves the same UI, exposes health/runtime endpoints, and can proxy an OpenAI-compatible chat backend using server-side environment variables.
 
-## Integration boundary
+The interface always distinguishes deterministic local control-plane output from remote model output.
 
-Before treating this deployment as a first-class Jarvis-X runtime, verify and import:
+## Operational state
 
-1. application source and dependency lockfile;
-2. build/start commands and environment variables;
-3. client/server API contract;
-4. model/provider configuration with secrets kept server-side;
-5. deterministic health endpoint and readiness semantics;
-6. CSP, CORS, authentication, rate limiting, and input-boundary controls;
-7. test suite covering chat state, failure recovery, and any DM-vΩΞ⁺ numerical transforms;
-8. CI build/test/deploy workflow;
-9. provenance/version metadata tying a deployment to a Git commit;
-10. deployment rollback procedure.
+For each accepted text input, the local field updates a bounded state
 
-## Verification status
+```text
+M_t = (Ψ_t, Φ_t, Λ_t, Ω_t, Θ_t)
+```
 
-The public endpoint is reachable through the browsing layer and identifies itself as `DM–vΩΞ⁺ Neural Interface`. The dynamic deployment source was not recoverable from the public page during this registration, so no source equivalence or backend-capability claim is made here.
+using deterministic, testable transforms implemented in `core.mjs`:
 
-## Target repository layout
+```text
+Ψ_t = normalized input information magnitude
+Φ_t = tanh(coupling · Ψ_t + 0.25 Θ_{t-1})
+residual_t = |Φ_t - Ψ_t|
+Ω_t = decay · Ω_{t-1} + (1-decay) · residual_t
+Λ_t = 1 / (1 + Ω_t)
+Θ_t = clamp(Θ_{t-1} + learningRate · (Φ_t - Ψ_t), -1, 1)
+```
 
-When source is available, converge on:
+These quantities are operational control/telemetry variables. They are not presented as evidence that the browser itself is a trained neural network or that the equations reproduce the internal state of an external LLM.
+
+## Files
 
 ```text
 apps/dmvann-chat/
-├── README.md
-├── package.json
-├── package-lock.json
-├── src/
-├── public/
-├── tests/
-└── deployment/
+├── index.html       # responsive neural-field + chat UI
+├── app.mjs          # browser state, rendering and runtime selection
+├── core.mjs         # deterministic Ψ–Φ–Λ–Ω–Θ transforms and validation
+├── server.mjs       # Node static server + server-side chat proxy
+├── test_core.mjs    # invariant tests
+├── package.json     # Node 22 scripts
+├── Dockerfile       # portable runtime image
+├── deployment.json  # external/reference deployment metadata
+└── README.md
 ```
 
-The acceptance criterion is **working → robust → portable → elegant → advanced**: first reproduce the deployed behavior locally, then harden, test, containerize, and optimize it.
+## Run locally
+
+```bash
+cd apps/dmvann-chat
+npm test
+npm run check
+npm start
+```
+
+Default address:
+
+```text
+http://localhost:8787/
+```
+
+Health endpoint:
+
+```text
+GET /healthz
+```
+
+Runtime metadata:
+
+```text
+GET /api/runtime
+```
+
+Chat endpoint:
+
+```text
+POST /api/chat
+```
+
+## Configure generative chat
+
+The Node runtime expects an OpenAI-compatible upstream at `/v1/chat/completions`.
+
+```bash
+export DMVANN_UPSTREAM_URL="https://your-trusted-model-gateway.example"
+export DMVANN_UPSTREAM_API_KEY="server-side-secret"
+export DMVANN_MODEL="your-model-id"
+node server.mjs
+```
+
+`DMVANN_UPSTREAM_API_KEY` is read only by the Node process and is never emitted by `/healthz`, `/api/runtime`, or browser code.
+
+If no upstream is configured, `/api/chat` fails closed with `503 UPSTREAM_NOT_CONFIGURED` and the browser uses a clearly labelled deterministic local fallback.
+
+## Container
+
+From this directory:
+
+```bash
+docker build -t dmvann-chat .
+docker run --rm -p 8787:8787 \
+  -e DMVANN_UPSTREAM_URL \
+  -e DMVANN_UPSTREAM_API_KEY \
+  -e DMVANN_MODEL \
+  dmvann-chat
+```
+
+## Security and reliability boundaries
+
+- request body bounded to 1 MiB;
+- conversation history and per-message lengths bounded in the core;
+- upstream request timeout enforced;
+- unsupported message roles normalized;
+- API keys remain server-side;
+- same-origin browser API surface by default;
+- CSP, no-sniff, referrer and permissions headers emitted by the Node server;
+- remote failure degrades to disclosed deterministic local mode instead of fabricating a model response;
+- no claim of byte-for-byte identity with the Manus deployment.
+
+## Verification
+
+```bash
+node --test apps/dmvann-chat/test_core.mjs
+node --check apps/dmvann-chat/core.mjs
+node --check apps/dmvann-chat/app.mjs
+node --check apps/dmvann-chat/server.mjs
+```
+
+The invariant suite covers bounded message normalization, deterministic field evolution, state bounds, fingerprints, chat request validation and disclosure of local fallback behavior.
+
+## Release criterion
+
+The integration follows the Jarvis-X progression:
+
+```text
+working → robust → portable → elegant → advanced
+```
+
+The current GitHub implementation reaches **portable**: it is runnable locally, testable, static-hostable, containerizable, and can attach to a server-side model gateway without exposing secrets. Further advancement should benchmark latency, add authenticated multi-user sessions, persistence, streaming inference, model-routing policy, observability and deployment provenance before stronger production claims are made.

--- a/apps/dmvann-chat/app.mjs
+++ b/apps/dmvann-chat/app.mjs
@@ -1,0 +1,136 @@
+import { DEFAULT_FIELD, localControlPlaneResponse, stepField } from './core.mjs';
+
+const $ = (selector) => document.querySelector(selector);
+const chat = $('#chat');
+const form = $('#composer');
+const input = $('#prompt');
+const sendButton = $('#send');
+const runtimeBadge = $('#runtime-badge');
+const metrics = {
+  psi: $('#psi'), phi: $('#phi'), lambda: $('#lambda'), omega: $('#omega'), theta: $('#theta'),
+};
+const canvas = $('#field-canvas');
+const ctx = canvas.getContext('2d');
+
+let field = { ...DEFAULT_FIELD };
+let messages = [];
+let remoteAvailable = false;
+let busy = false;
+let phase = 0;
+
+function addMessage(role, content) {
+  const article = document.createElement('article');
+  article.className = `message ${role}`;
+  const header = document.createElement('div');
+  header.className = 'message-role';
+  header.textContent = role === 'user' ? 'YOU' : 'DMVANN';
+  const body = document.createElement('pre');
+  body.textContent = content;
+  article.append(header, body);
+  chat.append(article);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+function renderMetrics() {
+  for (const [key, node] of Object.entries(metrics)) node.textContent = Number(field[key]).toFixed(4);
+}
+
+function resizeCanvas() {
+  const rect = canvas.getBoundingClientRect();
+  const ratio = Math.min(window.devicePixelRatio || 1, 2);
+  canvas.width = Math.max(1, Math.floor(rect.width * ratio));
+  canvas.height = Math.max(1, Math.floor(rect.height * ratio));
+  ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+}
+
+function drawField() {
+  const { width, height } = canvas.getBoundingClientRect();
+  ctx.clearRect(0, 0, width, height);
+  const cx = width / 2;
+  const cy = height / 2;
+  const scale = Math.min(width, height) * 0.28;
+  const count = 180;
+  for (let i = 0; i < count; i++) {
+    const t = i / count;
+    const a = t * Math.PI * 12 + phase;
+    const z = Math.sin(a * 0.47 + field.theta * 4);
+    const radius = (0.2 + 0.8 * t) * (0.68 + field.lambda * 0.32);
+    const x3 = Math.cos(a) * radius;
+    const y3 = Math.sin(a) * radius;
+    const perspective = 1 / (1.7 - z * 0.35);
+    const x = cx + x3 * scale * perspective;
+    const y = cy + (y3 * 0.55 + z * 0.34) * scale * perspective;
+    const size = 1.2 + 2.8 * perspective * (0.35 + field.omega);
+    ctx.beginPath();
+    ctx.arc(x, y, size, 0, Math.PI * 2);
+    ctx.fillStyle = `hsla(${188 + field.phi * 85}, 92%, ${55 + z * 12}%, ${0.22 + perspective * 0.48})`;
+    ctx.fill();
+  }
+  phase += 0.006 + field.psi * 0.012;
+  requestAnimationFrame(drawField);
+}
+
+async function detectRuntime() {
+  try {
+    const response = await fetch('./healthz', { cache: 'no-store' });
+    if (!response.ok) throw new Error('health unavailable');
+    const health = await response.json();
+    remoteAvailable = Boolean(health.upstreamConfigured);
+    runtimeBadge.textContent = remoteAvailable ? 'REMOTE MODEL READY' : 'LOCAL FIELD MODE';
+  } catch {
+    remoteAvailable = false;
+    runtimeBadge.textContent = 'STATIC / LOCAL FIELD MODE';
+  }
+}
+
+async function requestAssistant() {
+  if (!remoteAvailable) return localControlPlaneResponse(messages.at(-1)?.content || '', field);
+  const response = await fetch('./api/chat', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ messages }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || !payload?.message?.content) {
+    throw new Error(payload?.message || payload?.error || `chat request failed (${response.status})`);
+  }
+  return payload.message.content;
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const text = input.value.trim();
+  if (!text || busy) return;
+  busy = true;
+  sendButton.disabled = true;
+  input.value = '';
+  messages.push({ role: 'user', content: text });
+  messages = messages.slice(-48);
+  field = stepField(field, text);
+  renderMetrics();
+  addMessage('user', text);
+  try {
+    const content = await requestAssistant();
+    messages.push({ role: 'assistant', content });
+    field = stepField(field, content);
+    renderMetrics();
+    addMessage('assistant', content);
+  } catch (error) {
+    const content = `Runtime error: ${error.message}\nFalling back to deterministic local control-plane output.\n\n${localControlPlaneResponse(text, field)}`;
+    messages.push({ role: 'assistant', content });
+    addMessage('assistant', content);
+    remoteAvailable = false;
+    runtimeBadge.textContent = 'REMOTE DEGRADED / LOCAL MODE';
+  } finally {
+    busy = false;
+    sendButton.disabled = false;
+    input.focus();
+  }
+});
+
+window.addEventListener('resize', resizeCanvas);
+resizeCanvas();
+renderMetrics();
+detectRuntime();
+drawField();
+addMessage('assistant', 'DMVANN Chat initialized. The Ψ–Φ–Λ–Ω–Θ field is deterministic locally; generative chat activates only when a server-side upstream is configured.');

--- a/apps/dmvann-chat/core.mjs
+++ b/apps/dmvann-chat/core.mjs
@@ -1,0 +1,97 @@
+export const RUNTIME_VERSION = '0.1.0';
+
+export const DEFAULT_FIELD = Object.freeze({
+  psi: 0,
+  phi: 0,
+  lambda: 1,
+  omega: 0,
+  theta: 0,
+  coupling: 1.8,
+  memoryDecay: 0.82,
+  learningRate: 0.12,
+  tick: 0,
+});
+
+export function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, Number(value)));
+}
+
+export function normalizeText(value, maxLength = 16_384) {
+  if (typeof value !== 'string') return '';
+  return value.replace(/\u0000/g, '').slice(0, maxLength);
+}
+
+export function normalizeMessages(messages, { maxMessages = 64, maxLength = 16_384 } = {}) {
+  if (!Array.isArray(messages)) throw new TypeError('messages must be an array');
+  return messages
+    .slice(-maxMessages)
+    .map((message) => {
+      const role = ['system', 'user', 'assistant'].includes(message?.role) ? message.role : 'user';
+      return { role, content: normalizeText(message?.content, maxLength) };
+    })
+    .filter((message) => message.content.length > 0);
+}
+
+export function fingerprint(text) {
+  const bytes = new TextEncoder().encode(normalizeText(text, 65_536));
+  let hash = 0x811c9dc5;
+  for (const byte of bytes) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}
+
+export function stepField(previous = DEFAULT_FIELD, input = '') {
+  const text = normalizeText(input, 16_384);
+  const byteLength = new TextEncoder().encode(text).length;
+  const psi = clamp(Math.log2(1 + byteLength) / 14, 0, 1);
+  const coupling = clamp(previous.coupling ?? DEFAULT_FIELD.coupling, 0, 4);
+  const memoryDecay = clamp(previous.memoryDecay ?? DEFAULT_FIELD.memoryDecay, 0, 0.999);
+  const learningRate = clamp(previous.learningRate ?? DEFAULT_FIELD.learningRate, 0, 1);
+  const thetaPrev = clamp(previous.theta ?? 0, -1, 1);
+  const omegaPrev = clamp(previous.omega ?? 0, 0, 1);
+  const phi = Math.tanh(coupling * psi + thetaPrev * 0.25);
+  const residual = Math.abs(phi - psi);
+  const omega = clamp(memoryDecay * omegaPrev + (1 - memoryDecay) * residual, 0, 1);
+  const lambda = 1 / (1 + omega);
+  const theta = clamp(thetaPrev + learningRate * (phi - psi), -1, 1);
+
+  return {
+    psi,
+    phi,
+    lambda,
+    omega,
+    theta,
+    coupling,
+    memoryDecay,
+    learningRate,
+    residual,
+    tick: (previous.tick ?? 0) + 1,
+    fingerprint: fingerprint(text),
+  };
+}
+
+export function createChatPayload(messages, { model = 'dmvann-default', temperature = 0.2 } = {}) {
+  const normalized = normalizeMessages(messages);
+  if (!normalized.some((message) => message.role === 'user')) {
+    throw new Error('at least one user message is required');
+  }
+  return {
+    model: normalizeText(model, 256) || 'dmvann-default',
+    temperature: clamp(temperature, 0, 2),
+    messages: normalized,
+    stream: false,
+  };
+}
+
+export function localControlPlaneResponse(userText, field) {
+  const text = normalizeText(userText, 16_384);
+  const words = text.trim() ? text.trim().split(/\s+/).length : 0;
+  return [
+    'Local deterministic DMVANN control-plane fallback is active; no remote model response was used.',
+    `Input: ${words} words, fingerprint ${field.fingerprint}.`,
+    `Field state: Ψ=${field.psi.toFixed(4)}, Φ=${field.phi.toFixed(4)}, Λ=${field.lambda.toFixed(4)}, Ω=${field.omega.toFixed(4)}, Θ=${field.theta.toFixed(4)}.`,
+    'Configure the server-side upstream runtime to enable generative chat.',
+  ].join('\n');
+}

--- a/apps/dmvann-chat/deployment.json
+++ b/apps/dmvann-chat/deployment.json
@@ -1,0 +1,11 @@
+{
+  "name": "DMVANN Chat",
+  "interface": "DM-vΩΞ⁺ Neural Interface",
+  "environment": "external",
+  "provider": "Manus",
+  "url": "https://dmvannchat-utfg9t9j.manus.space/",
+  "registered_at": "2026-08-25",
+  "source_equivalence_verified": false,
+  "source_imported": false,
+  "status": "reachable"
+}

--- a/apps/dmvann-chat/deployment.json
+++ b/apps/dmvann-chat/deployment.json
@@ -15,12 +15,15 @@
     "node_mode": true,
     "containerized": true,
     "openai_compatible_upstream": true,
+    "remote_requires_explicit_enable": true,
+    "client_model_override": false,
     "secrets_server_side": true
   },
   "verification": {
-    "local_invariant_tests": 5,
-    "local_invariant_tests_passed": 5,
-    "syntax_checks_passed": true,
+    "local_invariant_and_endpoint_tests": 7,
+    "local_tests_passed_before_hardening": 5,
+    "syntax_checks_passed_before_hardening": true,
+    "runtime_pages_ci_required": true,
     "external_source_recovered": false
   },
   "status": "github_runtime_implemented_external_equivalence_unverified"

--- a/apps/dmvann-chat/deployment.json
+++ b/apps/dmvann-chat/deployment.json
@@ -1,11 +1,27 @@
 {
   "name": "DMVANN Chat",
   "interface": "DM-vΩΞ⁺ Neural Interface",
-  "environment": "external",
-  "provider": "Manus",
-  "url": "https://dmvannchat-utfg9t9j.manus.space/",
-  "registered_at": "2026-08-25",
-  "source_equivalence_verified": false,
-  "source_imported": false,
-  "status": "reachable"
+  "external_reference": {
+    "provider": "Manus",
+    "url": "https://dmvannchat-utfg9t9j.manus.space/",
+    "registered_at": "2026-08-25",
+    "source_equivalence_verified": false,
+    "source_imported": false
+  },
+  "jarvis_x_runtime": {
+    "version": "0.1.0",
+    "path": "apps/dmvann-chat",
+    "static_mode": true,
+    "node_mode": true,
+    "containerized": true,
+    "openai_compatible_upstream": true,
+    "secrets_server_side": true
+  },
+  "verification": {
+    "local_invariant_tests": 5,
+    "local_invariant_tests_passed": 5,
+    "syntax_checks_passed": true,
+    "external_source_recovered": false
+  },
+  "status": "github_runtime_implemented_external_equivalence_unverified"
 }

--- a/apps/dmvann-chat/index.html
+++ b/apps/dmvann-chat/index.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+  <meta name="theme-color" content="#02070c">
+  <title>DM–vΩΞ⁺ Neural Interface · DMVANN Chat</title>
+  <style>
+    :root{color-scheme:dark;--bg:#02070c;--panel:#07131d;--line:#153649;--text:#dff9ff;--muted:#7ba0b1;--cyan:#55e8ff;--violet:#b486ff}
+    *{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 50% -10%,#0c2533 0,var(--bg) 42%);color:var(--text);font:14px/1.45 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;min-height:100vh}
+    .shell{display:grid;grid-template-columns:minmax(280px,.9fr) minmax(360px,1.3fr);gap:16px;max-width:1500px;margin:auto;padding:18px;min-height:100vh}
+    .panel{border:1px solid var(--line);background:linear-gradient(180deg,rgba(7,19,29,.94),rgba(2,9,14,.94));border-radius:18px;box-shadow:0 18px 70px #0009;overflow:hidden}.field{display:grid;grid-template-rows:auto minmax(320px,1fr) auto}.header{padding:16px 18px;border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between;gap:12px}.brand{font-weight:800;letter-spacing:.12em}.brand span{color:var(--cyan)}.badge{font-size:11px;color:var(--cyan);border:1px solid #1f6070;border-radius:999px;padding:6px 9px}.canvas-wrap{min-height:320px;position:relative}.canvas-wrap:before{content:"";position:absolute;inset:8%;border:1px solid #17405155;border-radius:50%;box-shadow:0 0 80px #2eefff17 inset}canvas{width:100%;height:100%;display:block}.metrics{display:grid;grid-template-columns:repeat(5,1fr);border-top:1px solid var(--line)}.metric{padding:12px;text-align:center;border-right:1px solid var(--line)}.metric:last-child{border-right:0}.metric b{display:block;color:var(--cyan);font-size:16px}.metric small{color:var(--muted)}
+    .chat-panel{display:grid;grid-template-rows:auto 1fr auto;min-height:0}.chat{padding:18px;overflow:auto;min-height:420px;max-height:calc(100vh - 160px)}.message{max-width:88%;margin:0 0 14px;padding:12px 14px;border:1px solid var(--line);border-radius:14px;background:#061019}.message.user{margin-left:auto;border-color:#513e7e;background:#130f21}.message-role{font-size:10px;letter-spacing:.14em;color:var(--violet);margin-bottom:6px}.message.assistant .message-role{color:var(--cyan)}pre{white-space:pre-wrap;margin:0;font:inherit}.composer{display:grid;grid-template-columns:1fr auto;gap:10px;padding:14px;border-top:1px solid var(--line)}textarea{resize:none;min-height:54px;max-height:160px;background:#02080d;border:1px solid #1b4458;border-radius:12px;color:var(--text);padding:12px;font:inherit;outline:none}textarea:focus{border-color:var(--cyan);box-shadow:0 0 0 2px #55e8ff18}button{border:1px solid #2b7992;border-radius:12px;background:#0b2f3b;color:#cfffff;padding:0 18px;font:700 12px inherit;cursor:pointer}button:disabled{opacity:.45;cursor:not-allowed}.footer-note{padding:0 18px 16px;color:var(--muted);font-size:11px}
+    @media(max-width:900px){.shell{grid-template-columns:1fr;min-height:auto}.field{min-height:520px}.chat{max-height:64vh}.metrics{grid-template-columns:repeat(5,minmax(64px,1fr));overflow:auto}.metric{padding:10px 6px}.metric b{font-size:13px}}
+  </style>
+</head>
+<body>
+  <main class="shell">
+    <section class="panel field">
+      <div class="header"><div class="brand">DM–vΩΞ⁺ <span>NEURAL FIELD</span></div><div class="badge" id="runtime-badge">PROBING RUNTIME</div></div>
+      <div class="canvas-wrap"><canvas id="field-canvas" aria-label="Animated DMVANN latent field"></canvas></div>
+      <div class="metrics" aria-label="Field metrics">
+        <div class="metric"><b id="psi">0.0000</b><small>Ψ state</small></div>
+        <div class="metric"><b id="phi">0.0000</b><small>Φ transform</small></div>
+        <div class="metric"><b id="lambda">1.0000</b><small>Λ gate</small></div>
+        <div class="metric"><b id="omega">0.0000</b><small>Ω memory</small></div>
+        <div class="metric"><b id="theta">0.0000</b><small>Θ control</small></div>
+      </div>
+    </section>
+    <section class="panel chat-panel">
+      <div class="header"><div class="brand">DMVANN <span>CHAT</span></div><div class="badge">PROVISIONAL ≠ AUTHORITATIVE</div></div>
+      <div class="chat" id="chat" aria-live="polite"></div>
+      <div>
+        <form class="composer" id="composer"><textarea id="prompt" maxlength="16384" placeholder="Describe the next operation…" required></textarea><button id="send" type="submit">EXECUTE</button></form>
+        <div class="footer-note">Static mode performs only deterministic local field transforms. Generative responses require the Node runtime with a server-side upstream.</div>
+      </div>
+    </section>
+  </main>
+  <script type="module" src="./app.mjs"></script>
+</body>
+</html>

--- a/apps/dmvann-chat/package.json
+++ b/apps/dmvann-chat/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@jarvis-x/dmvann-chat",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=22" },
+  "scripts": {
+    "start": "node server.mjs",
+    "test": "node --test test_core.mjs",
+    "check": "node --check core.mjs && node --check app.mjs && node --check server.mjs"
+  }
+}

--- a/apps/dmvann-chat/server.mjs
+++ b/apps/dmvann-chat/server.mjs
@@ -1,0 +1,148 @@
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import { extname, join, normalize } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createChatPayload, RUNTIME_VERSION } from './core.mjs';
+
+const ROOT = fileURLToPath(new URL('.', import.meta.url));
+const PORT = Number.parseInt(process.env.PORT || '8787', 10);
+const UPSTREAM_URL = (process.env.DMVANN_UPSTREAM_URL || '').replace(/\/$/, '');
+const UPSTREAM_API_KEY = process.env.DMVANN_UPSTREAM_API_KEY || '';
+const UPSTREAM_MODEL = process.env.DMVANN_MODEL || 'dmvann-default';
+const MAX_BODY = 1_048_576;
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.webmanifest': 'application/manifest+json',
+};
+
+function send(res, status, body, type = 'application/json; charset=utf-8') {
+  res.writeHead(status, {
+    'content-type': type,
+    'cache-control': status >= 400 ? 'no-store' : 'no-cache',
+    'x-content-type-options': 'nosniff',
+    'referrer-policy': 'no-referrer',
+    'permissions-policy': 'camera=(), microphone=(), geolocation=()',
+    'content-security-policy': "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; base-uri 'none'; frame-ancestors 'none'",
+  });
+  res.end(body);
+}
+
+async function readJson(req) {
+  const chunks = [];
+  let size = 0;
+  for await (const chunk of req) {
+    size += chunk.length;
+    if (size > MAX_BODY) throw Object.assign(new Error('request body too large'), { statusCode: 413 });
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  return raw ? JSON.parse(raw) : {};
+}
+
+async function proxyChat(req, res) {
+  if (!UPSTREAM_URL) {
+    return send(res, 503, JSON.stringify({
+      ok: false,
+      error: 'UPSTREAM_NOT_CONFIGURED',
+      message: 'Set DMVANN_UPSTREAM_URL on the server to enable generative chat.',
+    }));
+  }
+
+  try {
+    const body = await readJson(req);
+    const payload = createChatPayload(body.messages, {
+      model: body.model || UPSTREAM_MODEL,
+      temperature: body.temperature,
+    });
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 45_000);
+    const headers = { 'content-type': 'application/json' };
+    if (UPSTREAM_API_KEY) headers.authorization = `Bearer ${UPSTREAM_API_KEY}`;
+    const response = await fetch(`${UPSTREAM_URL}/v1/chat/completions`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    }).finally(() => clearTimeout(timeout));
+    const text = await response.text();
+    if (!response.ok) {
+      return send(res, 502, JSON.stringify({
+        ok: false,
+        error: 'UPSTREAM_FAILURE',
+        upstreamStatus: response.status,
+        detail: text.slice(0, 2048),
+      }));
+    }
+    let parsed;
+    try { parsed = JSON.parse(text); } catch { parsed = null; }
+    const content = parsed?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string') {
+      return send(res, 502, JSON.stringify({ ok: false, error: 'INVALID_UPSTREAM_RESPONSE' }));
+    }
+    return send(res, 200, JSON.stringify({
+      ok: true,
+      model: parsed?.model || payload.model,
+      message: { role: 'assistant', content },
+    }));
+  } catch (error) {
+    const status = error?.statusCode || (error instanceof SyntaxError ? 400 : 500);
+    return send(res, status, JSON.stringify({
+      ok: false,
+      error: status === 400 ? 'INVALID_JSON' : 'CHAT_REQUEST_FAILED',
+      message: String(error?.message || error),
+    }));
+  }
+}
+
+async function serveStatic(pathname, res) {
+  const requested = pathname === '/' ? 'index.html' : pathname.replace(/^\/+/, '');
+  const safe = normalize(requested).replace(/^([.][.][/\\])+/, '');
+  const path = join(ROOT, safe);
+  if (!path.startsWith(ROOT)) return send(res, 403, 'forbidden', 'text/plain; charset=utf-8');
+  try {
+    const info = await stat(path);
+    if (!info.isFile()) throw new Error('not a file');
+    const data = await readFile(path);
+    send(res, 200, data, MIME[extname(path)] || 'application/octet-stream');
+  } catch {
+    send(res, 404, 'not found', 'text/plain; charset=utf-8');
+  }
+}
+
+export function createServer() {
+  return http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', 'http://localhost');
+    if (req.method === 'GET' && url.pathname === '/healthz') {
+      return send(res, 200, JSON.stringify({
+        ok: true,
+        service: 'dmvann-chat',
+        version: RUNTIME_VERSION,
+        upstreamConfigured: Boolean(UPSTREAM_URL),
+      }));
+    }
+    if (req.method === 'GET' && url.pathname === '/api/runtime') {
+      return send(res, 200, JSON.stringify({
+        ok: true,
+        version: RUNTIME_VERSION,
+        model: UPSTREAM_MODEL,
+        upstreamConfigured: Boolean(UPSTREAM_URL),
+      }));
+    }
+    if (req.method === 'POST' && url.pathname === '/api/chat') return proxyChat(req, res);
+    if (req.method !== 'GET' && req.method !== 'HEAD') return send(res, 405, 'method not allowed', 'text/plain; charset=utf-8');
+    return serveStatic(url.pathname, res);
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  createServer().listen(PORT, '0.0.0.0', () => {
+    console.log(`DMVANN Chat listening on http://0.0.0.0:${PORT}`);
+  });
+}

--- a/apps/dmvann-chat/server.mjs
+++ b/apps/dmvann-chat/server.mjs
@@ -9,6 +9,7 @@ const PORT = Number.parseInt(process.env.PORT || '8787', 10);
 const UPSTREAM_URL = (process.env.DMVANN_UPSTREAM_URL || '').replace(/\/$/, '');
 const UPSTREAM_API_KEY = process.env.DMVANN_UPSTREAM_API_KEY || '';
 const UPSTREAM_MODEL = process.env.DMVANN_MODEL || 'dmvann-default';
+const REMOTE_ENABLED = Boolean(UPSTREAM_URL && process.env.DMVANN_ENABLE_REMOTE === '1');
 const MAX_BODY = 1_048_576;
 
 const MIME = {
@@ -27,6 +28,7 @@ function send(res, status, body, type = 'application/json; charset=utf-8') {
     'content-type': type,
     'cache-control': status >= 400 ? 'no-store' : 'no-cache',
     'x-content-type-options': 'nosniff',
+    'x-frame-options': 'DENY',
     'referrer-policy': 'no-referrer',
     'permissions-policy': 'camera=(), microphone=(), geolocation=()',
     'content-security-policy': "default-src 'self'; connect-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; base-uri 'none'; frame-ancestors 'none'",
@@ -47,18 +49,20 @@ async function readJson(req) {
 }
 
 async function proxyChat(req, res) {
-  if (!UPSTREAM_URL) {
+  if (!REMOTE_ENABLED) {
     return send(res, 503, JSON.stringify({
       ok: false,
-      error: 'UPSTREAM_NOT_CONFIGURED',
-      message: 'Set DMVANN_UPSTREAM_URL on the server to enable generative chat.',
+      error: UPSTREAM_URL ? 'REMOTE_MODEL_DISABLED' : 'UPSTREAM_NOT_CONFIGURED',
+      message: UPSTREAM_URL
+        ? 'Set DMVANN_ENABLE_REMOTE=1 on the server to opt in to remote inference.'
+        : 'Set DMVANN_UPSTREAM_URL and DMVANN_ENABLE_REMOTE=1 on the server to enable generative chat.',
     }));
   }
 
   try {
     const body = await readJson(req);
     const payload = createChatPayload(body.messages, {
-      model: body.model || UPSTREAM_MODEL,
+      model: UPSTREAM_MODEL,
       temperature: body.temperature,
     });
     const controller = new AbortController();
@@ -77,7 +81,6 @@ async function proxyChat(req, res) {
         ok: false,
         error: 'UPSTREAM_FAILURE',
         upstreamStatus: response.status,
-        detail: text.slice(0, 2048),
       }));
     }
     let parsed;
@@ -125,6 +128,7 @@ export function createServer() {
         service: 'dmvann-chat',
         version: RUNTIME_VERSION,
         upstreamConfigured: Boolean(UPSTREAM_URL),
+        remoteEnabled: REMOTE_ENABLED,
       }));
     }
     if (req.method === 'GET' && url.pathname === '/api/runtime') {
@@ -133,6 +137,7 @@ export function createServer() {
         version: RUNTIME_VERSION,
         model: UPSTREAM_MODEL,
         upstreamConfigured: Boolean(UPSTREAM_URL),
+        remoteEnabled: REMOTE_ENABLED,
       }));
     }
     if (req.method === 'POST' && url.pathname === '/api/chat') return proxyChat(req, res);

--- a/apps/dmvann-chat/test_core.mjs
+++ b/apps/dmvann-chat/test_core.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_FIELD,
+  createChatPayload,
+  fingerprint,
+  localControlPlaneResponse,
+  normalizeMessages,
+  stepField,
+} from './core.mjs';
+
+test('message normalization is bounded and role-safe', () => {
+  const result = normalizeMessages([{ role: 'tool', content: 'abc' }, { role: 'assistant', content: '' }]);
+  assert.deepEqual(result, [{ role: 'user', content: 'abc' }]);
+});
+
+test('field evolution is deterministic and bounded', () => {
+  const a = stepField(DEFAULT_FIELD, 'encode this state');
+  const b = stepField(DEFAULT_FIELD, 'encode this state');
+  assert.deepEqual(a, b);
+  assert.ok(a.psi >= 0 && a.psi <= 1);
+  assert.ok(a.phi >= -1 && a.phi <= 1);
+  assert.ok(a.lambda > 0 && a.lambda <= 1);
+  assert.ok(a.omega >= 0 && a.omega <= 1);
+  assert.ok(a.theta >= -1 && a.theta <= 1);
+  assert.equal(a.tick, 1);
+});
+
+test('fingerprint changes with content', () => {
+  assert.equal(fingerprint('abc'), fingerprint('abc'));
+  assert.notEqual(fingerprint('abc'), fingerprint('abd'));
+});
+
+test('chat payload requires a user message', () => {
+  assert.throws(() => createChatPayload([{ role: 'assistant', content: 'x' }]), /user message/);
+  const payload = createChatPayload([{ role: 'user', content: 'hello' }], { temperature: 9 });
+  assert.equal(payload.temperature, 2);
+  assert.equal(payload.stream, false);
+});
+
+test('local fallback clearly discloses no model was used', () => {
+  const field = stepField(DEFAULT_FIELD, 'hello world');
+  const text = localControlPlaneResponse('hello world', field);
+  assert.match(text, /no remote model response was used/i);
+  assert.match(text, /Ψ=/);
+});

--- a/apps/dmvann-chat/test_core.mjs
+++ b/apps/dmvann-chat/test_core.mjs
@@ -8,6 +8,7 @@ import {
   normalizeMessages,
   stepField,
 } from './core.mjs';
+import { createServer } from './server.mjs';
 
 test('message normalization is bounded and role-safe', () => {
   const result = normalizeMessages([{ role: 'tool', content: 'abc' }, { role: 'assistant', content: '' }]);
@@ -43,4 +44,40 @@ test('local fallback clearly discloses no model was used', () => {
   const text = localControlPlaneResponse('hello world', field);
   assert.match(text, /no remote model response was used/i);
   assert.match(text, /Ψ=/);
+});
+
+async function withServer(callback) {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  try {
+    const address = server.address();
+    return await callback(`http://127.0.0.1:${address.port}`);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+}
+
+test('health endpoint exposes readiness without secrets', async () => {
+  await withServer(async (base) => {
+    const response = await fetch(`${base}/healthz`);
+    assert.equal(response.status, 200);
+    const health = await response.json();
+    assert.equal(health.ok, true);
+    assert.equal(health.service, 'dmvann-chat');
+    assert.equal(typeof health.remoteEnabled, 'boolean');
+    assert.equal('apiKey' in health, false);
+  });
+});
+
+test('chat endpoint fails closed when remote inference is disabled', async () => {
+  await withServer(async (base) => {
+    const response = await fetch(`${base}/api/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'hello' }] }),
+    });
+    assert.equal(response.status, 503);
+    const payload = await response.json();
+    assert.ok(['UPSTREAM_NOT_CONFIGURED', 'REMOTE_MODEL_DISABLED'].includes(payload.error));
+  });
 });


### PR DESCRIPTION
Implements a first-class DMVANN Chat / DM-vΩΞ⁺ Neural Interface runtime in Jarvis-X while preserving the external Manus deployment as an unverified reference.

Changes:
- add deterministic Ψ–Φ–Λ–Ω–Θ control-field core with bounded state evolution;
- add responsive browser chat + animated neural-field UI;
- add Node 22 runtime with `/healthz`, `/api/runtime`, and `/api/chat`;
- proxy OpenAI-compatible upstreams with provider credentials kept server-side;
- require explicit `DMVANN_ENABLE_REMOTE=1` before remote inference can activate;
- keep model selection server-controlled and do not reflect upstream error bodies to clients;
- fail closed when remote inference is unavailable and clearly disclose deterministic local fallback;
- add invariant + endpoint tests, syntax checks, package metadata, and Dockerfile;
- integrate `apps/dmvann-chat/**` into the shared Jarvis-X Runtime Pages CI/deployment workflow;
- retain Manus deployment metadata without asserting source-code equivalence.

Verification:
- initial local verification: 5/5 invariant tests passed plus syntax checks;
- expanded suite: 7 invariant/endpoint tests committed;
- runtime-specific GitHub Pages CI passed on the first implementation revision; the latest hardened head is re-running CI.

External reference: https://dmvannchat-utfg9t9j.manus.space/

Release progression: working → robust → portable. Production-hardening items such as authenticated multi-user sessions, persistence, streaming, routing policy, observability, rate limiting, and deployment provenance remain future work.