### PR TITLE
Build Dr Moagi inward intelligence media processor

### DIFF
--- a/.github/workflows/intelligence-media-windows.yml
+++ b/.github/workflows/intelligence-media-windows.yml
@@ -1,0 +1,103 @@
+name: Dr Moagi Intelligence Media Windows
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/include/jarvisx/intelligence_media_processor.hpp"
+      - "cpp_runtime/src/intelligence_media_processor_main.cpp"
+      - "cpp_runtime/tests/intelligence_media_processor_tests.cpp"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/DR_MOAGI_INTELLIGENCE_MEDIA_PROCESSOR.md"
+      - ".github/workflows/intelligence-media-windows.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/include/jarvisx/intelligence_media_processor.hpp"
+      - "cpp_runtime/src/intelligence_media_processor_main.cpp"
+      - "cpp_runtime/tests/intelligence_media_processor_tests.cpp"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/DR_MOAGI_INTELLIGENCE_MEDIA_PROCESSOR.md"
+      - ".github/workflows/intelligence-media-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: intelligence-media-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-package:
+    name: Windows x64 / MSVC
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure CMake
+        shell: pwsh
+        run: >-
+          cmake -S cpp_runtime -B build/intelligence-media
+          -A x64
+          -DJARVISX_BUILD_GL_VISUALIZER=OFF
+          -DJARVISX_ENABLE_SANITIZERS=OFF
+
+      - name: Build executable and focused tests
+        shell: pwsh
+        run: |
+          cmake --build build/intelligence-media --config Release --target jarvisx-intelligence-media --parallel 2
+          cmake --build build/intelligence-media --config Release --target jarvisx-intelligence-media-tests --parallel 2
+
+      - name: Run focused regression and smoke tests
+        shell: pwsh
+        run: |
+          ctest --test-dir build/intelligence-media -C Release -R "intelligence-media-(regressions|runtime-smoke)" --output-on-failure
+
+      - name: Execute canonical inward media profile
+        shell: pwsh
+        run: |
+          $exe = "build/intelligence-media/Release/DrMoagi-Intelligence-Media.exe"
+          & $exe --demo-bytes 8192 --modality visual --passes 3 --max-mse 4096 --output build/intelligence-media/demo-visual.bin
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Emit canonical VCL-BVM-8 program
+        shell: pwsh
+        run: |
+          [byte[]]$program = 0x40,0x00,0x00,0x30,0x02,0x00,0x20,0x00,0x07,0x50,0x00,0x08,0x60,0x01,0x80,0x08,0x70,0x00,0x07,0xFF
+          [System.IO.File]::WriteAllBytes("build/intelligence-media/default-media.vcl8", $program)
+
+      - name: Validate custom bytecode path
+        shell: pwsh
+        run: |
+          $exe = "build/intelligence-media/Release/DrMoagi-Intelligence-Media.exe"
+          & $exe --input build/intelligence-media/demo-visual.bin --bytecode build/intelligence-media/default-media.vcl8 --modality generic --passes 1 --output build/intelligence-media/demo-reprocessed.bin --quiet
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stage package and checksum
+        shell: pwsh
+        run: |
+          $stage = "build/intelligence-media/package"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "build/intelligence-media/Release/DrMoagi-Intelligence-Media.exe" "$stage/DrMoagi-Intelligence-Media.exe"
+          Copy-Item "build/intelligence-media/default-media.vcl8" "$stage/default-media.vcl8"
+          Copy-Item "build/intelligence-media/demo-visual.bin" "$stage/demo-visual.bin"
+          Copy-Item "docs/DR_MOAGI_INTELLIGENCE_MEDIA_PROCESSOR.md" "$stage/README.md"
+          $hash = (Get-FileHash "$stage/DrMoagi-Intelligence-Media.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  DrMoagi-Intelligence-Media.exe" | Set-Content -Encoding ascii "$stage/SHA256SUMS.txt"
+          Compress-Archive -Path "$stage/*" -DestinationPath "build/intelligence-media/DrMoagi-Intelligence-Media-Windows-x64.zip" -Force
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: DrMoagi-Intelligence-Media-Windows-x64
+          path: |
+            build/intelligence-media/package/DrMoagi-Intelligence-Media.exe
+            build/intelligence-media/package/default-media.vcl8
+            build/intelligence-media/package/demo-visual.bin
+            build/intelligence-media/package/README.md
+            build/intelligence-media/package/SHA256SUMS.txt
+            build/intelligence-media/DrMoagi-Intelligence-Media-Windows-x64.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -63,6 +63,13 @@ set_target_properties(jarvisx-intelligence3d PROPERTIES OUTPUT_NAME "JarvisX-3D-
 jarvisx_include_runtime(jarvisx-intelligence3d)
 jarvisx_harden(jarvisx-intelligence3d)
 
+add_executable(jarvisx-intelligence-media
+    src/intelligence_media_processor_main.cpp
+)
+set_target_properties(jarvisx-intelligence-media PROPERTIES OUTPUT_NAME "DrMoagi-Intelligence-Media")
+jarvisx_include_runtime(jarvisx-intelligence-media)
+jarvisx_harden(jarvisx-intelligence-media)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -165,6 +172,17 @@ add_test(
 )
 set_tests_properties(intelligence3d-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME intelligence-media-runtime-smoke
+    COMMAND jarvisx-intelligence-media
+        --demo-bytes 2048
+        --modality visual
+        --passes 2
+        --output ${CMAKE_CURRENT_BINARY_DIR}/dr-moagi-intelligence-media-smoke.bin
+        --quiet
+)
+set_tests_properties(intelligence-media-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -218,3 +236,12 @@ jarvisx_harden(jarvisx-intelligence3d-tests)
 
 add_test(NAME intelligence3d-regressions COMMAND jarvisx-intelligence3d-tests)
 set_tests_properties(intelligence3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-intelligence-media-tests
+    tests/intelligence_media_processor_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-intelligence-media-tests)
+jarvisx_harden(jarvisx-intelligence-media-tests)
+
+add_test(NAME intelligence-media-regressions COMMAND jarvisx-intelligence-media-tests)
+set_tests_properties(intelligence-media-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/intelligence_media_processor.hpp
+++ b/cpp_runtime/include/jarvisx/intelligence_media_processor.hpp
@@ -1,0 +1,706 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jarvisx::media8 {
+
+constexpr std::size_t kTileEdge = 8U;
+constexpr std::size_t kTileNodes = kTileEdge * kTileEdge * kTileEdge;
+constexpr std::size_t kCoreEdge = 2U;
+constexpr std::size_t kCoreNodes = kCoreEdge * kCoreEdge * kCoreEdge;
+
+enum class MediaModality : std::uint8_t {
+    Visual = 0U,
+    Audio = 1U,
+    Text = 2U,
+    Generic = 3U,
+};
+
+inline const char* modality_name(MediaModality modality) noexcept {
+    switch (modality) {
+    case MediaModality::Visual: return "visual";
+    case MediaModality::Audio: return "audio";
+    case MediaModality::Text: return "text";
+    case MediaModality::Generic: return "generic";
+    }
+    return "unknown";
+}
+
+enum class GateType : std::uint8_t {
+    And = 0x01U,
+    Or = 0x02U,
+    Xor = 0x03U,
+    Not = 0x04U,
+};
+
+enum class Opcode : std::uint8_t {
+    IngestRaw = 0x10U,
+    EncodeSpatial = 0x20U,
+    VclGate = 0x30U,
+    Conv3DInt8 = 0x40U,
+    EvalEntropy = 0x50U,
+    PruneLattice = 0x60U,
+    DecodeBytecode = 0x70U,
+    AutoEvolve = 0x80U,
+    SyncLock = 0xFFU,
+};
+
+struct VCLNode {
+    std::int8_t state{};
+    std::int8_t weight{};
+    std::uint8_t logic_mask{1U};
+    std::uint8_t control_flag{1U};
+};
+
+struct TileMetrics {
+    double reconstruction_mse{};
+    double normalized_entropy{};
+    std::size_t active_nodes{};
+    std::uint64_t evolution_commits{};
+    std::uint64_t evolution_rollbacks{};
+    bool entropy_prune_requested{};
+    bool synchronized{};
+};
+
+struct AdaptiveSnapshot {
+    std::array<std::int8_t, kTileNodes> weights{};
+    std::array<std::int16_t, kCoreNodes> omega{};
+};
+
+inline std::size_t tile_index(std::size_t x, std::size_t y, std::size_t z) noexcept {
+    return (z * kTileEdge + y) * kTileEdge + x;
+}
+
+inline std::size_t core_index(std::size_t x, std::size_t y, std::size_t z) noexcept {
+    return ((z & 1U) * kCoreEdge + (y & 1U)) * kCoreEdge + (x & 1U);
+}
+
+inline std::int8_t clamp_i8(int value) noexcept {
+    return static_cast<std::int8_t>(std::clamp(value, -128, 127));
+}
+
+inline std::int8_t byte_to_centered(std::uint8_t value) noexcept {
+    return clamp_i8(static_cast<int>(value) - 128);
+}
+
+inline std::uint8_t centered_to_byte(std::int8_t value) noexcept {
+    const int restored = static_cast<int>(value) + 128;
+    return static_cast<std::uint8_t>(std::clamp(restored, 0, 255));
+}
+
+class VCLTile8 {
+public:
+    VCLTile8() {
+        for (VCLNode& node : nodes_) {
+            node.logic_mask = 1U;
+            node.control_flag = 1U;
+        }
+    }
+
+    void ingest_tile(const std::array<std::uint8_t, kTileNodes>& bytes) {
+        synchronized_ = false;
+        entropy_prune_requested_ = false;
+        normalized_entropy_ = 0.0;
+        for (std::size_t i = 0U; i < kTileNodes; ++i) {
+            const auto centered = byte_to_centered(bytes[i]);
+            source_[i] = centered;
+            reconstruction_[i] = centered;
+            nodes_[i].state = centered;
+            nodes_[i].logic_mask = 1U;
+            nodes_[i].control_flag = 1U;
+        }
+    }
+
+    void ingest_plane(std::uint8_t z_slice, std::uint8_t raw_value) {
+        if (z_slice >= kTileEdge) {
+            throw std::out_of_range("VCL INGEST_RAW z-slice outside 8x8x8 tile");
+        }
+        synchronized_ = false;
+        const auto centered = byte_to_centered(raw_value);
+        for (std::size_t y = 0U; y < kTileEdge; ++y) {
+            for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                const std::size_t i = tile_index(x, y, z_slice);
+                source_[i] = centered;
+                reconstruction_[i] = centered;
+                nodes_[i].state = centered;
+                nodes_[i].logic_mask = 1U;
+                nodes_[i].control_flag = 1U;
+            }
+        }
+    }
+
+    void conv3d(std::uint8_t kernel_id, std::uint8_t bias_byte) {
+        const std::array<std::int8_t, kTileNodes> before = states();
+        std::array<std::int8_t, kTileNodes> next = before;
+        const int bias = bias_byte < 128U ? static_cast<int>(bias_byte)
+                                         : static_cast<int>(bias_byte) - 256;
+        for (std::size_t z = 0U; z < kTileEdge; ++z) {
+            for (std::size_t y = 0U; y < kTileEdge; ++y) {
+                for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                    const std::size_t out_index = tile_index(x, y, z);
+                    if (!active(nodes_[out_index])) continue;
+                    std::int32_t sum = 0;
+                    for (int dz = -1; dz <= 1; ++dz) {
+                        for (int dy = -1; dy <= 1; ++dy) {
+                            for (int dx = -1; dx <= 1; ++dx) {
+                                const std::size_t sx = clamp_coord(static_cast<int>(x) + dx);
+                                const std::size_t sy = clamp_coord(static_cast<int>(y) + dy);
+                                const std::size_t sz = clamp_coord(static_cast<int>(z) + dz);
+                                const int coefficient = kernel_coefficient(kernel_id, dx, dy, dz);
+                                sum += static_cast<std::int32_t>(coefficient) *
+                                       static_cast<std::int32_t>(before[tile_index(sx, sy, sz)]);
+                            }
+                        }
+                    }
+                    const int scaled = requantize_kernel(kernel_id, sum) + bias;
+                    next[out_index] = clamp_i8(scaled);
+                }
+            }
+        }
+        for (std::size_t i = 0U; i < kTileNodes; ++i) nodes_[i].state = next[i];
+    }
+
+    void vcl_gate(std::uint8_t gate_type, std::uint8_t threshold) {
+        for (VCLNode& node : nodes_) {
+            const bool above = centered_to_byte(node.state) > threshold;
+            const bool mask = node.logic_mask != 0U;
+            bool value = false;
+            switch (static_cast<GateType>(gate_type)) {
+            case GateType::And: value = above && mask; break;
+            case GateType::Or: value = above || mask; break;
+            case GateType::Xor: value = above != mask; break;
+            case GateType::Not: value = (!above) && mask; break;
+            default: throw std::invalid_argument("unsupported VCL gate type");
+            }
+            node.control_flag = value ? 1U : 0U;
+        }
+    }
+
+    void encode_spatial(std::uint8_t z_start, std::uint8_t z_end) {
+        validate_range(z_start, z_end, "ENC_SPATIAL");
+        std::array<std::int32_t, kCoreNodes> sums{};
+        std::array<std::uint16_t, kCoreNodes> counts{};
+        for (std::size_t z = z_start; z <= z_end; ++z) {
+            for (std::size_t y = 0U; y < kTileEdge; ++y) {
+                for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                    const std::size_t i = tile_index(x, y, z);
+                    if (!active(nodes_[i])) continue;
+                    const std::size_t c = core_index(x, y, z);
+                    sums[c] += static_cast<std::int32_t>(nodes_[i].state);
+                    ++counts[c];
+                }
+            }
+        }
+        for (std::size_t c = 0U; c < kCoreNodes; ++c) {
+            const int raw = counts[c] == 0U ? 0 :
+                static_cast<int>(sums[c] / static_cast<std::int32_t>(counts[c]));
+            raw_core_[c] = clamp_i8(raw);
+            const int fused = (3 * raw + static_cast<int>(omega_[c])) / 4;
+            core_[c] = clamp_i8(fused);
+        }
+    }
+
+    double eval_entropy(std::uint8_t shell_id, std::uint8_t threshold) {
+        std::array<std::uint32_t, 256U> histogram{};
+        std::uint64_t count = 0U;
+        for (std::size_t z = 0U; z < kTileEdge; ++z) {
+            for (std::size_t y = 0U; y < kTileEdge; ++y) {
+                for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                    if (!in_shell(shell_id, x, y, z)) continue;
+                    const VCLNode& node = nodes_[tile_index(x, y, z)];
+                    if (node.logic_mask == 0U) continue;
+                    ++histogram[centered_to_byte(node.state)];
+                    ++count;
+                }
+            }
+        }
+        if (count == 0U) {
+            normalized_entropy_ = 0.0;
+        } else {
+            double entropy = 0.0;
+            for (const std::uint32_t frequency : histogram) {
+                if (frequency == 0U) continue;
+                const double probability = static_cast<double>(frequency) /
+                                           static_cast<double>(count);
+                entropy -= probability * std::log2(probability);
+            }
+            normalized_entropy_ = entropy / 8.0;
+        }
+        entropy_prune_requested_ = normalized_entropy_ * 255.0 <
+                                   static_cast<double>(threshold);
+        return normalized_entropy_;
+    }
+
+    void prune_lattice(std::uint8_t target_mask) {
+        if (!entropy_prune_requested_) return;
+        for (VCLNode& node : nodes_) {
+            bool prune = false;
+            if ((target_mask & 0x01U) != 0U && node.control_flag == 0U) prune = true;
+            if ((target_mask & 0x02U) != 0U && std::abs(static_cast<int>(node.state)) < 8) {
+                prune = true;
+            }
+            if (prune) node.logic_mask = 0U;
+        }
+    }
+
+    void decode_bytecode(std::uint8_t z_start, std::uint8_t z_end) {
+        validate_range(z_start, z_end, "DEC_BYTECODE");
+        const auto decoded = shadow_decode();
+        for (std::size_t z = z_start; z <= z_end; ++z) {
+            for (std::size_t y = 0U; y < kTileEdge; ++y) {
+                for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                    const std::size_t i = tile_index(x, y, z);
+                    reconstruction_[i] = decoded[i];
+                    nodes_[i].state = decoded[i];
+                    nodes_[i].logic_mask = 1U;
+                }
+            }
+        }
+    }
+
+    bool auto_evolve(std::uint8_t learning_rate) {
+        const auto weights_before = weights();
+        const auto baseline_reconstruction = shadow_decode();
+        const double baseline = mse_against_source(baseline_reconstruction);
+
+        for (std::size_t i = 0U; i < kTileNodes; ++i) {
+            if (!active(nodes_[i])) continue;
+            const int residual = static_cast<int>(source_[i]) -
+                                 static_cast<int>(baseline_reconstruction[i]);
+            const int delta = (static_cast<int>(learning_rate) * residual) >> 4;
+            nodes_[i].weight = clamp_i8(static_cast<int>(nodes_[i].weight) + delta);
+        }
+
+        const auto candidate_reconstruction = shadow_decode();
+        const double candidate = mse_against_source(candidate_reconstruction);
+        if (std::isfinite(candidate) && candidate <= baseline + 1.0e-12) {
+            ++evolution_commits_;
+            return true;
+        }
+
+        restore_weights(weights_before);
+        ++evolution_rollbacks_;
+        return false;
+    }
+
+    void sync_lock() {
+        for (std::size_t c = 0U; c < kCoreNodes; ++c) {
+            omega_[c] = static_cast<std::int16_t>(
+                (7 * static_cast<int>(omega_[c]) +
+                 static_cast<int>(raw_core_[c])) / 8);
+        }
+        synchronized_ = true;
+    }
+
+    AdaptiveSnapshot adaptive_snapshot() const noexcept {
+        return {weights(), omega_};
+    }
+
+    void restore_adaptive(const AdaptiveSnapshot& snapshot) noexcept {
+        restore_weights(snapshot.weights);
+        omega_ = snapshot.omega;
+    }
+
+    std::array<std::uint8_t, kTileNodes> reconstruction_bytes() const noexcept {
+        std::array<std::uint8_t, kTileNodes> result{};
+        for (std::size_t i = 0U; i < kTileNodes; ++i) {
+            result[i] = centered_to_byte(reconstruction_[i]);
+        }
+        return result;
+    }
+
+    TileMetrics metrics() const noexcept {
+        TileMetrics result;
+        result.reconstruction_mse = mse_against_source(reconstruction_);
+        result.normalized_entropy = normalized_entropy_;
+        result.active_nodes = active_node_count();
+        result.evolution_commits = evolution_commits_;
+        result.evolution_rollbacks = evolution_rollbacks_;
+        result.entropy_prune_requested = entropy_prune_requested_;
+        result.synchronized = synchronized_;
+        return result;
+    }
+
+    const std::array<VCLNode, kTileNodes>& nodes() const noexcept { return nodes_; }
+    const std::array<std::int8_t, kCoreNodes>& core() const noexcept { return core_; }
+
+private:
+    std::array<VCLNode, kTileNodes> nodes_{};
+    std::array<std::int8_t, kTileNodes> source_{};
+    std::array<std::int8_t, kTileNodes> reconstruction_{};
+    std::array<std::int8_t, kCoreNodes> raw_core_{};
+    std::array<std::int8_t, kCoreNodes> core_{};
+    std::array<std::int16_t, kCoreNodes> omega_{};
+    double normalized_entropy_{};
+    bool entropy_prune_requested_{};
+    bool synchronized_{};
+    std::uint64_t evolution_commits_{};
+    std::uint64_t evolution_rollbacks_{};
+
+    static bool active(const VCLNode& node) noexcept {
+        return node.logic_mask != 0U && node.control_flag != 0U;
+    }
+
+    static std::size_t clamp_coord(int value) noexcept {
+        return static_cast<std::size_t>(std::clamp(value, 0, static_cast<int>(kTileEdge - 1U)));
+    }
+
+    static void validate_range(std::uint8_t start, std::uint8_t end, const char* op) {
+        if (start > end || end >= kTileEdge) {
+            throw std::out_of_range(std::string(op) + " z-range outside 8x8x8 tile");
+        }
+    }
+
+    static int kernel_coefficient(std::uint8_t kernel_id, int dx, int dy, int dz) {
+        switch (kernel_id) {
+        case 0U:
+            return (dx == 0 && dy == 0 && dz == 0) ? 1 : 0;
+        case 1U:
+            return 1;
+        case 2U:
+            return (dx == 0 && dy == 0 && dz == 0) ? 26 : -1;
+        case 3U: {
+            const int manhattan = std::abs(dx) + std::abs(dy) + std::abs(dz);
+            if (manhattan == 0) return 7;
+            if (manhattan == 1) return -1;
+            return 0;
+        }
+        default:
+            throw std::invalid_argument("unknown CONV_3D_INT8 kernel id");
+        }
+    }
+
+    static int requantize_kernel(std::uint8_t kernel_id, std::int32_t sum) noexcept {
+        switch (kernel_id) {
+        case 0U: return static_cast<int>(sum);
+        case 1U: return static_cast<int>(sum / 27);
+        case 2U: return static_cast<int>(sum / 16);
+        case 3U: return static_cast<int>(sum);
+        default: return 0;
+        }
+    }
+
+    static bool in_shell(std::uint8_t shell, std::size_t x,
+                         std::size_t y, std::size_t z) {
+        switch (shell) {
+        case 0U:
+            return true;
+        case 1U:
+            return x == 0U || y == 0U || z == 0U ||
+                   x + 1U == kTileEdge || y + 1U == kTileEdge || z + 1U == kTileEdge;
+        case 2U:
+            return x > 0U && y > 0U && z > 0U &&
+                   x + 1U < kTileEdge && y + 1U < kTileEdge && z + 1U < kTileEdge;
+        case 3U:
+            return (x == 3U || x == 4U) &&
+                   (y == 3U || y == 4U) &&
+                   (z == 3U || z == 4U);
+        default:
+            throw std::invalid_argument("unknown entropy shell id");
+        }
+    }
+
+    std::array<std::int8_t, kTileNodes> states() const noexcept {
+        std::array<std::int8_t, kTileNodes> result{};
+        for (std::size_t i = 0U; i < kTileNodes; ++i) result[i] = nodes_[i].state;
+        return result;
+    }
+
+    std::array<std::int8_t, kTileNodes> weights() const noexcept {
+        std::array<std::int8_t, kTileNodes> result{};
+        for (std::size_t i = 0U; i < kTileNodes; ++i) result[i] = nodes_[i].weight;
+        return result;
+    }
+
+    void restore_weights(const std::array<std::int8_t, kTileNodes>& values) noexcept {
+        for (std::size_t i = 0U; i < kTileNodes; ++i) nodes_[i].weight = values[i];
+    }
+
+    std::array<std::int8_t, kTileNodes> shadow_decode() const noexcept {
+        std::array<std::int8_t, kTileNodes> result{};
+        for (std::size_t z = 0U; z < kTileEdge; ++z) {
+            for (std::size_t y = 0U; y < kTileEdge; ++y) {
+                for (std::size_t x = 0U; x < kTileEdge; ++x) {
+                    const std::size_t i = tile_index(x, y, z);
+                    const std::size_t c = core_index(x, y, z);
+                    const int decoded = static_cast<int>(core_[c]) +
+                                        static_cast<int>(nodes_[i].weight) / 8;
+                    result[i] = clamp_i8(decoded);
+                }
+            }
+        }
+        return result;
+    }
+
+    double mse_against_source(const std::array<std::int8_t, kTileNodes>& values) const noexcept {
+        double squared = 0.0;
+        for (std::size_t i = 0U; i < kTileNodes; ++i) {
+            const double delta = static_cast<double>(source_[i]) -
+                                 static_cast<double>(values[i]);
+            squared += delta * delta;
+        }
+        return squared / static_cast<double>(kTileNodes);
+    }
+
+    std::size_t active_node_count() const noexcept {
+        std::size_t count = 0U;
+        for (const VCLNode& node : nodes_) if (active(node)) ++count;
+        return count;
+    }
+};
+
+class VCLBVM8 {
+public:
+    explicit VCLBVM8(VCLTile8& tile) : tile_(tile) {}
+
+    TileMetrics execute(const std::vector<std::uint8_t>& bytecode,
+                        std::size_t instruction_limit = 4096U) {
+        std::size_t ip = 0U;
+        std::size_t instructions = 0U;
+        while (ip < bytecode.size()) {
+            if (++instructions > instruction_limit) {
+                throw std::runtime_error("VCL-BVM-8 instruction limit exceeded");
+            }
+            const std::uint8_t header = bytecode[ip++];
+            if (header == static_cast<std::uint8_t>(Opcode::SyncLock)) {
+                tile_.sync_lock();
+                return tile_.metrics();
+            }
+            const std::uint8_t opcode = header & 0xF0U;
+            const std::uint8_t mode = header & 0x0FU;
+            (void)mode;
+            switch (opcode) {
+            case static_cast<std::uint8_t>(Opcode::IngestRaw): {
+                require(bytecode, ip, 2U);
+                const auto z = bytecode[ip++];
+                const auto value = bytecode[ip++];
+                tile_.ingest_plane(z, value);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::EncodeSpatial): {
+                require(bytecode, ip, 2U);
+                const auto start = bytecode[ip++];
+                const auto end = bytecode[ip++];
+                tile_.encode_spatial(start, end);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::VclGate): {
+                require(bytecode, ip, 2U);
+                const auto gate = bytecode[ip++];
+                const auto threshold = bytecode[ip++];
+                tile_.vcl_gate(gate, threshold);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::Conv3DInt8): {
+                require(bytecode, ip, 2U);
+                const auto kernel = bytecode[ip++];
+                const auto bias = bytecode[ip++];
+                tile_.conv3d(kernel, bias);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::EvalEntropy): {
+                require(bytecode, ip, 2U);
+                const auto shell = bytecode[ip++];
+                const auto threshold = bytecode[ip++];
+                tile_.eval_entropy(shell, threshold);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::PruneLattice): {
+                require(bytecode, ip, 1U);
+                tile_.prune_lattice(bytecode[ip++]);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::DecodeBytecode): {
+                require(bytecode, ip, 2U);
+                const auto start = bytecode[ip++];
+                const auto end = bytecode[ip++];
+                tile_.decode_bytecode(start, end);
+                break;
+            }
+            case static_cast<std::uint8_t>(Opcode::AutoEvolve): {
+                require(bytecode, ip, 1U);
+                tile_.auto_evolve(bytecode[ip++]);
+                break;
+            }
+            default:
+                throw std::runtime_error("unknown VCL-BVM-8 opcode header");
+            }
+        }
+        throw std::runtime_error("VCL-BVM-8 stream ended without SYNC_LOCK");
+    }
+
+private:
+    VCLTile8& tile_;
+
+    static void require(const std::vector<std::uint8_t>& bytecode,
+                        std::size_t ip, std::size_t count) {
+        if (count > bytecode.size() - std::min(ip, bytecode.size())) {
+            throw std::runtime_error("truncated VCL-BVM-8 instruction payload");
+        }
+    }
+};
+
+inline std::vector<std::uint8_t> default_media_program() {
+    return {
+        0x40U, 0x00U, 0x00U,       // identity 3D convolution, zero bias
+        0x30U, 0x02U, 0x00U,       // OR gate keeps valid mask active
+        0x20U, 0x00U, 0x07U,       // encode all eight Z slices inward
+        0x50U, 0x00U, 0x08U,       // true entropy over whole tile
+        0x60U, 0x01U,              // prune gate-disabled nodes if requested
+        0x80U, 0x08U,              // bounded residual candidate update
+        0x70U, 0x00U, 0x07U,       // decode the complete tile
+        0xFFU,                      // Lambda/Omega synchronization lock
+    };
+}
+
+struct ProcessorConfig {
+    double max_output_mse{4096.0};
+    bool fallback_on_regression{true};
+    std::size_t instruction_limit{4096U};
+
+    void validate() const {
+        if (!std::isfinite(max_output_mse) || max_output_mse < 0.0) {
+            throw std::invalid_argument("max_output_mse must be finite and non-negative");
+        }
+        if (instruction_limit == 0U) {
+            throw std::invalid_argument("instruction_limit must be positive");
+        }
+    }
+};
+
+struct ProcessorMetrics {
+    MediaModality modality{MediaModality::Generic};
+    std::uint64_t tiles{};
+    std::uint64_t accepted_tiles{};
+    std::uint64_t rejected_tiles{};
+    double average_candidate_mse{};
+    double average_output_mse{};
+    double hbar_semantic{};
+    double average_entropy{};
+    double average_active_nodes{};
+    std::uint64_t evolution_commits{};
+    std::uint64_t evolution_rollbacks{};
+};
+
+struct ProcessorResult {
+    std::vector<std::uint8_t> bytes;
+    ProcessorMetrics metrics;
+};
+
+class DrMoagiIntelligenceMediaProcessor {
+public:
+    explicit DrMoagiIntelligenceMediaProcessor(
+        ProcessorConfig config = {},
+        std::vector<std::uint8_t> program = default_media_program())
+        : config_(config), program_(std::move(program)) {
+        config_.validate();
+        if (program_.empty()) throw std::invalid_argument("VCL media program must not be empty");
+    }
+
+    const std::vector<std::uint8_t>& program() const noexcept { return program_; }
+    const VCLTile8& tile() const noexcept { return tile_; }
+
+    void set_program(std::vector<std::uint8_t> program) {
+        if (program.empty()) throw std::invalid_argument("VCL media program must not be empty");
+        program_ = std::move(program);
+    }
+
+    ProcessorResult process(const std::vector<std::uint8_t>& input,
+                            MediaModality modality = MediaModality::Generic) {
+        ProcessorResult result;
+        result.bytes.resize(input.size());
+        result.metrics.modality = modality;
+        if (input.empty()) return result;
+
+        double candidate_mse_sum = 0.0;
+        double output_mse_sum = 0.0;
+        double entropy_sum = 0.0;
+        double active_sum = 0.0;
+        std::uint64_t previous_evolution_commits = tile_.metrics().evolution_commits;
+        std::uint64_t previous_evolution_rollbacks = tile_.metrics().evolution_rollbacks;
+
+        for (std::size_t offset = 0U; offset < input.size(); offset += kTileNodes) {
+            const std::size_t available = std::min(kTileNodes, input.size() - offset);
+            std::array<std::uint8_t, kTileNodes> tile_bytes{};
+            tile_bytes.fill(128U);
+            std::copy_n(input.begin() + static_cast<std::ptrdiff_t>(offset),
+                        static_cast<std::ptrdiff_t>(available), tile_bytes.begin());
+
+            const AdaptiveSnapshot adaptive_before = tile_.adaptive_snapshot();
+            tile_.ingest_tile(tile_bytes);
+            VCLBVM8 vm(tile_);
+            const TileMetrics tile_metrics = vm.execute(program_, config_.instruction_limit);
+            const auto candidate = tile_.reconstruction_bytes();
+            const double candidate_mse = mse_bytes(tile_bytes, candidate, available);
+            const bool accept = std::isfinite(candidate_mse) &&
+                                candidate_mse <= config_.max_output_mse;
+
+            if (accept) {
+                ++result.metrics.accepted_tiles;
+                std::copy_n(candidate.begin(), static_cast<std::ptrdiff_t>(available),
+                            result.bytes.begin() + static_cast<std::ptrdiff_t>(offset));
+                output_mse_sum += candidate_mse;
+            } else {
+                ++result.metrics.rejected_tiles;
+                tile_.restore_adaptive(adaptive_before);
+                if (config_.fallback_on_regression) {
+                    std::copy_n(input.begin() + static_cast<std::ptrdiff_t>(offset),
+                                static_cast<std::ptrdiff_t>(available),
+                                result.bytes.begin() + static_cast<std::ptrdiff_t>(offset));
+                } else {
+                    std::copy_n(candidate.begin(), static_cast<std::ptrdiff_t>(available),
+                                result.bytes.begin() + static_cast<std::ptrdiff_t>(offset));
+                    output_mse_sum += candidate_mse;
+                }
+            }
+
+            ++result.metrics.tiles;
+            candidate_mse_sum += candidate_mse;
+            entropy_sum += tile_metrics.normalized_entropy;
+            active_sum += static_cast<double>(tile_metrics.active_nodes);
+        }
+
+        const double tile_count = static_cast<double>(result.metrics.tiles);
+        result.metrics.average_candidate_mse = candidate_mse_sum / tile_count;
+        result.metrics.average_output_mse = output_mse_sum / tile_count;
+        result.metrics.hbar_semantic =
+            std::sqrt(result.metrics.average_output_mse) / 255.0;
+        result.metrics.average_entropy = entropy_sum / tile_count;
+        result.metrics.average_active_nodes = active_sum / tile_count;
+        const TileMetrics final_tile = tile_.metrics();
+        result.metrics.evolution_commits =
+            final_tile.evolution_commits - previous_evolution_commits;
+        result.metrics.evolution_rollbacks =
+            final_tile.evolution_rollbacks - previous_evolution_rollbacks;
+        return result;
+    }
+
+private:
+    ProcessorConfig config_;
+    std::vector<std::uint8_t> program_;
+    VCLTile8 tile_;
+
+    static double mse_bytes(const std::array<std::uint8_t, kTileNodes>& left,
+                            const std::array<std::uint8_t, kTileNodes>& right,
+                            std::size_t count) noexcept {
+        if (count == 0U) return 0.0;
+        double squared = 0.0;
+        for (std::size_t i = 0U; i < count; ++i) {
+            const double delta = static_cast<double>(left[i]) -
+                                 static_cast<double>(right[i]);
+            squared += delta * delta;
+        }
+        return squared / static_cast<double>(count);
+    }
+};
+
+} // namespace jarvisx::media8

--- a/cpp_runtime/src/intelligence_media_processor_main.cpp
+++ b/cpp_runtime/src/intelligence_media_processor_main.cpp
@@ -1,0 +1,198 @@
+#include "jarvisx/intelligence_media_processor.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::filesystem::path input{};
+    std::filesystem::path output{"dr-moagi-intelligence-media-output.bin"};
+    std::filesystem::path bytecode{};
+    jarvisx::media8::MediaModality modality{jarvisx::media8::MediaModality::Generic};
+    std::size_t demo_bytes{4096U};
+    std::uint64_t passes{1U};
+    double max_mse{4096.0};
+    bool fallback{true};
+    bool quiet{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const char* name) {
+    std::size_t consumed = 0U;
+    const auto parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) throw std::invalid_argument(std::string(name) + " must be an integer");
+    return parsed;
+}
+
+double parse_double(const std::string& value, const char* name) {
+    std::size_t consumed = 0U;
+    const double parsed = std::stod(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument(std::string(name) + " must be finite");
+    }
+    return parsed;
+}
+
+jarvisx::media8::MediaModality parse_modality(const std::string& value) {
+    using jarvisx::media8::MediaModality;
+    if (value == "visual") return MediaModality::Visual;
+    if (value == "audio") return MediaModality::Audio;
+    if (value == "text") return MediaModality::Text;
+    if (value == "generic") return MediaModality::Generic;
+    throw std::invalid_argument("modality must be visual, audio, text, or generic");
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto next = [&](int& index, const char* flag) -> std::string {
+        if (index + 1 >= argc) throw std::invalid_argument(std::string("missing value for ") + flag);
+        return argv[++index];
+    };
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--input") options.input = next(i, "--input");
+        else if (arg == "--output") options.output = next(i, "--output");
+        else if (arg == "--bytecode") options.bytecode = next(i, "--bytecode");
+        else if (arg == "--modality") options.modality = parse_modality(next(i, "--modality"));
+        else if (arg == "--demo-bytes") options.demo_bytes = static_cast<std::size_t>(parse_u64(next(i, "--demo-bytes"), "demo-bytes"));
+        else if (arg == "--passes") options.passes = parse_u64(next(i, "--passes"), "passes");
+        else if (arg == "--max-mse") options.max_mse = parse_double(next(i, "--max-mse"), "max-mse");
+        else if (arg == "--no-fallback") options.fallback = false;
+        else if (arg == "--quiet") options.quiet = true;
+        else if (arg == "--help" || arg == "-h") {
+            std::cout
+                << "Dr Moagi Intelligence Media Processor\n"
+                << "  --input PATH        arbitrary binary/media input\n"
+                << "  --output PATH       processed output path\n"
+                << "  --bytecode PATH     VCL-BVM-8 program (raw bytes)\n"
+                << "  --modality NAME     visual|audio|text|generic\n"
+                << "  --demo-bytes N      deterministic demo size when --input is absent\n"
+                << "  --passes N          inward processing passes\n"
+                << "  --max-mse X         Lambda output-quality ceiling\n"
+                << "  --no-fallback       emit rejected candidate instead of original tile\n"
+                << "  --quiet             compact output\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + arg);
+        }
+    }
+    if (options.passes == 0U) throw std::invalid_argument("passes must be positive");
+    if (options.demo_bytes == 0U && options.input.empty()) {
+        throw std::invalid_argument("demo-bytes must be positive without --input");
+    }
+    return options;
+}
+
+std::vector<std::uint8_t> read_binary(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) throw std::runtime_error("cannot open input: " + path.string());
+    return std::vector<std::uint8_t>(std::istreambuf_iterator<char>(input),
+                                     std::istreambuf_iterator<char>());
+}
+
+void write_binary(const std::filesystem::path& path,
+                  const std::vector<std::uint8_t>& bytes) {
+    if (!path.parent_path().empty()) std::filesystem::create_directories(path.parent_path());
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output) throw std::runtime_error("cannot open output: " + path.string());
+    if (!bytes.empty()) {
+        output.write(reinterpret_cast<const char*>(bytes.data()),
+                     static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!output) throw std::runtime_error("cannot write output: " + path.string());
+}
+
+std::vector<std::uint8_t> make_demo(std::size_t count,
+                                    jarvisx::media8::MediaModality modality) {
+    std::vector<std::uint8_t> bytes(count);
+    for (std::size_t i = 0U; i < count; ++i) {
+        const std::uint32_t x = static_cast<std::uint32_t>(i & 7U);
+        const std::uint32_t y = static_cast<std::uint32_t>((i >> 3U) & 7U);
+        const std::uint32_t z = static_cast<std::uint32_t>((i >> 6U) & 7U);
+        std::uint32_t value = 0U;
+        switch (modality) {
+        case jarvisx::media8::MediaModality::Visual:
+            value = (31U * x + 17U * y + 11U * z + static_cast<std::uint32_t>(i / 512U)) & 0xFFU;
+            break;
+        case jarvisx::media8::MediaModality::Audio:
+            value = (128U + ((37U * static_cast<std::uint32_t>(i)) & 0x7FU)) & 0xFFU;
+            break;
+        case jarvisx::media8::MediaModality::Text: {
+            static constexpr char text[] = "I AM = I DESCRIBE | DR MOAGI INTELLIGENCE MEDIA PROCESSOR | ";
+            value = static_cast<std::uint8_t>(text[i % (sizeof(text) - 1U)]);
+            break;
+        }
+        case jarvisx::media8::MediaModality::Generic:
+            value = static_cast<std::uint32_t>((i * 73U + 19U) ^ (i >> 3U)) & 0xFFU;
+            break;
+        }
+        bytes[i] = static_cast<std::uint8_t>(value);
+    }
+    return bytes;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        std::vector<std::uint8_t> bytes = options.input.empty()
+            ? make_demo(options.demo_bytes, options.modality)
+            : read_binary(options.input);
+
+        jarvisx::media8::ProcessorConfig config;
+        config.max_output_mse = options.max_mse;
+        config.fallback_on_regression = options.fallback;
+
+        std::vector<std::uint8_t> program = options.bytecode.empty()
+            ? jarvisx::media8::default_media_program()
+            : read_binary(options.bytecode);
+
+        jarvisx::media8::DrMoagiIntelligenceMediaProcessor processor(config, program);
+        jarvisx::media8::ProcessorMetrics last{};
+        for (std::uint64_t pass = 0U; pass < options.passes; ++pass) {
+            auto result = processor.process(bytes, options.modality);
+            bytes = std::move(result.bytes);
+            last = result.metrics;
+            if (!options.quiet) {
+                std::cout << "pass=" << (pass + 1U)
+                          << " modality=" << jarvisx::media8::modality_name(last.modality)
+                          << " tiles=" << last.tiles
+                          << " accepted=" << last.accepted_tiles
+                          << " rejected=" << last.rejected_tiles
+                          << " candidate_mse=" << last.average_candidate_mse
+                          << " output_mse=" << last.average_output_mse
+                          << " hbar_semantic=" << last.hbar_semantic
+                          << " entropy=" << last.average_entropy
+                          << " active_nodes=" << last.average_active_nodes
+                          << " theta_commits=" << last.evolution_commits
+                          << " theta_rollbacks=" << last.evolution_rollbacks
+                          << '\n';
+            }
+        }
+
+        write_binary(options.output, bytes);
+        if (options.quiet) {
+            std::cout << "DMIMP OK bytes=" << bytes.size()
+                      << " tiles=" << last.tiles
+                      << " accepted=" << last.accepted_tiles
+                      << " rejected=" << last.rejected_tiles
+                      << " hbar=" << last.hbar_semantic << '\n';
+        } else {
+            std::cout << "output=" << options.output.string() << '\n';
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "dr-moagi-intelligence-media: " << error.what() << '\n';
+        return 2;
+    }
+}

--- a/cpp_runtime/src/intelligence_media_processor_main.cpp
+++ b/cpp_runtime/src/intelligence_media_processor_main.cpp
@@ -1,6 +1,7 @@
 #include "jarvisx/intelligence_media_processor.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <filesystem>

--- a/cpp_runtime/tests/intelligence_media_processor_tests.cpp
+++ b/cpp_runtime/tests/intelligence_media_processor_tests.cpp
@@ -1,0 +1,161 @@
+#include "jarvisx/intelligence_media_processor.hpp"
+
+#include <array>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+using namespace jarvisx::media8;
+
+namespace {
+
+std::array<std::uint8_t, kTileNodes> ramp_tile() {
+    std::array<std::uint8_t, kTileNodes> bytes{};
+    for (std::size_t i = 0U; i < bytes.size(); ++i) {
+        bytes[i] = static_cast<std::uint8_t>((i * 37U + (i >> 2U)) & 0xFFU);
+    }
+    return bytes;
+}
+
+void test_centered_byte_round_trip() {
+    for (const std::uint8_t value : {0U, 1U, 64U, 127U, 128U, 200U, 254U, 255U}) {
+        const std::uint8_t recovered = centered_to_byte(byte_to_centered(value));
+        assert(recovered == value || (value == 0U && recovered == 0U));
+    }
+}
+
+void test_boundary_convolution_is_defined() {
+    VCLTile8 tile;
+    std::array<std::uint8_t, kTileNodes> neutral{};
+    neutral.fill(128U);
+    tile.ingest_tile(neutral);
+    tile.ingest_plane(0U, 200U);
+    tile.conv3d(1U, 0U);
+    const auto& nodes = tile.nodes();
+    const int corner = static_cast<int>(nodes[tile_index(0U, 0U, 0U)].state);
+    const int adjacent = static_cast<int>(nodes[tile_index(0U, 0U, 1U)].state);
+    assert(corner != 0);
+    assert(adjacent != 0);
+}
+
+void test_true_entropy_distinguishes_uniform_and_varied_tiles() {
+    VCLTile8 tile;
+    std::array<std::uint8_t, kTileNodes> uniform{};
+    uniform.fill(77U);
+    tile.ingest_tile(uniform);
+    const double uniform_entropy = tile.eval_entropy(0U, 1U);
+    assert(std::fabs(uniform_entropy) < 1.0e-12);
+
+    auto varied = ramp_tile();
+    tile.ingest_tile(varied);
+    const double varied_entropy = tile.eval_entropy(0U, 1U);
+    assert(varied_entropy > 0.5);
+    assert(varied_entropy <= 1.0);
+}
+
+void test_vcl_program_executes_to_sync_lock() {
+    VCLTile8 tile;
+    const auto bytes = ramp_tile();
+    tile.ingest_tile(bytes);
+    VCLBVM8 vm(tile);
+    const TileMetrics metrics = vm.execute(default_media_program());
+    assert(metrics.synchronized);
+    assert(metrics.active_nodes <= kTileNodes);
+    assert(std::isfinite(metrics.reconstruction_mse));
+    assert(std::isfinite(metrics.normalized_entropy));
+    assert(metrics.evolution_commits + metrics.evolution_rollbacks == 1U);
+}
+
+void test_documented_vcl_cycle_executes() {
+    VCLTile8 tile;
+    std::array<std::uint8_t, kTileNodes> initial{};
+    initial.fill(128U);
+    tile.ingest_tile(initial);
+    const std::vector<std::uint8_t> program = {
+        0x10U, 0x00U, 0xC8U,
+        0x40U, 0x01U, 0x04U,
+        0x30U, 0x01U, 0x40U,
+        0x20U, 0x00U, 0x02U,
+        0x50U, 0x00U, 0x10U,
+        0x60U, 0x01U,
+        0x80U, 0x02U,
+        0x70U, 0x05U, 0x07U,
+        0xFFU,
+    };
+    VCLBVM8 vm(tile);
+    const TileMetrics metrics = vm.execute(program);
+    assert(metrics.synchronized);
+    assert(std::isfinite(metrics.reconstruction_mse));
+}
+
+void test_truncated_bytecode_is_rejected() {
+    VCLTile8 tile;
+    const std::vector<std::uint8_t> truncated = {0x40U, 0x01U};
+    VCLBVM8 vm(tile);
+    bool threw = false;
+    try {
+        (void)vm.execute(truncated);
+    } catch (const std::runtime_error&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+void test_lambda_fallback_preserves_media_bytes_and_adaptive_state() {
+    ProcessorConfig config;
+    config.max_output_mse = 0.0;
+    config.fallback_on_regression = true;
+    DrMoagiIntelligenceMediaProcessor processor(config);
+
+    std::vector<std::uint8_t> input(1500U);
+    for (std::size_t i = 0U; i < input.size(); ++i) {
+        input[i] = static_cast<std::uint8_t>((i * 73U + 29U) & 0xFFU);
+    }
+    const AdaptiveSnapshot before = processor.tile().adaptive_snapshot();
+    const ProcessorResult result = processor.process(input, MediaModality::Visual);
+    const AdaptiveSnapshot after = processor.tile().adaptive_snapshot();
+
+    assert(result.bytes == input);
+    assert(result.metrics.tiles == 3U);
+    assert(result.metrics.accepted_tiles + result.metrics.rejected_tiles == 3U);
+    assert(result.metrics.rejected_tiles > 0U);
+    assert(result.metrics.average_output_mse == 0.0);
+    assert(result.metrics.hbar_semantic == 0.0);
+    assert(before.weights == after.weights);
+    assert(before.omega == after.omega);
+}
+
+void test_processor_is_deterministic() {
+    std::vector<std::uint8_t> input(2048U);
+    for (std::size_t i = 0U; i < input.size(); ++i) {
+        input[i] = static_cast<std::uint8_t>((i * 17U + (i >> 1U)) & 0xFFU);
+    }
+    DrMoagiIntelligenceMediaProcessor left;
+    DrMoagiIntelligenceMediaProcessor right;
+    const auto left_result = left.process(input, MediaModality::Audio);
+    const auto right_result = right.process(input, MediaModality::Audio);
+    assert(left_result.bytes == right_result.bytes);
+    assert(left_result.metrics.tiles == right_result.metrics.tiles);
+    assert(left_result.metrics.accepted_tiles == right_result.metrics.accepted_tiles);
+    assert(left_result.metrics.rejected_tiles == right_result.metrics.rejected_tiles);
+    assert(left_result.metrics.average_candidate_mse == right_result.metrics.average_candidate_mse);
+    assert(left_result.metrics.hbar_semantic == right_result.metrics.hbar_semantic);
+}
+
+} // namespace
+
+int main() {
+    test_centered_byte_round_trip();
+    test_boundary_convolution_is_defined();
+    test_true_entropy_distinguishes_uniform_and_varied_tiles();
+    test_vcl_program_executes_to_sync_lock();
+    test_documented_vcl_cycle_executes();
+    test_truncated_bytecode_is_rejected();
+    test_lambda_fallback_preserves_media_bytes_and_adaptive_state();
+    test_processor_is_deterministic();
+    std::cout << "intelligence_media_processor_tests: OK\n";
+    return 0;
+}

--- a/docs/DR_MOAGI_INTELLIGENCE_MEDIA_PROCESSOR.md
+++ b/docs/DR_MOAGI_INTELLIGENCE_MEDIA_PROCESSOR.md
@@ -1,0 +1,209 @@
+# Dr Moagi Intelligence Media Processor
+
+## Operational contract
+
+The Dr Moagi Intelligence Media Processor (DM-IMP) is a bounded 8-bit spatial media execution layer for Jarvis-X. It does not replace the global sparse JX3DVM1 address space. Instead, arbitrary input bytes are divided into `8 x 8 x 8 = 512` byte tiles and processed locally through VCL-BVM-8.
+
+The execution hierarchy is:
+
+```text
+arbitrary media bytes
+      |
+      v
+512-byte / 8x8x8 VCL tile
+      |
+      v
+CONV_3D_INT8 -> VCL_GATE -> ENC_SPATIAL -> EVAL_ENTROPY
+      |                                         |
+      |                                         v
+      |                                  PRUNE_LATTICE
+      |                                         |
+      +-----------------> AUTO_EVOLVE <---------+
+                              |
+                              v
+                       DEC_BYTECODE
+                              |
+                              v
+                         SYNC_LOCK
+                              |
+                              v
+                 Lambda quality validation
+                    /               \
+                 accept            reject
+                   |                  |
+                   v                  v
+              keep Theta/Omega   restore Theta/Omega
+                   |                  |
+                   +-------> output/fallback
+```
+
+The implementation maps the project stack to explicit machine state:
+
+- **Psi**: the complete tile observation/transform path;
+- **Phi**: `ENC_SPATIAL` plus `DEC_BYTECODE`, giving an executable description/reconstruction operator;
+- **Lambda**: the outer MSE quality gate and the inner candidate comparison in `AUTO_EVOLVE`;
+- **Omega**: an 8-element integer latent memory fused into the 2x2x2 core;
+- **Theta**: 512 signed 8-bit adaptive node weights;
+- **M-hat**: `logic_mask AND control_flag` at each node;
+- **hbar_semantic**: normalized output RMSE, `sqrt(MSE) / 255`.
+
+A rejected tile restores both Theta and Omega to the snapshot taken before execution. If fallback is enabled, the original input tile is emitted, so a failed candidate cannot silently degrade authoritative media bytes.
+
+## VCL-BVM-8 wire format
+
+Except for `SYNC_LOCK = 0xFF`, each one-byte instruction header is split as:
+
+```text
+7 6 5 4 | 3 2 1 0
+ opcode | mode/reg
+```
+
+The current v1 implementation reserves the low nibble for future addressing/register modes and dispatches on the high nibble.
+
+| High nibble | Mnemonic | Payload | Runtime behavior |
+| --- | --- | --- | --- |
+| `0x10` | `INGEST_RAW` | `z_slice, value` | Fill one Z plane with a byte value |
+| `0x20` | `ENC_SPATIAL` | `z_start, z_end` | Average active nodes into a 2x2x2 core and fuse Omega |
+| `0x30` | `VCL_GATE` | `gate, threshold` | AND/OR/XOR/NOT control gating |
+| `0x40` | `CONV_3D_INT8` | `kernel_id, bias` | Signed INT8 3x3x3 convolution with defined boundary clamping |
+| `0x50` | `EVAL_ENTROPY` | `shell_id, threshold` | Compute actual empirical byte entropy and raise prune request |
+| `0x60` | `PRUNE_LATTICE` | `target_mask` | Apply requested low-information/control pruning |
+| `0x70` | `DEC_BYTECODE` | `z_start, z_end` | Decode the fused core back into tile space |
+| `0x80` | `AUTO_EVOLVE` | `learning_rate` | Stage residual weight update and retain it only if reconstruction MSE does not increase |
+| `0xFF` | `SYNC_LOCK` | none | Commit Omega update and end the VCL cycle |
+
+All instruction payload reads are bounds checked. Streams that end without `SYNC_LOCK`, contain an unknown opcode/kernel/gate/shell, address an invalid Z range, or exceed the instruction ceiling are rejected.
+
+## Kernel bank
+
+The initial deterministic convolution bank provides four signed integer kernels:
+
+1. `0`: identity;
+2. `1`: 27-point box smoothing;
+3. `2`: 3D Laplacian-style edge response;
+4. `3`: 6-neighbor sharpening.
+
+Every convolution uses a 32-bit accumulator and requantizes into signed INT8. Unlike the earlier reference pseudocode, the kernel operand is therefore active and boundary cells, including Z=0, are defined.
+
+## Inward encoding
+
+The input tile contains 512 signed states. The latent core contains 8 signed states:
+
+```text
+512 -> 8
+```
+
+which is a geometric state ratio of `64:1`. Each core bucket accumulates all active nodes with the corresponding `(x mod 2, y mod 2, z mod 2)` parity and divides once after accumulation. This avoids the order-dependent repeated half-average of the original pseudocode.
+
+The core then fuses bounded integer memory:
+
+```text
+core_fused = (3 * core_raw + Omega) / 4
+Omega_next = (7 * Omega + core_raw) / 8
+```
+
+`Omega_next` becomes authoritative only when the enclosing tile survives the Lambda quality gate.
+
+## Transactional auto-evolution
+
+`AUTO_EVOLVE` is deliberately candidate-first:
+
+```text
+W_before -> shadow decode -> baseline MSE
+         -> candidate residual update
+         -> shadow decode -> candidate MSE
+```
+
+The candidate is retained only if:
+
+```text
+candidate_MSE <= baseline_MSE
+```
+
+The processor then applies a second outer gate:
+
+```text
+candidate_MSE <= max_output_mse
+```
+
+A failure at the outer gate restores the complete adaptive snapshot, including weights and Omega.
+
+This is bounded model-state adaptation. It does not rewrite source code, execute host commands, or establish a claim of frontier/SOTA intelligence.
+
+## Media interface
+
+The processor accepts arbitrary binary input, so it can operate on encoded image, audio, text, video, container, model or generic byte streams without a codec dependency. At this layer media modality is an execution/telemetry classification rather than a promise that compressed file formats remain semantically decodable after lossy transformation.
+
+For format-aware image/audio/video processing, codec-specific adapters should decode the source format into raw frames/samples before DM-IMP and re-encode after processing.
+
+## CLI
+
+CMake target:
+
+```text
+jarvisx-intelligence-media
+```
+
+Windows output name:
+
+```text
+DrMoagi-Intelligence-Media.exe
+```
+
+Process a file:
+
+```powershell
+.\DrMoagi-Intelligence-Media.exe `
+  --input .\input.bin `
+  --output .\processed.bin `
+  --modality generic `
+  --passes 2 `
+  --max-mse 4096
+```
+
+Run the deterministic visual demo:
+
+```powershell
+.\DrMoagi-Intelligence-Media.exe `
+  --demo-bytes 4096 `
+  --modality visual `
+  --passes 2 `
+  --output .\demo-media.bin
+```
+
+Execute a custom raw VCL-BVM-8 program:
+
+```powershell
+.\DrMoagi-Intelligence-Media.exe `
+  --input .\input.bin `
+  --bytecode .\program.vcl8 `
+  --output .\processed.bin
+```
+
+## Canonical default program
+
+```text
+40 00 00       CONV_3D_INT8 identity, bias 0
+30 02 00       VCL_GATE OR, threshold 0
+20 00 07       ENC_SPATIAL all Z slices
+50 00 08       EVAL_ENTROPY whole tile, threshold 8
+60 01          PRUNE_LATTICE gate-disabled nodes
+80 08          AUTO_EVOLVE rate 8
+70 00 07       DEC_BYTECODE complete tile
+FF             SYNC_LOCK
+```
+
+## Verification
+
+`intelligence_media_processor_tests.cpp` checks:
+
+- signed byte centering round trips;
+- defined convolution at the tile boundary;
+- true entropy distinguishes uniform and varied tiles;
+- default VCL execution reaches `SYNC_LOCK`;
+- the corrected documented VCL cycle executes;
+- truncated bytecode is rejected;
+- Lambda fallback preserves original bytes and restores adaptive state;
+- deterministic replay produces identical results.
+
+CMake also registers a full executable smoke run so the CLI path is exercised by the existing cross-platform C++ workflow.


### PR DESCRIPTION
## Summary

Adds a fully executable bounded Dr Moagi Intelligence Media Processor (DM-IMP) as an 8-bit 3D tile execution layer inside the existing Jarvis-X runtime architecture.

### Runtime
- Adds `VCL-BVM-8` with high-nibble opcode / low-nibble mode decoding.
- Implements signed 8-bit `8x8x8` spatial nodes and a `2x2x2` inward core.
- Implements actual 3x3x3 kernel selection, defined boundary convolution, VCL AND/OR/XOR/NOT gating, true empirical byte entropy, explicit `PRUNE_LATTICE`, inward encode/decode, bounded residual `AUTO_EVOLVE`, and `SYNC_LOCK`.
- Maps Psi/Phi/Lambda/Omega/Theta to executable state transitions.
- Stages adaptive changes transactionally: rejected output tiles restore both Theta weights and Omega memory.
- Exposes normalized semantic residual as `hbar_semantic = sqrt(output_MSE)/255`.

### Media execution
- Adds `DrMoagi-Intelligence-Media` CLI.
- Processes arbitrary binary/media streams in 512-byte spatial tiles.
- Supports visual/audio/text/generic modality classification, repeated inward passes, custom raw VCL bytecode, MSE quality gates, deterministic demo input, and loss-protecting fallback.

### Verification
- Adds boundary convolution, entropy, bytecode safety, documented VCL cycle, transactional rollback, adaptive-state restoration, deterministic replay and processor-length tests.
- Adds executable smoke coverage to the existing cross-platform CMake/CTest matrix.

### Scope
This is a bounded deterministic/reference intelligence media processor and transactional adaptive runtime. It does not claim codec-aware semantics for arbitrary compressed file formats or external SOTA performance without benchmark evidence.