### PR TITLE
Formalize Dr Moagi auto-encoding equation as a real-valued research objective

### DIFF
--- a/docs/research/DR_MOAGI_AUTOENCODING_EQUATION.md
+++ b/docs/research/DR_MOAGI_AUTOENCODING_EQUATION.md
@@ -1,0 +1,429 @@
+# Dr. Moagi Auto-Encoding Equation
+
+## Rigorous differentiable formulation and executable contract
+
+**Status:** research specification  
+**Provenance:** based on the formulation supplied by Dr. Matladi Maxwell Moagi on 2026-08-26  
+**Implementation:** `src/jarvisx/moagi_autoencoding_equation.py`  
+**Tests:** `tests/test_moagi_autoencoding_equation.py`
+
+This document preserves the conceptual structure of the submitted formulation while separating mathematical statements that are directly executable from statements that require additional assumptions. It does not replace the deterministic Q16.16 3D runtime in `docs/Dr_Moagi_Equation_3D_Autoencoder_v4.txt`; instead, it defines a differentiable training/research objective whose learned parameters may later be quantized and deployed to that runtime.
+
+---
+
+## 1. Notation repair
+
+The submitted formulation uses `E` both for the encoder and for the scalar quantity being minimized. Those objects have different codomains and cannot be identified in a type-consistent implementation.
+
+We therefore reserve
+
+\[
+E_\theta:\mathbb R^n\rightarrow\mathbb R^m
+\]
+
+for the encoder,
+
+\[
+D_\phi:\mathbb R^m\rightarrow\mathbb R^n
+\]
+
+for the decoder, and
+
+\[
+\mathcal J:\mathbb R^n\times\Theta\times\Phi\rightarrow\mathbb R
+\]
+
+for the scalar optimization objective.
+
+The basic forward pass is
+
+\[
+z=E_\theta(x),\qquad \hat x=D_\phi(z).
+\]
+
+---
+
+## 2. Authoritative corrected objective
+
+The operational research objective is
+
+\[
+\boxed{
+\mathcal J(x;\theta,\phi)
+=
+\underbrace{\frac12\|x-D_\phi(E_\theta(x))\|_2^2}_{\mathcal L_{\rm rec}}
++
+\lambda\underbrace{\Omega(x;\theta)}_{\rm refinement}
++
+\eta\underbrace{Q_\Psi(x;\theta)}_{\rm quantum\text{-}inspired\ observable}
+}
+\]
+
+with \(\lambda\ge 0\) and \(\eta\ge 0\).
+
+Unlike the submitted `eta * Psi(x)` expression, every term above is real-valued, so gradients and ordering comparisons are defined.
+
+---
+
+## 3. Reconstruction term
+
+\[
+\boxed{
+\mathcal L_{\rm rec}(x)
+=
+\frac12\|x-\hat x\|_2^2
+=
+\frac12\sum_{i=1}^{n}(x_i-\hat x_i)^2
+}
+\]
+
+This is the classical autoencoder term and is implemented directly by `reconstruction_loss`.
+
+---
+
+## 4. Self-refinement term
+
+A dimensionally valid refinement functional is
+
+\[
+\boxed{
+\Omega(x;\theta)
+=
+w_H H(p(x))
++
+\frac{w_J}{2}\|J_{E_\theta}(x)\|_F^2
+}
+\]
+
+where
+
+\[
+H(p)=-\sum_i p_i\log_2p_i,
+\qquad
+J_{E_\theta}(x)=\left[\frac{\partial (E_\theta)_j}{\partial x_i}\right]_{j,i}.
+\]
+
+This replaces the diagonal-only expression
+
+\[
+\sum_j\left|\frac{\partial E_j}{\partial x_j}\right|,
+\]
+
+which is undefined as a general rule when \(m\ne n\) and ignores off-diagonal sensitivity.
+
+The implementation requires `p` to be an explicit normalized probability distribution. The repository does not silently infer what semantic object `p` represents; that choice belongs to the model definition.
+
+---
+
+## 5. Quantum-inspired state
+
+The Gaussian basis is corrected to its n-dimensional normalization:
+
+\[
+\boxed{
+\phi_k(x)
+=
+(2\pi\sigma_k^2)^{-n/2}
+\exp\left[-\frac{\|x-\mu_k\|_2^2}{2\sigma_k^2}\right]
+}
+\]
+
+and the complex components are
+
+\[
+\psi_k(x)=\alpha_k\phi_k(x)e^{i\vartheta_k}.
+\]
+
+The state vector is
+
+\[
+|\Psi(x)\rangle=(\psi_1,\ldots,\psi_K)^T,
+\]
+
+normalized so that
+
+\[
+\langle\Psi|\Psi\rangle=\sum_k|\psi_k|^2=1.
+\]
+
+The phase of a complex component is computed with the quadrant-correct function
+
+\[
+\vartheta_k=\operatorname{atan2}(\Im z_k,\Re z_k),
+\]
+
+not a one-argument arctangent ratio.
+
+---
+
+## 6. Real quantum-inspired contribution
+
+A complex wavefunction cannot be added directly to a scalar loss. The executable form uses the expectation of an explicitly Hermitian operator \(H_q=H_q^\dagger\):
+
+\[
+\boxed{
+Q_\Psi
+=
+\frac{\langle\Psi|H_q|\Psi\rangle}
+     {\langle\Psi|\Psi\rangle}
+\in\mathbb R.
+}
+\]
+
+The reference implementation validates Hermiticity numerically and rejects a non-Hermitian operator.
+
+This is **quantum-inspired mathematics**. It is not evidence of quantum entanglement, quantum speedup, quantum hardware execution, or physical wavefunction dynamics. Those claims would require a separate physical model and experimental validation.
+
+---
+
+## 7. Parameter optimization
+
+Training updates model parameters, not the input sample:
+
+\[
+\boxed{
+\theta_{t+1}=\theta_t-\alpha\nabla_\theta\mathcal J,
+\qquad
+\phi_{t+1}=\phi_t-\alpha\nabla_\phi\mathcal J.
+}
+\]
+
+An update of the form
+
+\[
+x_{t+1}=x_t-\alpha\nabla_x\mathcal J
+\]
+
+is instead an input-optimization or inference procedure. It may be useful, but it is not the ordinary autoencoder training update and must be labeled separately.
+
+---
+
+## 8. Correct derivative of the contractive term
+
+For a scalar function \(f\),
+
+\[
+\nabla_x\left(\frac12\|\nabla f(x)\|_2^2\right)
+=
+\nabla^2f(x)\,\nabla f(x),
+\]
+
+not simply \(\nabla^2 f(x)\).
+
+For the vector-valued encoder \(E_\theta\), differentiating
+
+\[
+\frac12\|J_{E_\theta}(x)\|_F^2
+\]
+
+requires contraction of the encoder Jacobian with its second derivatives. The implementation therefore evaluates the penalty itself but does not invent a model-independent closed-form gradient.
+
+---
+
+## 9. Entropy derivative
+
+If \(p_i=p_i(x)\), then
+
+\[
+\nabla_x H(p(x))
+=-\sum_i \nabla_xp_i
+\left(\log_2p_i+\frac{1}{\ln2}\right).
+\]
+
+When \(\sum_i p_i=1\), the constant term can cancel after summation because \(\sum_i\nabla p_i=0\), but that cancellation depends on an actually normalized differentiable parameterization.
+
+---
+
+## 10. Spectral forms are conditional special cases
+
+The expressions
+
+\[
+E(x)=\sum_k\lambda_k\langle x,v_k\rangle v_k
+\]
+
+and
+
+\[
+E(x)=U\Sigma V^Tx
+\]
+
+are valid only when the encoder is being treated as a linear operator with the corresponding spectral/SVD assumptions. They are not identities for a nonlinear neural encoder such as
+
+\[
+E_\theta(x)=\sigma(W_ex+b_e).
+\]
+
+The repository therefore treats spectral decompositions as analysis tools or special linear cases, not as universal definitions of the encoder.
+
+---
+
+## 11. Complex-domain extension
+
+A complex encoder may be defined independently as
+
+\[
+E_c:\mathbb C^n\rightarrow\mathbb C^m.
+\]
+
+A Hilbert-transform construction is meaningful only when the input has an ordered signal axis on which the Hilbert transform is defined. It is not a universal operation on arbitrary vectors or 3D fields without specifying the transform axis and boundary convention.
+
+A complex-valued reconstruction objective should remain real, for example
+
+\[
+\mathcal J_c
+=\|x-D_c(E_c(x))\|_2^2+\lambda\|E_c(x)\|_1,
+\]
+
+where \(\|u\|_2^2=\sum_i|u_i|^2\).
+
+---
+
+## 12. Time-dependent equations
+
+A physically or numerically meaningful dynamic extension must state what object evolves.
+
+For latent-state refinement, one valid gradient flow is
+
+\[
+\boxed{
+\frac{dz}{dt}=-\gamma\nabla_z\mathcal J_z(z),\qquad \gamma>0.
+}
+\]
+
+A Schrödinger-type equation
+
+\[
+i\hbar\frac{\partial\Psi}{\partial t}=H\Psi
+\]
+
+requires a self-adjoint Hamiltonian and an explicitly defined state space. If the autoencoder objective is inserted as a multiplicative potential, that potential must be real. This remains a quantum-inspired dynamical model unless tied to an actual physical quantum system.
+
+---
+
+## 13. Invariance claims
+
+The following properties are **not automatic invariants** of a tanh/affine autoencoder:
+
+* translation invariance;
+* scale invariance;
+* rotation invariance;
+* global phase invariance.
+
+They become valid only when enforced by architecture, preprocessing, group-equivariant operators, loss construction, or explicit proof.
+
+For example, rotation invariance requires an encoder/decoder or objective satisfying the relevant group action, not merely \(R^TR=I\).
+
+---
+
+## 14. Convergence claims
+
+For a nonlinear neural autoencoder, the total objective is generally non-convex. Therefore strong convexity and a Polyak-Lojasiewicz inequality cannot be asserted globally without proof.
+
+Safe conditional statements are:
+
+* if \(\nabla\mathcal J\) is L-Lipschitz on the region visited by optimization and the step size is chosen appropriately, standard smooth-optimization descent bounds may apply;
+* if a PL inequality is established on a specified domain, the corresponding convergence rate follows on that domain;
+* if a deployment update operator is contractive on a complete feasible state space, Banach fixed-point convergence follows for that operator.
+
+The existing v4 runtime already uses the same conditional style for its contractivity claim.
+
+---
+
+## 15. Energy conservation
+
+Gradient descent is dissipative and does not in general conserve
+
+\[
+E_{\rm kinetic}+E_{\rm potential}+E_{\rm quantum}.
+\]
+
+Energy conservation requires a conservative continuous-time system or an appropriate structure-preserving numerical integrator. It must not be declared as a generic property of autoencoder training.
+
+---
+
+## 16. Corrected compact form
+
+The implementation-ready mathematical statement is
+
+\[
+\boxed{
+\begin{aligned}
+z &= E_\theta(x),\\
+\hat x &= D_\phi(z),\\
+\Omega(x;\theta)
+&=w_HH(p(x))+\frac{w_J}{2}\|J_{E_\theta}(x)\|_F^2,\\
+Q_\Psi(x;\theta)
+&=\langle\Psi(x)|H_q|\Psi(x)\rangle,\\
+\mathcal J(x;\theta,\phi)
+&=\frac12\|x-\hat x\|_2^2+\lambda\Omega(x;\theta)+\eta Q_\Psi(x;\theta),\\
+\theta_{t+1}&=\theta_t-\alpha\nabla_\theta\mathcal J,\\
+\phi_{t+1}&=\phi_t-\alpha\nabla_\phi\mathcal J,
+\end{aligned}
+}
+\]
+
+subject to
+
+\[
+\sum_i p_i=1,\quad p_i\ge0,
+\]
+
+\[
+\langle\Psi|\Psi\rangle=1,
+\]
+
+and
+
+\[
+H_q=H_q^\dagger.
+\]
+
+This is the authoritative differentiable form implemented by the new reference module.
+
+---
+
+## 17. Relationship to the deterministic 3D engine
+
+The repository now has two deliberately distinct mathematical layers:
+
+1. **Differentiable research/training layer** — this document and `moagi_autoencoding_equation.py`. It uses real/complex floating-point mathematics to define and evaluate the training objective.
+2. **Deterministic deployment/runtime layer** — `Dr_Moagi_Equation_3D_Autoencoder_v4.txt` and the Q16.16 transactional engine. It uses bounded fixed-point state, validity projection, residual memory, and auditable commit semantics.
+
+A valid bridge is
+
+\[
+(\theta,\phi)_{\rm trained}
+\xrightarrow{\text{quantize/calibrate}}
+(\Theta,\Phi)_{\rm Q16.16}
+\xrightarrow{\text{validate}}
+\text{transactional 3D runtime}.
+\]
+
+The differentiable equation therefore trains or analyzes model parameters; it does not supersede the execution contract of the deterministic runtime.
+
+---
+
+## 18. Conformance requirements
+
+The reference implementation tests the following properties:
+
+1. reconstruction loss is exactly half squared Euclidean error;
+2. entropy inputs must form a probability distribution;
+3. the refinement penalty uses the full encoder Jacobian;
+4. Gaussian basis normalization is dimension-correct;
+5. complex phase uses `atan2` semantics;
+6. wavefunctions are explicitly normalized;
+7. quantum-inspired energy is the real expectation of a Hermitian operator;
+8. non-Hermitian operators are rejected;
+9. the total objective is finite and real;
+10. non-zero quantum coupling requires an explicit state and operator;
+11. parameter gradient steps update parameters rather than silently optimizing the input.
+
+---
+
+## 19. Provenance distinction
+
+The original supplied formulation introduced the combined reconstruction, self-refinement, entropy/Jacobian, phase/wavefunction, spectral, information-theoretic, complex-domain, time-dependent, and optimization ideas under the name **Dr. Moagi's Auto-Encoding Equation**.
+
+The notation repair, dimensional corrections, Hermitian expectation-value objective, conditional convergence language, and split between differentiable training semantics and deterministic Q16.16 deployment semantics are engineering/mathematical refinements introduced during repository integration so that the formulation can be tested without overstating what has been proven.

--- a/src/jarvisx/moagi_autoencoding_equation.py
+++ b/src/jarvisx/moagi_autoencoding_equation.py
@@ -1,0 +1,319 @@
+"""Reference objective for Dr. Moagi's auto-encoding equation.
+
+This module turns the submitted mathematical formulation into an executable,
+dimensionally consistent research objective while preserving an important
+separation of concerns:
+
+* ``encoder`` is a vector-valued map E_theta: R^n -> R^m.
+* ``decoder`` is a vector-valued map D_phi: R^m -> R^n.
+* ``J`` is the scalar objective that is minimized during training.
+* the quantum-inspired contribution is a real expectation value of a Hermitian
+  operator, not a complex-valued loss and not a claim of quantum execution.
+
+The deterministic Q16.16 runtime remains a separate deployment substrate.  This
+module is intended for research/training-time evaluation and conformance tests.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+Vector = tuple[float, ...]
+Matrix = tuple[tuple[float, ...], ...]
+ComplexVector = tuple[complex, ...]
+ComplexMatrix = tuple[tuple[complex, ...], ...]
+Encoder = Callable[[Vector], Sequence[float]]
+Decoder = Callable[[Vector], Sequence[float]]
+
+
+def _finite_vector(values: Sequence[float], *, name: str) -> Vector:
+    result = tuple(float(value) for value in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if not all(math.isfinite(value) for value in result):
+        raise ValueError(f"{name} must contain only finite values")
+    return result
+
+
+def _finite_matrix(values: Sequence[Sequence[float]], *, name: str) -> Matrix:
+    rows = tuple(_finite_vector(row, name=f"{name} row") for row in values)
+    if not rows:
+        raise ValueError(f"{name} must not be empty")
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise ValueError(f"{name} must be rectangular")
+    return rows
+
+
+def _finite_complex_vector(values: Sequence[complex], *, name: str) -> ComplexVector:
+    result = tuple(complex(value) for value in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if not all(math.isfinite(value.real) and math.isfinite(value.imag) for value in result):
+        raise ValueError(f"{name} must contain only finite values")
+    return result
+
+
+def _finite_complex_matrix(values: Sequence[Sequence[complex]], *, name: str) -> ComplexMatrix:
+    rows = tuple(_finite_complex_vector(row, name=f"{name} row") for row in values)
+    if not rows:
+        raise ValueError(f"{name} must not be empty")
+    width = len(rows[0])
+    if any(len(row) != width for row in rows):
+        raise ValueError(f"{name} must be rectangular")
+    return rows
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value) or value < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return value
+
+
+def reconstruction_loss(x: Sequence[float], x_hat: Sequence[float]) -> float:
+    """Return 1/2 ||x - x_hat||_2^2."""
+
+    left = _finite_vector(x, name="x")
+    right = _finite_vector(x_hat, name="x_hat")
+    if len(left) != len(right):
+        raise ValueError("x and x_hat must have the same dimension")
+    return 0.5 * sum((a - b) ** 2 for a, b in zip(left, right))
+
+
+def shannon_entropy(probabilities: Sequence[float], *, tolerance: float = 1e-9) -> float:
+    """Return Shannon entropy in bits for a normalized discrete distribution."""
+
+    tolerance = _non_negative(tolerance, name="tolerance")
+    values = _finite_vector(probabilities, name="probabilities")
+    if any(value < 0.0 or value > 1.0 for value in values):
+        raise ValueError("probabilities must lie within [0, 1]")
+    if not math.isclose(sum(values), 1.0, rel_tol=0.0, abs_tol=tolerance):
+        raise ValueError("probabilities must sum to one")
+    return -sum(value * math.log2(value) for value in values if value > 0.0)
+
+
+def contractive_penalty(encoder_jacobian: Sequence[Sequence[float]]) -> float:
+    """Return 1/2 ||J_E(x)||_F^2 for the full encoder Jacobian."""
+
+    jacobian = _finite_matrix(encoder_jacobian, name="encoder_jacobian")
+    return 0.5 * sum(value * value for row in jacobian for value in row)
+
+
+def refinement_energy(
+    probabilities: Sequence[float] | None = None,
+    encoder_jacobian: Sequence[Sequence[float]] | None = None,
+    *,
+    entropy_weight: float = 1.0,
+    jacobian_weight: float = 1.0,
+) -> float:
+    """Return a real, non-negative self-refinement regularizer.
+
+    Omega(x) = w_H H(p(x)) + w_J/2 ||J_E(x)||_F^2.
+    Either component may be omitted explicitly.
+    """
+
+    entropy_weight = _non_negative(entropy_weight, name="entropy_weight")
+    jacobian_weight = _non_negative(jacobian_weight, name="jacobian_weight")
+    entropy = 0.0 if probabilities is None else shannon_entropy(probabilities)
+    contractive = 0.0 if encoder_jacobian is None else contractive_penalty(encoder_jacobian)
+    return entropy_weight * entropy + jacobian_weight * contractive
+
+
+def gaussian_basis(x: Sequence[float], mean: Sequence[float], sigma: float) -> float:
+    """Return an isotropic n-dimensional normalized Gaussian density value."""
+
+    point = _finite_vector(x, name="x")
+    centre = _finite_vector(mean, name="mean")
+    if len(point) != len(centre):
+        raise ValueError("x and mean must have the same dimension")
+    sigma = float(sigma)
+    if not math.isfinite(sigma) or sigma <= 0.0:
+        raise ValueError("sigma must be finite and positive")
+    dimension = len(point)
+    squared_distance = sum((value - mu) ** 2 for value, mu in zip(point, centre))
+    normalizer = (2.0 * math.pi * sigma * sigma) ** (-dimension / 2.0)
+    return normalizer * math.exp(-squared_distance / (2.0 * sigma * sigma))
+
+
+def phase_angle(value: complex) -> float:
+    """Return the quadrant-correct phase angle atan2(Im(z), Re(z))."""
+
+    value = complex(value)
+    if not math.isfinite(value.real) or not math.isfinite(value.imag):
+        raise ValueError("value must be finite")
+    return math.atan2(value.imag, value.real)
+
+
+def wavefunction_components(
+    x: Sequence[float],
+    means: Sequence[Sequence[float]],
+    sigmas: Sequence[float],
+    amplitudes: Sequence[complex],
+    phases: Sequence[float],
+) -> ComplexVector:
+    """Construct quantum-inspired basis amplitudes alpha_k phi_k(x) exp(i theta_k)."""
+
+    point = _finite_vector(x, name="x")
+    means_tuple = tuple(tuple(float(value) for value in mean) for mean in means)
+    sigmas_tuple = tuple(float(value) for value in sigmas)
+    amplitudes_tuple = _finite_complex_vector(amplitudes, name="amplitudes")
+    phases_tuple = tuple(float(value) for value in phases)
+    count = len(means_tuple)
+    if not count or not (len(sigmas_tuple) == len(amplitudes_tuple) == len(phases_tuple) == count):
+        raise ValueError("means, sigmas, amplitudes, and phases must have equal non-zero length")
+    if any(len(mean) != len(point) for mean in means_tuple):
+        raise ValueError("every mean must match x dimension")
+    if not all(math.isfinite(phase) for phase in phases_tuple):
+        raise ValueError("phases must contain only finite values")
+
+    return tuple(
+        amplitude * gaussian_basis(point, mean, sigma) * cmath.exp(1j * phase)
+        for mean, sigma, amplitude, phase in zip(
+            means_tuple, sigmas_tuple, amplitudes_tuple, phases_tuple
+        )
+    )
+
+
+def normalize_wavefunction(psi: Sequence[complex]) -> ComplexVector:
+    """Normalize a finite complex state so that sum |psi_k|^2 = 1."""
+
+    state = _finite_complex_vector(psi, name="psi")
+    norm_squared = sum(abs(value) ** 2 for value in state)
+    if norm_squared <= 0.0:
+        raise ValueError("psi must have non-zero norm")
+    norm = math.sqrt(norm_squared)
+    return tuple(value / norm for value in state)
+
+
+def expectation_value(
+    psi: Sequence[complex],
+    hamiltonian: Sequence[Sequence[complex]],
+    *,
+    hermitian_tolerance: float = 1e-10,
+) -> float:
+    """Return the real normalized expectation <psi|H|psi> for Hermitian H."""
+
+    tolerance = _non_negative(hermitian_tolerance, name="hermitian_tolerance")
+    state = normalize_wavefunction(psi)
+    matrix = _finite_complex_matrix(hamiltonian, name="hamiltonian")
+    dimension = len(state)
+    if len(matrix) != dimension or any(len(row) != dimension for row in matrix):
+        raise ValueError("hamiltonian must be square with wavefunction dimension")
+
+    for row in range(dimension):
+        for col in range(dimension):
+            if abs(matrix[row][col] - matrix[col][row].conjugate()) > tolerance:
+                raise ValueError("hamiltonian must be Hermitian")
+
+    transformed = tuple(
+        sum(matrix[row][col] * state[col] for col in range(dimension))
+        for row in range(dimension)
+    )
+    value = sum(state[row].conjugate() * transformed[row] for row in range(dimension))
+    if abs(value.imag) > tolerance:
+        raise ValueError("Hermitian expectation must be real within tolerance")
+    return float(value.real)
+
+
+@dataclass(frozen=True)
+class MoagiObjectiveConfig:
+    """Weights for the corrected scalar Dr. Moagi autoencoding objective."""
+
+    lambda_refinement: float = 0.0
+    eta_quantum: float = 0.0
+    entropy_weight: float = 1.0
+    jacobian_weight: float = 1.0
+    hermitian_tolerance: float = 1e-10
+
+    def __post_init__(self) -> None:
+        _non_negative(self.lambda_refinement, name="lambda_refinement")
+        _non_negative(self.eta_quantum, name="eta_quantum")
+        _non_negative(self.entropy_weight, name="entropy_weight")
+        _non_negative(self.jacobian_weight, name="jacobian_weight")
+        _non_negative(self.hermitian_tolerance, name="hermitian_tolerance")
+
+
+@dataclass(frozen=True)
+class MoagiObjectiveTerms:
+    """Auditable decomposition of one objective evaluation."""
+
+    latent: Vector
+    reconstruction: Vector
+    reconstruction_loss: float
+    refinement: float
+    quantum_expectation: float
+    total: float
+
+
+def evaluate_autoencoding_objective(
+    x: Sequence[float],
+    encoder: Encoder,
+    decoder: Decoder,
+    *,
+    probabilities: Sequence[float] | None = None,
+    encoder_jacobian: Sequence[Sequence[float]] | None = None,
+    wavefunction: Sequence[complex] | None = None,
+    hamiltonian: Sequence[Sequence[complex]] | None = None,
+    config: MoagiObjectiveConfig | None = None,
+) -> MoagiObjectiveTerms:
+    """Evaluate the corrected Dr. Moagi scalar objective.
+
+    J(x; theta, phi) = L_rec + lambda * Omega + eta * <psi|H_q|psi>.
+
+    The caller supplies probabilities and the encoder Jacobian because their
+    definitions depend on the selected model.  A non-zero quantum coefficient
+    requires both a wavefunction and a Hermitian operator.
+    """
+
+    cfg = config or MoagiObjectiveConfig()
+    point = _finite_vector(x, name="x")
+    latent = _finite_vector(encoder(point), name="encoder output")
+    reconstruction = _finite_vector(decoder(latent), name="decoder output")
+    if len(reconstruction) != len(point):
+        raise ValueError("decoder output must match x dimension")
+
+    recon = reconstruction_loss(point, reconstruction)
+    omega = refinement_energy(
+        probabilities,
+        encoder_jacobian,
+        entropy_weight=cfg.entropy_weight,
+        jacobian_weight=cfg.jacobian_weight,
+    )
+
+    if (wavefunction is None) != (hamiltonian is None):
+        raise ValueError("wavefunction and hamiltonian must be supplied together")
+    if cfg.eta_quantum > 0.0 and wavefunction is None:
+        raise ValueError("eta_quantum > 0 requires a wavefunction and hamiltonian")
+    quantum = (
+        0.0
+        if wavefunction is None
+        else expectation_value(
+            wavefunction,
+            hamiltonian or (),
+            hermitian_tolerance=cfg.hermitian_tolerance,
+        )
+    )
+
+    total = recon + cfg.lambda_refinement * omega + cfg.eta_quantum * quantum
+    if not math.isfinite(total):
+        raise ValueError("objective must be finite and real")
+    return MoagiObjectiveTerms(latent, reconstruction, recon, omega, quantum, total)
+
+
+def gradient_step(
+    parameters: Sequence[float], gradient: Sequence[float], learning_rate: float
+) -> Vector:
+    """Apply theta_{t+1} = theta_t - alpha * grad(theta_t)."""
+
+    params = _finite_vector(parameters, name="parameters")
+    grad = _finite_vector(gradient, name="gradient")
+    if len(params) != len(grad):
+        raise ValueError("parameters and gradient must have the same dimension")
+    learning_rate = float(learning_rate)
+    if not math.isfinite(learning_rate) or learning_rate <= 0.0:
+        raise ValueError("learning_rate must be finite and positive")
+    return tuple(value - learning_rate * derivative for value, derivative in zip(params, grad))

--- a/tests/test_moagi_autoencoding_equation.py
+++ b/tests/test_moagi_autoencoding_equation.py
@@ -1,0 +1,123 @@
+import math
+
+import pytest
+
+from jarvisx.moagi_autoencoding_equation import (
+    MoagiObjectiveConfig,
+    contractive_penalty,
+    evaluate_autoencoding_objective,
+    expectation_value,
+    gaussian_basis,
+    gradient_step,
+    normalize_wavefunction,
+    phase_angle,
+    reconstruction_loss,
+    refinement_energy,
+    shannon_entropy,
+    wavefunction_components,
+)
+
+
+def test_reconstruction_loss_matches_half_squared_l2():
+    assert reconstruction_loss((1.0, 2.0), (0.0, 4.0)) == pytest.approx(2.5)
+
+
+def test_shannon_entropy_uses_normalized_distribution_in_bits():
+    assert shannon_entropy((0.5, 0.5)) == pytest.approx(1.0)
+    assert shannon_entropy((1.0, 0.0)) == pytest.approx(0.0)
+
+    with pytest.raises(ValueError, match="sum to one"):
+        shannon_entropy((0.4, 0.4))
+
+
+def test_contractive_penalty_uses_full_encoder_jacobian():
+    jacobian = ((1.0, 2.0), (3.0, 4.0))
+    assert contractive_penalty(jacobian) == pytest.approx(15.0)
+
+
+def test_refinement_energy_combines_entropy_and_jacobian_terms():
+    omega = refinement_energy(
+        probabilities=(0.5, 0.5),
+        encoder_jacobian=((1.0, 0.0),),
+        entropy_weight=2.0,
+        jacobian_weight=3.0,
+    )
+    assert omega == pytest.approx(3.5)
+
+
+def test_gaussian_basis_has_correct_n_dimensional_normalizer():
+    value = gaussian_basis((0.0, 0.0), (0.0, 0.0), 1.0)
+    assert value == pytest.approx(1.0 / (2.0 * math.pi))
+
+
+def test_phase_angle_uses_quadrant_correct_atan2():
+    assert phase_angle(complex(-1.0, 1.0)) == pytest.approx(3.0 * math.pi / 4.0)
+
+
+def test_wavefunction_components_preserve_complex_phase_and_normalize():
+    psi = wavefunction_components(
+        x=(0.0,),
+        means=((0.0,), (1.0,)),
+        sigmas=(1.0, 1.0),
+        amplitudes=(1.0 + 0.0j, 1.0 + 0.0j),
+        phases=(0.0, math.pi / 2.0),
+    )
+    assert len(psi) == 2
+    state = normalize_wavefunction(psi)
+    assert sum(abs(value) ** 2 for value in state) == pytest.approx(1.0)
+    assert abs(psi[0].imag) < 1e-12
+    assert psi[1].imag > 0.0
+
+
+def test_expectation_value_is_real_for_hermitian_operator():
+    psi = (1.0 + 0.0j, 1.0j)
+    hamiltonian = ((1.0, 0.0), (0.0, 3.0))
+    assert expectation_value(psi, hamiltonian) == pytest.approx(2.0)
+
+
+def test_expectation_value_rejects_non_hermitian_operator():
+    with pytest.raises(ValueError, match="Hermitian"):
+        expectation_value((1.0, 0.0), ((1.0, 1.0), (0.0, 1.0)))
+
+
+def test_objective_is_scalar_real_and_auditable():
+    encoder = lambda x: (x[0] + x[1],)
+    decoder = lambda z: (z[0] / 2.0, z[0] / 2.0)
+    config = MoagiObjectiveConfig(lambda_refinement=0.2, eta_quantum=0.1)
+
+    result = evaluate_autoencoding_objective(
+        (1.0, 3.0),
+        encoder,
+        decoder,
+        probabilities=(0.25, 0.75),
+        encoder_jacobian=((1.0, 1.0),),
+        wavefunction=(1.0 + 0.0j, 0.0 + 1.0j),
+        hamiltonian=((1.0, 0.0), (0.0, 3.0)),
+        config=config,
+    )
+
+    assert result.latent == pytest.approx((4.0,))
+    assert result.reconstruction == pytest.approx((2.0, 2.0))
+    assert result.reconstruction_loss == pytest.approx(1.0)
+    assert isinstance(result.total, float)
+    assert math.isfinite(result.total)
+    assert result.total == pytest.approx(
+        result.reconstruction_loss
+        + config.lambda_refinement * result.refinement
+        + config.eta_quantum * result.quantum_expectation
+    )
+
+
+def test_nonzero_quantum_weight_requires_explicit_state_and_operator():
+    with pytest.raises(ValueError, match="eta_quantum"):
+        evaluate_autoencoding_objective(
+            (1.0,),
+            lambda x: x,
+            lambda z: z,
+            config=MoagiObjectiveConfig(eta_quantum=1.0),
+        )
+
+
+def test_gradient_step_updates_parameters_not_input_state():
+    updated = gradient_step((1.0, -2.0), (0.5, -1.0), 0.1)
+    assert updated == pytest.approx((0.95, -1.9))


### PR DESCRIPTION
## Summary

Integrates the submitted **Dr. Moagi Auto-Encoding Equation** as a separate differentiable research/training layer without replacing the existing deterministic Q16.16 3D runtime.

### Added
- `docs/research/DR_MOAGI_AUTOENCODING_EQUATION.md`
  - preserves provenance of the submitted formulation
  - separates encoder `E_theta` from scalar objective `J`
  - makes convergence/invariance claims explicitly conditional
  - distinguishes quantum-inspired mathematics from physical quantum execution
  - defines the bridge from trained floating-point parameters to the Q16.16 deployment engine
- `src/jarvisx/moagi_autoencoding_equation.py`
  - reconstruction loss
  - Shannon entropy validation
  - full-Jacobian contractive refinement
  - n-dimensional Gaussian basis
  - quadrant-correct phase handling
  - normalized complex wavefunction components
  - Hermitian expectation-value quantum-inspired term
  - auditable scalar objective decomposition
  - parameter gradient-step primitive
- `tests/test_moagi_autoencoding_equation.py`
  - numerical and validation coverage for the corrected contract

## Mathematical repairs

The submitted formulation has several issues that prevent direct execution as written:

1. `E` is used as both a vector-valued encoder and a scalar loss.
2. `eta * Psi(x)` can make the optimization objective complex.
3. the diagonal-only derivative regularizer is not a general encoder Jacobian penalty.
4. the Gaussian normalization is one-dimensional while `x` is n-dimensional.
5. phase extraction should use `atan2(Im, Re)` rather than a one-argument ratio.
6. adding `lambda * grad Omega(z)` to the decoder is dimensionally undefined unless a latent-space `Omega` is separately specified.
7. the stated gradient of the Jacobian/gradient-norm term omits the required Hessian-gradient contraction.
8. spectral/SVD forms only define linear special cases, not a nonlinear neural encoder.
9. translation/scale/rotation/phase invariance are architectural conditions, not automatic properties.
10. strong convexity, PL convergence, and energy conservation are not generic neural-autoencoder guarantees.

## Corrected objective

`J = L_rec + lambda * Omega + eta * <Psi|H_q|Psi>`

where `H_q` is explicitly Hermitian, making the quantum-inspired contribution real and testable.

## Compatibility

No existing runtime files are modified. The current `docs/Dr_Moagi_Equation_3D_Autoencoder_v4.txt` remains the deterministic deployment contract.