### PR TITLE
Implement Psi Engine octree-fusion field operator

### DIFF
--- a/docs/PSI_ENGINE_OPERATOR.md
+++ b/docs/PSI_ENGINE_OPERATOR.md
@@ -1,0 +1,78 @@
+# Psi Engine — Octree Fusion Operator
+
+The executable reference in `src/jarvisx/psi_engine.py` implements the field operator
+
+\[
+\Psi_{\text{Engine}}(X,Y,Z,t)=
+\mathcal{D}_{\theta}\left(
+\Omega_{\text{fusion}}\left(
+\sum_{k=1}^{N_{\text{blocks}}}
+\mathbf{M}_{\text{octree}}(x,y,z)\cdot
+\mathcal{E}_{\phi}\left(\mathbf{V}^{(k)}_{(x,y,z,t)}\right)
+\right)
+\right).
+\]
+
+## Runtime semantics
+
+For one spacetime coordinate `(x, y, z, t)`:
+
+1. `BlockField` materializes each block `V^(k)_(x,y,z,t)`.
+2. `encoder` realizes `E_phi` independently for every block.
+3. `OctreeSpatialMask` realizes the current reference form of `M_octree` as the isotropic projector `m(x,y,z) I`.
+4. The gated latent vectors are accumulated across `N_blocks`.
+5. `fusion` realizes `Omega_fusion` on the aggregate latent state.
+6. `decoder` realizes `D_theta` and emits the final `Psi_Engine` vector.
+7. `EngineTrace` exposes every intermediate term so the composition can be verified numerically.
+
+## Current octree projection
+
+The repository's existing `FractalOctreeNode` is used as the spatial substrate. For the reference implementation,
+
+\[
+\mathbf{M}_{\text{octree}}(x,y,z)=m(x,y,z)\mathbf{I},
+\qquad
+m(x,y,z)\in\{0,1\}.
+\]
+
+`m=1` when the point traverses only active octree nodes; `m=0` outside the root cube or as soon as the point enters a culled octant. This keeps the implementation deterministic and makes the octree term operational without inventing learned matrix parameters that are not specified by the equation.
+
+A later learned implementation may replace `mI` with a full spatial matrix while retaining the outer `PsiEngine` contract.
+
+## Minimal use
+
+```python
+from jarvisx.fractal_octree import build_fractal_octree
+from jarvisx.psi_engine import OctreeSpatialMask, PsiEngine, identity_operator
+
+root = build_fractal_octree(size=1.0, max_depth=3)
+engine = PsiEngine(
+    encoder=identity_operator,
+    fusion=identity_operator,
+    decoder=identity_operator,
+    octree_mask=OctreeSpatialMask(root),
+)
+
+trace = engine.evaluate_blocks(
+    x=0.1,
+    y=0.1,
+    z=0.1,
+    t=0.0,
+    blocks=((1.0, 2.0), (3.0, 4.0)),
+)
+
+print(trace.output)
+```
+
+With learned encoder, fusion and decoder callables supplied, the same execution path becomes the parameterized `E_phi -> M_octree -> sum -> Omega_fusion -> D_theta` engine defined by the equation.
+
+## Verification invariants
+
+The accompanying tests assert that:
+
+- operator order matches the equation exactly;
+- every block is sampled at the same requested spacetime coordinate;
+- active octree regions pass latent state and culled regions project it to zero;
+- all encoded blocks share a common latent dimension;
+- `N_blocks` is strictly positive;
+- intermediate and final vectors are observable through `EngineTrace`.

--- a/src/jarvisx/psi_engine.py
+++ b/src/jarvisx/psi_engine.py
@@ -1,0 +1,210 @@
+"""Executable reference operator for the Dr. Moagi Psi engine.
+
+The module implements the compositional field equation
+
+    Psi_Engine(X, Y, Z, t) =
+        D_theta(Omega_fusion(sum_k M_octree(x, y, z) E_phi(V^k_(x,y,z,t))))
+
+as a deterministic, dependency-free Python reference.  The learned encoder,
+fusion operator and decoder remain injectable callables; this module fixes the
+runtime semantics, validation and octree gating needed to execute and test the
+equation.
+
+The current ``OctreeSpatialMask`` realizes ``M_octree`` as an isotropic
+projection ``m(x, y, z) I`` where ``m`` is 1 inside an active octree region and
+0 outside it.  A future implementation can replace the scalar gate with a
+full learned spatial matrix without changing the outer engine contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+from .fractal_octree import FractalOctreeNode
+
+Vector = tuple[float, ...]
+
+
+class VectorOperator(Protocol):
+    """Map one finite-dimensional vector to another."""
+
+    def __call__(self, values: Vector) -> Sequence[float]:
+        """Transform ``values`` and return the resulting vector."""
+
+
+class SpatialMask(Protocol):
+    """Return the scalar octree gate at one spatial coordinate."""
+
+    def __call__(self, x: float, y: float, z: float) -> float:
+        """Return a finite scalar spatial weight."""
+
+
+class BlockField(Protocol):
+    """Supply block ``V^(k)_(x,y,z,t)`` at a spacetime coordinate."""
+
+    def __call__(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        t: float,
+        block_index: int,
+    ) -> Sequence[float]:
+        """Return one block vector for ``block_index``."""
+
+
+@dataclass(frozen=True)
+class EngineTrace:
+    """Observable intermediate state for one Psi-engine evaluation."""
+
+    position: tuple[float, float, float]
+    time: float
+    octree_mask: float
+    encoded_blocks: tuple[Vector, ...]
+    latent_sum: Vector
+    fused_latent: Vector
+    output: Vector
+
+    @property
+    def block_count(self) -> int:
+        """Number of encoded blocks contributing to this evaluation."""
+
+        return len(self.encoded_blocks)
+
+
+@dataclass(frozen=True)
+class OctreeSpatialMask:
+    """Binary spatial projector derived from ``FractalOctreeNode``.
+
+    The root and its descendants are interpreted as axis-aligned cubes.  A
+    coordinate receives weight 1 exactly when it lies inside the root and its
+    traversal ends on an active node.  Coordinates entering any culled octant
+    receive weight 0.
+    """
+
+    root: FractalOctreeNode
+
+    def __call__(self, x: float, y: float, z: float) -> float:
+        node = self.root
+        if not _contains(node, x, y, z) or not node.is_active:
+            return 0.0
+
+        while node.children:
+            half = node.size / 2.0
+            dx = 1 if x >= node.x + half else 0
+            dy = 1 if y >= node.y + half else 0
+            dz = 1 if z >= node.z + half else 0
+            child_index = dx + (2 * dy) + (4 * dz)
+            child = node.children[child_index]
+            if not child.is_active:
+                return 0.0
+            node = child
+
+        return 1.0
+
+
+@dataclass(frozen=True)
+class PsiEngine:
+    """Composable runtime for the Psi-engine equation."""
+
+    encoder: VectorOperator
+    fusion: VectorOperator
+    decoder: VectorOperator
+    octree_mask: SpatialMask
+
+    def evaluate_blocks(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        t: float,
+        blocks: Sequence[Sequence[float]],
+    ) -> EngineTrace:
+        """Evaluate already-materialized block vectors at ``(x, y, z, t)``."""
+
+        if not blocks:
+            raise ValueError("at least one block is required")
+
+        mask = float(self.octree_mask(x, y, z))
+        encoded_blocks: list[Vector] = []
+        latent_sum: list[float] | None = None
+
+        for raw_block in blocks:
+            block = _vector(raw_block, "block")
+            encoded = _vector(self.encoder(block), "encoder output")
+            if not encoded:
+                raise ValueError("encoder output must not be empty")
+
+            if latent_sum is None:
+                latent_sum = [0.0] * len(encoded)
+            elif len(encoded) != len(latent_sum):
+                raise ValueError("all encoder outputs must have the same dimension")
+
+            for index, value in enumerate(encoded):
+                latent_sum[index] += mask * value
+            encoded_blocks.append(encoded)
+
+        assert latent_sum is not None
+        latent = tuple(latent_sum)
+        fused = _vector(self.fusion(latent), "fusion output")
+        if not fused:
+            raise ValueError("fusion output must not be empty")
+        output = _vector(self.decoder(fused), "decoder output")
+        if not output:
+            raise ValueError("decoder output must not be empty")
+
+        return EngineTrace(
+            position=(float(x), float(y), float(z)),
+            time=float(t),
+            octree_mask=mask,
+            encoded_blocks=tuple(encoded_blocks),
+            latent_sum=latent,
+            fused_latent=fused,
+            output=output,
+        )
+
+    def evaluate_field(
+        self,
+        x: float,
+        y: float,
+        z: float,
+        t: float,
+        n_blocks: int,
+        field: BlockField,
+    ) -> EngineTrace:
+        """Sample ``V^(k)_(x,y,z,t)`` then execute the full engine equation."""
+
+        if n_blocks <= 0:
+            raise ValueError("n_blocks must be positive")
+        blocks = tuple(field(x, y, z, t, index) for index in range(n_blocks))
+        return self.evaluate_blocks(x, y, z, t, blocks)
+
+
+def identity_operator(values: Vector) -> Vector:
+    """Return an immutable copy of ``values`` for reference configurations."""
+
+    return tuple(values)
+
+
+def _contains(node: FractalOctreeNode, x: float, y: float, z: float) -> bool:
+    upper_x = node.x + node.size
+    upper_y = node.y + node.size
+    upper_z = node.z + node.size
+    return (
+        node.x <= x <= upper_x
+        and node.y <= y <= upper_y
+        and node.z <= z <= upper_z
+    )
+
+
+def _vector(values: Sequence[float], label: str) -> Vector:
+    try:
+        vector = tuple(float(value) for value in values)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} must be a finite numeric sequence") from exc
+
+    for value in vector:
+        if value != value or value in (float("inf"), float("-inf")):
+            raise ValueError(f"{label} must contain only finite values")
+    return vector

--- a/src/jarvisx/psi_engine.py
+++ b/src/jarvisx/psi_engine.py
@@ -191,7 +191,7 @@ def _contains(node: FractalOctreeNode, x: float, y: float, z: float) -> bool:
     upper_x = node.x + node.size
     upper_y = node.y + node.size
     upper_z = node.z + node.size
-    return (
+    return bool(
         node.x <= x <= upper_x
         and node.y <= y <= upper_y
         and node.z <= z <= upper_z

--- a/tests/test_psi_engine.py
+++ b/tests/test_psi_engine.py
@@ -1,0 +1,109 @@
+import pytest
+
+from jarvisx.fractal_octree import build_fractal_octree
+from jarvisx.psi_engine import OctreeSpatialMask, PsiEngine, identity_operator
+
+
+def test_equation_composition_matches_operator_order():
+    engine = PsiEngine(
+        encoder=lambda values: (2.0 * values[0], 2.0 * values[1]),
+        fusion=lambda values: (values[0] + 1.0, values[1] - 1.0),
+        decoder=lambda values: (values[0] + values[1], values[0] - values[1]),
+        octree_mask=lambda _x, _y, _z: 0.5,
+    )
+
+    trace = engine.evaluate_blocks(
+        x=0.1,
+        y=0.2,
+        z=0.3,
+        t=4.0,
+        blocks=((1.0, 2.0), (3.0, 4.0)),
+    )
+
+    assert trace.encoded_blocks == ((2.0, 4.0), (6.0, 8.0))
+    assert trace.latent_sum == (4.0, 6.0)
+    assert trace.fused_latent == (5.0, 5.0)
+    assert trace.output == (10.0, 0.0)
+    assert trace.octree_mask == 0.5
+    assert trace.block_count == 2
+
+
+def test_octree_spatial_mask_projects_culled_octants_to_zero():
+    root = build_fractal_octree(size=1.0, max_depth=1)
+    mask = OctreeSpatialMask(root)
+
+    assert mask(0.25, 0.25, 0.25) == 1.0
+    assert mask(0.75, 0.75, 0.75) == 0.0
+    assert mask(1.25, 0.25, 0.25) == 0.0
+
+
+def test_evaluate_field_samples_every_block_at_same_spacetime_coordinate():
+    calls = []
+
+    def field(x, y, z, t, block_index):
+        calls.append((x, y, z, t, block_index))
+        return (x + y + z + t + block_index,)
+
+    engine = PsiEngine(
+        encoder=identity_operator,
+        fusion=identity_operator,
+        decoder=identity_operator,
+        octree_mask=lambda _x, _y, _z: 1.0,
+    )
+
+    trace = engine.evaluate_field(1.0, 2.0, 3.0, 4.0, 3, field)
+
+    assert calls == [
+        (1.0, 2.0, 3.0, 4.0, 0),
+        (1.0, 2.0, 3.0, 4.0, 1),
+        (1.0, 2.0, 3.0, 4.0, 2),
+    ]
+    assert trace.latent_sum == (33.0,)
+    assert trace.output == (33.0,)
+    assert trace.time == 4.0
+
+
+def test_culled_region_zeroes_aggregate_before_fusion_and_decode():
+    root = build_fractal_octree(size=1.0, max_depth=1)
+    engine = PsiEngine(
+        encoder=identity_operator,
+        fusion=identity_operator,
+        decoder=identity_operator,
+        octree_mask=OctreeSpatialMask(root),
+    )
+
+    trace = engine.evaluate_blocks(
+        x=0.75,
+        y=0.75,
+        z=0.75,
+        t=0.0,
+        blocks=((2.0, -3.0), (5.0, 7.0)),
+    )
+
+    assert trace.octree_mask == 0.0
+    assert trace.latent_sum == (0.0, 0.0)
+    assert trace.output == (0.0, 0.0)
+
+
+def test_encoder_outputs_must_share_one_latent_dimension():
+    engine = PsiEngine(
+        encoder=identity_operator,
+        fusion=identity_operator,
+        decoder=identity_operator,
+        octree_mask=lambda _x, _y, _z: 1.0,
+    )
+
+    with pytest.raises(ValueError, match="same dimension"):
+        engine.evaluate_blocks(0.0, 0.0, 0.0, 0.0, ((1.0,), (2.0, 3.0)))
+
+
+def test_evaluate_field_rejects_nonpositive_block_count():
+    engine = PsiEngine(
+        encoder=identity_operator,
+        fusion=identity_operator,
+        decoder=identity_operator,
+        octree_mask=lambda _x, _y, _z: 1.0,
+    )
+
+    with pytest.raises(ValueError, match="n_blocks must be positive"):
+        engine.evaluate_field(0.0, 0.0, 0.0, 0.0, 0, lambda *_args: (1.0,))


### PR DESCRIPTION
## Summary

Implements the Dr. Moagi field equation as an executable, dependency-free reference runtime:

\[
\Psi_{\text{Engine}}(X,Y,Z,t)=\mathcal{D}_{\theta}\left(\Omega_{\text{fusion}}\left(\sum_{k=1}^{N_{\text{blocks}}}\mathbf{M}_{\text{octree}}(x,y,z)\cdot\mathcal{E}_{\phi}(\mathbf{V}^{(k)}_{(x,y,z,t)})\right)\right)
\]

## Changes

- adds `src/jarvisx/psi_engine.py`
  - composable `PsiEngine` runtime
  - `BlockField`, `VectorOperator`, and `SpatialMask` contracts
  - `EngineTrace` for observable intermediate states
  - `OctreeSpatialMask` backed by the existing `FractalOctreeNode`
  - strict numeric and latent-dimension validation
- adds `tests/test_psi_engine.py`
  - verifies operator order
  - verifies shared spacetime sampling across blocks
  - verifies active/cull octree projection
  - verifies zero projection before fusion/decoding
  - verifies dimensional and block-count invariants
- adds `docs/PSI_ENGINE_OPERATOR.md`
  - maps every mathematical term to executable semantics

## Reference-model boundary

The equation writes `M_octree` as a matrix but does not specify learned matrix parameters. This PR therefore implements the deterministic reference form

\[
M_{\text{octree}}(x,y,z)=m(x,y,z)I, \quad m\in\{0,1\}
\]

using the repository's existing sparse inward-folding octree. The outer runtime contract is intentionally compatible with a future learned spatial matrix implementation.

## Validation

The branch is 3 commits ahead of `main`, with only the new operator, tests, and specification added. CI should run the full repository pytest matrix and package quality gates on this PR.