### PR TITLE
Add deterministic sparse HFT field engine

### DIFF
--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -80,6 +80,18 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_hazard_guard.sv
           vvp build/hft-rtl/hft_hazard.vvp
 
+      - name: Icarus guarded transaction pipeline regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_guarded_pipeline \
+            -o build/hft-rtl/hft_guarded.vvp \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/hft_field_cell_staged.sv \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv \
+            rtl/hft_field_q16/hft_field_guarded_pipeline.sv \
+            rtl/hft_field_q16/tb_hft_field_guarded_pipeline.sv
+          vvp build/hft-rtl/hft_guarded.vvp
+
       - name: Verilator lint
         run: |
           verilator --lint-only --sv -Wall -Wno-fatal \
@@ -93,6 +105,10 @@ jobs:
             rtl/hft_field_q16/hft_field_cell_staged.sv
           verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_hazard_guard \
             rtl/hft_field_q16/hft_field_hazard_guard.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_guarded_pipeline \
+            rtl/hft_field_q16/hft_field_cell_staged.sv \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv \
+            rtl/hft_field_q16/hft_field_guarded_pipeline.sv
 
       - name: Yosys reference synthesis
         run: |
@@ -119,6 +135,11 @@ jobs:
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_hazard_guard.sv; hierarchy -check -top hft_field_hazard_guard; proc; opt; check; synth -top hft_field_hazard_guard; stat' \
             | tee build/hft-rtl/hazard-synth.log
 
+      - name: Yosys guarded-pipeline synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_staged.sv rtl/hft_field_q16/hft_field_hazard_guard.sv rtl/hft_field_q16/hft_field_guarded_pipeline.sv; hierarchy -check -top hft_field_guarded_pipeline; proc; opt; check; synth -top hft_field_guarded_pipeline; stat' \
+            | tee build/hft-rtl/guarded-synth.log
+
       - name: Report generic gate counts
         run: |
           echo "Reference core:"
@@ -131,3 +152,5 @@ jobs:
           grep -A 20 '^=== hft_field_cell_staged ===' build/hft-rtl/staged-synth.log | tail -n 20
           echo "Hazard guard:"
           grep -A 20 '^=== hft_field_hazard_guard ===' build/hft-rtl/hazard-synth.log | tail -n 20
+          echo "Guarded staged pipeline:"
+          grep -A 20 '^=== hft_field_guarded_pipeline ===' build/hft-rtl/guarded-synth.log | tail -n 20

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -51,12 +51,36 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_pow2_equiv.sv
           vvp build/hft-rtl/hft_pow2_equiv.vvp
 
+      - name: Icarus fixed-latency pipeline regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_cell_pipeline \
+            -o build/hft-rtl/hft_pipeline.vvp \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/hft_field_cell_pipeline.sv \
+            rtl/hft_field_q16/tb_hft_field_cell_pipeline.sv
+          vvp build/hft-rtl/hft_pipeline.vvp
+
+      - name: Icarus coordinate hazard regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_hazard_guard \
+            -o build/hft-rtl/hft_hazard.vvp \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv \
+            rtl/hft_field_q16/tb_hft_field_hazard_guard.sv
+          vvp build/hft-rtl/hft_hazard.vvp
+
       - name: Verilator lint
         run: |
           verilator --lint-only --sv -Wall -Wno-fatal \
             rtl/hft_field_q16/hft_field_cell_core.sv
           verilator --lint-only --sv -Wall -Wno-fatal \
             rtl/hft_field_q16/hft_field_cell_pow2.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_cell_pipeline \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/hft_field_cell_pipeline.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_hazard_guard \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv
 
       - name: Yosys reference synthesis
         run: |
@@ -68,9 +92,23 @@ jobs:
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_pow2.sv; hierarchy -check -top hft_field_cell_pow2; proc; opt; check; synth -top hft_field_cell_pow2; stat' \
             | tee build/hft-rtl/pow2-synth.log
 
+      - name: Yosys registered-shell synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_pow2.sv rtl/hft_field_q16/hft_field_cell_pipeline.sv; hierarchy -check -top hft_field_cell_pipeline; proc; opt; check; synth -top hft_field_cell_pipeline; stat' \
+            | tee build/hft-rtl/pipeline-synth.log
+
+      - name: Yosys hazard-guard synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_hazard_guard.sv; hierarchy -check -top hft_field_hazard_guard; proc; opt; check; synth -top hft_field_hazard_guard; stat' \
+            | tee build/hft-rtl/hazard-synth.log
+
       - name: Report generic gate counts
         run: |
           echo "Reference core:"
           grep -A 20 '^=== hft_field_cell_core ===' build/hft-rtl/reference-synth.log | tail -n 20
           echo "Multiplier-free core:"
           grep -A 20 '^=== hft_field_cell_pow2 ===' build/hft-rtl/pow2-synth.log | tail -n 20
+          echo "Registered latency shell:"
+          grep -A 20 '^=== hft_field_cell_pipeline ===' build/hft-rtl/pipeline-synth.log | tail -n 20
+          echo "Hazard guard:"
+          grep -A 20 '^=== hft_field_hazard_guard ===' build/hft-rtl/hazard-synth.log | tail -n 20

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -92,6 +92,20 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_guarded_pipeline.sv
           vvp build/hft-rtl/hft_guarded.vvp
 
+      - name: Icarus persistent center-state recurrence
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_stateful_center \
+            -o build/hft-rtl/hft_stateful.vvp \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/hft_field_cell_staged.sv \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv \
+            rtl/hft_field_q16/hft_field_guarded_pipeline.sv \
+            rtl/hft_field_q16/hft_field_state_store.sv \
+            rtl/hft_field_q16/hft_field_stateful_center.sv \
+            rtl/hft_field_q16/tb_hft_field_stateful_center.sv
+          vvp build/hft-rtl/hft_stateful.vvp
+
       - name: Verilator lint
         run: |
           verilator --lint-only --sv -Wall -Wno-fatal \
@@ -109,6 +123,12 @@ jobs:
             rtl/hft_field_q16/hft_field_cell_staged.sv \
             rtl/hft_field_q16/hft_field_hazard_guard.sv \
             rtl/hft_field_q16/hft_field_guarded_pipeline.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_stateful_center \
+            rtl/hft_field_q16/hft_field_cell_staged.sv \
+            rtl/hft_field_q16/hft_field_hazard_guard.sv \
+            rtl/hft_field_q16/hft_field_guarded_pipeline.sv \
+            rtl/hft_field_q16/hft_field_state_store.sv \
+            rtl/hft_field_q16/hft_field_stateful_center.sv
 
       - name: Yosys reference synthesis
         run: |
@@ -140,6 +160,11 @@ jobs:
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_staged.sv rtl/hft_field_q16/hft_field_hazard_guard.sv rtl/hft_field_q16/hft_field_guarded_pipeline.sv; hierarchy -check -top hft_field_guarded_pipeline; proc; opt; check; synth -top hft_field_guarded_pipeline; stat' \
             | tee build/hft-rtl/guarded-synth.log
 
+      - name: Yosys stateful-center synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_staged.sv rtl/hft_field_q16/hft_field_hazard_guard.sv rtl/hft_field_q16/hft_field_guarded_pipeline.sv rtl/hft_field_q16/hft_field_state_store.sv rtl/hft_field_q16/hft_field_stateful_center.sv; hierarchy -check -top hft_field_stateful_center; proc; opt; check; synth -top hft_field_stateful_center; stat' \
+            | tee build/hft-rtl/stateful-synth.log
+
       - name: Report generic gate counts
         run: |
           echo "Reference core:"
@@ -154,3 +179,5 @@ jobs:
           grep -A 20 '^=== hft_field_hazard_guard ===' build/hft-rtl/hazard-synth.log | tail -n 20
           echo "Guarded staged pipeline:"
           grep -A 20 '^=== hft_field_guarded_pipeline ===' build/hft-rtl/guarded-synth.log | tail -n 20
+          echo "Stateful center engine:"
+          grep -A 20 '^=== hft_field_stateful_center ===' build/hft-rtl/stateful-synth.log | tail -n 20

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -31,7 +31,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y iverilog verilator yosys
 
-      - name: Icarus golden-vector simulation
+      - name: Icarus C++ golden-vector simulation
         run: |
           mkdir -p build/hft-rtl
           iverilog -g2012 \
@@ -41,12 +41,36 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_cell_core.sv
           vvp build/hft-rtl/hft_tb.vvp
 
+      - name: Icarus multiplier-free equivalence stress
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_pow2_equiv \
+            -o build/hft-rtl/hft_pow2_equiv.vvp \
+            rtl/hft_field_q16/hft_field_cell_core.sv \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/tb_hft_field_pow2_equiv.sv
+          vvp build/hft-rtl/hft_pow2_equiv.vvp
+
       - name: Verilator lint
         run: |
           verilator --lint-only --sv -Wall -Wno-fatal \
             rtl/hft_field_q16/hft_field_cell_core.sv
+          verilator --lint-only --sv -Wall -Wno-fatal \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv
 
-      - name: Yosys synthesizability check
+      - name: Yosys reference synthesis
         run: |
-          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_core.sv; hierarchy -check -top hft_field_cell_core; proc; opt; check; synth -top hft_field_cell_core; stat'
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_core.sv; hierarchy -check -top hft_field_cell_core; proc; opt; check; synth -top hft_field_cell_core; stat' \
+            | tee build/hft-rtl/reference-synth.log
 
+      - name: Yosys multiplier-free synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_pow2.sv; hierarchy -check -top hft_field_cell_pow2; proc; opt; check; synth -top hft_field_cell_pow2; stat' \
+            | tee build/hft-rtl/pow2-synth.log
+
+      - name: Report generic gate counts
+        run: |
+          echo "Reference core:"
+          grep -A 20 '^=== hft_field_cell_core ===' build/hft-rtl/reference-synth.log | tail -n 20
+          echo "Multiplier-free core:"
+          grep -A 20 '^=== hft_field_cell_pow2 ===' build/hft-rtl/pow2-synth.log | tail -n 20

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -1,0 +1,52 @@
+name: HFT Q16 RTL Equivalence
+
+on:
+  push:
+    paths:
+      - "rtl/hft_field_q16/**"
+      - "cpp_runtime/include/jarvisx/hft_field.hpp"
+      - ".github/workflows/hft-rtl.yml"
+  pull_request:
+    paths:
+      - "rtl/hft_field_q16/**"
+      - "cpp_runtime/include/jarvisx/hft_field.hpp"
+      - ".github/workflows/hft-rtl.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hft-rtl-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rtl-equivalence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install RTL tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iverilog verilator yosys
+
+      - name: Icarus golden-vector simulation
+        run: |
+          mkdir -p build/hft-rtl
+          iverilog -g2012 \
+            -s tb_hft_field_cell_core \
+            -o build/hft-rtl/hft_tb.vvp \
+            rtl/hft_field_q16/hft_field_cell_core.sv \
+            rtl/hft_field_q16/tb_hft_field_cell_core.sv
+          vvp build/hft-rtl/hft_tb.vvp
+
+      - name: Verilator lint
+        run: |
+          verilator --lint-only --sv -Wall -Wno-fatal \
+            rtl/hft_field_q16/hft_field_cell_core.sv
+
+      - name: Yosys synthesizability check
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_core.sv; hierarchy -check -top hft_field_cell_core; proc; opt; check; synth -top hft_field_cell_core; stat'
+

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -106,6 +106,15 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_stateful_center.sv
           vvp build/hft-rtl/hft_stateful.vvp
 
+      - name: Icarus 3D neighbour-address regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_neighbor_addr \
+            -o build/hft-rtl/hft_neighbor_addr.vvp \
+            rtl/hft_field_q16/hft_field_neighbor_addr.sv \
+            rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv
+          vvp build/hft-rtl/hft_neighbor_addr.vvp
+
       - name: Verilator lint
         run: |
           verilator --lint-only --sv -Wall -Wno-fatal \
@@ -129,6 +138,8 @@ jobs:
             rtl/hft_field_q16/hft_field_guarded_pipeline.sv \
             rtl/hft_field_q16/hft_field_state_store.sv \
             rtl/hft_field_q16/hft_field_stateful_center.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_neighbor_addr \
+            rtl/hft_field_q16/hft_field_neighbor_addr.sv
 
       - name: Yosys reference synthesis
         run: |
@@ -165,6 +176,11 @@ jobs:
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_staged.sv rtl/hft_field_q16/hft_field_hazard_guard.sv rtl/hft_field_q16/hft_field_guarded_pipeline.sv rtl/hft_field_q16/hft_field_state_store.sv rtl/hft_field_q16/hft_field_stateful_center.sv; hierarchy -check -top hft_field_stateful_center; proc; opt; check; synth -top hft_field_stateful_center; stat' \
             | tee build/hft-rtl/stateful-synth.log
 
+      - name: Yosys neighbour-address synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_neighbor_addr.sv; hierarchy -check -top hft_field_neighbor_addr; proc; opt; check; synth -top hft_field_neighbor_addr; stat' \
+            | tee build/hft-rtl/neighbor-addr-synth.log
+
       - name: Report generic gate counts
         run: |
           echo "Reference core:"
@@ -181,3 +197,5 @@ jobs:
           grep -A 20 '^=== hft_field_guarded_pipeline ===' build/hft-rtl/guarded-synth.log | tail -n 20
           echo "Stateful center engine:"
           grep -A 20 '^=== hft_field_stateful_center ===' build/hft-rtl/stateful-synth.log | tail -n 20
+          echo "Neighbour address generator:"
+          grep -A 20 '^=== hft_field_neighbor_addr ===' build/hft-rtl/neighbor-addr-synth.log | tail -n 20

--- a/.github/workflows/hft-rtl.yml
+++ b/.github/workflows/hft-rtl.yml
@@ -51,7 +51,7 @@ jobs:
             rtl/hft_field_q16/tb_hft_field_pow2_equiv.sv
           vvp build/hft-rtl/hft_pow2_equiv.vvp
 
-      - name: Icarus fixed-latency pipeline regression
+      - name: Icarus fixed-latency shell regression
         run: |
           iverilog -g2012 \
             -s tb_hft_field_cell_pipeline \
@@ -60,6 +60,16 @@ jobs:
             rtl/hft_field_q16/hft_field_cell_pipeline.sv \
             rtl/hft_field_q16/tb_hft_field_cell_pipeline.sv
           vvp build/hft-rtl/hft_pipeline.vvp
+
+      - name: Icarus staged arithmetic pipeline regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_cell_staged \
+            -o build/hft-rtl/hft_staged.vvp \
+            rtl/hft_field_q16/hft_field_cell_pow2.sv \
+            rtl/hft_field_q16/hft_field_cell_staged.sv \
+            rtl/hft_field_q16/tb_hft_field_cell_staged.sv
+          vvp build/hft-rtl/hft_staged.vvp
 
       - name: Icarus coordinate hazard regression
         run: |
@@ -79,6 +89,8 @@ jobs:
           verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_cell_pipeline \
             rtl/hft_field_q16/hft_field_cell_pow2.sv \
             rtl/hft_field_q16/hft_field_cell_pipeline.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_cell_staged \
+            rtl/hft_field_q16/hft_field_cell_staged.sv
           verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_hazard_guard \
             rtl/hft_field_q16/hft_field_hazard_guard.sv
 
@@ -97,6 +109,11 @@ jobs:
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_pow2.sv rtl/hft_field_q16/hft_field_cell_pipeline.sv; hierarchy -check -top hft_field_cell_pipeline; proc; opt; check; synth -top hft_field_cell_pipeline; stat' \
             | tee build/hft-rtl/pipeline-synth.log
 
+      - name: Yosys staged-pipeline synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_cell_staged.sv; hierarchy -check -top hft_field_cell_staged; proc; opt; check; synth -top hft_field_cell_staged; stat' \
+            | tee build/hft-rtl/staged-synth.log
+
       - name: Yosys hazard-guard synthesis
         run: |
           yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_hazard_guard.sv; hierarchy -check -top hft_field_hazard_guard; proc; opt; check; synth -top hft_field_hazard_guard; stat' \
@@ -110,5 +127,7 @@ jobs:
           grep -A 20 '^=== hft_field_cell_pow2 ===' build/hft-rtl/pow2-synth.log | tail -n 20
           echo "Registered latency shell:"
           grep -A 20 '^=== hft_field_cell_pipeline ===' build/hft-rtl/pipeline-synth.log | tail -n 20
+          echo "Staged arithmetic pipeline:"
+          grep -A 20 '^=== hft_field_cell_staged ===' build/hft-rtl/staged-synth.log | tail -n 20
           echo "Hazard guard:"
           grep -A 20 '^=== hft_field_hazard_guard ===' build/hft-rtl/hazard-synth.log | tail -n 20

--- a/.github/workflows/hft-spatial-rtl.yml
+++ b/.github/workflows/hft-spatial-rtl.yml
@@ -1,0 +1,73 @@
+name: HFT Spatial RTL Verification
+
+on:
+  push:
+    paths:
+      - "rtl/hft_field_q16/hft_field_neighbor_addr.sv"
+      - "rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv"
+      - "rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv"
+      - "rtl/hft_field_q16/tb_hft_field_stencil_hazard_guard.sv"
+      - ".github/workflows/hft-spatial-rtl.yml"
+  pull_request:
+    paths:
+      - "rtl/hft_field_q16/hft_field_neighbor_addr.sv"
+      - "rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv"
+      - "rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv"
+      - "rtl/hft_field_q16/tb_hft_field_stencil_hazard_guard.sv"
+      - ".github/workflows/hft-spatial-rtl.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hft-spatial-rtl-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spatial-verification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install RTL tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y iverilog verilator yosys
+
+      - name: Exhaustive 3D neighbour-address regression
+        run: |
+          mkdir -p build/hft-spatial-rtl
+          iverilog -g2012 \
+            -s tb_hft_field_neighbor_addr \
+            -o build/hft-spatial-rtl/neighbor_addr.vvp \
+            rtl/hft_field_q16/hft_field_neighbor_addr.sv \
+            rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv
+          vvp build/hft-spatial-rtl/neighbor_addr.vvp
+
+      - name: Stencil RAW-hazard regression
+        run: |
+          iverilog -g2012 \
+            -s tb_hft_field_stencil_hazard_guard \
+            -o build/hft-spatial-rtl/stencil_hazard.vvp \
+            rtl/hft_field_q16/hft_field_neighbor_addr.sv \
+            rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv \
+            rtl/hft_field_q16/tb_hft_field_stencil_hazard_guard.sv
+          vvp build/hft-spatial-rtl/stencil_hazard.vvp
+
+      - name: Verilator lint
+        run: |
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_neighbor_addr \
+            rtl/hft_field_q16/hft_field_neighbor_addr.sv
+          verilator --lint-only --sv -Wall -Wno-fatal --top-module hft_field_stencil_hazard_guard \
+            rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv
+
+      - name: Yosys neighbour-address synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_neighbor_addr.sv; hierarchy -check -top hft_field_neighbor_addr; proc; opt; check; synth -top hft_field_neighbor_addr; stat' \
+            | tee build/hft-spatial-rtl/neighbor-addr-synth.log
+
+      - name: Yosys stencil-hazard synthesis
+        run: |
+          yosys -p 'read_verilog -sv rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv; hierarchy -check -top hft_field_stencil_hazard_guard; proc; opt; check; synth -top hft_field_stencil_hazard_guard; stat' \
+            | tee build/hft-spatial-rtl/stencil-hazard-synth.log

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -56,6 +56,12 @@ add_executable(jarvisx-multimedia4d
 jarvisx_include_runtime(jarvisx-multimedia4d)
 jarvisx_harden(jarvisx-multimedia4d)
 
+add_executable(jarvisx-hft-field
+    src/hft_field_main.cpp
+)
+jarvisx_include_runtime(jarvisx-hft-field)
+jarvisx_harden(jarvisx-hft-field)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -190,3 +196,12 @@ jarvisx_harden(jarvisx-multimedia4d-tests)
 
 add_test(NAME multimedia4d-regressions COMMAND jarvisx-multimedia4d-tests)
 set_tests_properties(multimedia4d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-hft-field-tests
+    tests/hft_field_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-hft-field-tests)
+jarvisx_harden(jarvisx-hft-field-tests)
+
+add_test(NAME hft-field-regressions COMMAND jarvisx-hft-field-tests)
+set_tests_properties(hft-field-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/hft_field.hpp
+++ b/cpp_runtime/include/jarvisx/hft_field.hpp
@@ -1,0 +1,329 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+namespace jarvisx::hft {
+
+class Q16 {
+public:
+    static constexpr std::int64_t kScale = 1LL << 16;
+
+    constexpr Q16() noexcept = default;
+
+    static constexpr Q16 from_raw(std::int32_t raw) noexcept {
+        Q16 out;
+        out.raw_ = raw;
+        return out;
+    }
+
+    static constexpr Q16 from_int(std::int32_t value) noexcept {
+        return from_raw(saturate(static_cast<std::int64_t>(value) * kScale));
+    }
+
+    static constexpr Q16 from_ratio(std::int32_t numerator,
+                                    std::int32_t denominator) noexcept {
+        return denominator == 0
+            ? from_raw(numerator >= 0 ? std::numeric_limits<std::int32_t>::max()
+                                      : std::numeric_limits<std::int32_t>::min())
+            : from_raw(saturate((static_cast<std::int64_t>(numerator) * kScale) /
+                                static_cast<std::int64_t>(denominator)));
+    }
+
+    constexpr std::int32_t raw() const noexcept { return raw_; }
+    double to_double() const noexcept {
+        return static_cast<double>(raw_) / static_cast<double>(kScale);
+    }
+
+    friend constexpr Q16 operator+(Q16 a, Q16 b) noexcept {
+        return from_raw(saturate(static_cast<std::int64_t>(a.raw_) + b.raw_));
+    }
+
+    friend constexpr Q16 operator-(Q16 a, Q16 b) noexcept {
+        return from_raw(saturate(static_cast<std::int64_t>(a.raw_) - b.raw_));
+    }
+
+    friend constexpr Q16 operator-(Q16 value) noexcept {
+        return from_raw(saturate(-static_cast<std::int64_t>(value.raw_)));
+    }
+
+    friend constexpr Q16 operator*(Q16 a, Q16 b) noexcept {
+        const std::int64_t product = static_cast<std::int64_t>(a.raw_) * b.raw_;
+        // Integer division truncates toward zero in C++11+, avoiding signed-shift ambiguity.
+        return from_raw(saturate(product / kScale));
+    }
+
+    friend constexpr bool operator>(Q16 a, Q16 b) noexcept { return a.raw_ > b.raw_; }
+    friend constexpr bool operator<(Q16 a, Q16 b) noexcept { return a.raw_ < b.raw_; }
+    friend constexpr bool operator>=(Q16 a, Q16 b) noexcept { return a.raw_ >= b.raw_; }
+    friend constexpr bool operator<=(Q16 a, Q16 b) noexcept { return a.raw_ <= b.raw_; }
+    friend constexpr bool operator==(Q16 a, Q16 b) noexcept { return a.raw_ == b.raw_; }
+    friend constexpr bool operator!=(Q16 a, Q16 b) noexcept { return !(a == b); }
+
+    static constexpr Q16 min(Q16 a, Q16 b) noexcept { return a < b ? a : b; }
+    static constexpr Q16 max(Q16 a, Q16 b) noexcept { return a > b ? a : b; }
+    static constexpr Q16 clamp(Q16 v, Q16 lo, Q16 hi) noexcept {
+        return v < lo ? lo : (v > hi ? hi : v);
+    }
+    static constexpr Q16 abs(Q16 value) noexcept {
+        return value.raw_ >= 0
+            ? value
+            : from_raw(saturate(-static_cast<std::int64_t>(value.raw_)));
+    }
+
+private:
+    std::int32_t raw_{0};
+
+    static constexpr std::int32_t saturate(std::int64_t value) noexcept {
+        return value > std::numeric_limits<std::int32_t>::max()
+            ? std::numeric_limits<std::int32_t>::max()
+            : (value < std::numeric_limits<std::int32_t>::min()
+                   ? std::numeric_limits<std::int32_t>::min()
+                   : static_cast<std::int32_t>(value));
+    }
+};
+
+enum class Side : std::int8_t { Bid = 1, Ask = -1 };
+enum class Action : std::int8_t { None = 0, Buy = 1, Sell = -1 };
+
+struct MarketEvent {
+    std::int32_t price_tick{};
+    std::uint16_t venue{};
+    Side side{Side::Bid};
+    Q16 delta_quantity{}; // signed: add > 0, cancel/remove < 0
+    std::uint64_t sequence{};
+};
+
+struct OrderIntent {
+    Action action{Action::None};
+    Q16 quantity{};
+    Q16 score{};
+    bool risk_accepted{false};
+    std::uint64_t source_sequence{};
+};
+
+struct HftFieldConfig {
+    Q16 alpha{Q16::from_ratio(1, 4)};
+    Q16 lambda{Q16::from_ratio(1, 32)};
+    Q16 eta{Q16::from_ratio(1, 2)};
+    Q16 dt{Q16::from_ratio(1, 8)};
+    Q16 rho{Q16::from_ratio(15, 16)};
+    Q16 flow_decay{Q16::from_ratio(7, 8)};
+
+    Q16 w_psi{Q16::from_ratio(1, 1)};
+    Q16 w_omega{Q16::from_ratio(1, 2)};
+    Q16 w_flow{Q16::from_ratio(1, 2)};
+    Q16 w_laplacian{Q16::from_ratio(1, 8)};
+    Q16 w_inventory{Q16::from_ratio(1, 4)};
+
+    Q16 decision_threshold{Q16::from_ratio(1, 16)};
+    Q16 max_abs_field{Q16::from_int(32)};
+    Q16 max_inventory{Q16::from_int(64)};
+    Q16 max_order_quantity{Q16::from_int(4)};
+};
+
+struct PipelineBudget {
+    std::uint16_t ingress_cutthrough{8};
+    std::uint16_t book_update{4};
+    std::uint16_t state_load{4};
+    std::uint16_t field_gradient{8};
+    std::uint16_t memory_update{4};
+    std::uint16_t score{6};
+    std::uint16_t risk{4};
+    std::uint16_t order_encode{6};
+    std::uint16_t tx_launch{4};
+
+    constexpr std::uint16_t total_cycles() const noexcept {
+        return static_cast<std::uint16_t>(
+            ingress_cutthrough + book_update + state_load + field_gradient +
+            memory_update + score + risk + order_encode + tx_launch);
+    }
+
+    double target_latency_ns(double clock_mhz = 500.0) const noexcept {
+        return static_cast<double>(total_cycles()) * 1000.0 / clock_mhz;
+    }
+};
+
+template <std::size_t PriceBins = 64,
+          std::size_t Venues = 4,
+          std::size_t Horizons = 4>
+class HftFieldEngine {
+    static_assert(PriceBins >= 8 && (PriceBins & (PriceBins - 1U)) == 0U,
+                  "PriceBins must be a power of two >= 8");
+    static_assert(Venues >= 2 && (Venues & (Venues - 1U)) == 0U,
+                  "Venues must be a power of two >= 2");
+    static_assert(Horizons >= 2 && (Horizons & (Horizons - 1U)) == 0U,
+                  "Horizons must be a power of two >= 2");
+
+public:
+    struct Cell {
+        Q16 psi{};
+        Q16 omega{};
+        Q16 bid_depth{};
+        Q16 ask_depth{};
+        Q16 flow{};
+    };
+
+    static constexpr std::size_t kCellCount = PriceBins * Venues * Horizons;
+    static constexpr std::size_t kStencilReads = 7;
+
+    explicit constexpr HftFieldEngine(HftFieldConfig config = {}) noexcept
+        : config_(config) {}
+
+    OrderIntent process(const MarketEvent& event) noexcept {
+        const Coord c = map(event);
+        Cell& center = cells_[index(c)];
+
+        if (event.side == Side::Bid) {
+            center.bid_depth = Q16::max(Q16{}, center.bid_depth + event.delta_quantity);
+        } else {
+            center.ask_depth = Q16::max(Q16{}, center.ask_depth + event.delta_quantity);
+        }
+
+        const Q16 signed_impulse = event.side == Side::Bid
+            ? event.delta_quantity
+            : -event.delta_quantity;
+        center.flow = config_.flow_decay * center.flow + signed_impulse;
+
+        const Q16 lap = laplacian(c);
+        const Q16 residual = center.psi - center.omega;
+        const Q16 rhs = -(config_.alpha * residual)
+                      + config_.lambda * lap
+                      + config_.eta * signed_impulse;
+
+        const Q16 candidate = Q16::clamp(
+            center.psi + config_.dt * rhs,
+            -config_.max_abs_field,
+            config_.max_abs_field);
+
+        const Q16 one_minus_rho = Q16::from_int(1) - config_.rho;
+        center.omega = config_.rho * center.omega + one_minus_rho * candidate;
+        center.psi = candidate;
+
+        const Q16 score = config_.w_psi * center.psi
+                        + config_.w_omega * center.omega
+                        + config_.w_flow * center.flow
+                        + config_.w_laplacian * lap
+                        - config_.w_inventory * inventory_;
+
+        OrderIntent intent;
+        intent.score = score;
+        intent.source_sequence = event.sequence;
+
+        if (score > config_.decision_threshold) {
+            intent.action = Action::Buy;
+        } else if (score < -config_.decision_threshold) {
+            intent.action = Action::Sell;
+        } else {
+            return intent;
+        }
+
+        intent.quantity = Q16::min(Q16::abs(event.delta_quantity),
+                                   config_.max_order_quantity);
+        if (intent.quantity == Q16{}) {
+            intent.quantity = config_.max_order_quantity;
+        }
+
+        const Q16 signed_order = intent.action == Action::Buy
+            ? intent.quantity
+            : -intent.quantity;
+        const Q16 projected_inventory = inventory_ + signed_order;
+        intent.risk_accepted = Q16::abs(projected_inventory) <= config_.max_inventory;
+        if (!intent.risk_accepted) {
+            intent.action = Action::None;
+            intent.quantity = Q16{};
+        }
+        return intent;
+    }
+
+    void on_fill(Action action, Q16 quantity) noexcept {
+        if (action == Action::Buy) {
+            inventory_ = inventory_ + quantity;
+        } else if (action == Action::Sell) {
+            inventory_ = inventory_ - quantity;
+        }
+        inventory_ = Q16::clamp(inventory_, -config_.max_inventory,
+                                config_.max_inventory);
+    }
+
+    Q16 inventory() const noexcept { return inventory_; }
+
+    const Cell& cell(std::size_t price, std::size_t venue,
+                     std::size_t horizon) const {
+        if (price >= PriceBins || venue >= Venues || horizon >= Horizons) {
+            throw std::out_of_range("HFT field coordinate out of range");
+        }
+        return cells_[price + PriceBins * (venue + Venues * horizon)];
+    }
+
+    std::uint64_t digest() const noexcept {
+        std::uint64_t h = 1469598103934665603ULL;
+        for (const Cell& cell_value : cells_) {
+            hash_word(h, cell_value.psi.raw());
+            hash_word(h, cell_value.omega.raw());
+            hash_word(h, cell_value.bid_depth.raw());
+            hash_word(h, cell_value.ask_depth.raw());
+            hash_word(h, cell_value.flow.raw());
+        }
+        hash_word(h, inventory_.raw());
+        return h;
+    }
+
+private:
+    struct Coord {
+        std::size_t x{};
+        std::size_t y{};
+        std::size_t z{};
+    };
+
+    HftFieldConfig config_{};
+    std::array<Cell, kCellCount> cells_{};
+    Q16 inventory_{};
+
+    static constexpr std::size_t index(Coord c) noexcept {
+        return c.x + PriceBins * (c.y + Venues * c.z);
+    }
+
+    static constexpr std::size_t wrap(std::size_t value,
+                                      std::size_t mask) noexcept {
+        return value & mask;
+    }
+
+    static constexpr Coord map(const MarketEvent& event) noexcept {
+        const auto unsigned_price = static_cast<std::uint32_t>(event.price_tick);
+        return {
+            static_cast<std::size_t>(unsigned_price) & (PriceBins - 1U),
+            static_cast<std::size_t>(event.venue) & (Venues - 1U),
+            0U
+        };
+    }
+
+    Q16 psi(Coord c) const noexcept { return cells_[index(c)].psi; }
+
+    Q16 laplacian(Coord c) const noexcept {
+        const std::size_t xm = wrap(c.x + PriceBins - 1U, PriceBins - 1U);
+        const std::size_t xp = wrap(c.x + 1U, PriceBins - 1U);
+        const std::size_t ym = wrap(c.y + Venues - 1U, Venues - 1U);
+        const std::size_t yp = wrap(c.y + 1U, Venues - 1U);
+        const std::size_t zm = wrap(c.z + Horizons - 1U, Horizons - 1U);
+        const std::size_t zp = wrap(c.z + 1U, Horizons - 1U);
+
+        const Q16 neighbours = psi({xm, c.y, c.z}) + psi({xp, c.y, c.z})
+                             + psi({c.x, ym, c.z}) + psi({c.x, yp, c.z})
+                             + psi({c.x, c.y, zm}) + psi({c.x, c.y, zp});
+        return neighbours - Q16::from_int(6) * psi(c);
+    }
+
+    static void hash_word(std::uint64_t& h, std::int32_t word) noexcept {
+        const auto u = static_cast<std::uint32_t>(word);
+        for (unsigned shift = 0; shift < 32U; shift += 8U) {
+            h ^= static_cast<std::uint8_t>((u >> shift) & 0xFFU);
+            h *= 1099511628211ULL;
+        }
+    }
+};
+
+} // namespace jarvisx::hft

--- a/cpp_runtime/src/hft_field_main.cpp
+++ b/cpp_runtime/src/hft_field_main.cpp
@@ -1,0 +1,50 @@
+#include "jarvisx/hft_field.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+
+int main(int argc, char** argv) {
+    using namespace jarvisx::hft;
+    std::uint64_t events = 1'000'000ULL;
+    if (argc > 1) {
+        events = static_cast<std::uint64_t>(std::strtoull(argv[1], nullptr, 10));
+        if (events == 0U) events = 1U;
+    }
+
+    HftFieldEngine<> engine;
+    std::uint64_t intents = 0U;
+    const auto start = std::chrono::steady_clock::now();
+    for (std::uint64_t i = 0; i < events; ++i) {
+        const bool bid = (i & 1ULL) == 0ULL;
+        MarketEvent event{
+            static_cast<std::int32_t>(100000 + (i & 31ULL)),
+            static_cast<std::uint16_t>((i >> 5U) & 3ULL),
+            bid ? Side::Bid : Side::Ask,
+            Q16::from_ratio(static_cast<std::int32_t>((i % 7ULL) + 1ULL), 8),
+            i + 1ULL
+        };
+        const auto intent = engine.process(event);
+        if (intent.action != Action::None && intent.risk_accepted) {
+            ++intents;
+            // Functional simulator only: assume immediate fills to exercise risk state.
+            engine.on_fill(intent.action, intent.quantity);
+        }
+    }
+    const auto stop = std::chrono::steady_clock::now();
+    const auto elapsed_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+
+    const PipelineBudget budget{};
+    std::cout << "Jarvis-X HFT sparse field functional simulator\n"
+              << "events=" << events << "\n"
+              << "order_intents=" << intents << "\n"
+              << "digest=0x" << std::hex << engine.digest() << std::dec << "\n"
+              << "software_ns_per_event=" << std::fixed << std::setprecision(2)
+              << static_cast<double>(elapsed_ns) / static_cast<double>(events) << "\n"
+              << "fpga_target_cycles=" << budget.total_cycles() << "\n"
+              << "fpga_target_latency_ns_at_500MHz=" << budget.target_latency_ns(500.0) << "\n"
+              << "NOTE: software timing is not an FPGA latency measurement.\n";
+    return 0;
+}

--- a/cpp_runtime/tests/hft_field_tests.cpp
+++ b/cpp_runtime/tests/hft_field_tests.cpp
@@ -1,0 +1,84 @@
+#include "jarvisx/hft_field.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+
+using namespace jarvisx::hft;
+
+static void q16_arithmetic_is_deterministic() {
+    constexpr Q16 a = Q16::from_ratio(3, 2);
+    constexpr Q16 b = Q16::from_ratio(-5, 4);
+    constexpr Q16 c = a * b;
+    static_assert(c.raw() == -122880, "Q16 multiply regression");
+    assert((a + b).raw() == 16384);
+}
+
+static void replay_is_bit_exact() {
+    HftFieldEngine<> left;
+    HftFieldEngine<> right;
+    for (std::uint64_t i = 0; i < 4096U; ++i) {
+        const MarketEvent event{
+            static_cast<std::int32_t>(42000 + (i & 15U)),
+            static_cast<std::uint16_t>((i >> 4U) & 3U),
+            (i & 1U) == 0U ? Side::Bid : Side::Ask,
+            Q16::from_ratio(static_cast<std::int32_t>((i % 5U) + 1U), 16),
+            i
+        };
+        const auto a = left.process(event);
+        const auto b = right.process(event);
+        assert(a.action == b.action);
+        assert(a.quantity == b.quantity);
+        assert(a.score == b.score);
+        assert(a.risk_accepted == b.risk_accepted);
+        if (a.action != Action::None && a.risk_accepted) {
+            left.on_fill(a.action, a.quantity);
+            right.on_fill(b.action, b.quantity);
+        }
+    }
+    assert(left.digest() == right.digest());
+}
+
+static void positive_and_negative_impulses_separate() {
+    HftFieldEngine<> bid_engine;
+    HftFieldEngine<> ask_engine;
+    const MarketEvent bid{100, 0, Side::Bid, Q16::from_int(1), 1};
+    const MarketEvent ask{100, 0, Side::Ask, Q16::from_int(1), 1};
+    const auto bid_intent = bid_engine.process(bid);
+    const auto ask_intent = ask_engine.process(ask);
+    assert(bid_intent.score.raw() > 0);
+    assert(ask_intent.score.raw() < 0);
+    assert(bid_engine.digest() != ask_engine.digest());
+}
+
+static void risk_gate_fails_closed() {
+    HftFieldConfig config;
+    config.max_inventory = Q16::from_int(1);
+    config.max_order_quantity = Q16::from_int(1);
+    config.decision_threshold = Q16::from_ratio(1, 1024);
+    HftFieldEngine<> engine(config);
+
+    MarketEvent bid{100, 0, Side::Bid, Q16::from_int(1), 1};
+    auto first = engine.process(bid);
+    if (first.action == Action::Buy && first.risk_accepted) {
+        engine.on_fill(first.action, first.quantity);
+    }
+    auto second = engine.process({100, 0, Side::Bid, Q16::from_int(1), 2});
+    assert(second.action == Action::None || !second.risk_accepted);
+}
+
+static void pipeline_budget_is_inside_design_target() {
+    constexpr PipelineBudget budget{};
+    static_assert(budget.total_cycles() == 48, "pipeline budget changed");
+    assert(budget.target_latency_ns(500.0) == 96.0);
+}
+
+int main() {
+    q16_arithmetic_is_deterministic();
+    replay_is_bit_exact();
+    positive_and_negative_impulses_separate();
+    risk_gate_fails_closed();
+    pipeline_budget_is_inside_design_target();
+    std::cout << "hft field regressions passed\n";
+    return 0;
+}

--- a/docs/DR_MOAGI_HFT_FIELD_RUNTIME.md
+++ b/docs/DR_MOAGI_HFT_FIELD_RUNTIME.md
@@ -2,41 +2,38 @@
 
 ## Status
 
-Experimental specialization of the canonical Dr Moagi Field Runtime v2 for bounded, deterministic, ultra-low-latency streaming decisions. This document is an engineering target, not a claim of measured FPGA latency or trading profitability.
+Experimental specialization of the canonical Dr Moagi Field Runtime v2 for bounded, deterministic, ultra-low-latency streaming decisions. The repository now contains a bit-exact Q16.16 RTL arithmetic pipeline, conservative same-cell hazard protection, and a persistent center-state reference store. This document distinguishes verified functional/synthesis properties from unmeasured FPGA timing targets.
 
 ## 1. Objective
 
 The HFT specialization removes operations that are unsuitable for a nanosecond critical path: full encode/decode passes, iterative minimization, heap allocation, global attention, stochastic sampling, floating-point reductions, and runtime model mutation.
 
-Each market event performs one bounded local state transition:
+Each market event performs one bounded local transition:
 
 ```text
 market event
   -> coordinate map
-  -> local book update
+  -> state load
   -> six-neighbour field gradient
   -> one Q16.16 Euler step
-  -> persistent memory update
+  -> persistent memory/flow update
   -> fixed-weight score
   -> inventory/risk gate
+  -> state commit
   -> order intent
 ```
 
-The intended hardware target is a cut-through FPGA/ASIC pipeline. A CPU implementation exists only as a deterministic functional reference.
+The intended production target is a cut-through FPGA/ASIC pipeline. The C++ implementation remains the functional oracle.
 
-## 2. State
+## 2. State and arithmetic contract
 
-For each lattice cell `c = (price_bin, venue, horizon)` maintain
+For each logical lattice cell `c = (price_bin, venue, horizon)` maintain at least:
 
 ```text
 Psi[c]       instantaneous field state
 Omega[c]     persistent exponentially weighted memory
-Bid[c]       bounded bid-side depth proxy
-Ask[c]       bounded ask-side depth proxy
 Flow[c]      signed event-flow state
 ```
-
-Global risk state contains at least inventory `I_t`.
 
 The event is
 
@@ -44,124 +41,145 @@ The event is
 e_t = (price_tick, venue, side, delta_quantity, sequence)
 ```
 
-All critical-path scalar arithmetic is signed Q16.16 with saturating add/subtract/multiply and truncation-toward-zero after a 64-bit intermediate product.
+All implemented scalar hot-path arithmetic is signed Q16.16. The software and RTL contract preserves:
 
-## 3. Local field equation
+- saturating signed add/subtract;
+- 64-bit intermediate arithmetic where required;
+- truncation toward zero for dyadic division/fixed-point multiplication;
+- fixed left-associative reduction order;
+- fail-closed inventory risk behavior.
 
-For the active cell `c_t`, define the six-neighbour discrete Laplacian
+The default coefficients are dyadic rational values (`1/2`, `1/4`, `1/8`, `1/16`, `1/32`, `7/8`, `15/16`), so the optimized RTL removes general multipliers and uses exact shift/add/subtract lowering while retaining the reference arithmetic semantics.
+
+## 3. Local field transition
+
+For active cell `c_t`, define
 
 ```text
 Delta_6 Psi[c]
-  = sum(Psi[n] for n in face_neighbours(c)) - 6 Psi[c].
+  = (((((Psi[x-] + Psi[x+]) + Psi[y-]) + Psi[y+]) + Psi[z-]) + Psi[z+])
+    - 6 Psi[c]
 ```
 
-Define the memory residual
+where every addition/subtraction uses the same saturating Q16.16 order as the C++ reference.
+
+Memory residual and event impulse are
 
 ```text
-R_t[c] = Psi_t[c] - Omega_t[c].
-```
+R_t[c] = Psi_t[c] - Omega_t[c]
 
-and signed event impulse
-
-```text
 u_t = +delta_quantity  for bid events
-u_t = -delta_quantity  for ask events.
+u_t = -delta_quantity  for ask events
 ```
 
-The hot-path field update is one explicit step
+and the compiled reference update is
 
 ```text
 rhs_t[c]
-  = -alpha R_t[c]
-    + lambda Delta_6 Psi_t[c]
-    + eta u_t
+  = -R_t[c] / 4
+    + Delta_6 Psi_t[c] / 32
+    + u_t / 2
 
 Psi_(t+1)[c]
-  = clamp(Psi_t[c] + dt rhs_t[c], -Psi_max, +Psi_max).
-```
+  = clamp(Psi_t[c] + rhs_t[c] / 8, -Psi_max, +Psi_max)
 
-This is a deliberately compiled surrogate of the more general Field Runtime v2 transition. It preserves bounded local propagation and persistent state while eliminating full codec evaluation from the trading path.
-
-Persistent memory is
-
-```text
 Omega_(t+1)[c]
-  = rho Omega_t[c] + (1-rho) Psi_(t+1)[c].
-```
+  = 15 Omega_t[c] / 16 + Psi_(t+1)[c] / 16
 
-Flow is
-
-```text
 Flow_(t+1)[c]
-  = rho_flow Flow_t[c] + u_t.
+  = 7 Flow_t[c] / 8 + u_t
 ```
 
-Only one center cell is written by the reference transition; seven field values are read (center plus six neighbours). Therefore field work per event is bounded independently of total lattice size.
+Only one center cell is committed per accepted event. The complete stencil requires center plus six neighbouring `Psi` values.
 
 ## 4. Decision and risk
 
-The reference score is intentionally linear so it lowers to a fixed MAC tree:
+The implemented score is evaluated in fixed order:
 
 ```text
 s_t
-  = w_psi Psi_(t+1)[c]
-  + w_omega Omega_(t+1)[c]
-  + w_flow Flow_(t+1)[c]
-  + w_lap Delta_6 Psi_t[c]
-  - w_inventory I_t.
+  = Psi_(t+1)[c]
+  + Omega_(t+1)[c] / 2
+  + Flow_(t+1)[c] / 2
+  + Delta_6 Psi_t[c] / 8
+  - Inventory_t / 4
 ```
 
-Decision:
+Decision threshold is `1/16` in Q16.16 units. Order quantity is bounded at `4`; a zero requested quantity uses the same bounded fallback. Before emission, projected inventory must satisfy
 
 ```text
-if s_t >  threshold: BUY
-if s_t < -threshold: SELL
-otherwise:            NONE
+|Inventory_t + signed_order_quantity| <= 64
 ```
 
-Before an intent is emitted, projected inventory must satisfy
+otherwise the action is rejected and cleared. This score is a mechanics demonstrator, not a validated trading alpha model.
+
+## 5. Verified RTL layers
+
+Current RTL files include:
 
 ```text
-|I_t + signed_order_quantity| <= I_max.
+rtl/hft_field_q16/hft_field_cell_core.sv
+rtl/hft_field_q16/hft_field_cell_pow2.sv
+rtl/hft_field_q16/hft_field_cell_pipeline.sv
+rtl/hft_field_q16/hft_field_cell_staged.sv
+rtl/hft_field_q16/hft_field_hazard_guard.sv
+rtl/hft_field_q16/hft_field_guarded_pipeline.sv
+rtl/hft_field_q16/hft_field_state_store.sv
+rtl/hft_field_q16/hft_field_stateful_center.sv
 ```
 
-The reference kernel fails closed when this bound is violated.
+The CI verification chain currently proves:
 
-This score is a hardware/mechanics demonstrator, not a validated alpha model. A production strategy must be trained and evaluated separately from the latency kernel.
+1. C++-derived golden-vector agreement for the reference RTL;
+2. multiplier-free equivalence across 10,012 deterministic RTL vectors, including signed extrema/saturation cases;
+3. a fixed 17-cycle valid-to-valid shell contract;
+4. a genuinely staged 17-cycle arithmetic pipeline matching the multiplier-free oracle for back-to-back II=1 transactions;
+5. conservative RAW hazard rejection for a coordinate already in flight while independent coordinates remain issuable on consecutive clocks;
+6. exact coordinate/result alignment through the guarded pipeline;
+7. persistent center-state commit/reload across repeated same-cell transactions;
+8. fail-closed serialization of configuration writes against event issue;
+9. Verilator lint and generic Yosys synthesis for the reference, multiplier-free, staged, guarded, and stateful-center RTL layers.
 
-## 5. Complexity
+These are functional and generic synthesis results. They are not FPGA place-and-route timing results.
 
-For one event the field kernel performs a fixed number of operations:
+## 6. Stateful recurrence boundary
+
+The current stateful engine stores and reloads center-cell `Psi`, `Omega`, and `Flow` values. A same-coordinate transaction is blocked until the previous transaction has retired and committed, so the next recurrence observes the newly committed state.
+
+The current reference store uses a combinational center read and synchronous write. It is intentionally small and technology-neutral; generic Yosys acceptance does **not** prove BRAM/URAM inference, banking, routing, or target-device timing.
+
+Six-neighbour `Psi` values are still supplied externally to `hft_field_stateful_center.sv`. A production implementation must therefore add a physically realizable neighbour-address and memory-banking architecture rather than assume an unrealistic seven-read single RAM.
+
+## 7. Latency contracts and targets
+
+### Verified logical arithmetic latency
+
+The staged arithmetic transaction contract is:
 
 ```text
-7 field reads
-1 local depth update
-1 six-neighbour Laplacian
-1 explicit field step
-1 memory update
-1 flow update
-1 fixed-width score reduction
-1 bounded risk check
+accepted input -> result = 17 clock cycles
 ```
 
-For fixed channel/stencil width,
+The pipeline can accept independent transactions at initiation interval `II=1`. Same-coordinate traffic is conservatively stalled until commit; same-cell speculative forwarding is not implemented.
+
+If a future FPGA implementation closes at 500 MHz, the 17-cycle arithmetic latency would correspond to:
 
 ```text
-C_event = O(1)
+17 * 2 ns = 34 ns
 ```
 
-with respect to total historical state and total logical field size. This does not mean all-market global inference is O(1); it means the incremental critical-path update is bounded.
+`34 ns` is therefore a derived architectural target, **not a measured latency**.
 
-## 6. Pipeline budget
+### Broader wire-to-wire budget
 
-Reference design budget at 500 MHz:
+The original system-level budget remains:
 
 | Stage | Cycles |
 |---|---:|
 | ingress / cut-through parse | 8 |
 | local book update | 4 |
 | state load | 4 |
-| field-gradient MACs | 8 |
+| field-gradient arithmetic | 8 |
 | memory update | 4 |
 | score reduction | 6 |
 | risk gate | 4 |
@@ -169,34 +187,28 @@ Reference design budget at 500 MHz:
 | TX launch | 4 |
 | **Total** | **48** |
 
-At 500 MHz:
+At a hypothetical 500 MHz that is `96 ns`, also a synthesis target only. It must not be reported as measured network-to-network latency until the complete design is placed, routed, timed, and physically measured.
 
-```text
-48 cycles * 2 ns/cycle = 96 ns
-```
+## 8. Complexity
 
-`96 ns` is a synthesis target only. It must not be reported as measured latency until an RTL implementation is placed, routed, timed, and measured network-to-network.
+For fixed stencil/channel width, one accepted local event performs a fixed amount of arithmetic and center-state work, so the incremental compute kernel is `O(1)` with respect to total logical lattice size. This does not imply that all-market inference, memory footprint, neighbour addressing, or network processing is `O(1)`.
 
-For context, the audited STAC-T1 ADHOC HFFT-02A result published in October 2024 reported 115.07 ns mean and 140.04 ns 99th percentile SOM-to-SOF at 1x market rate, with 76.40 ns mean EOT-to-SOF. The benchmark version differs from earlier STAC-T1 versions, so cross-version comparisons must be handled carefully.
+## 9. Determinism contract
 
-Reference: https://docs.stacresearch.com/news/ADHC240918
-
-## 7. Determinism contract
-
-A conforming hardware/software implementation must specify and preserve:
+A conforming hardware/software implementation must preserve:
 
 1. Q16.16 representation and scaling;
-2. 64-bit multiply intermediate;
-3. truncation toward zero after fixed-point multiplication;
-4. saturating overflow behavior;
-5. fixed reduction order;
-6. fixed coordinate wrapping/mapping;
-7. no hidden floating-point operations in the hot path;
-8. no dynamic allocation in `process`;
-9. deterministic replay digest for an identical event stream;
-10. fail-closed risk behavior.
+2. saturating overflow behavior;
+3. truncation toward zero;
+4. fixed arithmetic/reduction order;
+5. deterministic coordinate mapping and boundary policy;
+6. no hidden floating-point operations in the hot path;
+7. no dynamic allocation in the event-processing path;
+8. deterministic replay for an identical event stream;
+9. fail-closed risk behavior;
+10. explicit state-hazard semantics.
 
-## 8. Verification ladder
+## 10. Verification ladder
 
 Performance claims advance only through these gates:
 
@@ -204,8 +216,8 @@ Performance claims advance only through these gates:
 G0 mathematical boundedness
 G1 bit-exact C++ replay
 G2 compiler/sanitizer regression
-G3 HLS/RTL equivalence against C++ vectors
-G4 synthesis timing closure
+G3 RTL functional equivalence + generic synthesis
+G4 target FPGA synthesis and timing constraints
 G5 post-route timing + resource utilization
 G6 loopback packet latency
 G7 dual-port network timestamping
@@ -213,36 +225,22 @@ G8 STAC-T1-compatible workload
 G9 independent/audited benchmark
 ```
 
-A failure at any gate blocks promotion of the corresponding performance claim.
+The current RTL has materially advanced through G3 for the arithmetic, hazard, guarded-transaction, and persistent center-state reference layers. G4 and later remain unproven.
 
-## 9. Current implementation
+## 11. Next hardware lowering
 
-Files:
-
-```text
-cpp_runtime/include/jarvisx/hft_field.hpp
-cpp_runtime/src/hft_field_main.cpp
-cpp_runtime/tests/hft_field_tests.cpp
-```
-
-The C++ simulator reports software throughput and the 48-cycle FPGA design target separately. Software timing must never be relabeled as FPGA tick-to-trade latency.
-
-## 10. Next hardware lowering
-
-The first RTL should preserve the C++ state transition exactly:
+The next implementation boundary is:
 
 ```text
-RX stream
- -> event parser
- -> coordinate mapper
- -> BRAM/URAM 7-cell read bank
- -> Laplacian MAC tree
- -> Q16.16 field-step pipeline
- -> Omega/Flow update
- -> score MAC tree
- -> risk comparator
- -> order-intent encoder
- -> TX stream
+3D coordinate
+ -> deterministic center/x-/x+/y-/y+/z-/z+ address generator
+ -> boundary policy
+ -> physically realizable bank/replica selection
+ -> center + six-neighbour Psi fetch
+ -> staged Q16.16 arithmetic
+ -> center-state commit
 ```
 
-The production design should support shadow mode first: receive live/replayed market data, calculate intents, timestamp them, but emit no exchange-bound orders. Order transmission is enabled only after deterministic equivalence, risk, and latency verification.
+After neighbour banking, the design still requires a named FPGA target, synchronous memory timing integration, constraints, place-and-route, packet parser/encoder, Ethernet MAC/PHY integration, and timestamped replay before any hardware latency comparison is defensible.
+
+Production rollout should begin in shadow mode: receive live/replayed market data, calculate and timestamp intents, but emit no exchange-bound orders until deterministic equivalence, risk controls, and physical latency verification are complete.

--- a/docs/DR_MOAGI_HFT_FIELD_RUNTIME.md
+++ b/docs/DR_MOAGI_HFT_FIELD_RUNTIME.md
@@ -1,0 +1,248 @@
+# Dr Moagi HFT Sparse Field Runtime
+
+## Status
+
+Experimental specialization of the canonical Dr Moagi Field Runtime v2 for bounded, deterministic, ultra-low-latency streaming decisions. This document is an engineering target, not a claim of measured FPGA latency or trading profitability.
+
+## 1. Objective
+
+The HFT specialization removes operations that are unsuitable for a nanosecond critical path: full encode/decode passes, iterative minimization, heap allocation, global attention, stochastic sampling, floating-point reductions, and runtime model mutation.
+
+Each market event performs one bounded local state transition:
+
+```text
+market event
+  -> coordinate map
+  -> local book update
+  -> six-neighbour field gradient
+  -> one Q16.16 Euler step
+  -> persistent memory update
+  -> fixed-weight score
+  -> inventory/risk gate
+  -> order intent
+```
+
+The intended hardware target is a cut-through FPGA/ASIC pipeline. A CPU implementation exists only as a deterministic functional reference.
+
+## 2. State
+
+For each lattice cell `c = (price_bin, venue, horizon)` maintain
+
+```text
+Psi[c]       instantaneous field state
+Omega[c]     persistent exponentially weighted memory
+Bid[c]       bounded bid-side depth proxy
+Ask[c]       bounded ask-side depth proxy
+Flow[c]      signed event-flow state
+```
+
+Global risk state contains at least inventory `I_t`.
+
+The event is
+
+```text
+e_t = (price_tick, venue, side, delta_quantity, sequence)
+```
+
+All critical-path scalar arithmetic is signed Q16.16 with saturating add/subtract/multiply and truncation-toward-zero after a 64-bit intermediate product.
+
+## 3. Local field equation
+
+For the active cell `c_t`, define the six-neighbour discrete Laplacian
+
+```text
+Delta_6 Psi[c]
+  = sum(Psi[n] for n in face_neighbours(c)) - 6 Psi[c].
+```
+
+Define the memory residual
+
+```text
+R_t[c] = Psi_t[c] - Omega_t[c].
+```
+
+and signed event impulse
+
+```text
+u_t = +delta_quantity  for bid events
+u_t = -delta_quantity  for ask events.
+```
+
+The hot-path field update is one explicit step
+
+```text
+rhs_t[c]
+  = -alpha R_t[c]
+    + lambda Delta_6 Psi_t[c]
+    + eta u_t
+
+Psi_(t+1)[c]
+  = clamp(Psi_t[c] + dt rhs_t[c], -Psi_max, +Psi_max).
+```
+
+This is a deliberately compiled surrogate of the more general Field Runtime v2 transition. It preserves bounded local propagation and persistent state while eliminating full codec evaluation from the trading path.
+
+Persistent memory is
+
+```text
+Omega_(t+1)[c]
+  = rho Omega_t[c] + (1-rho) Psi_(t+1)[c].
+```
+
+Flow is
+
+```text
+Flow_(t+1)[c]
+  = rho_flow Flow_t[c] + u_t.
+```
+
+Only one center cell is written by the reference transition; seven field values are read (center plus six neighbours). Therefore field work per event is bounded independently of total lattice size.
+
+## 4. Decision and risk
+
+The reference score is intentionally linear so it lowers to a fixed MAC tree:
+
+```text
+s_t
+  = w_psi Psi_(t+1)[c]
+  + w_omega Omega_(t+1)[c]
+  + w_flow Flow_(t+1)[c]
+  + w_lap Delta_6 Psi_t[c]
+  - w_inventory I_t.
+```
+
+Decision:
+
+```text
+if s_t >  threshold: BUY
+if s_t < -threshold: SELL
+otherwise:            NONE
+```
+
+Before an intent is emitted, projected inventory must satisfy
+
+```text
+|I_t + signed_order_quantity| <= I_max.
+```
+
+The reference kernel fails closed when this bound is violated.
+
+This score is a hardware/mechanics demonstrator, not a validated alpha model. A production strategy must be trained and evaluated separately from the latency kernel.
+
+## 5. Complexity
+
+For one event the field kernel performs a fixed number of operations:
+
+```text
+7 field reads
+1 local depth update
+1 six-neighbour Laplacian
+1 explicit field step
+1 memory update
+1 flow update
+1 fixed-width score reduction
+1 bounded risk check
+```
+
+For fixed channel/stencil width,
+
+```text
+C_event = O(1)
+```
+
+with respect to total historical state and total logical field size. This does not mean all-market global inference is O(1); it means the incremental critical-path update is bounded.
+
+## 6. Pipeline budget
+
+Reference design budget at 500 MHz:
+
+| Stage | Cycles |
+|---|---:|
+| ingress / cut-through parse | 8 |
+| local book update | 4 |
+| state load | 4 |
+| field-gradient MACs | 8 |
+| memory update | 4 |
+| score reduction | 6 |
+| risk gate | 4 |
+| order encode | 6 |
+| TX launch | 4 |
+| **Total** | **48** |
+
+At 500 MHz:
+
+```text
+48 cycles * 2 ns/cycle = 96 ns
+```
+
+`96 ns` is a synthesis target only. It must not be reported as measured latency until an RTL implementation is placed, routed, timed, and measured network-to-network.
+
+For context, the audited STAC-T1 ADHOC HFFT-02A result published in October 2024 reported 115.07 ns mean and 140.04 ns 99th percentile SOM-to-SOF at 1x market rate, with 76.40 ns mean EOT-to-SOF. The benchmark version differs from earlier STAC-T1 versions, so cross-version comparisons must be handled carefully.
+
+Reference: https://docs.stacresearch.com/news/ADHC240918
+
+## 7. Determinism contract
+
+A conforming hardware/software implementation must specify and preserve:
+
+1. Q16.16 representation and scaling;
+2. 64-bit multiply intermediate;
+3. truncation toward zero after fixed-point multiplication;
+4. saturating overflow behavior;
+5. fixed reduction order;
+6. fixed coordinate wrapping/mapping;
+7. no hidden floating-point operations in the hot path;
+8. no dynamic allocation in `process`;
+9. deterministic replay digest for an identical event stream;
+10. fail-closed risk behavior.
+
+## 8. Verification ladder
+
+Performance claims advance only through these gates:
+
+```text
+G0 mathematical boundedness
+G1 bit-exact C++ replay
+G2 compiler/sanitizer regression
+G3 HLS/RTL equivalence against C++ vectors
+G4 synthesis timing closure
+G5 post-route timing + resource utilization
+G6 loopback packet latency
+G7 dual-port network timestamping
+G8 STAC-T1-compatible workload
+G9 independent/audited benchmark
+```
+
+A failure at any gate blocks promotion of the corresponding performance claim.
+
+## 9. Current implementation
+
+Files:
+
+```text
+cpp_runtime/include/jarvisx/hft_field.hpp
+cpp_runtime/src/hft_field_main.cpp
+cpp_runtime/tests/hft_field_tests.cpp
+```
+
+The C++ simulator reports software throughput and the 48-cycle FPGA design target separately. Software timing must never be relabeled as FPGA tick-to-trade latency.
+
+## 10. Next hardware lowering
+
+The first RTL should preserve the C++ state transition exactly:
+
+```text
+RX stream
+ -> event parser
+ -> coordinate mapper
+ -> BRAM/URAM 7-cell read bank
+ -> Laplacian MAC tree
+ -> Q16.16 field-step pipeline
+ -> Omega/Flow update
+ -> score MAC tree
+ -> risk comparator
+ -> order-intent encoder
+ -> TX stream
+```
+
+The production design should support shadow mode first: receive live/replayed market data, calculate intents, timestamp them, but emit no exchange-bound orders. Order transmission is enabled only after deterministic equivalence, risk, and latency verification.

--- a/rtl/hft_field_q16/hft_field_cell_core.sv
+++ b/rtl/hft_field_q16/hft_field_cell_core.sv
@@ -1,0 +1,218 @@
+module hft_field_cell_core (
+    input  logic signed [31:0] psi_i,
+    input  logic signed [31:0] omega_i,
+    input  logic signed [31:0] flow_i,
+    input  logic signed [31:0] inventory_i,
+    input  logic signed [31:0] delta_quantity_i,
+    input  logic               side_bid_i,
+    input  logic signed [31:0] psi_xm_i,
+    input  logic signed [31:0] psi_xp_i,
+    input  logic signed [31:0] psi_ym_i,
+    input  logic signed [31:0] psi_yp_i,
+    input  logic signed [31:0] psi_zm_i,
+    input  logic signed [31:0] psi_zp_i,
+
+    output logic signed [31:0] psi_o,
+    output logic signed [31:0] omega_o,
+    output logic signed [31:0] flow_o,
+    output logic signed [31:0] laplacian_o,
+    output logic signed [31:0] score_o,
+    output logic signed [1:0]  action_o,
+    output logic signed [31:0] quantity_o,
+    output logic               risk_accepted_o
+);
+
+    // Q16.16 raw constants. These must match cpp_runtime/include/jarvisx/hft_field.hpp.
+    localparam logic signed [31:0] Q_ONE            = 32'sd65536;
+    localparam logic signed [31:0] Q_SIX            = 32'sd393216;
+    localparam logic signed [31:0] ALPHA            = 32'sd16384;   // 1/4
+    localparam logic signed [31:0] LAMBDA           = 32'sd2048;    // 1/32
+    localparam logic signed [31:0] ETA              = 32'sd32768;   // 1/2
+    localparam logic signed [31:0] DT               = 32'sd8192;    // 1/8
+    localparam logic signed [31:0] RHO              = 32'sd61440;   // 15/16
+    localparam logic signed [31:0] ONE_MINUS_RHO    = 32'sd4096;    // 1/16
+    localparam logic signed [31:0] FLOW_DECAY       = 32'sd57344;   // 7/8
+    localparam logic signed [31:0] W_PSI            = 32'sd65536;   // 1
+    localparam logic signed [31:0] W_OMEGA          = 32'sd32768;   // 1/2
+    localparam logic signed [31:0] W_FLOW           = 32'sd32768;   // 1/2
+    localparam logic signed [31:0] W_LAPLACIAN      = 32'sd8192;    // 1/8
+    localparam logic signed [31:0] W_INVENTORY      = 32'sd16384;   // 1/4
+    localparam logic signed [31:0] DECISION_THRESH  = 32'sd4096;    // 1/16
+    localparam logic signed [31:0] MAX_ABS_FIELD    = 32'sd2097152; // 32
+    localparam logic signed [31:0] MAX_INVENTORY    = 32'sd4194304; // 64
+    localparam logic signed [31:0] MAX_ORDER_QTY    = 32'sd262144;  // 4
+
+    function automatic logic signed [31:0] sat32(input logic signed [63:0] x);
+        begin
+            if (x > 64'sd2147483647)
+                sat32 = 32'sh7fffffff;
+            else if (x < -64'sd2147483648)
+                sat32 = 32'sh80000000;
+            else
+                sat32 = x[31:0];
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qadd(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        logic signed [63:0] aa;
+        logic signed [63:0] bb;
+        begin
+            aa = a;
+            bb = b;
+            qadd = sat32(aa + bb);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qsub(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        logic signed [63:0] aa;
+        logic signed [63:0] bb;
+        begin
+            aa = a;
+            bb = b;
+            qsub = sat32(aa - bb);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qneg(input logic signed [31:0] a);
+        logic signed [63:0] aa;
+        begin
+            aa = a;
+            qneg = sat32(-aa);
+        end
+    endfunction
+
+    // Q16.16 multiplication with a 64-bit product and truncation toward zero.
+    // The magnitude/shift form is intentional: arithmetic right shift alone would
+    // round negative products toward -infinity rather than toward zero.
+    function automatic logic signed [31:0] qmul(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        logic signed [63:0] product;
+        logic signed [63:0] magnitude;
+        logic signed [63:0] scaled;
+        begin
+            product = $signed(a) * $signed(b);
+            if (product < 0) begin
+                magnitude = -product;
+                scaled = -(magnitude >>> 16);
+            end else begin
+                scaled = product >>> 16;
+            end
+            qmul = sat32(scaled);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qabs(input logic signed [31:0] a);
+        begin
+            qabs = a >= 0 ? a : qneg(a);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qclamp(
+        input logic signed [31:0] v,
+        input logic signed [31:0] lo,
+        input logic signed [31:0] hi
+    );
+        begin
+            if (v < lo)
+                qclamp = lo;
+            else if (v > hi)
+                qclamp = hi;
+            else
+                qclamp = v;
+        end
+    endfunction
+
+    logic signed [31:0] impulse;
+    logic signed [31:0] neighbours;
+    logic signed [31:0] lap;
+    logic signed [31:0] residual;
+    logic signed [31:0] rhs;
+    logic signed [31:0] candidate;
+    logic signed [31:0] omega_next;
+    logic signed [31:0] flow_next;
+    logic signed [31:0] score;
+    logic signed [31:0] quantity;
+    logic signed [31:0] signed_order;
+    logic signed [31:0] projected_inventory;
+    logic signed [1:0]  action;
+    logic               risk;
+
+    always_comb begin
+        impulse = side_bid_i ? delta_quantity_i : qneg(delta_quantity_i);
+        flow_next = qadd(qmul(FLOW_DECAY, flow_i), impulse);
+
+        // Preserve the C++ left-associative saturating reduction order exactly.
+        neighbours = qadd(psi_xm_i, psi_xp_i);
+        neighbours = qadd(neighbours, psi_ym_i);
+        neighbours = qadd(neighbours, psi_yp_i);
+        neighbours = qadd(neighbours, psi_zm_i);
+        neighbours = qadd(neighbours, psi_zp_i);
+        lap = qsub(neighbours, qmul(Q_SIX, psi_i));
+
+        residual = qsub(psi_i, omega_i);
+        rhs = qneg(qmul(ALPHA, residual));
+        rhs = qadd(rhs, qmul(LAMBDA, lap));
+        rhs = qadd(rhs, qmul(ETA, impulse));
+
+        candidate = qclamp(
+            qadd(psi_i, qmul(DT, rhs)),
+            qneg(MAX_ABS_FIELD),
+            MAX_ABS_FIELD
+        );
+
+        omega_next = qadd(qmul(RHO, omega_i), qmul(ONE_MINUS_RHO, candidate));
+
+        score = qmul(W_PSI, candidate);
+        score = qadd(score, qmul(W_OMEGA, omega_next));
+        score = qadd(score, qmul(W_FLOW, flow_next));
+        score = qadd(score, qmul(W_LAPLACIAN, lap));
+        score = qsub(score, qmul(W_INVENTORY, inventory_i));
+
+        action = 2'sd0;
+        quantity = 32'sd0;
+        risk = 1'b0;
+
+        if (score > DECISION_THRESH)
+            action = 2'sd1;
+        else if (score < qneg(DECISION_THRESH))
+            action = -2'sd1;
+
+        if (action != 0) begin
+            quantity = qabs(delta_quantity_i);
+            if (quantity > MAX_ORDER_QTY)
+                quantity = MAX_ORDER_QTY;
+            if (quantity == 0)
+                quantity = MAX_ORDER_QTY;
+
+            signed_order = action == 2'sd1 ? quantity : qneg(quantity);
+            projected_inventory = qadd(inventory_i, signed_order);
+            risk = qabs(projected_inventory) <= MAX_INVENTORY;
+
+            if (!risk) begin
+                action = 2'sd0;
+                quantity = 32'sd0;
+            end
+        end else begin
+            signed_order = 32'sd0;
+            projected_inventory = inventory_i;
+        end
+
+        psi_o = candidate;
+        omega_o = omega_next;
+        flow_o = flow_next;
+        laplacian_o = lap;
+        score_o = score;
+        action_o = action;
+        quantity_o = quantity;
+        risk_accepted_o = risk;
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_cell_pipeline.sv
+++ b/rtl/hft_field_q16/hft_field_cell_pipeline.sv
@@ -1,0 +1,139 @@
+module hft_field_cell_pipeline #(
+    parameter integer LATENCY_CYCLES = 17
+) (
+    input  logic                    clk,
+    input  logic                    rst_n,
+    input  logic                    in_valid,
+
+    input  logic signed [31:0]      psi_i,
+    input  logic signed [31:0]      omega_i,
+    input  logic signed [31:0]      flow_i,
+    input  logic signed [31:0]      inventory_i,
+    input  logic signed [31:0]      delta_quantity_i,
+    input  logic                    side_bid_i,
+    input  logic signed [31:0]      psi_xm_i,
+    input  logic signed [31:0]      psi_xp_i,
+    input  logic signed [31:0]      psi_ym_i,
+    input  logic signed [31:0]      psi_yp_i,
+    input  logic signed [31:0]      psi_zm_i,
+    input  logic signed [31:0]      psi_zp_i,
+
+    output logic                    out_valid,
+    output logic signed [31:0]      psi_o,
+    output logic signed [31:0]      omega_o,
+    output logic signed [31:0]      flow_o,
+    output logic signed [31:0]      laplacian_o,
+    output logic signed [31:0]      score_o,
+    output logic signed [1:0]       action_o,
+    output logic signed [31:0]      quantity_o,
+    output logic                    risk_accepted_o
+);
+
+    // This module establishes the fixed valid-to-valid latency contract around
+    // the bit-exact multiplier-free arithmetic core. It intentionally does not
+    // claim timing closure: hft_field_cell_pow2 remains combinational here and
+    // is the correctness oracle to be repartitioned across registers later.
+
+    logic signed [31:0] comb_psi;
+    logic signed [31:0] comb_omega;
+    logic signed [31:0] comb_flow;
+    logic signed [31:0] comb_laplacian;
+    logic signed [31:0] comb_score;
+    logic signed [1:0]  comb_action;
+    logic signed [31:0] comb_quantity;
+    logic               comb_risk;
+
+    hft_field_cell_pow2 arithmetic_core (
+        .psi_i(psi_i),
+        .omega_i(omega_i),
+        .flow_i(flow_i),
+        .inventory_i(inventory_i),
+        .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i),
+        .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i),
+        .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i),
+        .psi_zp_i(psi_zp_i),
+        .psi_o(comb_psi),
+        .omega_o(comb_omega),
+        .flow_o(comb_flow),
+        .laplacian_o(comb_laplacian),
+        .score_o(comb_score),
+        .action_o(comb_action),
+        .quantity_o(comb_quantity),
+        .risk_accepted_o(comb_risk)
+    );
+
+    logic                    valid_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      psi_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      omega_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      flow_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      lap_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      score_pipe [0:LATENCY_CYCLES];
+    logic signed [1:0]       action_pipe [0:LATENCY_CYCLES];
+    logic signed [31:0]      quantity_pipe [0:LATENCY_CYCLES];
+    logic                    risk_pipe [0:LATENCY_CYCLES];
+
+    integer i;
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (i = 0; i <= LATENCY_CYCLES; i = i + 1) begin
+                valid_pipe[i] <= 1'b0;
+                psi_pipe[i] <= '0;
+                omega_pipe[i] <= '0;
+                flow_pipe[i] <= '0;
+                lap_pipe[i] <= '0;
+                score_pipe[i] <= '0;
+                action_pipe[i] <= '0;
+                quantity_pipe[i] <= '0;
+                risk_pipe[i] <= 1'b0;
+            end
+        end else begin
+            valid_pipe[0] <= in_valid;
+            if (in_valid) begin
+                psi_pipe[0] <= comb_psi;
+                omega_pipe[0] <= comb_omega;
+                flow_pipe[0] <= comb_flow;
+                lap_pipe[0] <= comb_laplacian;
+                score_pipe[0] <= comb_score;
+                action_pipe[0] <= comb_action;
+                quantity_pipe[0] <= comb_quantity;
+                risk_pipe[0] <= comb_risk;
+            end
+
+            for (i = 1; i <= LATENCY_CYCLES; i = i + 1) begin
+                valid_pipe[i] <= valid_pipe[i - 1];
+                if (valid_pipe[i - 1]) begin
+                    psi_pipe[i] <= psi_pipe[i - 1];
+                    omega_pipe[i] <= omega_pipe[i - 1];
+                    flow_pipe[i] <= flow_pipe[i - 1];
+                    lap_pipe[i] <= lap_pipe[i - 1];
+                    score_pipe[i] <= score_pipe[i - 1];
+                    action_pipe[i] <= action_pipe[i - 1];
+                    quantity_pipe[i] <= quantity_pipe[i - 1];
+                    risk_pipe[i] <= risk_pipe[i - 1];
+                end
+            end
+        end
+    end
+
+    always_comb begin
+        out_valid = valid_pipe[LATENCY_CYCLES];
+        psi_o = psi_pipe[LATENCY_CYCLES];
+        omega_o = omega_pipe[LATENCY_CYCLES];
+        flow_o = flow_pipe[LATENCY_CYCLES];
+        laplacian_o = lap_pipe[LATENCY_CYCLES];
+        score_o = score_pipe[LATENCY_CYCLES];
+        action_o = action_pipe[LATENCY_CYCLES];
+        quantity_o = quantity_pipe[LATENCY_CYCLES];
+        risk_accepted_o = risk_pipe[LATENCY_CYCLES];
+    end
+
+    initial begin
+        if (LATENCY_CYCLES < 1)
+            $error("LATENCY_CYCLES must be >= 1");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_cell_pow2.sv
+++ b/rtl/hft_field_q16/hft_field_cell_pow2.sv
@@ -1,0 +1,238 @@
+module hft_field_cell_pow2 (
+    input  logic signed [31:0] psi_i,
+    input  logic signed [31:0] omega_i,
+    input  logic signed [31:0] flow_i,
+    input  logic signed [31:0] inventory_i,
+    input  logic signed [31:0] delta_quantity_i,
+    input  logic               side_bid_i,
+    input  logic signed [31:0] psi_xm_i,
+    input  logic signed [31:0] psi_xp_i,
+    input  logic signed [31:0] psi_ym_i,
+    input  logic signed [31:0] psi_yp_i,
+    input  logic signed [31:0] psi_zm_i,
+    input  logic signed [31:0] psi_zp_i,
+
+    output logic signed [31:0] psi_o,
+    output logic signed [31:0] omega_o,
+    output logic signed [31:0] flow_o,
+    output logic signed [31:0] laplacian_o,
+    output logic signed [31:0] score_o,
+    output logic signed [1:0]  action_o,
+    output logic signed [31:0] quantity_o,
+    output logic               risk_accepted_o
+);
+
+    // Fixed default HFT configuration. All coefficients are dyadic rationals,
+    // so the exact C++ Q16.16 products can be lowered to shift/add operations.
+    localparam logic signed [31:0] DECISION_THRESH = 32'sd4096;    // 1/16
+    localparam logic signed [31:0] MAX_ABS_FIELD   = 32'sd2097152; // 32
+    localparam logic signed [31:0] MAX_INVENTORY   = 32'sd4194304; // 64
+    localparam logic signed [31:0] MAX_ORDER_QTY   = 32'sd262144;  // 4
+
+    function automatic logic signed [63:0] sx32(input logic signed [31:0] a);
+        begin
+            sx32 = {{32{a[31]}}, a};
+        end
+    endfunction
+
+    function automatic logic signed [31:0] sat32(input logic signed [63:0] x);
+        begin
+            if (x > 64'sd2147483647)
+                sat32 = 32'sh7fffffff;
+            else if (x < -64'sd2147483648)
+                sat32 = 32'sh80000000;
+            else
+                sat32 = x[31:0];
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qadd(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        begin
+            qadd = sat32(sx32(a) + sx32(b));
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qsub(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        begin
+            qsub = sat32(sx32(a) - sx32(b));
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qneg(input logic signed [31:0] a);
+        begin
+            qneg = sat32(-sx32(a));
+        end
+    endfunction
+
+    // Exact signed division by 2^shift with C++ truncation toward zero.
+    function automatic logic signed [31:0] div_pow2_tz(
+        input logic signed [63:0] value,
+        input integer shift
+    );
+        logic signed [63:0] magnitude;
+        logic signed [63:0] scaled;
+        begin
+            if (value < 0) begin
+                magnitude = -value;
+                scaled = -(magnitude >>> shift);
+            end else begin
+                scaled = value >>> shift;
+            end
+            div_pow2_tz = sat32(scaled);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv2(input logic signed [31:0] a);
+        begin qdiv2 = div_pow2_tz(sx32(a), 1); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv4(input logic signed [31:0] a);
+        begin qdiv4 = div_pow2_tz(sx32(a), 2); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv8(input logic signed [31:0] a);
+        begin qdiv8 = div_pow2_tz(sx32(a), 3); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv16(input logic signed [31:0] a);
+        begin qdiv16 = div_pow2_tz(sx32(a), 4); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv32(input logic signed [31:0] a);
+        begin qdiv32 = div_pow2_tz(sx32(a), 5); end
+    endfunction
+
+    function automatic logic signed [31:0] qmul7div8(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 3) - sx32(a);
+            qmul7div8 = div_pow2_tz(v, 3);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qmul15div16(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 4) - sx32(a);
+            qmul15div16 = div_pow2_tz(v, 4);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qmul6(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 2) + (sx32(a) <<< 1);
+            qmul6 = sat32(v);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qabs(input logic signed [31:0] a);
+        begin qabs = a >= 0 ? a : qneg(a); end
+    endfunction
+
+    function automatic logic signed [31:0] qclamp(
+        input logic signed [31:0] v,
+        input logic signed [31:0] lo,
+        input logic signed [31:0] hi
+    );
+        begin
+            if (v < lo)
+                qclamp = lo;
+            else if (v > hi)
+                qclamp = hi;
+            else
+                qclamp = v;
+        end
+    endfunction
+
+    logic signed [31:0] impulse;
+    logic signed [31:0] neighbours;
+    logic signed [31:0] lap;
+    logic signed [31:0] residual;
+    logic signed [31:0] rhs;
+    logic signed [31:0] candidate;
+    logic signed [31:0] omega_next;
+    logic signed [31:0] flow_next;
+    logic signed [31:0] score;
+    logic signed [31:0] quantity;
+    logic signed [31:0] signed_order;
+    logic signed [31:0] projected_inventory;
+    logic signed [1:0]  action;
+    logic               risk;
+
+    always_comb begin
+        impulse = side_bid_i ? delta_quantity_i : qneg(delta_quantity_i);
+        flow_next = qadd(qmul7div8(flow_i), impulse);
+
+        // Exact left-associative saturated six-neighbour reduction.
+        neighbours = qadd(psi_xm_i, psi_xp_i);
+        neighbours = qadd(neighbours, psi_ym_i);
+        neighbours = qadd(neighbours, psi_yp_i);
+        neighbours = qadd(neighbours, psi_zm_i);
+        neighbours = qadd(neighbours, psi_zp_i);
+        lap = qsub(neighbours, qmul6(psi_i));
+
+        residual = qsub(psi_i, omega_i);
+        rhs = qneg(qdiv4(residual));
+        rhs = qadd(rhs, qdiv32(lap));
+        rhs = qadd(rhs, qdiv2(impulse));
+
+        candidate = qclamp(
+            qadd(psi_i, qdiv8(rhs)),
+            qneg(MAX_ABS_FIELD),
+            MAX_ABS_FIELD
+        );
+
+        omega_next = qadd(qmul15div16(omega_i), qdiv16(candidate));
+
+        score = candidate;
+        score = qadd(score, qdiv2(omega_next));
+        score = qadd(score, qdiv2(flow_next));
+        score = qadd(score, qdiv8(lap));
+        score = qsub(score, qdiv4(inventory_i));
+
+        action = 2'sd0;
+        quantity = 32'sd0;
+        risk = 1'b0;
+        signed_order = 32'sd0;
+        projected_inventory = inventory_i;
+
+        if (score > DECISION_THRESH)
+            action = 2'sd1;
+        else if (score < qneg(DECISION_THRESH))
+            action = -2'sd1;
+
+        if (action != 0) begin
+            quantity = qabs(delta_quantity_i);
+            if (quantity > MAX_ORDER_QTY)
+                quantity = MAX_ORDER_QTY;
+            if (quantity == 0)
+                quantity = MAX_ORDER_QTY;
+
+            signed_order = action == 2'sd1 ? quantity : qneg(quantity);
+            projected_inventory = qadd(inventory_i, signed_order);
+            risk = qabs(projected_inventory) <= MAX_INVENTORY;
+
+            if (!risk) begin
+                action = 2'sd0;
+                quantity = 32'sd0;
+            end
+        end
+
+        psi_o = candidate;
+        omega_o = omega_next;
+        flow_o = flow_next;
+        laplacian_o = lap;
+        score_o = score;
+        action_o = action;
+        quantity_o = quantity;
+        risk_accepted_o = risk;
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_cell_staged.sv
+++ b/rtl/hft_field_q16/hft_field_cell_staged.sv
@@ -1,0 +1,406 @@
+module hft_field_cell_staged (
+    input  logic                    clk,
+    input  logic                    rst_n,
+    input  logic                    in_valid,
+
+    input  logic signed [31:0]      psi_i,
+    input  logic signed [31:0]      omega_i,
+    input  logic signed [31:0]      flow_i,
+    input  logic signed [31:0]      inventory_i,
+    input  logic signed [31:0]      delta_quantity_i,
+    input  logic                    side_bid_i,
+    input  logic signed [31:0]      psi_xm_i,
+    input  logic signed [31:0]      psi_xp_i,
+    input  logic signed [31:0]      psi_ym_i,
+    input  logic signed [31:0]      psi_yp_i,
+    input  logic signed [31:0]      psi_zm_i,
+    input  logic signed [31:0]      psi_zp_i,
+
+    output logic                    out_valid,
+    output logic signed [31:0]      psi_o,
+    output logic signed [31:0]      omega_o,
+    output logic signed [31:0]      flow_o,
+    output logic signed [31:0]      laplacian_o,
+    output logic signed [31:0]      score_o,
+    output logic signed [1:0]       action_o,
+    output logic signed [31:0]      quantity_o,
+    output logic                    risk_accepted_o
+);
+
+    localparam logic signed [31:0] DECISION_THRESH = 32'sd4096;
+    localparam logic signed [31:0] MAX_ABS_FIELD   = 32'sd2097152;
+    localparam logic signed [31:0] MAX_INVENTORY   = 32'sd4194304;
+    localparam logic signed [31:0] MAX_ORDER_QTY   = 32'sd262144;
+
+    function automatic logic signed [63:0] sx32(input logic signed [31:0] a);
+        begin sx32 = {{32{a[31]}}, a}; end
+    endfunction
+
+    function automatic logic signed [31:0] sat32(input logic signed [63:0] x);
+        begin
+            if (x > 64'sd2147483647)
+                sat32 = 32'sh7fffffff;
+            else if (x < -64'sd2147483648)
+                sat32 = 32'sh80000000;
+            else
+                sat32 = x[31:0];
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qadd(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        begin qadd = sat32(sx32(a) + sx32(b)); end
+    endfunction
+
+    function automatic logic signed [31:0] qsub(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        begin qsub = sat32(sx32(a) - sx32(b)); end
+    endfunction
+
+    function automatic logic signed [31:0] qneg(input logic signed [31:0] a);
+        begin qneg = sat32(-sx32(a)); end
+    endfunction
+
+    function automatic logic signed [31:0] div_pow2_tz(
+        input logic signed [63:0] value,
+        input integer shift
+    );
+        logic signed [63:0] magnitude;
+        logic signed [63:0] scaled;
+        begin
+            if (value < 0) begin
+                magnitude = -value;
+                scaled = -(magnitude >>> shift);
+            end else begin
+                scaled = value >>> shift;
+            end
+            div_pow2_tz = sat32(scaled);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv2(input logic signed [31:0] a);
+        begin qdiv2 = div_pow2_tz(sx32(a), 1); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv4(input logic signed [31:0] a);
+        begin qdiv4 = div_pow2_tz(sx32(a), 2); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv8(input logic signed [31:0] a);
+        begin qdiv8 = div_pow2_tz(sx32(a), 3); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv16(input logic signed [31:0] a);
+        begin qdiv16 = div_pow2_tz(sx32(a), 4); end
+    endfunction
+
+    function automatic logic signed [31:0] qdiv32(input logic signed [31:0] a);
+        begin qdiv32 = div_pow2_tz(sx32(a), 5); end
+    endfunction
+
+    function automatic logic signed [31:0] qmul7div8(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 3) - sx32(a);
+            qmul7div8 = div_pow2_tz(v, 3);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qmul15div16(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 4) - sx32(a);
+            qmul15div16 = div_pow2_tz(v, 4);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qmul6(input logic signed [31:0] a);
+        logic signed [63:0] v;
+        begin
+            v = (sx32(a) <<< 2) + (sx32(a) <<< 1);
+            qmul6 = sat32(v);
+        end
+    endfunction
+
+    function automatic logic signed [31:0] qabs(input logic signed [31:0] a);
+        begin qabs = a >= 0 ? a : qneg(a); end
+    endfunction
+
+    function automatic logic signed [31:0] qclamp(
+        input logic signed [31:0] v,
+        input logic signed [31:0] lo,
+        input logic signed [31:0] hi
+    );
+        begin
+            if (v < lo)
+                qclamp = lo;
+            else if (v > hi)
+                qclamp = hi;
+            else
+                qclamp = v;
+        end
+    endfunction
+
+    logic v0, v1, v2, v3, v4, v5, v6, v7, v8;
+    logic v9, v10, v11, v12, v13, v14, v15, v16;
+
+    // Stage 0: captured inputs.
+    logic signed [31:0] s0_psi, s0_omega, s0_flow, s0_inventory, s0_delta;
+    logic s0_side_bid;
+    logic signed [31:0] s0_xm, s0_xp, s0_ym, s0_yp, s0_zm, s0_zp;
+
+    // Stage 1: impulse, flow, residual and first neighbour reduction.
+    logic signed [31:0] s1_psi, s1_omega, s1_inventory, s1_delta;
+    logic signed [31:0] s1_impulse, s1_flow_next, s1_residual, s1_neighbours;
+    logic signed [31:0] s1_ym, s1_yp, s1_zm, s1_zp;
+
+    logic signed [31:0] s2_psi, s2_omega, s2_inventory, s2_delta;
+    logic signed [31:0] s2_impulse, s2_flow_next, s2_residual, s2_neighbours;
+    logic signed [31:0] s2_yp, s2_zm, s2_zp;
+
+    logic signed [31:0] s3_psi, s3_omega, s3_inventory, s3_delta;
+    logic signed [31:0] s3_impulse, s3_flow_next, s3_residual, s3_neighbours;
+    logic signed [31:0] s3_zm, s3_zp;
+
+    logic signed [31:0] s4_psi, s4_omega, s4_inventory, s4_delta;
+    logic signed [31:0] s4_impulse, s4_flow_next, s4_residual, s4_neighbours;
+    logic signed [31:0] s4_zp;
+
+    logic signed [31:0] s5_psi, s5_omega, s5_inventory, s5_delta;
+    logic signed [31:0] s5_impulse, s5_flow_next, s5_residual, s5_neighbours;
+
+    logic signed [31:0] s6_psi, s6_omega, s6_inventory, s6_delta;
+    logic signed [31:0] s6_impulse, s6_flow_next, s6_residual, s6_lap;
+
+    logic signed [31:0] s7_psi, s7_omega, s7_inventory, s7_delta;
+    logic signed [31:0] s7_impulse, s7_flow_next, s7_lap, s7_rhs;
+
+    logic signed [31:0] s8_psi, s8_omega, s8_inventory, s8_delta;
+    logic signed [31:0] s8_impulse, s8_flow_next, s8_lap, s8_rhs;
+
+    logic signed [31:0] s9_psi, s9_omega, s9_inventory, s9_delta;
+    logic signed [31:0] s9_flow_next, s9_lap, s9_rhs;
+
+    logic signed [31:0] s10_omega, s10_inventory, s10_delta;
+    logic signed [31:0] s10_flow_next, s10_lap, s10_candidate;
+
+    logic signed [31:0] s11_inventory, s11_delta, s11_flow_next, s11_lap;
+    logic signed [31:0] s11_candidate, s11_omega_next;
+
+    logic signed [31:0] s12_inventory, s12_delta, s12_flow_next, s12_lap;
+    logic signed [31:0] s12_candidate, s12_omega_next, s12_score;
+
+    logic signed [31:0] s13_inventory, s13_delta, s13_lap;
+    logic signed [31:0] s13_candidate, s13_omega_next, s13_flow_next, s13_score;
+
+    logic signed [31:0] s14_inventory, s14_delta, s14_lap;
+    logic signed [31:0] s14_candidate, s14_omega_next, s14_flow_next, s14_score;
+
+    logic signed [31:0] s15_inventory, s15_delta, s15_lap;
+    logic signed [31:0] s15_candidate, s15_omega_next, s15_flow_next, s15_score;
+
+    logic signed [31:0] s16_candidate, s16_omega_next, s16_flow_next, s16_lap, s16_score;
+    logic signed [1:0]  s16_action;
+    logic signed [31:0] s16_quantity;
+    logic               s16_risk;
+
+    logic signed [1:0]  final_action_c;
+    logic signed [31:0] final_quantity_c;
+    logic signed [31:0] final_signed_order_c;
+    logic signed [31:0] final_projected_inventory_c;
+    logic               final_risk_c;
+
+    always_comb begin
+        final_action_c = 2'sd0;
+        final_quantity_c = 32'sd0;
+        final_signed_order_c = 32'sd0;
+        final_projected_inventory_c = s15_inventory;
+        final_risk_c = 1'b0;
+
+        if (s15_score > DECISION_THRESH)
+            final_action_c = 2'sd1;
+        else if (s15_score < qneg(DECISION_THRESH))
+            final_action_c = -2'sd1;
+
+        if (final_action_c != 0) begin
+            final_quantity_c = qabs(s15_delta);
+            if (final_quantity_c > MAX_ORDER_QTY)
+                final_quantity_c = MAX_ORDER_QTY;
+            if (final_quantity_c == 0)
+                final_quantity_c = MAX_ORDER_QTY;
+
+            final_signed_order_c = final_action_c == 2'sd1
+                ? final_quantity_c
+                : qneg(final_quantity_c);
+            final_projected_inventory_c = qadd(s15_inventory, final_signed_order_c);
+            final_risk_c = qabs(final_projected_inventory_c) <= MAX_INVENTORY;
+
+            if (!final_risk_c) begin
+                final_action_c = 2'sd0;
+                final_quantity_c = 32'sd0;
+            end
+        end
+    end
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            v0 <= 1'b0; v1 <= 1'b0; v2 <= 1'b0; v3 <= 1'b0; v4 <= 1'b0;
+            v5 <= 1'b0; v6 <= 1'b0; v7 <= 1'b0; v8 <= 1'b0; v9 <= 1'b0;
+            v10 <= 1'b0; v11 <= 1'b0; v12 <= 1'b0; v13 <= 1'b0;
+            v14 <= 1'b0; v15 <= 1'b0; v16 <= 1'b0;
+            out_valid <= 1'b0;
+            psi_o <= '0; omega_o <= '0; flow_o <= '0; laplacian_o <= '0;
+            score_o <= '0; action_o <= '0; quantity_o <= '0; risk_accepted_o <= 1'b0;
+
+            s0_psi <= '0; s0_omega <= '0; s0_flow <= '0; s0_inventory <= '0; s0_delta <= '0;
+            s0_side_bid <= 1'b0; s0_xm <= '0; s0_xp <= '0; s0_ym <= '0; s0_yp <= '0; s0_zm <= '0; s0_zp <= '0;
+            s1_psi <= '0; s1_omega <= '0; s1_inventory <= '0; s1_delta <= '0; s1_impulse <= '0; s1_flow_next <= '0; s1_residual <= '0; s1_neighbours <= '0; s1_ym <= '0; s1_yp <= '0; s1_zm <= '0; s1_zp <= '0;
+            s2_psi <= '0; s2_omega <= '0; s2_inventory <= '0; s2_delta <= '0; s2_impulse <= '0; s2_flow_next <= '0; s2_residual <= '0; s2_neighbours <= '0; s2_yp <= '0; s2_zm <= '0; s2_zp <= '0;
+            s3_psi <= '0; s3_omega <= '0; s3_inventory <= '0; s3_delta <= '0; s3_impulse <= '0; s3_flow_next <= '0; s3_residual <= '0; s3_neighbours <= '0; s3_zm <= '0; s3_zp <= '0;
+            s4_psi <= '0; s4_omega <= '0; s4_inventory <= '0; s4_delta <= '0; s4_impulse <= '0; s4_flow_next <= '0; s4_residual <= '0; s4_neighbours <= '0; s4_zp <= '0;
+            s5_psi <= '0; s5_omega <= '0; s5_inventory <= '0; s5_delta <= '0; s5_impulse <= '0; s5_flow_next <= '0; s5_residual <= '0; s5_neighbours <= '0;
+            s6_psi <= '0; s6_omega <= '0; s6_inventory <= '0; s6_delta <= '0; s6_impulse <= '0; s6_flow_next <= '0; s6_residual <= '0; s6_lap <= '0;
+            s7_psi <= '0; s7_omega <= '0; s7_inventory <= '0; s7_delta <= '0; s7_impulse <= '0; s7_flow_next <= '0; s7_lap <= '0; s7_rhs <= '0;
+            s8_psi <= '0; s8_omega <= '0; s8_inventory <= '0; s8_delta <= '0; s8_impulse <= '0; s8_flow_next <= '0; s8_lap <= '0; s8_rhs <= '0;
+            s9_psi <= '0; s9_omega <= '0; s9_inventory <= '0; s9_delta <= '0; s9_flow_next <= '0; s9_lap <= '0; s9_rhs <= '0;
+            s10_omega <= '0; s10_inventory <= '0; s10_delta <= '0; s10_flow_next <= '0; s10_lap <= '0; s10_candidate <= '0;
+            s11_inventory <= '0; s11_delta <= '0; s11_flow_next <= '0; s11_lap <= '0; s11_candidate <= '0; s11_omega_next <= '0;
+            s12_inventory <= '0; s12_delta <= '0; s12_flow_next <= '0; s12_lap <= '0; s12_candidate <= '0; s12_omega_next <= '0; s12_score <= '0;
+            s13_inventory <= '0; s13_delta <= '0; s13_lap <= '0; s13_candidate <= '0; s13_omega_next <= '0; s13_flow_next <= '0; s13_score <= '0;
+            s14_inventory <= '0; s14_delta <= '0; s14_lap <= '0; s14_candidate <= '0; s14_omega_next <= '0; s14_flow_next <= '0; s14_score <= '0;
+            s15_inventory <= '0; s15_delta <= '0; s15_lap <= '0; s15_candidate <= '0; s15_omega_next <= '0; s15_flow_next <= '0; s15_score <= '0;
+            s16_candidate <= '0; s16_omega_next <= '0; s16_flow_next <= '0; s16_lap <= '0; s16_score <= '0; s16_action <= '0; s16_quantity <= '0; s16_risk <= 1'b0;
+        end else begin
+            v0 <= in_valid;
+            v1 <= v0; v2 <= v1; v3 <= v2; v4 <= v3; v5 <= v4; v6 <= v5;
+            v7 <= v6; v8 <= v7; v9 <= v8; v10 <= v9; v11 <= v10;
+            v12 <= v11; v13 <= v12; v14 <= v13; v15 <= v14; v16 <= v15;
+            out_valid <= v16;
+
+            if (in_valid) begin
+                s0_psi <= psi_i; s0_omega <= omega_i; s0_flow <= flow_i;
+                s0_inventory <= inventory_i; s0_delta <= delta_quantity_i; s0_side_bid <= side_bid_i;
+                s0_xm <= psi_xm_i; s0_xp <= psi_xp_i; s0_ym <= psi_ym_i;
+                s0_yp <= psi_yp_i; s0_zm <= psi_zm_i; s0_zp <= psi_zp_i;
+            end
+
+            if (v0) begin
+                s1_psi <= s0_psi; s1_omega <= s0_omega; s1_inventory <= s0_inventory; s1_delta <= s0_delta;
+                s1_impulse <= s0_side_bid ? s0_delta : qneg(s0_delta);
+                s1_flow_next <= qadd(qmul7div8(s0_flow), s0_side_bid ? s0_delta : qneg(s0_delta));
+                s1_residual <= qsub(s0_psi, s0_omega);
+                s1_neighbours <= qadd(s0_xm, s0_xp);
+                s1_ym <= s0_ym; s1_yp <= s0_yp; s1_zm <= s0_zm; s1_zp <= s0_zp;
+            end
+
+            if (v1) begin
+                s2_psi <= s1_psi; s2_omega <= s1_omega; s2_inventory <= s1_inventory; s2_delta <= s1_delta;
+                s2_impulse <= s1_impulse; s2_flow_next <= s1_flow_next; s2_residual <= s1_residual;
+                s2_neighbours <= qadd(s1_neighbours, s1_ym);
+                s2_yp <= s1_yp; s2_zm <= s1_zm; s2_zp <= s1_zp;
+            end
+
+            if (v2) begin
+                s3_psi <= s2_psi; s3_omega <= s2_omega; s3_inventory <= s2_inventory; s3_delta <= s2_delta;
+                s3_impulse <= s2_impulse; s3_flow_next <= s2_flow_next; s3_residual <= s2_residual;
+                s3_neighbours <= qadd(s2_neighbours, s2_yp);
+                s3_zm <= s2_zm; s3_zp <= s2_zp;
+            end
+
+            if (v3) begin
+                s4_psi <= s3_psi; s4_omega <= s3_omega; s4_inventory <= s3_inventory; s4_delta <= s3_delta;
+                s4_impulse <= s3_impulse; s4_flow_next <= s3_flow_next; s4_residual <= s3_residual;
+                s4_neighbours <= qadd(s3_neighbours, s3_zm);
+                s4_zp <= s3_zp;
+            end
+
+            if (v4) begin
+                s5_psi <= s4_psi; s5_omega <= s4_omega; s5_inventory <= s4_inventory; s5_delta <= s4_delta;
+                s5_impulse <= s4_impulse; s5_flow_next <= s4_flow_next; s5_residual <= s4_residual;
+                s5_neighbours <= qadd(s4_neighbours, s4_zp);
+            end
+
+            if (v5) begin
+                s6_psi <= s5_psi; s6_omega <= s5_omega; s6_inventory <= s5_inventory; s6_delta <= s5_delta;
+                s6_impulse <= s5_impulse; s6_flow_next <= s5_flow_next; s6_residual <= s5_residual;
+                s6_lap <= qsub(s5_neighbours, qmul6(s5_psi));
+            end
+
+            if (v6) begin
+                s7_psi <= s6_psi; s7_omega <= s6_omega; s7_inventory <= s6_inventory; s7_delta <= s6_delta;
+                s7_impulse <= s6_impulse; s7_flow_next <= s6_flow_next; s7_lap <= s6_lap;
+                s7_rhs <= qneg(qdiv4(s6_residual));
+            end
+
+            if (v7) begin
+                s8_psi <= s7_psi; s8_omega <= s7_omega; s8_inventory <= s7_inventory; s8_delta <= s7_delta;
+                s8_impulse <= s7_impulse; s8_flow_next <= s7_flow_next; s8_lap <= s7_lap;
+                s8_rhs <= qadd(s7_rhs, qdiv32(s7_lap));
+            end
+
+            if (v8) begin
+                s9_psi <= s8_psi; s9_omega <= s8_omega; s9_inventory <= s8_inventory; s9_delta <= s8_delta;
+                s9_flow_next <= s8_flow_next; s9_lap <= s8_lap;
+                s9_rhs <= qadd(s8_rhs, qdiv2(s8_impulse));
+            end
+
+            if (v9) begin
+                s10_omega <= s9_omega; s10_inventory <= s9_inventory; s10_delta <= s9_delta;
+                s10_flow_next <= s9_flow_next; s10_lap <= s9_lap;
+                s10_candidate <= qclamp(qadd(s9_psi, qdiv8(s9_rhs)), qneg(MAX_ABS_FIELD), MAX_ABS_FIELD);
+            end
+
+            if (v10) begin
+                s11_inventory <= s10_inventory; s11_delta <= s10_delta; s11_flow_next <= s10_flow_next; s11_lap <= s10_lap;
+                s11_candidate <= s10_candidate;
+                s11_omega_next <= qadd(qmul15div16(s10_omega), qdiv16(s10_candidate));
+            end
+
+            if (v11) begin
+                s12_inventory <= s11_inventory; s12_delta <= s11_delta; s12_flow_next <= s11_flow_next; s12_lap <= s11_lap;
+                s12_candidate <= s11_candidate; s12_omega_next <= s11_omega_next;
+                s12_score <= qadd(s11_candidate, qdiv2(s11_omega_next));
+            end
+
+            if (v12) begin
+                s13_inventory <= s12_inventory; s13_delta <= s12_delta; s13_lap <= s12_lap;
+                s13_candidate <= s12_candidate; s13_omega_next <= s12_omega_next; s13_flow_next <= s12_flow_next;
+                s13_score <= qadd(s12_score, qdiv2(s12_flow_next));
+            end
+
+            if (v13) begin
+                s14_inventory <= s13_inventory; s14_delta <= s13_delta; s14_lap <= s13_lap;
+                s14_candidate <= s13_candidate; s14_omega_next <= s13_omega_next; s14_flow_next <= s13_flow_next;
+                s14_score <= qadd(s13_score, qdiv8(s13_lap));
+            end
+
+            if (v14) begin
+                s15_inventory <= s14_inventory; s15_delta <= s14_delta; s15_lap <= s14_lap;
+                s15_candidate <= s14_candidate; s15_omega_next <= s14_omega_next; s15_flow_next <= s14_flow_next;
+                s15_score <= qsub(s14_score, qdiv4(s14_inventory));
+            end
+
+            if (v15) begin
+                s16_candidate <= s15_candidate; s16_omega_next <= s15_omega_next;
+                s16_flow_next <= s15_flow_next; s16_lap <= s15_lap; s16_score <= s15_score;
+                s16_action <= final_action_c; s16_quantity <= final_quantity_c; s16_risk <= final_risk_c;
+            end
+
+            if (v16) begin
+                psi_o <= s16_candidate;
+                omega_o <= s16_omega_next;
+                flow_o <= s16_flow_next;
+                laplacian_o <= s16_lap;
+                score_o <= s16_score;
+                action_o <= s16_action;
+                quantity_o <= s16_quantity;
+                risk_accepted_o <= s16_risk;
+            end
+        end
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_guarded_pipeline.sv
+++ b/rtl/hft_field_q16/hft_field_guarded_pipeline.sv
@@ -1,0 +1,104 @@
+module hft_field_guarded_pipeline #(
+    parameter integer COORD_WIDTH = 16,
+    parameter integer LATENCY_CYCLES = 17
+) (
+    input  logic                    clk,
+    input  logic                    rst_n,
+    input  logic                    in_valid,
+    input  logic [COORD_WIDTH-1:0]  in_coord,
+
+    input  logic signed [31:0]      psi_i,
+    input  logic signed [31:0]      omega_i,
+    input  logic signed [31:0]      flow_i,
+    input  logic signed [31:0]      inventory_i,
+    input  logic signed [31:0]      delta_quantity_i,
+    input  logic                    side_bid_i,
+    input  logic signed [31:0]      psi_xm_i,
+    input  logic signed [31:0]      psi_xp_i,
+    input  logic signed [31:0]      psi_ym_i,
+    input  logic signed [31:0]      psi_yp_i,
+    input  logic signed [31:0]      psi_zm_i,
+    input  logic signed [31:0]      psi_zp_i,
+
+    output logic                    in_ready,
+    output logic                    conflict_o,
+    output logic                    out_valid,
+    output logic [COORD_WIDTH-1:0]  out_coord,
+    output logic signed [31:0]      psi_o,
+    output logic signed [31:0]      omega_o,
+    output logic signed [31:0]      flow_o,
+    output logic signed [31:0]      laplacian_o,
+    output logic signed [31:0]      score_o,
+    output logic signed [1:0]       action_o,
+    output logic signed [31:0]      quantity_o,
+    output logic                    risk_accepted_o,
+    output logic                    alignment_error_o
+);
+
+    // Transaction integration boundary:
+    //   1. reject a coordinate already in flight (RAW hazard),
+    //   2. launch accepted independent coordinates into the staged core,
+    //   3. retire coordinate and arithmetic result on the same cycle.
+    //
+    // This block still consumes state values supplied by an external store.
+    // It does not yet implement BRAM/URAM banking or neighbour fetch.
+
+    logic accept;
+    logic commit_valid;
+    logic [COORD_WIDTH-1:0] commit_coord;
+    logic core_out_valid;
+
+    hft_field_hazard_guard #(
+        .COORD_WIDTH(COORD_WIDTH),
+        .LATENCY_CYCLES(LATENCY_CYCLES)
+    ) guard (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(in_valid),
+        .in_coord(in_coord),
+        .in_ready(in_ready),
+        .accept_o(accept),
+        .conflict_o(conflict_o),
+        .commit_valid_o(commit_valid),
+        .commit_coord_o(commit_coord)
+    );
+
+    hft_field_cell_staged arithmetic (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(accept),
+        .psi_i(psi_i),
+        .omega_i(omega_i),
+        .flow_i(flow_i),
+        .inventory_i(inventory_i),
+        .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i),
+        .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i),
+        .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i),
+        .psi_zp_i(psi_zp_i),
+        .out_valid(core_out_valid),
+        .psi_o(psi_o),
+        .omega_o(omega_o),
+        .flow_o(flow_o),
+        .laplacian_o(laplacian_o),
+        .score_o(score_o),
+        .action_o(action_o),
+        .quantity_o(quantity_o),
+        .risk_accepted_o(risk_accepted_o)
+    );
+
+    always_comb begin
+        out_valid = core_out_valid && commit_valid;
+        out_coord = commit_coord;
+        alignment_error_o = core_out_valid ^ commit_valid;
+    end
+
+    initial begin
+        if (LATENCY_CYCLES != 17)
+            $error("hft_field_cell_staged currently has a fixed 17-cycle latency");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_hazard_guard.sv
+++ b/rtl/hft_field_q16/hft_field_hazard_guard.sv
@@ -1,0 +1,62 @@
+module hft_field_hazard_guard #(
+    parameter integer COORD_WIDTH = 16,
+    parameter integer LATENCY_CYCLES = 17
+) (
+    input  logic                   clk,
+    input  logic                   rst_n,
+    input  logic                   in_valid,
+    input  logic [COORD_WIDTH-1:0] in_coord,
+
+    output logic                   in_ready,
+    output logic                   accept_o,
+    output logic                   conflict_o,
+    output logic                   commit_valid_o,
+    output logic [COORD_WIDTH-1:0] commit_coord_o
+);
+
+    // Conservative RAW-hazard scoreboard. A coordinate cannot be re-issued
+    // while an earlier transaction for that coordinate remains in flight.
+    // Independent coordinates are still accepted at II=1.
+
+    logic                   busy_valid [0:LATENCY_CYCLES];
+    logic [COORD_WIDTH-1:0] busy_coord [0:LATENCY_CYCLES];
+
+    integer i;
+    always_comb begin
+        conflict_o = 1'b0;
+        for (i = 0; i <= LATENCY_CYCLES; i = i + 1) begin
+            if (busy_valid[i] && busy_coord[i] == in_coord)
+                conflict_o = 1'b1;
+        end
+        in_ready = !conflict_o;
+        accept_o = in_valid && in_ready;
+        commit_valid_o = busy_valid[LATENCY_CYCLES];
+        commit_coord_o = busy_coord[LATENCY_CYCLES];
+    end
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (i = 0; i <= LATENCY_CYCLES; i = i + 1) begin
+                busy_valid[i] <= 1'b0;
+                busy_coord[i] <= '0;
+            end
+        end else begin
+            for (i = LATENCY_CYCLES; i > 0; i = i - 1) begin
+                busy_valid[i] <= busy_valid[i - 1];
+                busy_coord[i] <= busy_coord[i - 1];
+            end
+
+            busy_valid[0] <= accept_o;
+            if (accept_o)
+                busy_coord[0] <= in_coord;
+        end
+    end
+
+    initial begin
+        if (COORD_WIDTH < 1)
+            $error("COORD_WIDTH must be >= 1");
+        if (LATENCY_CYCLES < 1)
+            $error("LATENCY_CYCLES must be >= 1");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_neighbor_addr.sv
+++ b/rtl/hft_field_q16/hft_field_neighbor_addr.sv
@@ -1,0 +1,59 @@
+module hft_field_neighbor_addr #(
+    parameter integer X_BITS = 6,
+    parameter integer Y_BITS = 2,
+    parameter integer Z_BITS = 2,
+    parameter integer ADDR_WIDTH = X_BITS + Y_BITS + Z_BITS
+) (
+    input  logic [X_BITS-1:0] x_i,
+    input  logic [Y_BITS-1:0] y_i,
+    input  logic [Z_BITS-1:0] z_i,
+
+    output logic [ADDR_WIDTH-1:0] center_addr_o,
+    output logic [ADDR_WIDTH-1:0] xm_addr_o,
+    output logic [ADDR_WIDTH-1:0] xp_addr_o,
+    output logic [ADDR_WIDTH-1:0] ym_addr_o,
+    output logic [ADDR_WIDTH-1:0] yp_addr_o,
+    output logic [ADDR_WIDTH-1:0] zm_addr_o,
+    output logic [ADDR_WIDTH-1:0] zp_addr_o
+);
+
+    // Exact hardware lowering of the C++ default coordinate/index policy for
+    // power-of-two dimensions:
+    //
+    //   index = x + 2^X_BITS * (y + 2^Y_BITS * z)
+    //
+    // which is bitwise concatenation {z,y,x}. Fixed-width +/- 1 arithmetic
+    // naturally implements the C++ mask-based toroidal wrap on each axis.
+
+    logic [X_BITS-1:0] xm;
+    logic [X_BITS-1:0] xp;
+    logic [Y_BITS-1:0] ym;
+    logic [Y_BITS-1:0] yp;
+    logic [Z_BITS-1:0] zm;
+    logic [Z_BITS-1:0] zp;
+
+    always_comb begin
+        xm = x_i - {{(X_BITS-1){1'b0}}, 1'b1};
+        xp = x_i + {{(X_BITS-1){1'b0}}, 1'b1};
+        ym = y_i - {{(Y_BITS-1){1'b0}}, 1'b1};
+        yp = y_i + {{(Y_BITS-1){1'b0}}, 1'b1};
+        zm = z_i - {{(Z_BITS-1){1'b0}}, 1'b1};
+        zp = z_i + {{(Z_BITS-1){1'b0}}, 1'b1};
+
+        center_addr_o = {z_i, y_i, x_i};
+        xm_addr_o = {z_i, y_i, xm};
+        xp_addr_o = {z_i, y_i, xp};
+        ym_addr_o = {z_i, ym, x_i};
+        yp_addr_o = {z_i, yp, x_i};
+        zm_addr_o = {zm, y_i, x_i};
+        zp_addr_o = {zp, y_i, x_i};
+    end
+
+    initial begin
+        if (X_BITS < 1 || Y_BITS < 1 || Z_BITS < 1)
+            $error("All coordinate widths must be >= 1");
+        if (ADDR_WIDTH != X_BITS + Y_BITS + Z_BITS)
+            $error("ADDR_WIDTH must equal X_BITS + Y_BITS + Z_BITS");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_state_store.sv
+++ b/rtl/hft_field_q16/hft_field_state_store.sv
@@ -1,0 +1,53 @@
+module hft_field_state_store #(
+    parameter integer ADDR_WIDTH = 6,
+    parameter integer DEPTH = (1 << ADDR_WIDTH)
+) (
+    input  logic                    clk,
+
+    input  logic [ADDR_WIDTH-1:0]   read_addr,
+    output logic signed [31:0]      psi_r,
+    output logic signed [31:0]      omega_r,
+    output logic signed [31:0]      flow_r,
+
+    input  logic                    write_valid,
+    input  logic [ADDR_WIDTH-1:0]   write_addr,
+    input  logic signed [31:0]      psi_w,
+    input  logic signed [31:0]      omega_w,
+    input  logic signed [31:0]      flow_w
+);
+
+    // Center-cell state store reference. No reset is applied to the memory
+    // arrays so a future FPGA implementation can preserve RAM inference.
+    // Deterministic initialization is performed through the explicit write
+    // port before event processing begins.
+    //
+    // This module intentionally provides only one center-state read. Six-
+    // neighbour Psi fetch/banking is a separate hardware problem and is not
+    // hidden behind an unrealistic multi-read RAM abstraction here.
+
+    logic signed [31:0] psi_mem   [0:DEPTH-1];
+    logic signed [31:0] omega_mem [0:DEPTH-1];
+    logic signed [31:0] flow_mem  [0:DEPTH-1];
+
+    always_comb begin
+        psi_r = psi_mem[read_addr];
+        omega_r = omega_mem[read_addr];
+        flow_r = flow_mem[read_addr];
+    end
+
+    always_ff @(posedge clk) begin
+        if (write_valid) begin
+            psi_mem[write_addr] <= psi_w;
+            omega_mem[write_addr] <= omega_w;
+            flow_mem[write_addr] <= flow_w;
+        end
+    end
+
+    initial begin
+        if (ADDR_WIDTH < 1)
+            $error("ADDR_WIDTH must be >= 1");
+        if (DEPTH < 2)
+            $error("DEPTH must be >= 2");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_stateful_center.sv
+++ b/rtl/hft_field_q16/hft_field_stateful_center.sv
@@ -1,0 +1,129 @@
+module hft_field_stateful_center #(
+    parameter integer ADDR_WIDTH = 6,
+    parameter integer LATENCY_CYCLES = 17
+) (
+    input  logic                    clk,
+    input  logic                    rst_n,
+
+    // Initialization/configuration write port. Use before streaming events.
+    input  logic                    cfg_write_valid,
+    input  logic [ADDR_WIDTH-1:0]   cfg_write_addr,
+    input  logic signed [31:0]      cfg_psi,
+    input  logic signed [31:0]      cfg_omega,
+    input  logic signed [31:0]      cfg_flow,
+    output logic                    cfg_write_ready,
+
+    // Event transaction. Center Psi/Omega/Flow are loaded from the store.
+    input  logic                    in_valid,
+    input  logic [ADDR_WIDTH-1:0]   in_coord,
+    input  logic signed [31:0]      inventory_i,
+    input  logic signed [31:0]      delta_quantity_i,
+    input  logic                    side_bid_i,
+
+    // Neighbour Psi values remain external until the seven-read banking
+    // architecture is implemented.
+    input  logic signed [31:0]      psi_xm_i,
+    input  logic signed [31:0]      psi_xp_i,
+    input  logic signed [31:0]      psi_ym_i,
+    input  logic signed [31:0]      psi_yp_i,
+    input  logic signed [31:0]      psi_zm_i,
+    input  logic signed [31:0]      psi_zp_i,
+
+    output logic                    in_ready,
+    output logic                    conflict_o,
+    output logic                    out_valid,
+    output logic [ADDR_WIDTH-1:0]   out_coord,
+    output logic signed [31:0]      psi_o,
+    output logic signed [31:0]      omega_o,
+    output logic signed [31:0]      flow_o,
+    output logic signed [31:0]      laplacian_o,
+    output logic signed [31:0]      score_o,
+    output logic signed [1:0]       action_o,
+    output logic signed [31:0]      quantity_o,
+    output logic                    risk_accepted_o,
+    output logic                    alignment_error_o
+);
+
+    logic signed [31:0] state_psi;
+    logic signed [31:0] state_omega;
+    logic signed [31:0] state_flow;
+
+    logic store_write_valid;
+    logic [ADDR_WIDTH-1:0] store_write_addr;
+    logic signed [31:0] store_psi_w;
+    logic signed [31:0] store_omega_w;
+    logic signed [31:0] store_flow_w;
+
+    // Pipeline retirement has priority over configuration so a committed
+    // market-state transition cannot be overwritten by a simultaneous host
+    // write. The host can observe cfg_write_ready and retry deterministically.
+    always_comb begin
+        cfg_write_ready = !out_valid;
+
+        if (out_valid) begin
+            store_write_valid = 1'b1;
+            store_write_addr = out_coord;
+            store_psi_w = psi_o;
+            store_omega_w = omega_o;
+            store_flow_w = flow_o;
+        end else begin
+            store_write_valid = cfg_write_valid;
+            store_write_addr = cfg_write_addr;
+            store_psi_w = cfg_psi;
+            store_omega_w = cfg_omega;
+            store_flow_w = cfg_flow;
+        end
+    end
+
+    hft_field_state_store #(
+        .ADDR_WIDTH(ADDR_WIDTH),
+        .DEPTH(1 << ADDR_WIDTH)
+    ) state_store (
+        .clk(clk),
+        .read_addr(in_coord),
+        .psi_r(state_psi),
+        .omega_r(state_omega),
+        .flow_r(state_flow),
+        .write_valid(store_write_valid),
+        .write_addr(store_write_addr),
+        .psi_w(store_psi_w),
+        .omega_w(store_omega_w),
+        .flow_w(store_flow_w)
+    );
+
+    hft_field_guarded_pipeline #(
+        .COORD_WIDTH(ADDR_WIDTH),
+        .LATENCY_CYCLES(LATENCY_CYCLES)
+    ) guarded_pipeline (
+        .clk(clk),
+        .rst_n(rst_n),
+        .in_valid(in_valid),
+        .in_coord(in_coord),
+        .psi_i(state_psi),
+        .omega_i(state_omega),
+        .flow_i(state_flow),
+        .inventory_i(inventory_i),
+        .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i),
+        .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i),
+        .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i),
+        .psi_zp_i(psi_zp_i),
+        .in_ready(in_ready),
+        .conflict_o(conflict_o),
+        .out_valid(out_valid),
+        .out_coord(out_coord),
+        .psi_o(psi_o),
+        .omega_o(omega_o),
+        .flow_o(flow_o),
+        .laplacian_o(laplacian_o),
+        .score_o(score_o),
+        .action_o(action_o),
+        .quantity_o(quantity_o),
+        .risk_accepted_o(risk_accepted_o),
+        .alignment_error_o(alignment_error_o)
+    );
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_stateful_center.sv
+++ b/rtl/hft_field_q16/hft_field_stateful_center.sv
@@ -54,11 +54,21 @@ module hft_field_stateful_center #(
     logic signed [31:0] store_omega_w;
     logic signed [31:0] store_flow_w;
 
-    // Pipeline retirement has priority over configuration so a committed
-    // market-state transition cannot be overwritten by a simultaneous host
-    // write. The host can observe cfg_write_ready and retry deterministically.
+    logic guarded_in_ready;
+    logic guarded_conflict;
+    logic guarded_in_valid;
+
+    // Configuration and market-event issue are mutually exclusive. A config
+    // write therefore cannot change a center state on the same edge at which
+    // that state is sampled by a new event transaction.
     always_comb begin
-        cfg_write_ready = !out_valid;
+        guarded_in_valid = in_valid && !cfg_write_valid;
+        in_ready = guarded_in_ready && !cfg_write_valid;
+        conflict_o = guarded_conflict || (in_valid && cfg_write_valid);
+
+        // Pipeline retirement has priority over host configuration so a state
+        // transition can never be overwritten by a simultaneous config write.
+        cfg_write_ready = !out_valid && !in_valid;
 
         if (out_valid) begin
             store_write_valid = 1'b1;
@@ -66,12 +76,18 @@ module hft_field_stateful_center #(
             store_psi_w = psi_o;
             store_omega_w = omega_o;
             store_flow_w = flow_o;
-        end else begin
-            store_write_valid = cfg_write_valid;
+        end else if (cfg_write_valid && cfg_write_ready) begin
+            store_write_valid = 1'b1;
             store_write_addr = cfg_write_addr;
             store_psi_w = cfg_psi;
             store_omega_w = cfg_omega;
             store_flow_w = cfg_flow;
+        end else begin
+            store_write_valid = 1'b0;
+            store_write_addr = '0;
+            store_psi_w = '0;
+            store_omega_w = '0;
+            store_flow_w = '0;
         end
     end
 
@@ -97,7 +113,7 @@ module hft_field_stateful_center #(
     ) guarded_pipeline (
         .clk(clk),
         .rst_n(rst_n),
-        .in_valid(in_valid),
+        .in_valid(guarded_in_valid),
         .in_coord(in_coord),
         .psi_i(state_psi),
         .omega_i(state_omega),
@@ -111,8 +127,8 @@ module hft_field_stateful_center #(
         .psi_yp_i(psi_yp_i),
         .psi_zm_i(psi_zm_i),
         .psi_zp_i(psi_zp_i),
-        .in_ready(in_ready),
-        .conflict_o(conflict_o),
+        .in_ready(guarded_in_ready),
+        .conflict_o(guarded_conflict),
         .out_valid(out_valid),
         .out_coord(out_coord),
         .psi_o(psi_o),

--- a/rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv
+++ b/rtl/hft_field_q16/hft_field_stencil_hazard_guard.sv
@@ -1,0 +1,78 @@
+module hft_field_stencil_hazard_guard #(
+    parameter integer COORD_WIDTH = 10,
+    parameter integer LATENCY_CYCLES = 17
+) (
+    input  logic                   clk,
+    input  logic                   rst_n,
+    input  logic                   in_valid,
+    input  logic [COORD_WIDTH-1:0] center_coord_i,
+    input  logic [COORD_WIDTH-1:0] xm_coord_i,
+    input  logic [COORD_WIDTH-1:0] xp_coord_i,
+    input  logic [COORD_WIDTH-1:0] ym_coord_i,
+    input  logic [COORD_WIDTH-1:0] yp_coord_i,
+    input  logic [COORD_WIDTH-1:0] zm_coord_i,
+    input  logic [COORD_WIDTH-1:0] zp_coord_i,
+
+    output logic                   in_ready,
+    output logic                   accept_o,
+    output logic                   conflict_o,
+    output logic                   commit_valid_o,
+    output logic [COORD_WIDTH-1:0] commit_coord_o
+);
+
+    // Each accepted transaction reads a seven-cell Psi stencil but writes only
+    // its center coordinate. To preserve sequential field semantics, a new
+    // transaction must not read any coordinate whose prior center write is
+    // still pending. This generalizes the earlier same-center RAW scoreboard.
+
+    logic                   busy_valid [0:LATENCY_CYCLES];
+    logic [COORD_WIDTH-1:0] busy_coord [0:LATENCY_CYCLES];
+
+    integer i;
+    always_comb begin
+        conflict_o = 1'b0;
+        for (i = 0; i <= LATENCY_CYCLES; i = i + 1) begin
+            if (busy_valid[i] && (
+                busy_coord[i] == center_coord_i ||
+                busy_coord[i] == xm_coord_i ||
+                busy_coord[i] == xp_coord_i ||
+                busy_coord[i] == ym_coord_i ||
+                busy_coord[i] == yp_coord_i ||
+                busy_coord[i] == zm_coord_i ||
+                busy_coord[i] == zp_coord_i)) begin
+                conflict_o = 1'b1;
+            end
+        end
+
+        in_ready = !conflict_o;
+        accept_o = in_valid && in_ready;
+        commit_valid_o = busy_valid[LATENCY_CYCLES];
+        commit_coord_o = busy_coord[LATENCY_CYCLES];
+    end
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            for (i = 0; i <= LATENCY_CYCLES; i = i + 1) begin
+                busy_valid[i] <= 1'b0;
+                busy_coord[i] <= '0;
+            end
+        end else begin
+            for (i = LATENCY_CYCLES; i > 0; i = i - 1) begin
+                busy_valid[i] <= busy_valid[i - 1];
+                busy_coord[i] <= busy_coord[i - 1];
+            end
+
+            busy_valid[0] <= accept_o;
+            if (accept_o)
+                busy_coord[0] <= center_coord_i;
+        end
+    end
+
+    initial begin
+        if (COORD_WIDTH < 1)
+            $error("COORD_WIDTH must be >= 1");
+        if (LATENCY_CYCLES < 1)
+            $error("LATENCY_CYCLES must be >= 1");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/hft_field_stencil_store_replicated.sv
+++ b/rtl/hft_field_q16/hft_field_stencil_store_replicated.sv
@@ -1,0 +1,100 @@
+module hft_field_stencil_store_replicated #(
+    parameter integer ADDR_WIDTH = 10,
+    parameter integer DEPTH = (1 << ADDR_WIDTH)
+) (
+    input  logic                    clk,
+
+    input  logic                    read_valid_i,
+    input  logic [ADDR_WIDTH-1:0]   center_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   xm_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   xp_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   ym_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   yp_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   zm_addr_i,
+    input  logic [ADDR_WIDTH-1:0]   zp_addr_i,
+
+    output logic                    read_valid_o,
+    output logic [ADDR_WIDTH-1:0]   center_addr_o,
+    output logic signed [31:0]      psi_center_o,
+    output logic signed [31:0]      psi_xm_o,
+    output logic signed [31:0]      psi_xp_o,
+    output logic signed [31:0]      psi_ym_o,
+    output logic signed [31:0]      psi_yp_o,
+    output logic signed [31:0]      psi_zm_o,
+    output logic signed [31:0]      psi_zp_o,
+    output logic signed [31:0]      omega_center_o,
+    output logic signed [31:0]      flow_center_o,
+
+    input  logic                    write_valid_i,
+    input  logic [ADDR_WIDTH-1:0]   write_addr_i,
+    input  logic signed [31:0]      psi_write_i,
+    input  logic signed [31:0]      omega_write_i,
+    input  logic signed [31:0]      flow_write_i
+);
+
+    // Physically realizable reference architecture for seven simultaneous Psi
+    // reads: seven identical single-read replicas, with every center-state Psi
+    // write broadcast to all copies. Omega and Flow need only the center read.
+    //
+    // Synchronous reads intentionally model FPGA block-memory timing. Vendor
+    // BRAM/URAM inference and exact read-during-write behavior remain target-
+    // dependent and must be proven in device-specific synthesis/P&R.
+
+    (* ram_style = "block" *) logic signed [31:0] psi_center_mem [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_xm_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_xp_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_ym_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_yp_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_zm_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] psi_zp_mem     [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] omega_mem      [0:DEPTH-1];
+    (* ram_style = "block" *) logic signed [31:0] flow_mem       [0:DEPTH-1];
+
+    always_ff @(posedge clk) begin
+        read_valid_o <= read_valid_i;
+        if (read_valid_i) begin
+            center_addr_o <= center_addr_i;
+            psi_center_o <= psi_center_mem[center_addr_i];
+            psi_xm_o <= psi_xm_mem[xm_addr_i];
+            psi_xp_o <= psi_xp_mem[xp_addr_i];
+            psi_ym_o <= psi_ym_mem[ym_addr_i];
+            psi_yp_o <= psi_yp_mem[yp_addr_i];
+            psi_zm_o <= psi_zm_mem[zm_addr_i];
+            psi_zp_o <= psi_zp_mem[zp_addr_i];
+            omega_center_o <= omega_mem[center_addr_i];
+            flow_center_o <= flow_mem[center_addr_i];
+        end
+
+        if (write_valid_i) begin
+            psi_center_mem[write_addr_i] <= psi_write_i;
+            psi_xm_mem[write_addr_i] <= psi_write_i;
+            psi_xp_mem[write_addr_i] <= psi_write_i;
+            psi_ym_mem[write_addr_i] <= psi_write_i;
+            psi_yp_mem[write_addr_i] <= psi_write_i;
+            psi_zm_mem[write_addr_i] <= psi_write_i;
+            psi_zp_mem[write_addr_i] <= psi_write_i;
+            omega_mem[write_addr_i] <= omega_write_i;
+            flow_mem[write_addr_i] <= flow_write_i;
+        end
+    end
+
+    initial begin
+        read_valid_o = 1'b0;
+        center_addr_o = '0;
+        psi_center_o = '0;
+        psi_xm_o = '0;
+        psi_xp_o = '0;
+        psi_ym_o = '0;
+        psi_yp_o = '0;
+        psi_zm_o = '0;
+        psi_zp_o = '0;
+        omega_center_o = '0;
+        flow_center_o = '0;
+
+        if (ADDR_WIDTH < 1)
+            $error("ADDR_WIDTH must be >= 1");
+        if (DEPTH < 2)
+            $error("DEPTH must be >= 2");
+    end
+
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_cell_core.sv
+++ b/rtl/hft_field_q16/tb_hft_field_cell_core.sv
@@ -1,0 +1,158 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_cell_core;
+    logic signed [31:0] psi_i;
+    logic signed [31:0] omega_i;
+    logic signed [31:0] flow_i;
+    logic signed [31:0] inventory_i;
+    logic signed [31:0] delta_quantity_i;
+    logic               side_bid_i;
+    logic signed [31:0] psi_xm_i;
+    logic signed [31:0] psi_xp_i;
+    logic signed [31:0] psi_ym_i;
+    logic signed [31:0] psi_yp_i;
+    logic signed [31:0] psi_zm_i;
+    logic signed [31:0] psi_zp_i;
+
+    logic signed [31:0] psi_o;
+    logic signed [31:0] omega_o;
+    logic signed [31:0] flow_o;
+    logic signed [31:0] laplacian_o;
+    logic signed [31:0] score_o;
+    logic signed [1:0]  action_o;
+    logic signed [31:0] quantity_o;
+    logic               risk_accepted_o;
+
+    hft_field_cell_core dut (
+        .psi_i,
+        .omega_i,
+        .flow_i,
+        .inventory_i,
+        .delta_quantity_i,
+        .side_bid_i,
+        .psi_xm_i,
+        .psi_xp_i,
+        .psi_ym_i,
+        .psi_yp_i,
+        .psi_zm_i,
+        .psi_zp_i,
+        .psi_o,
+        .omega_o,
+        .flow_o,
+        .laplacian_o,
+        .score_o,
+        .action_o,
+        .quantity_o,
+        .risk_accepted_o
+    );
+
+    task automatic check_vector(
+        input string name,
+        input logic signed [31:0] in_psi,
+        input logic signed [31:0] in_omega,
+        input logic signed [31:0] in_flow,
+        input logic signed [31:0] in_inventory,
+        input logic signed [31:0] in_delta,
+        input logic in_side_bid,
+        input logic signed [31:0] in_xm,
+        input logic signed [31:0] in_xp,
+        input logic signed [31:0] in_ym,
+        input logic signed [31:0] in_yp,
+        input logic signed [31:0] in_zm,
+        input logic signed [31:0] in_zp,
+        input logic signed [31:0] exp_psi,
+        input logic signed [31:0] exp_omega,
+        input logic signed [31:0] exp_flow,
+        input logic signed [31:0] exp_lap,
+        input logic signed [31:0] exp_score,
+        input logic signed [1:0]  exp_action,
+        input logic signed [31:0] exp_quantity,
+        input logic exp_risk
+    );
+        begin
+            psi_i = in_psi;
+            omega_i = in_omega;
+            flow_i = in_flow;
+            inventory_i = in_inventory;
+            delta_quantity_i = in_delta;
+            side_bid_i = in_side_bid;
+            psi_xm_i = in_xm;
+            psi_xp_i = in_xp;
+            psi_ym_i = in_ym;
+            psi_yp_i = in_yp;
+            psi_zm_i = in_zm;
+            psi_zp_i = in_zp;
+            #1;
+
+            if (psi_o !== exp_psi)
+                $fatal(1, "%s psi: got %0d expected %0d", name, psi_o, exp_psi);
+            if (omega_o !== exp_omega)
+                $fatal(1, "%s omega: got %0d expected %0d", name, omega_o, exp_omega);
+            if (flow_o !== exp_flow)
+                $fatal(1, "%s flow: got %0d expected %0d", name, flow_o, exp_flow);
+            if (laplacian_o !== exp_lap)
+                $fatal(1, "%s lap: got %0d expected %0d", name, laplacian_o, exp_lap);
+            if (score_o !== exp_score)
+                $fatal(1, "%s score: got %0d expected %0d", name, score_o, exp_score);
+            if (action_o !== exp_action)
+                $fatal(1, "%s action: got %0d expected %0d", name, action_o, exp_action);
+            if (quantity_o !== exp_quantity)
+                $fatal(1, "%s quantity: got %0d expected %0d", name, quantity_o, exp_quantity);
+            if (risk_accepted_o !== exp_risk)
+                $fatal(1, "%s risk: got %0d expected %0d", name, risk_accepted_o, exp_risk);
+
+            $display("PASS %-16s psi=%0d omega=%0d flow=%0d lap=%0d score=%0d action=%0d qty=%0d risk=%0d",
+                     name, psi_o, omega_o, flow_o, laplacian_o, score_o,
+                     action_o, quantity_o, risk_accepted_o);
+        end
+    endtask
+
+    initial begin
+        // Golden vectors were generated from the C++ Q16.16 reference semantics.
+        check_vector(
+            "bid1",
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd65536, 1'b1,
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0,
+            32'sd4096, 32'sd256, 32'sd65536, 32'sd0, 32'sd36992,
+            2'sd1, 32'sd65536, 1'b1
+        );
+
+        check_vector(
+            "ask1",
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd65536, 1'b0,
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0,
+            -32'sd4096, -32'sd256, -32'sd65536, 32'sd0, -32'sd36992,
+            -2'sd1, 32'sd65536, 1'b1
+        );
+
+        check_vector(
+            "mixed",
+            32'sd32768, 32'sd16384, -32'sd8192, 32'sd131072,
+            32'sd32768, 1'b1,
+            32'sd16384, -32'sd16384, 32'sd8192, 32'sd0,
+            32'sd4096, -32'sd4096,
+            32'sd33568, 32'sd17458, 32'sd25600, -32'sd188416,
+            -32'sd1223, 2'sd0, 32'sd0, 1'b0
+        );
+
+        check_vector(
+            "risk_reject",
+            32'sd0, 32'sd0, 32'sd0, 32'sd4194304,
+            32'sd2097152, 1'b1,
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0,
+            32'sd131072, 32'sd8192, 32'sd2097152, 32'sd0,
+            32'sd135168, 2'sd0, 32'sd0, 1'b0
+        );
+
+        check_vector(
+            "zeroqty_forced",
+            32'sd65536, 32'sd0, 32'sd0, 32'sd0, 32'sd0, 1'b1,
+            32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0, 32'sd0,
+            32'sd61952, 32'sd3872, 32'sd0, -32'sd393216,
+            32'sd14736, 2'sd1, 32'sd262144, 1'b1
+        );
+
+        $display("hft_field_cell_core RTL equivalence vectors passed");
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_cell_pipeline.sv
+++ b/rtl/hft_field_q16/tb_hft_field_cell_pipeline.sv
@@ -1,0 +1,200 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_cell_pipeline;
+    localparam integer LATENCY = 17;
+    localparam integer MAX_CYCLES = 256;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+    logic in_valid = 1'b0;
+
+    logic signed [31:0] psi_i;
+    logic signed [31:0] omega_i;
+    logic signed [31:0] flow_i;
+    logic signed [31:0] inventory_i;
+    logic signed [31:0] delta_quantity_i;
+    logic side_bid_i;
+    logic signed [31:0] psi_xm_i;
+    logic signed [31:0] psi_xp_i;
+    logic signed [31:0] psi_ym_i;
+    logic signed [31:0] psi_yp_i;
+    logic signed [31:0] psi_zm_i;
+    logic signed [31:0] psi_zp_i;
+
+    logic signed [31:0] ref_psi;
+    logic signed [31:0] ref_omega;
+    logic signed [31:0] ref_flow;
+    logic signed [31:0] ref_lap;
+    logic signed [31:0] ref_score;
+    logic signed [1:0] ref_action;
+    logic signed [31:0] ref_quantity;
+    logic ref_risk;
+
+    logic out_valid;
+    logic signed [31:0] pipe_psi;
+    logic signed [31:0] pipe_omega;
+    logic signed [31:0] pipe_flow;
+    logic signed [31:0] pipe_lap;
+    logic signed [31:0] pipe_score;
+    logic signed [1:0] pipe_action;
+    logic signed [31:0] pipe_quantity;
+    logic pipe_risk;
+
+    logic exp_valid [0:MAX_CYCLES];
+    logic signed [31:0] exp_psi [0:MAX_CYCLES];
+    logic signed [31:0] exp_omega [0:MAX_CYCLES];
+    logic signed [31:0] exp_flow [0:MAX_CYCLES];
+    logic signed [31:0] exp_lap [0:MAX_CYCLES];
+    logic signed [31:0] exp_score [0:MAX_CYCLES];
+    logic signed [1:0] exp_action [0:MAX_CYCLES];
+    logic signed [31:0] exp_quantity [0:MAX_CYCLES];
+    logic exp_risk [0:MAX_CYCLES];
+
+    integer cycle;
+    integer n;
+    integer i;
+    integer failures;
+
+    always #5 clk = ~clk;
+
+    hft_field_cell_pow2 ref_core (
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .psi_o(ref_psi), .omega_o(ref_omega), .flow_o(ref_flow),
+        .laplacian_o(ref_lap), .score_o(ref_score),
+        .action_o(ref_action), .quantity_o(ref_quantity),
+        .risk_accepted_o(ref_risk)
+    );
+
+    hft_field_cell_pipeline #(.LATENCY_CYCLES(LATENCY)) dut (
+        .clk(clk), .rst_n(rst_n), .in_valid(in_valid),
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .out_valid(out_valid), .psi_o(pipe_psi), .omega_o(pipe_omega),
+        .flow_o(pipe_flow), .laplacian_o(pipe_lap), .score_o(pipe_score),
+        .action_o(pipe_action), .quantity_o(pipe_quantity),
+        .risk_accepted_o(pipe_risk)
+    );
+
+    task automatic drive_vector(input integer k);
+        begin
+            psi_i = $signed((k * 7919) % 1200000) - 32'sd600000;
+            omega_i = $signed((k * 3571) % 800000) - 32'sd400000;
+            flow_i = $signed((k * 1237) % 500000) - 32'sd250000;
+            inventory_i = $signed((k * 6151) % 6000000) - 32'sd3000000;
+            delta_quantity_i = $signed(((k + 1) * 4099) % 350000) - 32'sd175000;
+            side_bid_i = k[0];
+            psi_xm_i = psi_i + 32'sd1100;
+            psi_xp_i = psi_i - 32'sd2300;
+            psi_ym_i = psi_i + 32'sd3700;
+            psi_yp_i = psi_i - 32'sd4100;
+            psi_zm_i = psi_i + 32'sd5300;
+            psi_zp_i = psi_i - 32'sd6700;
+        end
+    endtask
+
+    task automatic check_cycle;
+        begin
+            if (exp_valid[cycle]) begin
+                if (!out_valid ||
+                    pipe_psi !== exp_psi[cycle] ||
+                    pipe_omega !== exp_omega[cycle] ||
+                    pipe_flow !== exp_flow[cycle] ||
+                    pipe_lap !== exp_lap[cycle] ||
+                    pipe_score !== exp_score[cycle] ||
+                    pipe_action !== exp_action[cycle] ||
+                    pipe_quantity !== exp_quantity[cycle] ||
+                    pipe_risk !== exp_risk[cycle]) begin
+                    $display("FAIL cycle=%0d out_valid=%0b psi=%0d/%0d score=%0d/%0d action=%0d/%0d risk=%0b/%0b",
+                             cycle, out_valid, pipe_psi, exp_psi[cycle],
+                             pipe_score, exp_score[cycle], pipe_action,
+                             exp_action[cycle], pipe_risk, exp_risk[cycle]);
+                    failures = failures + 1;
+                end
+            end else if (out_valid) begin
+                $display("FAIL unexpected out_valid at cycle=%0d", cycle);
+                failures = failures + 1;
+            end
+        end
+    endtask
+
+    initial begin
+        cycle = 0;
+        failures = 0;
+        psi_i = '0;
+        omega_i = '0;
+        flow_i = '0;
+        inventory_i = '0;
+        delta_quantity_i = '0;
+        side_bid_i = 1'b1;
+        psi_xm_i = '0;
+        psi_xp_i = '0;
+        psi_ym_i = '0;
+        psi_yp_i = '0;
+        psi_zm_i = '0;
+        psi_zp_i = '0;
+
+        for (i = 0; i <= MAX_CYCLES; i = i + 1) begin
+            exp_valid[i] = 1'b0;
+            exp_psi[i] = '0;
+            exp_omega[i] = '0;
+            exp_flow[i] = '0;
+            exp_lap[i] = '0;
+            exp_score[i] = '0;
+            exp_action[i] = '0;
+            exp_quantity[i] = '0;
+            exp_risk[i] = 1'b0;
+        end
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        // Stream 64 independent arithmetic transactions at II=1.
+        for (n = 0; n < 64; n = n + 1) begin
+            @(negedge clk);
+            drive_vector(n);
+            in_valid = 1'b1;
+
+            @(posedge clk);
+            #1;
+            cycle = cycle + 1;
+            check_cycle();
+            exp_valid[cycle + LATENCY] = 1'b1;
+            exp_psi[cycle + LATENCY] = ref_psi;
+            exp_omega[cycle + LATENCY] = ref_omega;
+            exp_flow[cycle + LATENCY] = ref_flow;
+            exp_lap[cycle + LATENCY] = ref_lap;
+            exp_score[cycle + LATENCY] = ref_score;
+            exp_action[cycle + LATENCY] = ref_action;
+            exp_quantity[cycle + LATENCY] = ref_quantity;
+            exp_risk[cycle + LATENCY] = ref_risk;
+        end
+
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        repeat (LATENCY + 4) begin
+            @(posedge clk);
+            #1;
+            cycle = cycle + 1;
+            check_cycle();
+        end
+
+        if (failures == 0)
+            $display("PASS: fixed-latency pipeline matched reference for 64 II=1 transactions at %0d cycles", LATENCY);
+        else begin
+            $display("FAIL: %0d pipeline mismatches", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_cell_staged.sv
+++ b/rtl/hft_field_q16/tb_hft_field_cell_staged.sv
@@ -1,0 +1,177 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_cell_staged;
+    localparam integer LATENCY = 17;
+    localparam integer MAX_CYCLES = 256;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+    logic in_valid = 1'b0;
+
+    logic signed [31:0] psi_i;
+    logic signed [31:0] omega_i;
+    logic signed [31:0] flow_i;
+    logic signed [31:0] inventory_i;
+    logic signed [31:0] delta_quantity_i;
+    logic side_bid_i;
+    logic signed [31:0] psi_xm_i;
+    logic signed [31:0] psi_xp_i;
+    logic signed [31:0] psi_ym_i;
+    logic signed [31:0] psi_yp_i;
+    logic signed [31:0] psi_zm_i;
+    logic signed [31:0] psi_zp_i;
+
+    logic signed [31:0] ref_psi, ref_omega, ref_flow, ref_lap, ref_score, ref_quantity;
+    logic signed [1:0] ref_action;
+    logic ref_risk;
+
+    logic out_valid;
+    logic signed [31:0] dut_psi, dut_omega, dut_flow, dut_lap, dut_score, dut_quantity;
+    logic signed [1:0] dut_action;
+    logic dut_risk;
+
+    logic exp_valid [0:MAX_CYCLES];
+    logic signed [31:0] exp_psi [0:MAX_CYCLES];
+    logic signed [31:0] exp_omega [0:MAX_CYCLES];
+    logic signed [31:0] exp_flow [0:MAX_CYCLES];
+    logic signed [31:0] exp_lap [0:MAX_CYCLES];
+    logic signed [31:0] exp_score [0:MAX_CYCLES];
+    logic signed [1:0] exp_action [0:MAX_CYCLES];
+    logic signed [31:0] exp_quantity [0:MAX_CYCLES];
+    logic exp_risk [0:MAX_CYCLES];
+
+    integer cycle;
+    integer n;
+    integer i;
+    integer failures;
+
+    always #5 clk = ~clk;
+
+    hft_field_cell_pow2 ref_core (
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .psi_o(ref_psi), .omega_o(ref_omega), .flow_o(ref_flow),
+        .laplacian_o(ref_lap), .score_o(ref_score),
+        .action_o(ref_action), .quantity_o(ref_quantity),
+        .risk_accepted_o(ref_risk)
+    );
+
+    hft_field_cell_staged dut (
+        .clk(clk), .rst_n(rst_n), .in_valid(in_valid),
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .out_valid(out_valid), .psi_o(dut_psi), .omega_o(dut_omega),
+        .flow_o(dut_flow), .laplacian_o(dut_lap), .score_o(dut_score),
+        .action_o(dut_action), .quantity_o(dut_quantity),
+        .risk_accepted_o(dut_risk)
+    );
+
+    task automatic drive_vector(input integer k);
+        begin
+            psi_i = $signed((k * 104729) % 3000000) - 32'sd1500000;
+            omega_i = $signed((k * 65537) % 2200000) - 32'sd1100000;
+            flow_i = $signed((k * 8191) % 1600000) - 32'sd800000;
+            inventory_i = $signed((k * 32771) % 8200000) - 32'sd4100000;
+            delta_quantity_i = $signed(((k + 3) * 12289) % 700000) - 32'sd350000;
+            side_bid_i = k[0];
+            psi_xm_i = psi_i + 32'sd17000;
+            psi_xp_i = psi_i - 32'sd29000;
+            psi_ym_i = psi_i + 32'sd43000;
+            psi_yp_i = psi_i - 32'sd51000;
+            psi_zm_i = psi_i + 32'sd61000;
+            psi_zp_i = psi_i - 32'sd73000;
+        end
+    endtask
+
+    task automatic check_cycle;
+        begin
+            if (exp_valid[cycle]) begin
+                if (!out_valid ||
+                    dut_psi !== exp_psi[cycle] ||
+                    dut_omega !== exp_omega[cycle] ||
+                    dut_flow !== exp_flow[cycle] ||
+                    dut_lap !== exp_lap[cycle] ||
+                    dut_score !== exp_score[cycle] ||
+                    dut_action !== exp_action[cycle] ||
+                    dut_quantity !== exp_quantity[cycle] ||
+                    dut_risk !== exp_risk[cycle]) begin
+                    $display("FAIL cycle=%0d valid=%0b psi=%0d/%0d omega=%0d/%0d flow=%0d/%0d lap=%0d/%0d score=%0d/%0d action=%0d/%0d qty=%0d/%0d risk=%0b/%0b",
+                             cycle, out_valid,
+                             dut_psi, exp_psi[cycle], dut_omega, exp_omega[cycle],
+                             dut_flow, exp_flow[cycle], dut_lap, exp_lap[cycle],
+                             dut_score, exp_score[cycle], dut_action, exp_action[cycle],
+                             dut_quantity, exp_quantity[cycle], dut_risk, exp_risk[cycle]);
+                    failures = failures + 1;
+                end
+            end else if (out_valid) begin
+                $display("FAIL unexpected out_valid at cycle=%0d", cycle);
+                failures = failures + 1;
+            end
+        end
+    endtask
+
+    initial begin
+        cycle = 0;
+        failures = 0;
+        psi_i = '0; omega_i = '0; flow_i = '0; inventory_i = '0;
+        delta_quantity_i = '0; side_bid_i = 1'b1;
+        psi_xm_i = '0; psi_xp_i = '0; psi_ym_i = '0; psi_yp_i = '0; psi_zm_i = '0; psi_zp_i = '0;
+
+        for (i = 0; i <= MAX_CYCLES; i = i + 1) begin
+            exp_valid[i] = 1'b0;
+            exp_psi[i] = '0; exp_omega[i] = '0; exp_flow[i] = '0; exp_lap[i] = '0;
+            exp_score[i] = '0; exp_action[i] = '0; exp_quantity[i] = '0; exp_risk[i] = 1'b0;
+        end
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        // Consecutive transactions prove II=1 arithmetic throughput.
+        for (n = 0; n < 96; n = n + 1) begin
+            @(negedge clk);
+            drive_vector(n);
+            in_valid = 1'b1;
+
+            @(posedge clk);
+            #1;
+            cycle = cycle + 1;
+            check_cycle();
+            exp_valid[cycle + LATENCY] = 1'b1;
+            exp_psi[cycle + LATENCY] = ref_psi;
+            exp_omega[cycle + LATENCY] = ref_omega;
+            exp_flow[cycle + LATENCY] = ref_flow;
+            exp_lap[cycle + LATENCY] = ref_lap;
+            exp_score[cycle + LATENCY] = ref_score;
+            exp_action[cycle + LATENCY] = ref_action;
+            exp_quantity[cycle + LATENCY] = ref_quantity;
+            exp_risk[cycle + LATENCY] = ref_risk;
+        end
+
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        repeat (LATENCY + 4) begin
+            @(posedge clk);
+            #1;
+            cycle = cycle + 1;
+            check_cycle();
+        end
+
+        if (failures == 0)
+            $display("PASS: staged arithmetic pipeline matched multiplier-free oracle for 96 II=1 transactions at 17-cycle latency");
+        else begin
+            $display("FAIL: %0d staged-pipeline mismatches", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_guarded_pipeline.sv
+++ b/rtl/hft_field_q16/tb_hft_field_guarded_pipeline.sv
@@ -1,0 +1,224 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_guarded_pipeline;
+    localparam integer COORD_WIDTH = 12;
+    localparam integer LATENCY = 17;
+    localparam integer MAX_TX = 64;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+    logic in_valid = 1'b0;
+    logic [COORD_WIDTH-1:0] in_coord = '0;
+
+    logic signed [31:0] psi_i, omega_i, flow_i, inventory_i, delta_quantity_i;
+    logic side_bid_i;
+    logic signed [31:0] psi_xm_i, psi_xp_i, psi_ym_i, psi_yp_i, psi_zm_i, psi_zp_i;
+
+    logic in_ready, conflict_o, out_valid, risk_accepted_o, alignment_error_o;
+    logic [COORD_WIDTH-1:0] out_coord;
+    logic signed [31:0] psi_o, omega_o, flow_o, laplacian_o, score_o, quantity_o;
+    logic signed [1:0] action_o;
+
+    logic signed [31:0] ref_psi, ref_omega, ref_flow, ref_lap, ref_score, ref_quantity;
+    logic signed [1:0] ref_action;
+    logic ref_risk;
+
+    logic [COORD_WIDTH-1:0] exp_coord [0:MAX_TX-1];
+    logic signed [31:0] exp_psi [0:MAX_TX-1];
+    logic signed [31:0] exp_omega [0:MAX_TX-1];
+    logic signed [31:0] exp_flow [0:MAX_TX-1];
+    logic signed [31:0] exp_lap [0:MAX_TX-1];
+    logic signed [31:0] exp_score [0:MAX_TX-1];
+    logic signed [1:0] exp_action [0:MAX_TX-1];
+    logic signed [31:0] exp_quantity [0:MAX_TX-1];
+    logic exp_risk [0:MAX_TX-1];
+    integer exp_due [0:MAX_TX-1];
+
+    integer head;
+    integer tail;
+    integer failures;
+    integer cycle_count;
+    integer k;
+
+    localparam logic [COORD_WIDTH-1:0] A = 12'h123;
+    localparam logic [COORD_WIDTH-1:0] B = 12'h456;
+    localparam logic [COORD_WIDTH-1:0] C = 12'h789;
+
+    always #5 clk = ~clk;
+
+    hft_field_cell_pow2 ref_core (
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .psi_o(ref_psi), .omega_o(ref_omega), .flow_o(ref_flow),
+        .laplacian_o(ref_lap), .score_o(ref_score),
+        .action_o(ref_action), .quantity_o(ref_quantity),
+        .risk_accepted_o(ref_risk)
+    );
+
+    hft_field_guarded_pipeline #(
+        .COORD_WIDTH(COORD_WIDTH),
+        .LATENCY_CYCLES(LATENCY)
+    ) dut (
+        .clk(clk), .rst_n(rst_n), .in_valid(in_valid), .in_coord(in_coord),
+        .psi_i(psi_i), .omega_i(omega_i), .flow_i(flow_i),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .in_ready(in_ready), .conflict_o(conflict_o),
+        .out_valid(out_valid), .out_coord(out_coord),
+        .psi_o(psi_o), .omega_o(omega_o), .flow_o(flow_o),
+        .laplacian_o(laplacian_o), .score_o(score_o),
+        .action_o(action_o), .quantity_o(quantity_o),
+        .risk_accepted_o(risk_accepted_o),
+        .alignment_error_o(alignment_error_o)
+    );
+
+    task automatic drive_vector(input integer seed);
+        begin
+            psi_i = $signed((seed * 65537) % 2000000) - 32'sd1000000;
+            omega_i = $signed((seed * 32771) % 1400000) - 32'sd700000;
+            flow_i = $signed((seed * 12289) % 900000) - 32'sd450000;
+            inventory_i = $signed((seed * 8191) % 7000000) - 32'sd3500000;
+            delta_quantity_i = $signed(((seed + 5) * 4099) % 500000) - 32'sd250000;
+            side_bid_i = seed[0];
+            psi_xm_i = psi_i + 32'sd11000;
+            psi_xp_i = psi_i - 32'sd13000;
+            psi_ym_i = psi_i + 32'sd17000;
+            psi_yp_i = psi_i - 32'sd19000;
+            psi_zm_i = psi_i + 32'sd23000;
+            psi_zp_i = psi_i - 32'sd29000;
+        end
+    endtask
+
+    task automatic issue(
+        input logic [COORD_WIDTH-1:0] coord,
+        input integer seed,
+        input logic expect_ready
+    );
+        begin
+            @(negedge clk);
+            in_coord = coord;
+            drive_vector(seed);
+            in_valid = 1'b1;
+            #1;
+
+            if (expect_ready) begin
+                if (!in_ready || conflict_o) begin
+                    $display("FAIL expected ready coord=%h ready=%0b conflict=%0b", coord, in_ready, conflict_o);
+                    failures = failures + 1;
+                end else begin
+                    exp_coord[tail] = coord;
+                    exp_psi[tail] = ref_psi;
+                    exp_omega[tail] = ref_omega;
+                    exp_flow[tail] = ref_flow;
+                    exp_lap[tail] = ref_lap;
+                    exp_score[tail] = ref_score;
+                    exp_action[tail] = ref_action;
+                    exp_quantity[tail] = ref_quantity;
+                    exp_risk[tail] = ref_risk;
+                    exp_due[tail] = cycle_count + 1 + LATENCY;
+                    tail = tail + 1;
+                end
+            end else begin
+                if (in_ready || !conflict_o) begin
+                    $display("FAIL expected RAW block coord=%h ready=%0b conflict=%0b", coord, in_ready, conflict_o);
+                    failures = failures + 1;
+                end
+            end
+
+            @(posedge clk);
+            #1;
+        end
+    endtask
+
+    always @(posedge clk) begin
+        #1;
+        if (rst_n) begin
+            cycle_count = cycle_count + 1;
+
+            if (alignment_error_o) begin
+                $display("FAIL guard/arithmetic valid misalignment at cycle=%0d", cycle_count);
+                failures = failures + 1;
+            end
+
+            if (out_valid) begin
+                if (head >= tail) begin
+                    $display("FAIL unexpected output at cycle=%0d coord=%h", cycle_count, out_coord);
+                    failures = failures + 1;
+                end else begin
+                    if (cycle_count != exp_due[head]) begin
+                        $display("FAIL latency tx=%0d got_cycle=%0d expected_cycle=%0d", head, cycle_count, exp_due[head]);
+                        failures = failures + 1;
+                    end
+                    if (out_coord !== exp_coord[head] ||
+                        psi_o !== exp_psi[head] || omega_o !== exp_omega[head] ||
+                        flow_o !== exp_flow[head] || laplacian_o !== exp_lap[head] ||
+                        score_o !== exp_score[head] || action_o !== exp_action[head] ||
+                        quantity_o !== exp_quantity[head] || risk_accepted_o !== exp_risk[head]) begin
+                        $display("FAIL tx=%0d coord=%h/%h psi=%0d/%0d score=%0d/%0d action=%0d/%0d risk=%0b/%0b",
+                                 head, out_coord, exp_coord[head], psi_o, exp_psi[head],
+                                 score_o, exp_score[head], action_o, exp_action[head],
+                                 risk_accepted_o, exp_risk[head]);
+                        failures = failures + 1;
+                    end
+                    head = head + 1;
+                end
+            end
+        end
+    end
+
+    initial begin
+        head = 0;
+        tail = 0;
+        failures = 0;
+        cycle_count = 0;
+        psi_i = '0; omega_i = '0; flow_i = '0; inventory_i = '0;
+        delta_quantity_i = '0; side_bid_i = 1'b1;
+        psi_xm_i = '0; psi_xp_i = '0; psi_ym_i = '0; psi_yp_i = '0; psi_zm_i = '0; psi_zp_i = '0;
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        // A/B/C demonstrate independent-coordinate issue plus same-A rejection.
+        issue(A, 1, 1'b1);
+        issue(B, 2, 1'b1);
+        issue(A, 3, 1'b0);
+        issue(C, 4, 1'b1);
+
+        // Additional unique coordinates demonstrate sustained independent II=1 issue.
+        for (k = 0; k < 8; k = k + 1)
+            issue(12'h800 + k, 10 + k, 1'b1);
+
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        repeat (LATENCY + 5) @(posedge clk);
+
+        // A must be issuable again once its earlier transaction has retired.
+        issue(A, 40, 1'b1);
+        @(negedge clk);
+        in_valid = 1'b0;
+        repeat (LATENCY + 3) @(posedge clk);
+        #2;
+
+        if (head != tail) begin
+            $display("FAIL missing outputs head=%0d tail=%0d", head, tail);
+            failures = failures + 1;
+        end
+
+        if (failures == 0)
+            $display("PASS: guarded staged pipeline preserves 17-cycle coordinate/result alignment, blocks same-cell RAW hazards, and accepts independent II=1 traffic");
+        else begin
+            $display("FAIL: %0d guarded-pipeline failures", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_hazard_guard.sv
+++ b/rtl/hft_field_q16/tb_hft_field_hazard_guard.sv
@@ -1,0 +1,127 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_hazard_guard;
+    localparam integer COORD_WIDTH = 12;
+    localparam integer LATENCY = 17;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+    logic in_valid = 1'b0;
+    logic [COORD_WIDTH-1:0] in_coord = '0;
+    logic in_ready;
+    logic accept_o;
+    logic conflict_o;
+    logic commit_valid_o;
+    logic [COORD_WIDTH-1:0] commit_coord_o;
+
+    integer failures;
+    integer cycles;
+    integer accepted_independent;
+    logic seen_a_commit;
+
+    localparam logic [COORD_WIDTH-1:0] A = 12'h123;
+    localparam logic [COORD_WIDTH-1:0] B = 12'h456;
+    localparam logic [COORD_WIDTH-1:0] C = 12'h789;
+
+    always #5 clk = ~clk;
+
+    hft_field_hazard_guard #(
+        .COORD_WIDTH(COORD_WIDTH),
+        .LATENCY_CYCLES(LATENCY)
+    ) dut (
+        .clk(clk), .rst_n(rst_n),
+        .in_valid(in_valid), .in_coord(in_coord),
+        .in_ready(in_ready), .accept_o(accept_o), .conflict_o(conflict_o),
+        .commit_valid_o(commit_valid_o), .commit_coord_o(commit_coord_o)
+    );
+
+    task automatic expect_accept(input logic [COORD_WIDTH-1:0] coord);
+        begin
+            @(negedge clk);
+            in_coord = coord;
+            in_valid = 1'b1;
+            #1;
+            if (!in_ready || !accept_o || conflict_o) begin
+                $display("FAIL expected accept coord=%h ready=%0b accept=%0b conflict=%0b",
+                         coord, in_ready, accept_o, conflict_o);
+                failures = failures + 1;
+            end
+            @(posedge clk);
+            #1;
+        end
+    endtask
+
+    task automatic expect_block(input logic [COORD_WIDTH-1:0] coord);
+        begin
+            @(negedge clk);
+            in_coord = coord;
+            in_valid = 1'b1;
+            #1;
+            if (in_ready || accept_o || !conflict_o) begin
+                $display("FAIL expected block coord=%h ready=%0b accept=%0b conflict=%0b",
+                         coord, in_ready, accept_o, conflict_o);
+                failures = failures + 1;
+            end
+            @(posedge clk);
+            #1;
+        end
+    endtask
+
+    initial begin
+        failures = 0;
+        cycles = 0;
+        accepted_independent = 0;
+        seen_a_commit = 1'b0;
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        // First A enters.
+        expect_accept(A);
+
+        // Independent coordinates can still enter on consecutive clocks.
+        expect_accept(B);
+        accepted_independent = accepted_independent + 1;
+        expect_accept(C);
+        accepted_independent = accepted_independent + 1;
+
+        // Re-issuing A while A is in flight must fail closed.
+        expect_block(A);
+
+        // Stop injecting and observe the A commit.
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        for (cycles = 0; cycles < LATENCY + 4; cycles = cycles + 1) begin
+            @(posedge clk);
+            #1;
+            if (commit_valid_o && commit_coord_o == A)
+                seen_a_commit = 1'b1;
+        end
+
+        if (!seen_a_commit) begin
+            $display("FAIL never observed commit for A");
+            failures = failures + 1;
+        end
+
+        // After the scoreboard drains, A must be issuable again.
+        expect_accept(A);
+
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        if (accepted_independent != 2) begin
+            $display("FAIL independent acceptance accounting");
+            failures = failures + 1;
+        end
+
+        if (failures == 0)
+            $display("PASS: hazard guard blocks same-coordinate RAW hazards and permits independent II=1 traffic");
+        else begin
+            $display("FAIL: %0d hazard-guard failures", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv
+++ b/rtl/hft_field_q16/tb_hft_field_neighbor_addr.sv
@@ -1,0 +1,102 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_neighbor_addr;
+    localparam integer X_BITS = 6;
+    localparam integer Y_BITS = 2;
+    localparam integer Z_BITS = 2;
+    localparam integer ADDR_WIDTH = X_BITS + Y_BITS + Z_BITS;
+    localparam integer X_SIZE = 1 << X_BITS;
+    localparam integer Y_SIZE = 1 << Y_BITS;
+    localparam integer Z_SIZE = 1 << Z_BITS;
+
+    logic [X_BITS-1:0] x_i;
+    logic [Y_BITS-1:0] y_i;
+    logic [Z_BITS-1:0] z_i;
+
+    logic [ADDR_WIDTH-1:0] center_addr_o;
+    logic [ADDR_WIDTH-1:0] xm_addr_o, xp_addr_o;
+    logic [ADDR_WIDTH-1:0] ym_addr_o, yp_addr_o;
+    logic [ADDR_WIDTH-1:0] zm_addr_o, zp_addr_o;
+
+    integer failures;
+    integer x;
+    integer y;
+    integer z;
+    integer expected_center;
+    integer expected_xm;
+    integer expected_xp;
+    integer expected_ym;
+    integer expected_yp;
+    integer expected_zm;
+    integer expected_zp;
+
+    hft_field_neighbor_addr #(
+        .X_BITS(X_BITS),
+        .Y_BITS(Y_BITS),
+        .Z_BITS(Z_BITS),
+        .ADDR_WIDTH(ADDR_WIDTH)
+    ) dut (
+        .x_i(x_i), .y_i(y_i), .z_i(z_i),
+        .center_addr_o(center_addr_o),
+        .xm_addr_o(xm_addr_o), .xp_addr_o(xp_addr_o),
+        .ym_addr_o(ym_addr_o), .yp_addr_o(yp_addr_o),
+        .zm_addr_o(zm_addr_o), .zp_addr_o(zp_addr_o)
+    );
+
+    task automatic check_coord(input integer xi, input integer yi, input integer zi);
+        begin
+            x_i = xi[X_BITS-1:0];
+            y_i = yi[Y_BITS-1:0];
+            z_i = zi[Z_BITS-1:0];
+            #1;
+
+            expected_center = xi + X_SIZE * (yi + Y_SIZE * zi);
+            expected_xm = ((xi + X_SIZE - 1) % X_SIZE) + X_SIZE * (yi + Y_SIZE * zi);
+            expected_xp = ((xi + 1) % X_SIZE) + X_SIZE * (yi + Y_SIZE * zi);
+            expected_ym = xi + X_SIZE * (((yi + Y_SIZE - 1) % Y_SIZE) + Y_SIZE * zi);
+            expected_yp = xi + X_SIZE * (((yi + 1) % Y_SIZE) + Y_SIZE * zi);
+            expected_zm = xi + X_SIZE * (yi + Y_SIZE * ((zi + Z_SIZE - 1) % Z_SIZE));
+            expected_zp = xi + X_SIZE * (yi + Y_SIZE * ((zi + 1) % Z_SIZE));
+
+            if (center_addr_o !== expected_center[ADDR_WIDTH-1:0] ||
+                xm_addr_o !== expected_xm[ADDR_WIDTH-1:0] ||
+                xp_addr_o !== expected_xp[ADDR_WIDTH-1:0] ||
+                ym_addr_o !== expected_ym[ADDR_WIDTH-1:0] ||
+                yp_addr_o !== expected_yp[ADDR_WIDTH-1:0] ||
+                zm_addr_o !== expected_zm[ADDR_WIDTH-1:0] ||
+                zp_addr_o !== expected_zp[ADDR_WIDTH-1:0]) begin
+                $display("FAIL (%0d,%0d,%0d) center=%0d/%0d xm=%0d/%0d xp=%0d/%0d ym=%0d/%0d yp=%0d/%0d zm=%0d/%0d zp=%0d/%0d",
+                         xi, yi, zi,
+                         center_addr_o, expected_center,
+                         xm_addr_o, expected_xm,
+                         xp_addr_o, expected_xp,
+                         ym_addr_o, expected_ym,
+                         yp_addr_o, expected_yp,
+                         zm_addr_o, expected_zm,
+                         zp_addr_o, expected_zp);
+                failures = failures + 1;
+            end
+        end
+    endtask
+
+    initial begin
+        failures = 0;
+        x_i = '0; y_i = '0; z_i = '0;
+
+        // Exhaust the full default 64 x 4 x 4 lattice. This covers all six
+        // toroidal boundary wraps and every flattened address exactly.
+        for (z = 0; z < Z_SIZE; z = z + 1)
+            for (y = 0; y < Y_SIZE; y = y + 1)
+                for (x = 0; x < X_SIZE; x = x + 1)
+                    check_coord(x, y, z);
+
+        if (failures == 0)
+            $display("PASS: all %0d coordinates matched C++ flattening and toroidal six-neighbour wrapping", X_SIZE * Y_SIZE * Z_SIZE);
+        else begin
+            $display("FAIL: %0d neighbour-address mismatches", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_pow2_equiv.sv
+++ b/rtl/hft_field_q16/tb_hft_field_pow2_equiv.sv
@@ -1,0 +1,162 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_pow2_equiv;
+    logic signed [31:0] psi_i;
+    logic signed [31:0] omega_i;
+    logic signed [31:0] flow_i;
+    logic signed [31:0] inventory_i;
+    logic signed [31:0] delta_quantity_i;
+    logic               side_bid_i;
+    logic signed [31:0] psi_xm_i;
+    logic signed [31:0] psi_xp_i;
+    logic signed [31:0] psi_ym_i;
+    logic signed [31:0] psi_yp_i;
+    logic signed [31:0] psi_zm_i;
+    logic signed [31:0] psi_zp_i;
+
+    logic signed [31:0] ref_psi;
+    logic signed [31:0] ref_omega;
+    logic signed [31:0] ref_flow;
+    logic signed [31:0] ref_lap;
+    logic signed [31:0] ref_score;
+    logic signed [1:0]  ref_action;
+    logic signed [31:0] ref_quantity;
+    logic               ref_risk;
+
+    logic signed [31:0] opt_psi;
+    logic signed [31:0] opt_omega;
+    logic signed [31:0] opt_flow;
+    logic signed [31:0] opt_lap;
+    logic signed [31:0] opt_score;
+    logic signed [1:0]  opt_action;
+    logic signed [31:0] opt_quantity;
+    logic               opt_risk;
+
+    integer vectors_checked;
+    logic [31:0] rng;
+
+    hft_field_cell_core reference (
+        .psi_i, .omega_i, .flow_i, .inventory_i, .delta_quantity_i,
+        .side_bid_i, .psi_xm_i, .psi_xp_i, .psi_ym_i, .psi_yp_i,
+        .psi_zm_i, .psi_zp_i,
+        .psi_o(ref_psi), .omega_o(ref_omega), .flow_o(ref_flow),
+        .laplacian_o(ref_lap), .score_o(ref_score), .action_o(ref_action),
+        .quantity_o(ref_quantity), .risk_accepted_o(ref_risk)
+    );
+
+    hft_field_cell_pow2 optimized (
+        .psi_i, .omega_i, .flow_i, .inventory_i, .delta_quantity_i,
+        .side_bid_i, .psi_xm_i, .psi_xp_i, .psi_ym_i, .psi_yp_i,
+        .psi_zm_i, .psi_zp_i,
+        .psi_o(opt_psi), .omega_o(opt_omega), .flow_o(opt_flow),
+        .laplacian_o(opt_lap), .score_o(opt_score), .action_o(opt_action),
+        .quantity_o(opt_quantity), .risk_accepted_o(opt_risk)
+    );
+
+    function automatic logic [31:0] xorshift32(input logic [31:0] x);
+        logic [31:0] y;
+        begin
+            y = x;
+            y = y ^ (y << 13);
+            y = y ^ (y >> 17);
+            y = y ^ (y << 5);
+            xorshift32 = y;
+        end
+    endfunction
+
+    task automatic next_word(output logic signed [31:0] value);
+        begin
+            rng = xorshift32(rng);
+            value = $signed(rng);
+        end
+    endtask
+
+    task automatic check_current(input string name);
+        begin
+            #1;
+            vectors_checked = vectors_checked + 1;
+            if (ref_psi !== opt_psi ||
+                ref_omega !== opt_omega ||
+                ref_flow !== opt_flow ||
+                ref_lap !== opt_lap ||
+                ref_score !== opt_score ||
+                ref_action !== opt_action ||
+                ref_quantity !== opt_quantity ||
+                ref_risk !== opt_risk) begin
+                $display("EQUIV FAIL %s vector=%0d", name, vectors_checked);
+                $display(" inputs psi=%0d omega=%0d flow=%0d inv=%0d dq=%0d bid=%0d",
+                         psi_i, omega_i, flow_i, inventory_i, delta_quantity_i,
+                         side_bid_i);
+                $display(" neighbors xm=%0d xp=%0d ym=%0d yp=%0d zm=%0d zp=%0d",
+                         psi_xm_i, psi_xp_i, psi_ym_i, psi_yp_i, psi_zm_i, psi_zp_i);
+                $display(" ref psi=%0d omega=%0d flow=%0d lap=%0d score=%0d action=%0d qty=%0d risk=%0d",
+                         ref_psi, ref_omega, ref_flow, ref_lap, ref_score,
+                         ref_action, ref_quantity, ref_risk);
+                $display(" opt psi=%0d omega=%0d flow=%0d lap=%0d score=%0d action=%0d qty=%0d risk=%0d",
+                         opt_psi, opt_omega, opt_flow, opt_lap, opt_score,
+                         opt_action, opt_quantity, opt_risk);
+                $fatal(1, "multiplier-free core is not bit-exact");
+            end
+        end
+    endtask
+
+    task automatic drive_extreme(
+        input logic signed [31:0] a,
+        input logic signed [31:0] b
+    );
+        begin
+            psi_i = a;
+            omega_i = b;
+            flow_i = a;
+            inventory_i = b;
+            delta_quantity_i = a;
+            side_bid_i = 1'b1;
+            psi_xm_i = a;
+            psi_xp_i = b;
+            psi_ym_i = a;
+            psi_yp_i = b;
+            psi_zm_i = a;
+            psi_zp_i = b;
+            check_current("extreme-bid");
+
+            side_bid_i = 1'b0;
+            check_current("extreme-ask");
+        end
+    endtask
+
+    integer i;
+    initial begin
+        vectors_checked = 0;
+        rng = 32'h4A58_4831;
+
+        // Directed saturation/zero/sign boundary cases.
+        drive_extreme(32'sh7fffffff, 32'sh80000000);
+        drive_extreme(32'sh80000000, 32'sh7fffffff);
+        drive_extreme(32'sd0, 32'sd0);
+        drive_extreme(32'sd1, -32'sd1);
+        drive_extreme(32'sd65536, -32'sd65536);
+        drive_extreme(32'sd4194304, -32'sd4194304);
+
+        // Deterministic full-range stress. This exercises saturation as well as
+        // truncation-toward-zero behavior for negative dyadic products.
+        for (i = 0; i < 10000; i = i + 1) begin
+            next_word(psi_i);
+            next_word(omega_i);
+            next_word(flow_i);
+            next_word(inventory_i);
+            next_word(delta_quantity_i);
+            rng = xorshift32(rng);
+            side_bid_i = rng[0];
+            next_word(psi_xm_i);
+            next_word(psi_xp_i);
+            next_word(psi_ym_i);
+            next_word(psi_yp_i);
+            next_word(psi_zm_i);
+            next_word(psi_zp_i);
+            check_current("random");
+        end
+
+        $display("PASS multiplier-free equivalence: %0d vectors bit-exact", vectors_checked);
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_stateful_center.sv
+++ b/rtl/hft_field_q16/tb_hft_field_stateful_center.sv
@@ -1,0 +1,274 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_stateful_center;
+    localparam integer ADDR_WIDTH = 6;
+    localparam integer LATENCY = 17;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+
+    logic cfg_write_valid = 1'b0;
+    logic [ADDR_WIDTH-1:0] cfg_write_addr = '0;
+    logic signed [31:0] cfg_psi = '0, cfg_omega = '0, cfg_flow = '0;
+    logic cfg_write_ready;
+
+    logic in_valid = 1'b0;
+    logic [ADDR_WIDTH-1:0] in_coord = '0;
+    logic signed [31:0] inventory_i = '0, delta_quantity_i = '0;
+    logic side_bid_i = 1'b1;
+    logic signed [31:0] psi_xm_i = '0, psi_xp_i = '0, psi_ym_i = '0;
+    logic signed [31:0] psi_yp_i = '0, psi_zm_i = '0, psi_zp_i = '0;
+
+    logic in_ready, conflict_o, out_valid, risk_accepted_o, alignment_error_o;
+    logic [ADDR_WIDTH-1:0] out_coord;
+    logic signed [31:0] psi_o, omega_o, flow_o, laplacian_o, score_o, quantity_o;
+    logic signed [1:0] action_o;
+
+    logic signed [31:0] model_psi, model_omega, model_flow;
+    logic signed [31:0] ref_psi, ref_omega, ref_flow, ref_lap, ref_score, ref_quantity;
+    logic signed [1:0] ref_action;
+    logic ref_risk;
+
+    logic signed [31:0] exp_psi, exp_omega, exp_flow, exp_lap, exp_score, exp_quantity;
+    logic signed [1:0] exp_action;
+    logic exp_risk;
+
+    integer failures;
+    integer cycles_waited;
+
+    localparam logic [ADDR_WIDTH-1:0] A = 6'h15;
+
+    always #5 clk = ~clk;
+
+    hft_field_cell_pow2 ref_core (
+        .psi_i(model_psi), .omega_i(model_omega), .flow_i(model_flow),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .psi_o(ref_psi), .omega_o(ref_omega), .flow_o(ref_flow),
+        .laplacian_o(ref_lap), .score_o(ref_score),
+        .action_o(ref_action), .quantity_o(ref_quantity),
+        .risk_accepted_o(ref_risk)
+    );
+
+    hft_field_stateful_center #(
+        .ADDR_WIDTH(ADDR_WIDTH),
+        .LATENCY_CYCLES(LATENCY)
+    ) dut (
+        .clk(clk), .rst_n(rst_n),
+        .cfg_write_valid(cfg_write_valid), .cfg_write_addr(cfg_write_addr),
+        .cfg_psi(cfg_psi), .cfg_omega(cfg_omega), .cfg_flow(cfg_flow),
+        .cfg_write_ready(cfg_write_ready),
+        .in_valid(in_valid), .in_coord(in_coord),
+        .inventory_i(inventory_i), .delta_quantity_i(delta_quantity_i),
+        .side_bid_i(side_bid_i),
+        .psi_xm_i(psi_xm_i), .psi_xp_i(psi_xp_i),
+        .psi_ym_i(psi_ym_i), .psi_yp_i(psi_yp_i),
+        .psi_zm_i(psi_zm_i), .psi_zp_i(psi_zp_i),
+        .in_ready(in_ready), .conflict_o(conflict_o),
+        .out_valid(out_valid), .out_coord(out_coord),
+        .psi_o(psi_o), .omega_o(omega_o), .flow_o(flow_o),
+        .laplacian_o(laplacian_o), .score_o(score_o),
+        .action_o(action_o), .quantity_o(quantity_o),
+        .risk_accepted_o(risk_accepted_o),
+        .alignment_error_o(alignment_error_o)
+    );
+
+    task automatic configure_state(
+        input logic [ADDR_WIDTH-1:0] coord,
+        input logic signed [31:0] psi,
+        input logic signed [31:0] omega,
+        input logic signed [31:0] flow
+    );
+        begin
+            @(negedge clk);
+            in_valid = 1'b0;
+            cfg_write_addr = coord;
+            cfg_psi = psi;
+            cfg_omega = omega;
+            cfg_flow = flow;
+            cfg_write_valid = 1'b1;
+            #1;
+            if (!cfg_write_ready) begin
+                $display("FAIL config unexpectedly not ready");
+                failures = failures + 1;
+            end
+            @(posedge clk);
+            #1;
+            @(negedge clk);
+            cfg_write_valid = 1'b0;
+        end
+    endtask
+
+    task automatic prepare_event(
+        input logic signed [31:0] inventory,
+        input logic signed [31:0] delta,
+        input logic side_bid,
+        input logic signed [31:0] neighbour_bias
+    );
+        begin
+            inventory_i = inventory;
+            delta_quantity_i = delta;
+            side_bid_i = side_bid;
+            psi_xm_i = model_psi + neighbour_bias;
+            psi_xp_i = model_psi - neighbour_bias - 32'sd1700;
+            psi_ym_i = model_psi + neighbour_bias + 32'sd2300;
+            psi_yp_i = model_psi - neighbour_bias - 32'sd3100;
+            psi_zm_i = model_psi + neighbour_bias + 32'sd4300;
+            psi_zp_i = model_psi - neighbour_bias - 32'sd5900;
+        end
+    endtask
+
+    task automatic capture_expected;
+        begin
+            #1;
+            exp_psi = ref_psi;
+            exp_omega = ref_omega;
+            exp_flow = ref_flow;
+            exp_lap = ref_lap;
+            exp_score = ref_score;
+            exp_action = ref_action;
+            exp_quantity = ref_quantity;
+            exp_risk = ref_risk;
+        end
+    endtask
+
+    task automatic check_result;
+        begin
+            if (out_coord !== A ||
+                psi_o !== exp_psi || omega_o !== exp_omega || flow_o !== exp_flow ||
+                laplacian_o !== exp_lap || score_o !== exp_score ||
+                action_o !== exp_action || quantity_o !== exp_quantity ||
+                risk_accepted_o !== exp_risk) begin
+                $display("FAIL stateful result coord=%h/%h psi=%0d/%0d omega=%0d/%0d flow=%0d/%0d score=%0d/%0d",
+                         out_coord, A, psi_o, exp_psi, omega_o, exp_omega,
+                         flow_o, exp_flow, score_o, exp_score);
+                failures = failures + 1;
+            end
+            if (alignment_error_o) begin
+                $display("FAIL alignment_error_o asserted");
+                failures = failures + 1;
+            end
+        end
+    endtask
+
+    task automatic wait_for_result;
+        begin
+            cycles_waited = 0;
+            while (!out_valid && cycles_waited < LATENCY + 4) begin
+                @(posedge clk);
+                #1;
+                cycles_waited = cycles_waited + 1;
+            end
+            if (!out_valid) begin
+                $display("FAIL timed out waiting for stateful result");
+                failures = failures + 1;
+            end else begin
+                check_result();
+            end
+        end
+    endtask
+
+    initial begin
+        failures = 0;
+        model_psi = 32'sd210000;
+        model_omega = -32'sd70000;
+        model_flow = 32'sd33000;
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        configure_state(A, model_psi, model_omega, model_flow);
+
+        // First transition from configured persistent state.
+        @(negedge clk);
+        in_coord = A;
+        prepare_event(32'sd500000, 32'sd85000, 1'b1, 32'sd7000);
+        capture_expected();
+        in_valid = 1'b1;
+        #1;
+        if (!in_ready || conflict_o) begin
+            $display("FAIL first A transaction not accepted");
+            failures = failures + 1;
+        end
+        @(posedge clk);
+        #1;
+
+        // Same coordinate must remain blocked while the first update is in flight.
+        @(negedge clk);
+        in_valid = 1'b1;
+        #1;
+        if (in_ready || !conflict_o) begin
+            $display("FAIL same-coordinate recurrence was not blocked in flight");
+            failures = failures + 1;
+        end
+        @(posedge clk);
+        #1;
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        wait_for_result();
+
+        // Update the software model to the committed result. The RTL store
+        // writes this same state on the next rising edge.
+        model_psi = exp_psi;
+        model_omega = exp_omega;
+        model_flow = exp_flow;
+
+        @(posedge clk);
+        #1;
+
+        // Second A transition must reload the newly committed state, not the
+        // original configured state. Matching the oracle proves recurrence.
+        @(negedge clk);
+        prepare_event(-32'sd350000, 32'sd62000, 1'b0, 32'sd9000);
+        capture_expected();
+        in_coord = A;
+        in_valid = 1'b1;
+        #1;
+        if (!in_ready || conflict_o) begin
+            $display("FAIL A was not accepted after prior commit");
+            failures = failures + 1;
+        end
+        @(posedge clk);
+        #1;
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        wait_for_result();
+
+        // Configuration/event collision must fail closed: neither interface
+        // claims readiness for the ambiguous simultaneous operation.
+        @(posedge clk);
+        #1;
+        @(negedge clk);
+        in_coord = A;
+        in_valid = 1'b1;
+        cfg_write_valid = 1'b1;
+        cfg_write_addr = A;
+        cfg_psi = 32'sd1;
+        cfg_omega = 32'sd2;
+        cfg_flow = 32'sd3;
+        #1;
+        if (in_ready || cfg_write_ready || !conflict_o) begin
+            $display("FAIL config/event collision did not fail closed");
+            failures = failures + 1;
+        end
+        @(posedge clk);
+        #1;
+        @(negedge clk);
+        in_valid = 1'b0;
+        cfg_write_valid = 1'b0;
+
+        if (failures == 0)
+            $display("PASS: persistent center state commits and reloads bit-exactly across same-cell recurrence; config/event collision fails closed");
+        else begin
+            $display("FAIL: %0d stateful-center failures", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule

--- a/rtl/hft_field_q16/tb_hft_field_stencil_hazard_guard.sv
+++ b/rtl/hft_field_q16/tb_hft_field_stencil_hazard_guard.sv
@@ -1,0 +1,139 @@
+`timescale 1ns/1ps
+
+module tb_hft_field_stencil_hazard_guard;
+    localparam integer X_BITS = 6;
+    localparam integer Y_BITS = 2;
+    localparam integer Z_BITS = 2;
+    localparam integer COORD_WIDTH = X_BITS + Y_BITS + Z_BITS;
+    localparam integer LATENCY = 17;
+
+    logic clk = 1'b0;
+    logic rst_n = 1'b0;
+    logic in_valid = 1'b0;
+    logic [X_BITS-1:0] x_i = '0;
+    logic [Y_BITS-1:0] y_i = '0;
+    logic [Z_BITS-1:0] z_i = '0;
+
+    logic [COORD_WIDTH-1:0] center_addr;
+    logic [COORD_WIDTH-1:0] xm_addr, xp_addr, ym_addr, yp_addr, zm_addr, zp_addr;
+    logic in_ready, accept_o, conflict_o, commit_valid_o;
+    logic [COORD_WIDTH-1:0] commit_coord_o;
+
+    integer failures;
+    integer i;
+    logic saw_a_commit;
+
+    always #5 clk = ~clk;
+
+    hft_field_neighbor_addr #(
+        .X_BITS(X_BITS), .Y_BITS(Y_BITS), .Z_BITS(Z_BITS),
+        .ADDR_WIDTH(COORD_WIDTH)
+    ) addr_gen (
+        .x_i(x_i), .y_i(y_i), .z_i(z_i),
+        .center_addr_o(center_addr),
+        .xm_addr_o(xm_addr), .xp_addr_o(xp_addr),
+        .ym_addr_o(ym_addr), .yp_addr_o(yp_addr),
+        .zm_addr_o(zm_addr), .zp_addr_o(zp_addr)
+    );
+
+    hft_field_stencil_hazard_guard #(
+        .COORD_WIDTH(COORD_WIDTH),
+        .LATENCY_CYCLES(LATENCY)
+    ) dut (
+        .clk(clk), .rst_n(rst_n), .in_valid(in_valid),
+        .center_coord_i(center_addr),
+        .xm_coord_i(xm_addr), .xp_coord_i(xp_addr),
+        .ym_coord_i(ym_addr), .yp_coord_i(yp_addr),
+        .zm_coord_i(zm_addr), .zp_coord_i(zp_addr),
+        .in_ready(in_ready), .accept_o(accept_o), .conflict_o(conflict_o),
+        .commit_valid_o(commit_valid_o), .commit_coord_o(commit_coord_o)
+    );
+
+    task automatic drive_coord(
+        input integer x,
+        input integer y,
+        input integer z,
+        input logic expect_accept
+    );
+        begin
+            @(negedge clk);
+            x_i = x[X_BITS-1:0];
+            y_i = y[Y_BITS-1:0];
+            z_i = z[Z_BITS-1:0];
+            in_valid = 1'b1;
+            #1;
+            if (expect_accept) begin
+                if (!in_ready || !accept_o || conflict_o) begin
+                    $display("FAIL expected accept (%0d,%0d,%0d) ready=%0b accept=%0b conflict=%0b",
+                             x, y, z, in_ready, accept_o, conflict_o);
+                    failures = failures + 1;
+                end
+            end else begin
+                if (in_ready || accept_o || !conflict_o) begin
+                    $display("FAIL expected stencil block (%0d,%0d,%0d) ready=%0b accept=%0b conflict=%0b",
+                             x, y, z, in_ready, accept_o, conflict_o);
+                    failures = failures + 1;
+                end
+            end
+            @(posedge clk);
+            #1;
+        end
+    endtask
+
+    initial begin
+        failures = 0;
+        saw_a_commit = 1'b0;
+
+        repeat (3) @(posedge clk);
+        rst_n = 1'b1;
+
+        // A=(0,0,0) becomes the pending write coordinate.
+        drive_coord(0, 0, 0, 1'b1);
+
+        // Both direct x neighbours read A, so both must block. x=63 verifies
+        // that the dependency check also respects toroidal wrap.
+        drive_coord(1, 0, 0, 1'b0);
+        drive_coord(63, 0, 0, 1'b0);
+
+        // A y-neighbour and z-neighbour also read A and must block.
+        drive_coord(0, 1, 0, 1'b0);
+        drive_coord(0, 0, 3, 1'b0);
+
+        // Spatially disjoint stencils remain issuable on consecutive clocks.
+        drive_coord(10, 2, 2, 1'b1);
+        drive_coord(20, 2, 2, 1'b1);
+
+        // A new event adjacent to the pending center at x=10 must block even
+        // though its own center is different.
+        drive_coord(11, 2, 2, 1'b0);
+
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        for (i = 0; i < LATENCY + 8; i = i + 1) begin
+            @(posedge clk);
+            #1;
+            if (commit_valid_o && commit_coord_o == {2'b00, 2'b00, 6'b000000})
+                saw_a_commit = 1'b1;
+        end
+
+        if (!saw_a_commit) begin
+            $display("FAIL never observed A commit");
+            failures = failures + 1;
+        end
+
+        // Once all pending writes retire, A is legal again.
+        drive_coord(0, 0, 0, 1'b1);
+        @(negedge clk);
+        in_valid = 1'b0;
+
+        if (failures == 0)
+            $display("PASS: stencil scoreboard blocks center and six-neighbour RAW dependencies, including toroidal wrap, while allowing disjoint II=1 traffic");
+        else begin
+            $display("FAIL: %0d stencil-hazard failures", failures);
+            $fatal(1);
+        end
+
+        $finish;
+    end
+endmodule


### PR DESCRIPTION
## Summary

Introduces an experimental ultra-low-latency specialization of the canonical Dr Moagi Field Runtime v2.

### Hot-path mechanics
- Q16.16 saturating arithmetic with deterministic multiply semantics
- fixed-size 3D `(price_bin, venue, horizon)` field
- six-neighbour Laplacian
- one explicit local field step per market event
- persistent `Omega` and event-flow state
- fixed MAC-tree decision score
- fail-closed inventory risk gate
- no dynamic allocation, softmax, stochastic sampling, or iterative minimization in `process`

### Verification
- deterministic Q16 arithmetic regression
- bit-exact event-stream replay digest
- positive/negative directional response
- inventory risk rejection
- explicit 48-cycle design budget (`96 ns @ 500 MHz`)

The 96 ns figure is a **design/synthesis target only**, not a measured FPGA latency result. The documentation defines a verification ladder from C++ replay through RTL equivalence, timing closure, loopback measurement, STAC-T1-compatible workload, and independent audit.

### Local reference run
The new C++ regression executable was compiled with C++17 and warnings enabled and passed locally. A 1,000,000-event functional simulation completed deterministically; its CPU timing is reported separately and explicitly not treated as FPGA tick-to-trade latency.

### External comparison target
The engineering document uses the audited October 2024 ADHOC/STAC-T1 HFFT-02A result as the latency reference: 115.07 ns mean SOM-to-SOF and 140.04 ns p99 at 1x market rate; 76.40 ns mean EOT-to-SOF.

Reference: https://docs.stacresearch.com/news/ADHC240918
