### PR TITLE
Add bounded 10x10x10 inward 4D ANN reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,14 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
           src/jarvisx/verification.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
           tests/test_verification.py
@@ -67,12 +69,14 @@ jobs:
           src/jarvisx/ledger.py
           src/jarvisx/ledger_store.py
           src/jarvisx/fractional_smoothing_3d.py
+          src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
           src/jarvisx/verification.py
           tests/test_vm.py
           tests/test_ledger.py
           tests/test_fractional_smoothing_3d.py
+          tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
           tests/test_verification.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,12 @@ The project follows semantic versioning where practical during alpha development
 - analytic constant-forcing updates for `du/dt = -D(-Delta)^alpha u + Omega`;
 - `2×2×2` restriction, prolongation and coarse-to-fine fusion;
 - ordered mechanistic traces, mass drift, gradient energy, residual and convergence telemetry;
-- independent direct-DFT, spatial-stencil and semigroup validation tests.
+- independent direct-DFT, spatial-stencil and semigroup validation tests;
+- dependency-free `10 x 10 x 10` inward-4D graph autoencoder reference;
+- exact 2,700-edge open-cube and 3,000-edge fully wrapped topology contracts;
+- analytic tied-edge gradients with central finite-difference verification;
+- transactional non-regressing adaptation and connectivity-preserving pruning;
+- machine-readable arithmetic telemetry and a bounded command-line example.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The symbolic vocabulary used in the research documents maps to ordinary engineer
 | C++ processor laboratory | sparse virtual `8192³` lattice, signed 3-bit latent cycle, deterministic bounded genome/schedule search | Reference laboratory |
 | Fractional 3D smoothing | periodic spectral fractional diffusion, analytic forcing and multiresolution fusion | Numerical reference |
 | Sparse geometry | deterministic inward-folding fractal octree with closed-form invariants | Reference |
+| Inward 4D graph ANN | deterministic 1,000-node folded graph autoencoder with exact gradients, guarded pruning and rollback | Reference laboratory |
 | Model packaging | Hugging Face-compatible configuration, model and safetensors exporter | Reference |
 | Research specifications | reality-grounded observer dynamics, spatial bytecode and bounded optimization documents | Proposed / reference |
 
@@ -120,6 +121,19 @@ assert result.field.variance < field.variance
 ```
 
 The solver uses a dependency-free separable direct DFT for small correctness fixtures. See [Hierarchical 3D Fractional Smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md) for the equations, complexity and production boundary.
+
+### Run the 10x10x10 inward 4D ANN reference
+
+```bash
+python examples/inward4d_ann_demo.py --epochs 25
+```
+
+The reference executes a same-width graph autoencoder over exactly 1,000 nodes
+and 3,000 fully wrapped undirected synapses. It reports the complete
+self-description objective and commits an update only when the candidate does
+not regress. See the
+[end-to-end arithmetic](docs/DR_MOAGI_10X10X10_INWARD_4D_ANN.md) for the fold,
+forward pass, analytic gradient, pruning, and capability boundary.
 
 ### Build the C++ processor laboratory
 
@@ -227,6 +241,7 @@ Every canonical subsystem should provide:
 - [Architecture](docs/ARCHITECTURE.md)
 - [Project status](docs/PROJECT_STATUS.md)
 - [Inward 3D kinetic end-to-end specification](docs/INWARD_3D_KINETIC_END_TO_END.md)
+- [10x10x10 inward 4D graph ANN](docs/DR_MOAGI_10X10X10_INWARD_4D_ANN.md)
 - [Dr. Moagi 4D quantum-inspired autoencoding equation](docs/DR_MOAGI_4D_QUANTUM_INSPIRED_AUTOENCODING.md)
 - [Hierarchical 3D fractional smoothing](docs/HIERARCHICAL_3D_FRACTIONAL_SMOOTHING.md)
 - [Roadmap](ROADMAP.md)

--- a/docs/DR_MOAGI_10X10X10_INWARD_4D_ANN.md
+++ b/docs/DR_MOAGI_10X10X10_INWARD_4D_ANN.md
@@ -1,0 +1,511 @@
+# Dr Moagi 10x10x10 Inward 4D Auto-Optimizing ANN
+
+## Status and implemented boundary
+
+This document specifies the dependency-free reference implemented in
+`src/jarvisx/inward4d_ann.py`.
+
+It implements:
+
+- a `10 x 10 x 10` lattice with exactly 1,000 nodes;
+- a deterministic coordinate feature map from the lattice into `R^4`;
+- open-cube and fully wrapped six-neighbour graph topologies;
+- a tied, same-width graph encoder and decoder;
+- an explicit self-reconstruction objective;
+- analytic reverse-mode gradients;
+- non-negative bounded synaptic weights;
+- connectivity-preserving pruning;
+- candidate evaluation, commit, rollback, and audit telemetry.
+
+The fourth value is a mathematical feature coordinate. It is not time, a claim
+about physical spacetime, or evidence of a quantum process. The latent field has
+1,000 scalars, so this reference is an autoencoder but not a compressor. The
+fixed-point tolerance is a stopping test for a supplied input; it is not a proof
+that every possible input converges.
+
+## 1. State and indexing
+
+Let the lattice side be `n = 10`. Its coordinates and node count are
+
+\[
+(x,y,z)\in\{0,\ldots,9\}^3,
+\qquad N=n^3=1000.
+\]
+
+The authoritative linear address is
+
+\[
+\boxed{i(x,y,z)=n^2x+ny+z=100x+10y+z.}
+\]
+
+The inverse is
+
+\[
+x=\left\lfloor\frac{i}{100}\right\rfloor,
+\qquad
+y=\left\lfloor\frac{i\bmod100}{10}\right\rfloor,
+\qquad
+z=i\bmod10.
+\]
+
+Normalized box coordinates are
+
+\[
+u_x=\frac{2x}{9}-1,
+\qquad
+u_y=\frac{2y}{9}-1,
+\qquad
+u_z=\frac{2z}{9}-1.
+\]
+
+Every integer index round-trips through these discrete coordinates; floating
+point geometry never becomes an address.
+
+## 2. Inward `R^4` fold
+
+### 2.1 Flat box
+
+For spacing `S = 2.2`, the centered flat coordinate is
+
+\[
+\mathbf B(x,y,z)=
+\left(
+S(x-4.5),
+S(y-4.5),
+S(z-4.5),
+0
+\right).
+\]
+
+### 2.2 Toroidal feature coordinate
+
+Use three discrete phase angles
+
+\[
+\theta_x=\frac{2\pi x}{10},
+\qquad
+\theta_y=\frac{2\pi y}{10},
+\qquad
+\theta_z=\frac{2\pi z}{10}.
+\]
+
+The layer radius is
+
+\[
+\boxed{r(z)=2.5+1.5\frac{z}{9},}
+\]
+
+so `r(0) = 2.5` and `r(9) = 4.0`. With major radius `R = 4.5`, define
+
+\[
+\begin{aligned}
+T_0&=(R+r\cos\theta_y)\cos\theta_x,\\
+T_1&=(R+r\cos\theta_y)\sin\theta_x,\\
+T_2&=r\sin\theta_y\cos\theta_z,\\
+T_3&=r\sin\theta_y\sin\theta_z.
+\end{aligned}
+\]
+
+This is the engine's deterministic `R^4` coordinate feature map. The runtime
+does not require the map to be a globally isometric embedding of a continuous
+three-torus; graph topology remains discrete and authoritative.
+
+### 2.3 Fold interpolation
+
+For fold factor `gamma in [0,1]`,
+
+\[
+\boxed{
+\mathbf q_\gamma(x,y,z)
+=(1-\gamma)\mathbf B(x,y,z)+\gamma\mathbf T(x,y,z).
+}
+\]
+
+- `gamma = 0`: flat `R^3` box carried in `R^4` with `q_3 = 0`;
+- `gamma = 1`: fully folded toroidal feature coordinates;
+- intermediate values: a deterministic coordinate interpolation, not a
+  physical deformation claim.
+
+## 3. Synaptic graph
+
+### 3.1 Topological support
+
+Each node proposes one positive-direction neighbour on each axis. Internal
+edges use `c + 1`; seam edges use `(c + 1) mod 10` when folding is enabled.
+The graph is undirected, so one weight is authoritative for both directions:
+
+\[
+w_{ij}=w_{ji},
+\qquad 0\leq w_{ij}\leq1.
+\]
+
+The exact open-cube edge count is
+
+\[
+\boxed{M_{flat}=3(n-1)n^2=3(9)(100)=2700.}
+\]
+
+Closing one seam per axis contributes
+
+\[
+\boxed{M_{seam}=3n^2=300,}
+\]
+
+therefore the fully wrapped count is
+
+\[
+\boxed{M_{wrapped}=M_{flat}+M_{seam}=3000.}
+\]
+
+This resolves the earlier approximate `2,700-3,100` range: 2,700 and 3,000
+are exact for the declared six-neighbour contracts. A pure all-pairs radius
+graph does not have a predetermined edge count and can be disconnected.
+
+### 3.2 Folded distance and coupling
+
+For a supported pair,
+
+\[
+d_{ij}^{(4)}=
+\left\|\mathbf q_\gamma(i)-\mathbf q_\gamma(j)\right\|_2.
+\]
+
+The default proximity gate is `rho = 5.5`. A supported edge is admitted only
+when `d_ij^(4) <= rho`. Its immutable geometry gain is
+
+\[
+g_{ij}=s_{ij}(\gamma)
+\exp\left[-\frac12\left(\frac{d_{ij}^{(4)}}{\rho}\right)^2\right],
+\]
+
+where `s_ij = 1` for an internal edge and `s_ij = gamma` for a seam edge. At
+full fold, the maximum supported edge distance is `5.2532889044`, so all 3,000
+supported edges pass the `5.5` gate and every node has degree six.
+
+## 4. Encoder, decoder, and self-description
+
+Let `I in R^1000` be the input field. Let `d_i` be the active degree of node
+`i`, `delta = 0.88`, and `kappa = 1-delta = 0.12`.
+
+The encoder is
+
+\[
+p_i^E
+=\delta I_i
++\frac{\kappa}{d_i}
+\sum_{j\in\mathcal N(i)}w_{ij}g_{ij}I_j
++b_i^E,
+\qquad
+z_i=\tanh(p_i^E).
+\]
+
+The tied graph decoder is
+
+\[
+p_i^D
+=\delta z_i
++\frac{\kappa}{d_i}
+\sum_{j\in\mathcal N(i)}w_{ij}g_{ij}z_j
++b_i^D,
+\qquad
+\widehat I_i=\tanh(p_i^D).
+\]
+
+Therefore
+
+\[
+\boxed{
+\operatorname{Describe}_\Theta(I)
+=D_\Theta(E_\Theta(I))=\widehat I.
+}
+\]
+
+`Theta` consists only of the active symmetric edge weights and the two bias
+vectors. The geometry and node addresses are immutable during one engine
+instance.
+
+## 5. Objective functional
+
+The reconstruction term is
+
+\[
+L_{rec}=\frac1N\sum_{i=0}^{N-1}(\widehat I_i-I_i)^2.
+\]
+
+The folded-field disagreement energy is
+
+\[
+L_E=\frac1{M_a}
+\sum_{(i,j)\in E_a}
+w_{ij}g_{ij}(z_i-z_j)^2.
+\]
+
+Energy alone would drive conductances toward zero. The runtime therefore uses
+an explicit homeostatic anchor `w_0 = 0.40`:
+
+\[
+L_H=\frac1{M_a}\sum_{(i,j)\in E_a}(w_{ij}-w_0)^2.
+\]
+
+The bias penalty is
+
+\[
+L_B=\frac1{2N}
+\left(\|b^E\|_2^2+\|b^D\|_2^2\right).
+\]
+
+The complete implemented objective is
+
+\[
+\boxed{
+\mathcal L
+=L_{rec}+0.02L_E+0.01L_H+10^{-4}L_B.
+}
+\]
+
+This is self-supervised: the input is its own reconstruction target. It does not
+require class labels, but it still requires an explicit objective and data.
+
+## 6. Exact local gradient update
+
+For one active undirected edge `e = (i,j)`, reverse-mode differentiation yields
+
+\[
+\frac{\partial\mathcal L}{\partial w_e}
+=G_e^{decoder}
++G_e^{encoder}
++\frac{0.02}{M_a}g_e(z_i-z_j)^2
++\frac{0.02}{M_a}(w_e-w_0).
+\]
+
+The last coefficient is `2 * 0.01 / M_a`. The encoder and decoder terms are the
+ordinary chain-rule contributions through both directions of the symmetric
+edge. The implementation also propagates `L_E` through `z`; it does not treat
+the latent values as constants.
+
+The proposed update is
+
+\[
+\boxed{
+w_e'=\operatorname{clip}_{[0,1]}
+\left(w_e-0.005\frac{\partial\mathcal L}{\partial w_e}\right).
+}
+\]
+
+Biases use the same learning rate and are clipped to `[-2,2]`. If the full
+candidate objective increases, the engine retries with learning rates
+`eta/2, eta/4, ...` for at most six backtracks. No proposed value is
+authoritative before evaluation.
+
+## 7. Structural pruning
+
+Every 25 epochs, an active edge becomes a pruning candidate when
+
+\[
+\boxed{w_e<\tau_{prune}=0.15.}
+\]
+
+Because this reference constrains weights to be non-negative, this is equivalent
+to `abs(w_e) < 0.15`. Candidates are processed deterministically by weight and
+node address. An edge is removed only if:
+
+1. both endpoint degrees remain at or above the configured minimum;
+2. the complete 1,000-node graph remains connected;
+3. the full post-pruning objective passes the non-regression gate.
+
+Pruning is symmetric because each undirected pair has one active flag and one
+weight.
+
+## 8. End-to-end transaction
+
+```mermaid
+flowchart TD
+    A["Input I: 1,000 scalars"] --> B["Encode on folded graph"]
+    B --> C["Latent field z"]
+    C --> D["Decode / Describe"]
+    D --> E["Loss and exact gradients"]
+    E --> F["Bounded candidate update"]
+    F --> G{"Finite, connected, non-regressing?"}
+    G -->|yes| H["Commit weights, biases, topology"]
+    G -->|no| I["Backtrack or rollback"]
+```
+
+The complete execution order is:
+
+1. validate configuration and build 1,000 immutable addresses;
+2. compute flat and toroidal coordinates, then `q_gamma`;
+3. build unique symmetric positive-axis edges;
+4. gate supported edges by folded distance and validate connectivity;
+5. validate exactly 1,000 finite input values;
+6. execute encoder graph propagation and `tanh`;
+7. execute tied decoder graph propagation and `tanh`;
+8. compute reconstruction, energy, homeostasis, and bias losses;
+9. differentiate the complete smooth objective;
+10. create bounded weight and bias candidates;
+11. optionally propose connectivity-preserving pruning;
+12. evaluate the candidate and commit only on non-regression, otherwise
+    backtrack or roll back;
+13. emit epoch, loss, residual, learning rate, active-edge, pruning, and
+    convergence telemetry.
+
+## 9. Worked arithmetic
+
+For node `(x,y,z) = (2,3,4)`:
+
+\[
+i=100(2)+10(3)+4=234.
+\]
+
+Its flat point is
+
+\[
+\mathbf B=(-5.5,-3.3,-1.1,0).
+\]
+
+Its layer radius and phases are
+
+\[
+r=2.5+1.5\frac49=3.1666666667,
+\]
+
+\[
+(\theta_x,\theta_y,\theta_z)
+=(0.4\pi,0.6\pi,0.8\pi).
+\]
+
+At full fold,
+
+\[
+\boxed{
+\mathbf q_1(2,3,4)
+=(1.088186716,
+  3.349094341,
+ -2.436499467,
+  1.770220482).
+}
+\]
+
+The positive-z neighbour is node `235`. Their folded distance and gain are
+
+\[
+d_{234,235}^{(4)}=1.916933105,
+\qquad
+g_{234,235}=0.941070024.
+\]
+
+For one illustrative encoder node with `I_i = 0.4` and a complete weighted
+neighbour sum of `0.9`,
+
+\[
+p_i^E=0.88(0.4)+\frac{0.12}{6}(0.9)=0.3700000000,
+\]
+
+\[
+z_i=\tanh(0.37)=0.3539917125.
+\]
+
+If the decoder weighted neighbour sum is `0.78`,
+
+\[
+p_i^D=0.88(0.3539917125)+\frac{0.12}{6}(0.78)
+=0.3271127070,
+\]
+
+\[
+\widehat I_i=\tanh(p_i^D)=0.3159240347.
+\]
+
+The node residual is `-0.0840759653`, contributing `0.0070687679` before the
+`1/N` average. For an illustrative neighbouring latent value `z_j = 0.28` and
+`w_ij = 0.4`, the unscaled local disagreement derivative is
+
+\[
+(z_i-z_j)^2=0.0054747735.
+\]
+
+If that were the only gradient term, one `eta = 0.005` update would give
+
+\[
+w_{ij}'=0.4-0.005(0.0054747735)=0.3999726261.
+\]
+
+The runtime uses the complete chain-rule gradient rather than this isolated
+illustration.
+
+## 10. Arithmetic summary
+
+| Metric | Symbol | Operational value | Exact relationship |
+|---|---:|---:|---|
+| Grid | `n x n x n` | `10 x 10 x 10` | `N = n^3 = 1,000` |
+| Address | `i` | `0 ... 999` | `i = 100x + 10y + z` |
+| Spacing | `S` | `2.2` | centered flat step |
+| Fold | `gamma` | `1.0` | `q_gamma = (1-gamma)B + gamma T` |
+| Major radius | `R` | `4.5` | toroidal ring radius |
+| Layer radius | `r(z)` | `2.5 ... 4.0` | `2.5 + 1.5z/9` |
+| Proximity gate | `rho` | `5.5` | supported edge requires `d4 <= rho` |
+| Open edges | `M_flat` | `2,700` | `3(n-1)n^2` |
+| Seam edges | `M_seam` | `300` | `3n^2` |
+| Full-fold edges | `M` | `3,000` | `3n^3` |
+| Potential retention | `delta` | `0.88` | neighbour scale `1-delta = 0.12` |
+| Learning rate | `eta` | `0.005` | backtracked on regression |
+| Prune threshold | `tau_prune` | `0.15` | non-negative `w < tau` |
+| Prune interval | `K` | `25` epochs | topology remains connected |
+| Fixed-point target | `epsilon` | `< 10^-6` | `sqrt(L_rec) < epsilon` |
+
+## 11. Complexity and resource bound
+
+For `N = 1,000` and `M = 3,000`:
+
+- folded coordinate construction: `O(N)`;
+- graph construction: `O(N)` for fixed degree;
+- one encode/decode evaluation: `O(N + M)`;
+- one exact gradient: `O(N + M)`;
+- adaptive scalar state: `M + 2N = 5,000` floating-point values plus topology;
+- pruning: bounded by `M` candidates with explicit connectivity checks;
+- optimization: bounded by `max_epochs` and at most six learning-rate
+  backtracks per epoch.
+
+No throughput, energy, HFT, or hardware superiority claim follows from these
+operation counts. The implementation is a correctness-oriented Python
+reference.
+
+## 12. Verification contract
+
+Focused tests verify:
+
+- all 1,000 indices round-trip exactly;
+- node `234` matches the closed-form `R^4` coordinate;
+- flat and full-fold graphs contain exactly 2,700 and 3,000 edges;
+- the full-fold graph is six-regular and connected;
+- the zero field is an exact self-description fixed point;
+- non-finite and dimensionally invalid inputs are rejected;
+- analytic edge and bias gradients match central finite differences;
+- equal initial state and input produce identical updates;
+- committed objectives do not increase;
+- validator rejection rolls parameters and topology back;
+- pruning preserves symmetry, minimum degree, and connectivity;
+- optimization respects its finite epoch budget.
+
+Run the reference:
+
+```bash
+python examples/inward4d_ann_demo.py --epochs 25
+```
+
+Run focused verification:
+
+```bash
+pytest -q tests/test_inward4d_ann.py
+```
+
+## 13. What remains future work
+
+- an undercomplete latent bottleneck with a separately measured rate-distortion
+  trade-off;
+- datasets and held-out reconstruction tests;
+- sparse/native acceleration and reproducible benchmarks;
+- checkpoint serialization with a version and topology digest;
+- convergence analysis for declared input classes;
+- comparison against ordinary grid, graph autoencoder, and convolutional
+  baselines;
+- ablation of the `R^4` geometry gain versus the same graph without folding.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-12  
+**Last reviewed:** 2026-08-28
 **Release line:** `0.1.x` alpha
 
 This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
@@ -34,6 +34,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
 | Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
+| 10x10x10 inward 4D graph ANN | Reference laboratory | `inward4d_ann.py`, `test_inward4d_ann.py`, ADR-010 | same-width 1,000-node graph autoencoder; `R^4` is feature geometry; no universal convergence, compression, or performance claim |
 | Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures, not production neural or MP4 implementations |
 | Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, `test_orthogonal_quantization.py`, ADR-005 | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production DCT/video codec kernel |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
@@ -59,7 +60,7 @@ The gate currently tests five falsifiable properties:
 4. fractal-octree agreement with exact recursive closed forms;
 5. fractional-smoothing conservation, dissipation and semigroup tolerances.
 
-The Field Runtime v2, Moagi-Helmholtz orchestration runtime and orthogonal quantization precision gate are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
+The Field Runtime v2, inward 4D graph ANN, Moagi-Helmholtz orchestration runtime and orthogonal quantization precision gate are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
@@ -99,6 +100,8 @@ Jarvis-X does not currently claim:
 - bit-exact cross-platform floating-point results from the C++ research processor;
 - production-scale fractional PDE performance or physical validity from the numerical reference solver;
 - convergence of arbitrary learned Dr Moagi codecs from the reference explicit-step guard alone;
+- universal convergence or compression from the same-width inward 4D graph autoencoder;
+- that an `R^4` feature coordinate establishes a physical fourth spatial dimension;
 - empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines.
 
 ## Canonical promotion checklist

--- a/docs/adr/0010-inward4d-ann-reference.md
+++ b/docs/adr/0010-inward4d-ann-reference.md
@@ -1,0 +1,66 @@
+# ADR-010: Adopt a bounded inward-4D graph autoencoder reference
+
+**Status:** Proposed
+**Date:** 2026-08-28
+**Extends:** ADR-003, ADR-006, ADR-007
+
+## Context
+
+The proposed `10 x 10 x 10` engine combines four separate ideas: discrete
+lattice addressing, a toroidal `R^4` coordinate map, an autoencoder objective,
+and online structural adaptation. Without an explicit boundary, the geometry
+can be mistaken for the neural computation, a radius graph can be assigned an
+unsupported edge count, and energy minimization can trivially delete every
+weight instead of learning a reconstruction.
+
+The repository needs one executable interpretation whose topology, objective,
+gradient, update authority, and claims can be tested independently.
+
+## Decision
+
+Jarvis-X will treat this subsystem as a bounded reference laboratory with the
+following contracts.
+
+1. Integer coordinates and the `100x + 10y + z` map are authoritative.
+2. The `R^4` fold is immutable feature geometry, not a physical-dimension
+   claim.
+3. Graph membership is positive-axis six-neighbour support plus a folded
+   distance gate. A pure all-pairs radius graph is not assigned a predetermined
+   edge count.
+4. The exact open and full-fold edge counts are 2,700 and 3,000.
+5. Encoder and decoder use the same symmetric, non-negative edge weights.
+6. The reference is same-width and therefore does not claim compression.
+7. The objective contains reconstruction, folded edge energy, weight
+   homeostasis, and bias regularization. Edge energy alone is rejected because
+   it has a trivial all-zero-conductance direction.
+8. Gradients are analytic and checked against finite differences.
+9. Pruning must preserve minimum degree and whole-graph connectivity.
+10. A candidate update becomes authoritative only when the complete objective
+    does not regress and any supplied validator accepts it.
+
+## Consequences
+
+- The fourth coordinate changes coupling strengths but never changes node
+  identity.
+- The runtime has explicit `O(N+M)` forward and gradient passes for fixed-degree
+  topology.
+- A residual target below `1e-6` is a measured stopping condition for a supplied
+  input, not a universal convergence guarantee.
+- "Auto-optimizing" means bounded parameter and topology updates inside the
+  declared objective; it does not mean arbitrary code rewriting.
+- Performance and superiority claims require separate benchmarks and baselines.
+
+## Evidence required for acceptance
+
+- exact address and topology invariant tests;
+- closed-form coordinate fixture;
+- central finite-difference gradient checks;
+- deterministic replay;
+- objective non-regression on commit;
+- validator rollback;
+- connectivity-preserving pruning;
+- documentation of resource and inference boundaries.
+
+The proposed implementation is `src/jarvisx/inward4d_ann.py`, with focused tests
+in `tests/test_inward4d_ann.py` and the full arithmetic in
+`docs/DR_MOAGI_10X10X10_INWARD_4D_ANN.md`.

--- a/examples/inward4d_ann_demo.py
+++ b/examples/inward4d_ann_demo.py
@@ -1,0 +1,59 @@
+"""Run a bounded 10x10x10 inward-4D self-description experiment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+
+from jarvisx.inward4d_ann import Inward4DANN, index_to_coordinate
+
+
+def target_field(side: int = 10) -> list[float]:
+    """Create a deterministic bounded volumetric interference fixture."""
+
+    field: list[float] = []
+    center = (side - 1) / 2.0
+    for index in range(side**3):
+        x, y, z = index_to_coordinate(index, side)
+        dx = (x - center) / center
+        dy = (y - center) / center
+        dz = (z - center) / center
+        radius = math.sqrt(dx * dx + dy * dy + dz * dz)
+        envelope = math.exp(-1.8 * radius * radius)
+        interference = math.sin(2.0 * math.pi * dx) * math.cos(math.pi * dy * dz)
+        field.append(0.65 * envelope * interference)
+    return field
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epochs", type=int, default=25)
+    args = parser.parse_args()
+
+    engine = Inward4DANN()
+    target = target_field()
+    report = engine.optimize(target, max_epochs=args.epochs)
+    last_step = report.history[-1] if report.history else None
+    output = {
+        "engine": "Jarvis-X 10x10x10 Inward 4D ANN reference",
+        "arithmetic": engine.arithmetic_summary(),
+        "optimization": {
+            "attempted_epochs": report.attempted_epochs,
+            "committed_epochs": report.committed_epochs,
+            "initial_loss": report.initial.loss.total,
+            "final_loss": report.final.loss.total,
+            "initial_description_residual_rms": report.initial.description_residual_rms,
+            "final_description_residual_rms": report.final.description_residual_rms,
+            "converged": report.converged,
+            "last_learning_rate": last_step.learning_rate_used if last_step else 0.0,
+            "active_synapses": engine.active_synapse_count,
+        },
+        "claim_boundary": "bounded deterministic Python reference; no compression or performance claim",
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/inward4d_ann.py
+++ b/src/jarvisx/inward4d_ann.py
@@ -1,0 +1,872 @@
+"""Bounded 10x10x10 inward-4D graph autoencoder reference.
+
+The fourth coordinate in this module is a geometric embedding coordinate, not
+time, consciousness, or an extra physical spatial dimension.  The reference
+keeps one latent activation per lattice node and therefore does not claim
+compression.  It exists to make the supplied inward-fold arithmetic executable,
+deterministic, and falsifiable without adding a numerical dependency.
+
+The authoritative adaptive state is deliberately small: symmetric edge weights
+and encoder/decoder biases.  Every proposed update is evaluated against the
+complete objective before it is committed.  A rejected update leaves those
+parameters and the active topology unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Sequence
+
+Coordinate3D = tuple[int, int, int]
+Point4D = tuple[float, float, float, float]
+NumericSequence = Sequence[float | int]
+
+
+def coordinate_to_index(coordinate: Coordinate3D, side: int = 10) -> int:
+    """Map ``(x, y, z)`` to ``side**2*x + side*y + z``."""
+
+    if isinstance(side, bool) or not isinstance(side, int) or side < 2:
+        raise ValueError("side must be an integer of at least 2")
+    if (
+        not isinstance(coordinate, tuple)
+        or len(coordinate) != 3
+        or any(isinstance(value, bool) or not isinstance(value, int) for value in coordinate)
+    ):
+        raise TypeError("coordinate must be an integer (x, y, z) tuple")
+    x, y, z = coordinate
+    if not all(0 <= value < side for value in coordinate):
+        raise ValueError("coordinate is outside the lattice")
+    return side * side * x + side * y + z
+
+
+def index_to_coordinate(index: int, side: int = 10) -> Coordinate3D:
+    """Invert :func:`coordinate_to_index`."""
+
+    if isinstance(side, bool) or not isinstance(side, int) or side < 2:
+        raise ValueError("side must be an integer of at least 2")
+    if isinstance(index, bool) or not isinstance(index, int):
+        raise TypeError("index must be an integer")
+    if not 0 <= index < side**3:
+        raise ValueError("index is outside the lattice")
+    x, remainder = divmod(index, side * side)
+    y, z = divmod(remainder, side)
+    return x, y, z
+
+
+@dataclass(frozen=True)
+class Inward4DConfig:
+    """Numerical and structural contract for the reference engine."""
+
+    side: int = 10
+    spacing: float = 2.2
+    fold_factor: float = 1.0
+    core_radius: float = 4.5
+    inner_radius_min: float = 2.5
+    inner_radius_max: float = 4.0
+    proximity_radius: float = 5.5
+    decay: float = 0.88
+    learning_rate: float = 0.005
+    prune_threshold: float = 0.15
+    prune_interval: int = 25
+    base_weight: float = 0.40
+    max_weight: float = 1.0
+    max_abs_bias: float = 2.0
+    edge_energy_weight: float = 0.02
+    homeostasis_weight: float = 0.01
+    bias_regularization_weight: float = 1.0e-4
+    min_degree: int = 2
+    max_backtracks: int = 6
+    convergence_tolerance: float = 1.0e-6
+    seed: int = 41
+
+    def __post_init__(self) -> None:
+        if isinstance(self.side, bool) or not isinstance(self.side, int) or self.side < 3:
+            raise ValueError("side must be an integer of at least 3")
+        positive = {
+            "spacing": self.spacing,
+            "core_radius": self.core_radius,
+            "inner_radius_min": self.inner_radius_min,
+            "inner_radius_max": self.inner_radius_max,
+            "proximity_radius": self.proximity_radius,
+            "learning_rate": self.learning_rate,
+            "max_weight": self.max_weight,
+            "max_abs_bias": self.max_abs_bias,
+            "convergence_tolerance": self.convergence_tolerance,
+        }
+        for name, value in positive.items():
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+        if self.inner_radius_max < self.inner_radius_min:
+            raise ValueError("inner_radius_max must be at least inner_radius_min")
+        if not 0.0 <= self.fold_factor <= 1.0:
+            raise ValueError("fold_factor must be in [0, 1]")
+        if not 0.0 < self.decay < 1.0:
+            raise ValueError("decay must be in (0, 1)")
+        if not 0.0 <= self.prune_threshold <= self.max_weight:
+            raise ValueError("prune_threshold must be in [0, max_weight]")
+        if not 0.0 <= self.base_weight <= self.max_weight:
+            raise ValueError("base_weight must be in [0, max_weight]")
+        nonnegative = {
+            "edge_energy_weight": self.edge_energy_weight,
+            "homeostasis_weight": self.homeostasis_weight,
+            "bias_regularization_weight": self.bias_regularization_weight,
+        }
+        for name, value in nonnegative.items():
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        if (
+            isinstance(self.prune_interval, bool)
+            or not isinstance(self.prune_interval, int)
+            or self.prune_interval < 1
+        ):
+            raise ValueError("prune_interval must be a positive integer")
+        if (
+            isinstance(self.min_degree, bool)
+            or not isinstance(self.min_degree, int)
+            or not 1 <= self.min_degree <= 6
+        ):
+            raise ValueError("min_degree must be an integer in [1, 6]")
+        if (
+            isinstance(self.max_backtracks, bool)
+            or not isinstance(self.max_backtracks, int)
+            or self.max_backtracks < 0
+        ):
+            raise ValueError("max_backtracks must be a non-negative integer")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise ValueError("seed must be an integer")
+
+
+@dataclass(frozen=True)
+class EdgeGeometry:
+    """Immutable geometry for one undirected synapse."""
+
+    source: int
+    target: int
+    axis: int
+    wraps: bool
+    distance4d: float
+    geometry_gain: float
+
+
+@dataclass(frozen=True)
+class ForwardPass:
+    latent: tuple[float, ...]
+    reconstruction: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class LossTerms:
+    reconstruction_mse: float
+    edge_energy: float
+    homeostasis: float
+    bias_penalty: float
+    total: float
+
+
+@dataclass(frozen=True)
+class EvaluationMetrics:
+    loss: LossTerms
+    description_residual_rms: float
+    max_abs_residual: float
+    converged: bool
+
+
+@dataclass(frozen=True)
+class GradientSnapshot:
+    evaluation: EvaluationMetrics
+    edge_weights: tuple[float, ...]
+    encoder_bias: tuple[float, ...]
+    decoder_bias: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class Inward4DSnapshot:
+    epoch: int
+    weights: tuple[float, ...]
+    encoder_bias: tuple[float, ...]
+    decoder_bias: tuple[float, ...]
+    active_edges: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class StepMetrics:
+    epoch: int
+    committed: bool
+    rejection_reason: str | None
+    learning_rate_used: float
+    loss_before: float
+    loss_after: float
+    description_residual_rms: float
+    max_abs_residual: float
+    active_synapses: int
+    pruned_synapses: int
+    converged: bool
+
+
+@dataclass(frozen=True)
+class OptimizationReport:
+    initial: EvaluationMetrics
+    final: EvaluationMetrics
+    attempted_epochs: int
+    committed_epochs: int
+    converged: bool
+    history: tuple[StepMetrics, ...]
+
+
+CandidateValidator = Callable[[EvaluationMetrics], bool]
+
+
+class Inward4DANN:
+    """A deterministic graph autoencoder on a folded 3D lattice.
+
+    The graph uses positive-axis six-neighbour support.  At ``fold_factor=0``
+    the three flat boundaries remain open, yielding 2,700 edges for a 10-cube.
+    At ``fold_factor=1`` all three seams close, yielding exactly 3,000
+    undirected edges.  Folded 4D distance modulates coupling strength and also
+    gates seam candidates through ``proximity_radius``.
+    """
+
+    def __init__(self, config: Inward4DConfig | None = None) -> None:
+        self.config = config or Inward4DConfig()
+        self._node_count = self.config.side**3
+        self._positions = tuple(
+            self._folded_position(index_to_coordinate(index, self.config.side))
+            for index in range(self._node_count)
+        )
+        self._edges = self._build_edges()
+        self._incident_edges = self._build_incident_edges()
+        self._weights = [
+            self._initial_weight(index, edge) for index, edge in enumerate(self._edges)
+        ]
+        self._encoder_bias = [0.0] * self._node_count
+        self._decoder_bias = [0.0] * self._node_count
+        self._active = [True] * len(self._edges)
+        self._epoch = 0
+        self._validate_topology(self._active)
+
+    @property
+    def node_count(self) -> int:
+        return self._node_count
+
+    @property
+    def epoch(self) -> int:
+        return self._epoch
+
+    @property
+    def positions(self) -> tuple[Point4D, ...]:
+        return self._positions
+
+    @property
+    def edge_geometries(self) -> tuple[EdgeGeometry, ...]:
+        return self._edges
+
+    @property
+    def active_synapse_count(self) -> int:
+        return sum(self._active)
+
+    @property
+    def active_wrap_synapse_count(self) -> int:
+        return sum(is_active and edge.wraps for is_active, edge in zip(self._active, self._edges))
+
+    @property
+    def degrees(self) -> tuple[int, ...]:
+        return tuple(self._degrees(self._active))
+
+    def arithmetic_summary(self) -> dict[str, int | float]:
+        """Return the exact default-table quantities as machine-readable data."""
+
+        side = self.config.side
+        return {
+            "side": side,
+            "nodes": self.node_count,
+            "flat_synapses": 3 * (side - 1) * side * side,
+            "periodic_synapses": 3 * side**3,
+            "topological_wrap_candidates": 3 * side * side,
+            "active_synapses": self.active_synapse_count,
+            "active_wrap_synapses": self.active_wrap_synapse_count,
+            "fold_factor": self.config.fold_factor,
+            "spacing": self.config.spacing,
+            "core_radius": self.config.core_radius,
+            "inner_radius_min": self.config.inner_radius_min,
+            "inner_radius_max": self.config.inner_radius_max,
+            "decay": self.config.decay,
+            "learning_rate": self.config.learning_rate,
+            "prune_threshold": self.config.prune_threshold,
+        }
+
+    def forward(self, values: NumericSequence) -> ForwardPass:
+        vector = self._validated_vector(values, "values")
+        _, latent, _, reconstruction, _ = self._forward_with(
+            vector,
+            self._weights,
+            self._encoder_bias,
+            self._decoder_bias,
+            self._active,
+        )
+        return ForwardPass(tuple(latent), tuple(reconstruction))
+
+    def encode(self, values: NumericSequence) -> tuple[float, ...]:
+        return self.forward(values).latent
+
+    def decode(self, latent: NumericSequence) -> tuple[float, ...]:
+        vector = self._validated_vector(latent, "latent")
+        _, decoded = self._layer(
+            vector,
+            self._decoder_bias,
+            self._weights,
+            self._active,
+        )
+        return tuple(decoded)
+
+    def describe(self, values: NumericSequence) -> tuple[float, ...]:
+        """Compute ``Decode(Encode(values))``."""
+
+        return self.forward(values).reconstruction
+
+    def evaluate(self, target: NumericSequence) -> EvaluationMetrics:
+        vector = self._validated_vector(target, "target")
+        return self._evaluate_with(
+            vector,
+            self._weights,
+            self._encoder_bias,
+            self._decoder_bias,
+            self._active,
+        )
+
+    def gradients(self, target: NumericSequence) -> GradientSnapshot:
+        """Return the exact reverse-mode gradient of the declared smooth loss."""
+
+        vector = self._validated_vector(target, "target")
+        encoder_potential, latent, decoder_potential, reconstruction, degrees = self._forward_with(
+            vector,
+            self._weights,
+            self._encoder_bias,
+            self._decoder_bias,
+            self._active,
+        )
+        del encoder_potential, decoder_potential
+        evaluation = self._evaluation_from_forward(
+            vector,
+            latent,
+            reconstruction,
+            self._weights,
+            self._encoder_bias,
+            self._decoder_bias,
+            self._active,
+        )
+
+        node_count = self.node_count
+        edge_count = self.active_synapse_count
+        interaction = 1.0 - self.config.decay
+        d_decoder = [
+            (2.0 / node_count)
+            * (reconstruction[index] - vector[index])
+            * (1.0 - reconstruction[index] ** 2)
+            for index in range(node_count)
+        ]
+        gradient_weights = [0.0] * len(self._edges)
+        d_latent = [self.config.decay * value for value in d_decoder]
+
+        for edge_index, edge in enumerate(self._edges):
+            if not self._active[edge_index]:
+                continue
+            source = edge.source
+            target_index = edge.target
+            coefficient = interaction * edge.geometry_gain
+            gradient_weights[edge_index] += coefficient * (
+                d_decoder[source] * latent[target_index] / degrees[source]
+                + d_decoder[target_index] * latent[source] / degrees[target_index]
+            )
+            coupling = self._weights[edge_index] * coefficient
+            d_latent[target_index] += d_decoder[source] * coupling / degrees[source]
+            d_latent[source] += d_decoder[target_index] * coupling / degrees[target_index]
+
+        energy_scale = self.config.edge_energy_weight / edge_count
+        homeostasis_scale = self.config.homeostasis_weight / edge_count
+        for edge_index, edge in enumerate(self._edges):
+            if not self._active[edge_index]:
+                continue
+            source = edge.source
+            target_index = edge.target
+            difference = latent[source] - latent[target_index]
+            weighted_scale = energy_scale * edge.geometry_gain
+            gradient_weights[edge_index] += weighted_scale * difference * difference
+            latent_gradient = 2.0 * weighted_scale * self._weights[edge_index] * difference
+            d_latent[source] += latent_gradient
+            d_latent[target_index] -= latent_gradient
+            gradient_weights[edge_index] += (
+                2.0 * homeostasis_scale * (self._weights[edge_index] - self.config.base_weight)
+            )
+
+        d_encoder = [d_latent[index] * (1.0 - latent[index] ** 2) for index in range(node_count)]
+        for edge_index, edge in enumerate(self._edges):
+            if not self._active[edge_index]:
+                continue
+            source = edge.source
+            target_index = edge.target
+            coefficient = interaction * edge.geometry_gain
+            gradient_weights[edge_index] += coefficient * (
+                d_encoder[source] * vector[target_index] / degrees[source]
+                + d_encoder[target_index] * vector[source] / degrees[target_index]
+            )
+
+        bias_scale = self.config.bias_regularization_weight / node_count
+        gradient_encoder_bias = [
+            d_encoder[index] + bias_scale * self._encoder_bias[index] for index in range(node_count)
+        ]
+        gradient_decoder_bias = [
+            d_decoder[index] + bias_scale * self._decoder_bias[index] for index in range(node_count)
+        ]
+        return GradientSnapshot(
+            evaluation=evaluation,
+            edge_weights=tuple(gradient_weights),
+            encoder_bias=tuple(gradient_encoder_bias),
+            decoder_bias=tuple(gradient_decoder_bias),
+        )
+
+    def train_step(
+        self,
+        target: NumericSequence,
+        *,
+        validator: CandidateValidator | None = None,
+    ) -> StepMetrics:
+        """Propose, evaluate, and atomically commit one bounded update."""
+
+        vector = self._validated_vector(target, "target")
+        gradient = self.gradients(vector)
+        before = gradient.evaluation
+        next_epoch = self._epoch + 1
+        rejection_reason = "candidate did not improve objective"
+
+        for backtrack in range(self.config.max_backtracks + 1):
+            learning_rate = self.config.learning_rate * (0.5**backtrack)
+            candidate_weights = list(self._weights)
+            for index, value in enumerate(candidate_weights):
+                if not self._active[index]:
+                    continue
+                candidate_weights[index] = min(
+                    self.config.max_weight,
+                    max(0.0, value - learning_rate * gradient.edge_weights[index]),
+                )
+            candidate_encoder_bias = [
+                min(
+                    self.config.max_abs_bias,
+                    max(
+                        -self.config.max_abs_bias,
+                        value - learning_rate * gradient.encoder_bias[index],
+                    ),
+                )
+                for index, value in enumerate(self._encoder_bias)
+            ]
+            candidate_decoder_bias = [
+                min(
+                    self.config.max_abs_bias,
+                    max(
+                        -self.config.max_abs_bias,
+                        value - learning_rate * gradient.decoder_bias[index],
+                    ),
+                )
+                for index, value in enumerate(self._decoder_bias)
+            ]
+            candidate_active = list(self._active)
+            pruned = 0
+            if next_epoch % self.config.prune_interval == 0:
+                pruned = self._propose_pruning(candidate_weights, candidate_active)
+
+            candidate = self._evaluate_with(
+                vector,
+                candidate_weights,
+                candidate_encoder_bias,
+                candidate_decoder_bias,
+                candidate_active,
+            )
+            if validator is not None and not bool(validator(candidate)):
+                rejection_reason = "validator rejected candidate"
+                break
+            if candidate.loss.total <= before.loss.total + 1.0e-12:
+                self._weights = candidate_weights
+                self._encoder_bias = candidate_encoder_bias
+                self._decoder_bias = candidate_decoder_bias
+                self._active = candidate_active
+                self._epoch = next_epoch
+                return StepMetrics(
+                    epoch=self._epoch,
+                    committed=True,
+                    rejection_reason=None,
+                    learning_rate_used=learning_rate,
+                    loss_before=before.loss.total,
+                    loss_after=candidate.loss.total,
+                    description_residual_rms=candidate.description_residual_rms,
+                    max_abs_residual=candidate.max_abs_residual,
+                    active_synapses=sum(candidate_active),
+                    pruned_synapses=pruned,
+                    converged=candidate.converged,
+                )
+
+        self._epoch = next_epoch
+        return StepMetrics(
+            epoch=self._epoch,
+            committed=False,
+            rejection_reason=rejection_reason,
+            learning_rate_used=0.0,
+            loss_before=before.loss.total,
+            loss_after=before.loss.total,
+            description_residual_rms=before.description_residual_rms,
+            max_abs_residual=before.max_abs_residual,
+            active_synapses=self.active_synapse_count,
+            pruned_synapses=0,
+            converged=before.converged,
+        )
+
+    def optimize(
+        self,
+        target: NumericSequence,
+        *,
+        max_epochs: int = 100,
+        tolerance: float | None = None,
+        validator: CandidateValidator | None = None,
+    ) -> OptimizationReport:
+        """Run a finite optimization budget and return its full audit history."""
+
+        if isinstance(max_epochs, bool) or not isinstance(max_epochs, int) or max_epochs < 0:
+            raise ValueError("max_epochs must be a non-negative integer")
+        resolved_tolerance = (
+            self.config.convergence_tolerance if tolerance is None else float(tolerance)
+        )
+        if not math.isfinite(resolved_tolerance) or resolved_tolerance <= 0.0:
+            raise ValueError("tolerance must be finite and positive")
+        vector = self._validated_vector(target, "target")
+        initial = self.evaluate(vector)
+        history: list[StepMetrics] = []
+        current = initial
+        for _ in range(max_epochs):
+            if current.description_residual_rms < resolved_tolerance:
+                break
+            step = self.train_step(vector, validator=validator)
+            history.append(step)
+            current = self.evaluate(vector)
+            if not step.committed and step.rejection_reason == "validator rejected candidate":
+                break
+        final = self.evaluate(vector)
+        return OptimizationReport(
+            initial=initial,
+            final=final,
+            attempted_epochs=len(history),
+            committed_epochs=sum(step.committed for step in history),
+            converged=final.description_residual_rms < resolved_tolerance,
+            history=tuple(history),
+        )
+
+    def snapshot(self) -> Inward4DSnapshot:
+        return Inward4DSnapshot(
+            epoch=self._epoch,
+            weights=tuple(self._weights),
+            encoder_bias=tuple(self._encoder_bias),
+            decoder_bias=tuple(self._decoder_bias),
+            active_edges=tuple(self._active),
+        )
+
+    def restore(self, snapshot: Inward4DSnapshot) -> None:
+        """Atomically restore a validated in-memory snapshot."""
+
+        if not isinstance(snapshot, Inward4DSnapshot):
+            raise TypeError("snapshot must be an Inward4DSnapshot")
+        if isinstance(snapshot.epoch, bool) or snapshot.epoch < 0:
+            raise ValueError("snapshot epoch must be non-negative")
+        if len(snapshot.weights) != len(self._edges):
+            raise ValueError("snapshot weight count does not match topology")
+        if len(snapshot.active_edges) != len(self._edges):
+            raise ValueError("snapshot active-edge count does not match topology")
+        if (
+            len(snapshot.encoder_bias) != self.node_count
+            or len(snapshot.decoder_bias) != self.node_count
+        ):
+            raise ValueError("snapshot bias count does not match node count")
+        weights = [self._finite(value, "snapshot weight") for value in snapshot.weights]
+        if any(not 0.0 <= value <= self.config.max_weight for value in weights):
+            raise ValueError("snapshot weight is outside configured bounds")
+        encoder_bias = [
+            self._finite(value, "snapshot encoder bias") for value in snapshot.encoder_bias
+        ]
+        decoder_bias = [
+            self._finite(value, "snapshot decoder bias") for value in snapshot.decoder_bias
+        ]
+        if any(abs(value) > self.config.max_abs_bias for value in encoder_bias + decoder_bias):
+            raise ValueError("snapshot bias is outside configured bounds")
+        active = list(snapshot.active_edges)
+        if any(not isinstance(value, bool) for value in active):
+            raise TypeError("snapshot active-edge flags must be bool")
+        self._validate_topology(active)
+        self._weights = weights
+        self._encoder_bias = encoder_bias
+        self._decoder_bias = decoder_bias
+        self._active = active
+        self._epoch = snapshot.epoch
+
+    def _folded_position(self, coordinate: Coordinate3D) -> Point4D:
+        side = self.config.side
+        x, y, z = coordinate
+        center = (side - 1) / 2.0
+        box = (
+            self.config.spacing * (x - center),
+            self.config.spacing * (y - center),
+            self.config.spacing * (z - center),
+            0.0,
+        )
+        theta = 2.0 * math.pi * x / side
+        phi = 2.0 * math.pi * y / side
+        psi = 2.0 * math.pi * z / side
+        layer = z / (side - 1)
+        inner_radius = (
+            self.config.inner_radius_min
+            + (self.config.inner_radius_max - self.config.inner_radius_min) * layer
+        )
+        ring = self.config.core_radius + inner_radius * math.cos(phi)
+        cross_section = inner_radius * math.sin(phi)
+        toroidal = (
+            ring * math.cos(theta),
+            ring * math.sin(theta),
+            cross_section * math.cos(psi),
+            cross_section * math.sin(psi),
+        )
+        gamma = self.config.fold_factor
+        return tuple(
+            (1.0 - gamma) * box[axis] + gamma * toroidal[axis] for axis in range(4)
+        )  # type: ignore[return-value]
+
+    def _build_edges(self) -> tuple[EdgeGeometry, ...]:
+        side = self.config.side
+        edges: list[EdgeGeometry] = []
+        seen: set[tuple[int, int]] = set()
+        for source in range(self.node_count):
+            coordinate = list(index_to_coordinate(source, side))
+            for axis in range(3):
+                wraps = coordinate[axis] == side - 1
+                if wraps and self.config.fold_factor == 0.0:
+                    continue
+                neighbour = list(coordinate)
+                neighbour[axis] = (neighbour[axis] + 1) % side
+                target = coordinate_to_index(tuple(neighbour), side)  # type: ignore[arg-type]
+                pair = min(source, target), max(source, target)
+                if pair in seen:
+                    continue
+                distance = math.dist(self._positions[source], self._positions[target])
+                if distance > self.config.proximity_radius + 1.0e-12:
+                    continue
+                fold_scale = self.config.fold_factor if wraps else 1.0
+                geometry_gain = fold_scale * math.exp(
+                    -0.5 * (distance / self.config.proximity_radius) ** 2
+                )
+                edges.append(
+                    EdgeGeometry(
+                        source=pair[0],
+                        target=pair[1],
+                        axis=axis,
+                        wraps=wraps,
+                        distance4d=distance,
+                        geometry_gain=geometry_gain,
+                    )
+                )
+                seen.add(pair)
+        edges.sort(key=lambda edge: (edge.source, edge.target, edge.axis))
+        return tuple(edges)
+
+    def _build_incident_edges(self) -> tuple[tuple[int, ...], ...]:
+        incident: list[list[int]] = [[] for _ in range(self.node_count)]
+        for edge_index, edge in enumerate(self._edges):
+            incident[edge.source].append(edge_index)
+            incident[edge.target].append(edge_index)
+        return tuple(tuple(values) for values in incident)
+
+    def _initial_weight(self, edge_index: int, edge: EdgeGeometry) -> float:
+        mixed = (
+            edge.source * 73_856_093
+            ^ edge.target * 19_349_663
+            ^ edge.axis * 83_492_791
+            ^ edge_index * 2_654_435_761
+            ^ self.config.seed
+        )
+        jitter = ((mixed % 2001) - 1000) / 100_000.0
+        return min(self.config.max_weight, max(0.0, self.config.base_weight + jitter))
+
+    def _layer(
+        self,
+        values: list[float],
+        bias: Sequence[float],
+        weights: Sequence[float],
+        active: Sequence[bool],
+    ) -> tuple[list[float], list[float]]:
+        degrees = self._degrees(active)
+        neighbour_sum = [0.0] * self.node_count
+        for edge_index, edge in enumerate(self._edges):
+            if not active[edge_index]:
+                continue
+            coupling = weights[edge_index] * edge.geometry_gain
+            neighbour_sum[edge.source] += coupling * values[edge.target]
+            neighbour_sum[edge.target] += coupling * values[edge.source]
+        interaction = 1.0 - self.config.decay
+        potential = [
+            self.config.decay * values[index]
+            + interaction * neighbour_sum[index] / degrees[index]
+            + bias[index]
+            for index in range(self.node_count)
+        ]
+        return potential, [math.tanh(value) for value in potential]
+
+    def _forward_with(
+        self,
+        values: list[float],
+        weights: Sequence[float],
+        encoder_bias: Sequence[float],
+        decoder_bias: Sequence[float],
+        active: Sequence[bool],
+    ) -> tuple[list[float], list[float], list[float], list[float], list[int]]:
+        degrees = self._degrees(active)
+        encoder_potential, latent = self._layer(values, encoder_bias, weights, active)
+        decoder_potential, reconstruction = self._layer(latent, decoder_bias, weights, active)
+        return encoder_potential, latent, decoder_potential, reconstruction, degrees
+
+    def _evaluate_with(
+        self,
+        target: list[float],
+        weights: Sequence[float],
+        encoder_bias: Sequence[float],
+        decoder_bias: Sequence[float],
+        active: Sequence[bool],
+    ) -> EvaluationMetrics:
+        _, latent, _, reconstruction, _ = self._forward_with(
+            target, weights, encoder_bias, decoder_bias, active
+        )
+        return self._evaluation_from_forward(
+            target,
+            latent,
+            reconstruction,
+            weights,
+            encoder_bias,
+            decoder_bias,
+            active,
+        )
+
+    def _evaluation_from_forward(
+        self,
+        target: Sequence[float],
+        latent: Sequence[float],
+        reconstruction: Sequence[float],
+        weights: Sequence[float],
+        encoder_bias: Sequence[float],
+        decoder_bias: Sequence[float],
+        active: Sequence[bool],
+    ) -> EvaluationMetrics:
+        residuals = [reconstruction[index] - target[index] for index in range(self.node_count)]
+        reconstruction_mse = sum(value * value for value in residuals) / self.node_count
+        edge_count = sum(active)
+        edge_energy = 0.0
+        homeostasis = 0.0
+        for edge_index, edge in enumerate(self._edges):
+            if not active[edge_index]:
+                continue
+            difference = latent[edge.source] - latent[edge.target]
+            edge_energy += weights[edge_index] * edge.geometry_gain * difference * difference
+            weight_residual = weights[edge_index] - self.config.base_weight
+            homeostasis += weight_residual * weight_residual
+        edge_energy /= edge_count
+        homeostasis /= edge_count
+        bias_penalty = (
+            sum(value * value for value in encoder_bias)
+            + sum(value * value for value in decoder_bias)
+        ) / (2.0 * self.node_count)
+        total = (
+            reconstruction_mse
+            + self.config.edge_energy_weight * edge_energy
+            + self.config.homeostasis_weight * homeostasis
+            + self.config.bias_regularization_weight * bias_penalty
+        )
+        residual_rms = math.sqrt(reconstruction_mse)
+        return EvaluationMetrics(
+            loss=LossTerms(
+                reconstruction_mse=reconstruction_mse,
+                edge_energy=edge_energy,
+                homeostasis=homeostasis,
+                bias_penalty=bias_penalty,
+                total=total,
+            ),
+            description_residual_rms=residual_rms,
+            max_abs_residual=max((abs(value) for value in residuals), default=0.0),
+            converged=residual_rms < self.config.convergence_tolerance,
+        )
+
+    def _propose_pruning(self, weights: Sequence[float], active: list[bool]) -> int:
+        degrees = self._degrees(active)
+        pruned = 0
+        candidates = sorted(
+            (
+                (weights[index], index)
+                for index, is_active in enumerate(active)
+                if is_active and weights[index] < self.config.prune_threshold
+            ),
+            key=lambda item: (item[0], self._edges[item[1]].source, self._edges[item[1]].target),
+        )
+        for _, edge_index in candidates:
+            edge = self._edges[edge_index]
+            if (
+                degrees[edge.source] <= self.config.min_degree
+                or degrees[edge.target] <= self.config.min_degree
+            ):
+                continue
+            active[edge_index] = False
+            if self._is_connected(active):
+                degrees[edge.source] -= 1
+                degrees[edge.target] -= 1
+                pruned += 1
+            else:
+                active[edge_index] = True
+        return pruned
+
+    def _degrees(self, active: Sequence[bool]) -> list[int]:
+        degrees = [0] * self.node_count
+        for edge_index, edge in enumerate(self._edges):
+            if active[edge_index]:
+                degrees[edge.source] += 1
+                degrees[edge.target] += 1
+        if any(value == 0 for value in degrees):
+            raise RuntimeError("active topology contains an isolated node")
+        return degrees
+
+    def _is_connected(self, active: Sequence[bool]) -> bool:
+        seen = {0}
+        stack = [0]
+        while stack:
+            node = stack.pop()
+            for edge_index in self._incident_edges[node]:
+                if not active[edge_index]:
+                    continue
+                edge = self._edges[edge_index]
+                neighbour = edge.target if edge.source == node else edge.source
+                if neighbour not in seen:
+                    seen.add(neighbour)
+                    stack.append(neighbour)
+        return len(seen) == self.node_count
+
+    def _validate_topology(self, active: Sequence[bool]) -> None:
+        if not self._edges:
+            raise ValueError("proximity radius removed every synapse")
+        degrees = self._degrees(active)
+        if min(degrees) < self.config.min_degree:
+            raise ValueError("topology violates the configured minimum degree")
+        if not self._is_connected(active):
+            raise ValueError("topology is disconnected")
+
+    def _validated_vector(self, values: NumericSequence, name: str) -> list[float]:
+        if isinstance(values, (str, bytes)) or len(values) != self.node_count:
+            raise ValueError(f"{name} must contain exactly {self.node_count} values")
+        return [self._finite(value, f"{name} value") for value in values]
+
+    @staticmethod
+    def _finite(value: float | int, name: str) -> float:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} must be numeric")
+        result = float(value)
+        if not math.isfinite(result):
+            raise ValueError(f"{name} must be finite")
+        return result

--- a/tests/test_inward4d_ann.py
+++ b/tests/test_inward4d_ann.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import math
+from dataclasses import replace
+
+import pytest
+
+from jarvisx.inward4d_ann import (
+    Inward4DANN,
+    Inward4DConfig,
+    coordinate_to_index,
+    index_to_coordinate,
+)
+
+
+def signal() -> list[float]:
+    return [
+        0.30 * math.sin(index * 0.013) + 0.10 * math.cos(index * 0.031) for index in range(1000)
+    ]
+
+
+def test_default_index_mapping_is_a_complete_bijection():
+    assert coordinate_to_index((2, 3, 4)) == 234
+    assert index_to_coordinate(234) == (2, 3, 4)
+    assert {coordinate_to_index(index_to_coordinate(index)) for index in range(1000)} == set(
+        range(1000)
+    )
+
+
+@pytest.mark.parametrize(
+    ("call", "error"),
+    [
+        (lambda: coordinate_to_index((10, 0, 0)), ValueError),
+        (lambda: coordinate_to_index((True, 0, 0)), TypeError),
+        (lambda: index_to_coordinate(1000), ValueError),
+        (lambda: index_to_coordinate(True), TypeError),
+    ],
+)
+def test_index_mapping_rejects_invalid_addresses(call, error):
+    with pytest.raises(error):
+        call()
+
+
+def test_full_fold_has_exact_periodic_topology_and_finite_r4_geometry():
+    engine = Inward4DANN()
+    summary = engine.arithmetic_summary()
+
+    assert summary["nodes"] == 1000
+    assert summary["flat_synapses"] == 2700
+    assert summary["periodic_synapses"] == 3000
+    assert summary["active_synapses"] == 3000
+    assert summary["active_wrap_synapses"] == 300
+    assert min(engine.degrees) == max(engine.degrees) == 6
+    assert max(edge.distance4d for edge in engine.edge_geometries) <= 5.5
+    assert all(
+        len(point) == 4 and all(math.isfinite(value) for value in point)
+        for point in engine.positions
+    )
+
+
+def test_worked_node_234_position_matches_closed_form():
+    engine = Inward4DANN()
+    point = engine.positions[234]
+
+    assert point == pytest.approx(
+        (1.0881867157809302, 3.3490943405317752, -2.436499466930409, 1.770220482187334)
+    )
+
+
+def test_zero_fold_is_a_flat_open_boundary_cube():
+    engine = Inward4DANN(Inward4DConfig(fold_factor=0.0))
+
+    assert engine.active_synapse_count == 2700
+    assert engine.active_wrap_synapse_count == 0
+    assert min(engine.degrees) == 3
+    assert max(engine.degrees) == 6
+    assert all(point[3] == pytest.approx(0.0) for point in engine.positions)
+
+
+def test_proximity_radius_cannot_create_an_invalid_graph():
+    with pytest.raises(ValueError, match="synapse|degree|disconnected"):
+        Inward4DANN(Inward4DConfig(proximity_radius=0.01))
+
+
+def test_forward_zero_is_an_exact_self_description_fixed_point():
+    engine = Inward4DANN()
+    zero = [0.0] * engine.node_count
+
+    forward = engine.forward(zero)
+    evaluation = engine.evaluate(zero)
+
+    assert forward.latent == pytest.approx(zero)
+    assert forward.reconstruction == pytest.approx(zero)
+    assert evaluation.description_residual_rms == pytest.approx(0.0)
+    assert evaluation.max_abs_residual == pytest.approx(0.0)
+    assert evaluation.converged
+
+
+def test_forward_validates_shape_type_and_finiteness():
+    engine = Inward4DANN()
+
+    with pytest.raises(ValueError, match="exactly 1000"):
+        engine.forward([0.0] * 999)
+    with pytest.raises(TypeError, match="numeric"):
+        engine.forward([False] + [0.0] * 999)
+    with pytest.raises(ValueError, match="finite"):
+        engine.forward([math.inf] + [0.0] * 999)
+
+
+def test_reverse_mode_edge_and_bias_gradients_match_finite_differences():
+    engine = Inward4DANN()
+    target = signal()
+    gradient = engine.gradients(target)
+    snapshot = engine.snapshot()
+    epsilon = 1.0e-6
+
+    edge_index = 1234
+    edge_losses = []
+    for direction in (1.0, -1.0):
+        weights = list(snapshot.weights)
+        weights[edge_index] += direction * epsilon
+        engine.restore(replace(snapshot, weights=tuple(weights)))
+        edge_losses.append(engine.evaluate(target).loss.total)
+    edge_finite_difference = (edge_losses[0] - edge_losses[1]) / (2.0 * epsilon)
+    assert gradient.edge_weights[edge_index] == pytest.approx(
+        edge_finite_difference, rel=2.0e-5, abs=1.0e-11
+    )
+
+    engine.restore(snapshot)
+    node_index = 234
+    bias_losses = []
+    for direction in (1.0, -1.0):
+        decoder_bias = list(snapshot.decoder_bias)
+        decoder_bias[node_index] += direction * epsilon
+        engine.restore(replace(snapshot, decoder_bias=tuple(decoder_bias)))
+        bias_losses.append(engine.evaluate(target).loss.total)
+    bias_finite_difference = (bias_losses[0] - bias_losses[1]) / (2.0 * epsilon)
+    assert gradient.decoder_bias[node_index] == pytest.approx(
+        bias_finite_difference, rel=2.0e-5, abs=1.0e-11
+    )
+    engine.restore(snapshot)
+
+
+def test_transactional_step_is_deterministic_and_non_regressing():
+    target = signal()
+    first = Inward4DANN()
+    second = Inward4DANN()
+
+    first_step = first.train_step(target)
+    second_step = second.train_step(target)
+
+    assert first_step == second_step
+    assert first.snapshot() == second.snapshot()
+    assert first_step.committed
+    assert first_step.loss_after <= first_step.loss_before
+    assert first_step.active_synapses == 3000
+    assert first_step.pruned_synapses == 0
+
+
+def test_validator_rejection_rolls_parameters_and_topology_back():
+    engine = Inward4DANN()
+    before = engine.snapshot()
+
+    metrics = engine.train_step(signal(), validator=lambda candidate: False)
+    after = engine.snapshot()
+
+    assert not metrics.committed
+    assert metrics.rejection_reason == "validator rejected candidate"
+    assert metrics.learning_rate_used == 0.0
+    assert after.epoch == before.epoch + 1
+    assert after.weights == before.weights
+    assert after.encoder_bias == before.encoder_bias
+    assert after.decoder_bias == before.decoder_bias
+    assert after.active_edges == before.active_edges
+
+
+def test_pruning_is_symmetric_bounded_and_connectivity_preserving():
+    engine = Inward4DANN(
+        Inward4DConfig(
+            base_weight=0.10,
+            prune_interval=1,
+            min_degree=4,
+            edge_energy_weight=0.0,
+            homeostasis_weight=0.0,
+            bias_regularization_weight=0.0,
+        )
+    )
+
+    metrics = engine.train_step([0.0] * engine.node_count)
+
+    assert metrics.committed
+    assert metrics.pruned_synapses > 0
+    assert metrics.active_synapses == 3000 - metrics.pruned_synapses
+    assert min(engine.degrees) >= 4
+
+
+def test_restore_rejects_malformed_state_without_mutation():
+    engine = Inward4DANN()
+    before = engine.snapshot()
+    malformed = replace(before, weights=before.weights[:-1])
+
+    with pytest.raises(ValueError, match="weight count"):
+        engine.restore(malformed)
+
+    assert engine.snapshot() == before
+
+
+def test_optimization_budget_is_finite_and_auditable():
+    engine = Inward4DANN()
+    report = engine.optimize(signal(), max_epochs=3)
+
+    assert report.attempted_epochs == 3
+    assert report.committed_epochs == 3
+    assert len(report.history) == 3
+    assert report.final.loss.total <= report.initial.loss.total
+    assert report.final.description_residual_rms <= report.initial.description_residual_rms
+
+
+def test_zero_signal_converges_without_claiming_an_optimization_epoch():
+    engine = Inward4DANN()
+    report = engine.optimize([0.0] * engine.node_count, max_epochs=10)
+
+    assert report.converged
+    assert report.attempted_epochs == 0
+    assert report.committed_epochs == 0
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        Inward4DConfig,
+    ],
+)
+def test_config_rejects_unbounded_or_incoherent_values(config):
+    with pytest.raises(ValueError):
+        config(fold_factor=1.1)
+    with pytest.raises(ValueError):
+        config(decay=1.0)
+    with pytest.raises(ValueError):
+        config(prune_threshold=2.0)
+    with pytest.raises(ValueError):
+        config(min_degree=0)
+
+
+def test_optimization_rejects_invalid_budget_and_tolerance():
+    engine = Inward4DANN()
+    zero = [0.0] * engine.node_count
+
+    with pytest.raises(ValueError, match="max_epochs"):
+        engine.optimize(zero, max_epochs=-1)
+    with pytest.raises(ValueError, match="tolerance"):
+        engine.optimize(zero, tolerance=0.0)


### PR DESCRIPTION
## Purpose

Operationalize the 10×10×10 inward-fold proposal as one bounded, dependency-free, falsifiable graph-autoencoder reference.

Closes #170.

## Classification

- [ ] Canonical implementation
- [x] Integration candidate
- [ ] Bug fix
- [ ] Demonstration
- [ ] Specification or documentation
- [ ] Infrastructure or test repair

## What changed

- adds a 1,000-node deterministic lattice with exact `i = 100x + 10y + z` inversion;
- maps flat coordinates into an inward toroidal R⁴ feature coordinate;
- resolves the proposed approximate synapse range into exact counts: 2,700 open-cube + 300 seam = 3,000 full-fold undirected edges;
- adds a tied same-width graph encoder/decoder;
- implements reconstruction, folded-edge-energy, homeostasis, and bias objectives;
- implements exact reverse-mode edge and bias gradients;
- adds bounded non-negative updates with six-step backtracking;
- adds deterministic, connectivity-preserving pruning;
- adds snapshot/restore, validator rejection, and objective non-regression rollback;
- adds a JSON demo, 20 focused tests, arithmetic documentation, ADR-010, status/changelog/README updates, and CI formatting coverage.

## Authoritative state and contracts

Integer lattice addresses remain authoritative. R⁴ coordinates are immutable feature geometry. Adaptive authority is restricted to one symmetric weight per active undirected edge and two 1,000-value bias vectors.

At `gamma = 1`, `rho = 5.5` admits exactly 3,000 supported edges; each node has degree six and the measured maximum supported R⁴ edge length is `5.2532889043741084`.

The commit predicate is:

```text
finite candidate
AND connected topology
AND configured minimum degree
AND complete candidate loss <= incumbent loss
AND optional validator accepts
```

Otherwise the incumbent parameters and topology remain authoritative.

## Implemented boundary

This is a same-width graph autoencoder, not a compressor. R⁴ is computational feature geometry, not a physical fourth spatial dimension. The `1e-6` residual is a measured stopping criterion for a supplied input, not a universal convergence theorem.

The PR makes no claim of trained generalization, production throughput, HFT advantage, hardware superiority, quantum execution, consciousness, or unrestricted self-modification.

## Determinism and resource bounds

- no random runtime dependency; integer-mixed initialization is deterministic;
- `N = 1,000`, default `M = 3,000`;
- forward and analytic gradient passes are `O(N + M)`;
- adaptive scalar state is `M + 2N = 5,000` values plus topology;
- optimization is bounded by `max_epochs`;
- each epoch has at most six learning-rate backtracks;
- pruning is bounded by the finite active edge set.

## Failure, rollback and persistence

Malformed dimensions, types, non-finite values, invalid configuration, disconnected topology, and out-of-bound snapshots fail closed. Candidate values are evaluated before assignment. Validator rejection or objective regression preserves all incumbent weights, biases, and active-edge flags; the attempted epoch still advances for auditability.

Snapshots are validated in memory. Versioned durable checkpoint serialization remains future work and is not implied.

## Validation

```text
python -m compileall -q src tests examples/inward4d_ann_demo.py
pytest
  339 passed, 2 skipped
  total coverage: 83.32%
pytest -q tests/test_inward4d_ann.py --cov=jarvisx.inward4d_ann --cov-branch
  20 passed
  new runtime coverage: 90%
mypy src/jarvisx --ignore-missing-imports
  Success: no issues found in 73 source files
black --check / isort --check
  changed Python files clean
flake8 src/jarvisx tests --select=E9,F63,F7,F82
  clean
git diff --check
  clean
```

The two skips are the existing optional native kinetic backend, which is not compiled in the local validation environment.

The analytic edge gradient was also checked against a central finite difference at edge 1234; relative disagreement was approximately `1.34e-8`.

## Performance evidence

No performance claim is made. The included Python demo is a correctness-oriented reference workload.

## Security considerations

The runtime performs no file, network, subprocess, dynamic-code, model-loading, or secret operations. Inputs are finite scalar sequences. Mutable state is bounded and candidate-first.

## Documentation

- [x] README or usage documentation updated
- [x] Project status updated
- [x] Changelog updated
- [x] ADR added or updated where required
- [ ] No documentation change required

## Merge dependencies and successors

No merge prerequisite beyond current `main`. Follow-ups are explicitly listed in the arithmetic document: undercomplete bottleneck, durable checkpoint format, held-out datasets, native acceleration, convergence analysis, baselines, and geometry ablation.

## Final checklist

- [x] Scope is focused and reviewable
- [x] Tests cover normal, invalid and boundary behavior
- [x] CI is green
- [x] Claims match measured or executable evidence
- [x] No secrets or sensitive personal information are included
- [x] Persistent formats and public APIs are documented