### PR TITLE
Build end-to-end DM-vOmegaXi+ pixels-to-bits codec

### DIFF
--- a/.github/workflows/pixels-to-bits-windows.yml
+++ b/.github/workflows/pixels-to-bits-windows.yml
@@ -1,0 +1,103 @@
+name: Dr Moagi Pixels-to-Bits Windows
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/include/jarvisx/dm8kb_container.hpp"
+      - "cpp_runtime/include/jarvisx/pixels_to_bits_codec.hpp"
+      - "cpp_runtime/src/pixels_to_bits_main.cpp"
+      - "cpp_runtime/tests/pixels_to_bits_tests.cpp"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/PIXELS_TO_BITS_8K120_REFERENCE.md"
+      - ".github/workflows/pixels-to-bits-windows.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/include/jarvisx/dm8kb_container.hpp"
+      - "cpp_runtime/include/jarvisx/pixels_to_bits_codec.hpp"
+      - "cpp_runtime/src/pixels_to_bits_main.cpp"
+      - "cpp_runtime/tests/pixels_to_bits_tests.cpp"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/PIXELS_TO_BITS_8K120_REFERENCE.md"
+      - ".github/workflows/pixels-to-bits-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pixels-to-bits-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-package:
+    name: Windows x64 / MSVC
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure CMake
+        shell: pwsh
+        run: >-
+          cmake -S cpp_runtime -B build/pixels-to-bits
+          -A x64
+          -DJARVISX_BUILD_GL_VISUALIZER=OFF
+          -DJARVISX_ENABLE_SANITIZERS=OFF
+
+      - name: Build executable and focused tests
+        shell: pwsh
+        run: |
+          cmake --build build/pixels-to-bits --config Release --target jarvisx-pixels-to-bits --parallel 2
+          cmake --build build/pixels-to-bits --config Release --target jarvisx-pixels-to-bits-tests --parallel 2
+
+      - name: Run focused regression and smoke tests
+        shell: pwsh
+        run: |
+          ctest --test-dir build/pixels-to-bits -C Release -R "pixels-to-bits-(regressions|runtime-smoke)" --output-on-failure
+
+      - name: Execute near-lossless reference profile
+        shell: pwsh
+        run: |
+          $exe = "build/pixels-to-bits/Release/DrMoagi-Pixels-to-Bits.exe"
+          & $exe --width 64 --height 64 --fps 120 --max-shift 4 --max-mse 100 --min-psnr 40 --encoded build/pixels-to-bits/near-lossless.dmpb --decoded build/pixels-to-bits/near-lossless.ppm
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Execute exact lossless profile
+        shell: pwsh
+        run: |
+          $exe = "build/pixels-to-bits/Release/DrMoagi-Pixels-to-Bits.exe"
+          & $exe --width 16 --height 16 --fps 120 --lossless --encoded build/pixels-to-bits/lossless.dmpb --decoded build/pixels-to-bits/lossless.ppm
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stage package and checksum
+        shell: pwsh
+        run: |
+          $stage = "build/pixels-to-bits/package"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "build/pixels-to-bits/Release/DrMoagi-Pixels-to-Bits.exe" "$stage/DrMoagi-Pixels-to-Bits.exe"
+          Copy-Item "build/pixels-to-bits/near-lossless.dmpb" "$stage/near-lossless.dmpb"
+          Copy-Item "build/pixels-to-bits/near-lossless.ppm" "$stage/near-lossless.ppm"
+          Copy-Item "build/pixels-to-bits/lossless.dmpb" "$stage/lossless.dmpb"
+          Copy-Item "build/pixels-to-bits/lossless.ppm" "$stage/lossless.ppm"
+          Copy-Item "docs/PIXELS_TO_BITS_8K120_REFERENCE.md" "$stage/README.md"
+          $hash = (Get-FileHash "$stage/DrMoagi-Pixels-to-Bits.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  DrMoagi-Pixels-to-Bits.exe" | Set-Content -Encoding ascii "$stage/SHA256SUMS.txt"
+          Compress-Archive -Path "$stage/*" -DestinationPath "build/pixels-to-bits/DrMoagi-Pixels-to-Bits-Windows-x64.zip" -Force
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: DrMoagi-Pixels-to-Bits-Windows-x64
+          path: |
+            build/pixels-to-bits/package/DrMoagi-Pixels-to-Bits.exe
+            build/pixels-to-bits/package/near-lossless.dmpb
+            build/pixels-to-bits/package/near-lossless.ppm
+            build/pixels-to-bits/package/lossless.dmpb
+            build/pixels-to-bits/package/lossless.ppm
+            build/pixels-to-bits/package/README.md
+            build/pixels-to-bits/package/SHA256SUMS.txt
+            build/pixels-to-bits/DrMoagi-Pixels-to-Bits-Windows-x64.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -70,6 +70,13 @@ set_target_properties(jarvisx-intelligence-media PROPERTIES OUTPUT_NAME "DrMoagi
 jarvisx_include_runtime(jarvisx-intelligence-media)
 jarvisx_harden(jarvisx-intelligence-media)
 
+add_executable(jarvisx-pixels-to-bits
+    src/pixels_to_bits_main.cpp
+)
+set_target_properties(jarvisx-pixels-to-bits PROPERTIES OUTPUT_NAME "DrMoagi-Pixels-to-Bits")
+jarvisx_include_runtime(jarvisx-pixels-to-bits)
+jarvisx_harden(jarvisx-pixels-to-bits)
+
 if(JARVISX_BUILD_GL_VISUALIZER)
     find_package(OpenGL QUIET)
     find_package(GLUT QUIET)
@@ -183,6 +190,18 @@ add_test(
 )
 set_tests_properties(intelligence-media-runtime-smoke PROPERTIES TIMEOUT 120)
 
+add_test(
+    NAME pixels-to-bits-runtime-smoke
+    COMMAND jarvisx-pixels-to-bits
+        --width 16
+        --height 16
+        --lossless
+        --encoded ${CMAKE_CURRENT_BINARY_DIR}/pixels-to-bits-smoke.dmpb
+        --decoded ${CMAKE_CURRENT_BINARY_DIR}/pixels-to-bits-smoke.ppm
+        --quiet
+)
+set_tests_properties(pixels-to-bits-runtime-smoke PROPERTIES TIMEOUT 120)
+
 add_executable(jarvisx-processor-tests
     tests/processor_tests.cpp
 )
@@ -245,3 +264,12 @@ jarvisx_harden(jarvisx-intelligence-media-tests)
 
 add_test(NAME intelligence-media-regressions COMMAND jarvisx-intelligence-media-tests)
 set_tests_properties(intelligence-media-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-pixels-to-bits-tests
+    tests/pixels_to_bits_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-pixels-to-bits-tests)
+jarvisx_harden(jarvisx-pixels-to-bits-tests)
+
+add_test(NAME pixels-to-bits-regressions COMMAND jarvisx-pixels-to-bits-tests)
+set_tests_properties(pixels-to-bits-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/include/jarvisx/dm8kb_container.hpp
+++ b/cpp_runtime/include/jarvisx/dm8kb_container.hpp
@@ -1,0 +1,321 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace jarvisx::dm8kb {
+
+constexpr std::size_t kContainerBytes = 8192U;
+constexpr std::size_t kRegionCount = 10U;
+
+enum class Region : std::uint8_t {
+    Control = 0U,
+    VclState = 1U,
+    Theta = 2U,
+    Masks = 3U,
+    Omega = 4U,
+    Microcode = 5U,
+    Residual = 6U,
+    Features = 7U,
+    Shadow = 8U,
+    Integrity = 9U,
+};
+
+struct RegionSpec {
+    Region region;
+    std::size_t offset;
+    std::size_t size;
+    const char* name;
+};
+
+constexpr std::array<RegionSpec, kRegionCount> kRegions{{
+    {Region::Control, 0x0000U, 128U, "CONTROL"},
+    {Region::VclState, 0x0080U, 512U, "VCL_STATE"},
+    {Region::Theta, 0x0280U, 512U, "THETA"},
+    {Region::Masks, 0x0480U, 128U, "MASKS"},
+    {Region::Omega, 0x0500U, 512U, "OMEGA"},
+    {Region::Microcode, 0x0700U, 1024U, "MICROCODE"},
+    {Region::Residual, 0x0B00U, 2048U, "RESIDUAL"},
+    {Region::Features, 0x1300U, 2048U, "FEATURES"},
+    {Region::Shadow, 0x1B00U, 1024U, "SHADOW"},
+    {Region::Integrity, 0x1F00U, 256U, "INTEGRITY"},
+}};
+
+constexpr std::size_t region_offset(Region region) noexcept {
+    return kRegions[static_cast<std::size_t>(region)].offset;
+}
+
+constexpr std::size_t region_size(Region region) noexcept {
+    return kRegions[static_cast<std::size_t>(region)].size;
+}
+
+constexpr bool layout_is_exact() noexcept {
+    std::size_t cursor = 0U;
+    for (const RegionSpec& spec : kRegions) {
+        if (spec.offset != cursor) return false;
+        cursor += spec.size;
+    }
+    return cursor == kContainerBytes;
+}
+
+static_assert(layout_is_exact(), "DM-vOmegaXi+ container map must total exactly 8192 bytes");
+
+struct CommitReceipt {
+    std::uint64_t prior_digest{};
+    std::uint64_t candidate_digest{};
+    std::uint64_t result_digest{};
+    std::uint64_t microcode_digest{};
+    std::uint64_t epoch{};
+    std::uint16_t changed_regions{};
+    std::uint32_t semantic_gap_q24{};
+    std::uint32_t state_delta_q24{};
+    bool accepted{};
+};
+
+inline std::uint64_t fnv1a64(const std::uint8_t* data, std::size_t size) noexcept {
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (std::size_t i = 0U; i < size; ++i) {
+        hash ^= static_cast<std::uint64_t>(data[i]);
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+class Container {
+public:
+    Container() { reset(); }
+
+    void reset() noexcept {
+        bytes_.fill(0U);
+        constexpr std::array<std::uint8_t, 8U> magic{{
+            'D', 'M', '8', 'K', 'B', '1', 0U, 0U,
+        }};
+        std::copy(magic.begin(), magic.end(), bytes_.begin());
+        write_u16_unchecked(8U, 1U);
+        write_u16_unchecked(10U, static_cast<std::uint16_t>(kContainerBytes));
+    }
+
+    const std::array<std::uint8_t, kContainerBytes>& bytes() const noexcept { return bytes_; }
+    std::array<std::uint8_t, kContainerBytes> snapshot() const noexcept { return bytes_; }
+
+    void restore(const std::array<std::uint8_t, kContainerBytes>& snapshot) noexcept {
+        bytes_ = snapshot;
+    }
+
+    std::uint8_t read(std::size_t offset) const {
+        check_bounds(offset, 1U);
+        return bytes_[offset];
+    }
+
+    void write(std::size_t offset, std::uint8_t value) {
+        check_bounds(offset, 1U);
+        bytes_[offset] = value;
+    }
+
+    void write_region(Region region, const std::uint8_t* data, std::size_t size) {
+        if (size > region_size(region)) {
+            throw std::out_of_range(std::string("DM8KB region overflow: ") +
+                                    kRegions[static_cast<std::size_t>(region)].name);
+        }
+        const std::size_t offset = region_offset(region);
+        std::fill(bytes_.begin() + static_cast<std::ptrdiff_t>(offset),
+                  bytes_.begin() + static_cast<std::ptrdiff_t>(offset + region_size(region)), 0U);
+        if (size != 0U) {
+            std::copy_n(data, static_cast<std::ptrdiff_t>(size),
+                        bytes_.begin() + static_cast<std::ptrdiff_t>(offset));
+        }
+    }
+
+    void write_region(Region region, const std::vector<std::uint8_t>& values) {
+        write_region(region, values.data(), values.size());
+    }
+
+    std::vector<std::uint8_t> read_region(Region region, std::size_t size) const {
+        if (size > region_size(region)) throw std::out_of_range("DM8KB region read overflow");
+        const std::size_t offset = region_offset(region);
+        return std::vector<std::uint8_t>(
+            bytes_.begin() + static_cast<std::ptrdiff_t>(offset),
+            bytes_.begin() + static_cast<std::ptrdiff_t>(offset + size));
+    }
+
+    void set_microcode(const std::vector<std::uint8_t>& program) {
+        if (program.empty() || program.size() > region_size(Region::Microcode)) {
+            throw std::invalid_argument("DM8KB microcode must fit in 1024 bytes and be non-empty");
+        }
+        write_region(Region::Microcode, program);
+        write_u16(12U, static_cast<std::uint16_t>(program.size()));
+    }
+
+    std::size_t microcode_size() const noexcept { return static_cast<std::size_t>(read_u16_unchecked(12U)); }
+
+    std::vector<std::uint8_t> microcode() const {
+        const std::size_t size = microcode_size();
+        if (size == 0U || size > region_size(Region::Microcode)) {
+            throw std::runtime_error("DM8KB invalid microcode length");
+        }
+        return read_region(Region::Microcode, size);
+    }
+
+    void stage_shadow(const std::vector<std::uint8_t>& candidate) {
+        if (candidate.size() > region_size(Region::Shadow)) {
+            throw std::out_of_range("DM8KB shadow candidate exceeds 1024 bytes");
+        }
+        write_region(Region::Shadow, candidate);
+        write_u16(14U, static_cast<std::uint16_t>(candidate.size()));
+    }
+
+    std::size_t shadow_size() const noexcept { return static_cast<std::size_t>(read_u16_unchecked(14U)); }
+
+    std::uint64_t epoch() const noexcept { return read_u64_unchecked(16U); }
+
+    void set_epoch(std::uint64_t value) noexcept { write_u64_unchecked(16U, value); }
+
+    void increment_epoch() noexcept { set_epoch(epoch() + 1ULL); }
+
+    std::uint64_t digest() const noexcept {
+        return fnv1a64(bytes_.data(), region_offset(Region::Integrity));
+    }
+
+    std::uint64_t microcode_digest() const {
+        const std::size_t size = microcode_size();
+        if (size == 0U || size > region_size(Region::Microcode)) return 0ULL;
+        return fnv1a64(bytes_.data() + region_offset(Region::Microcode), size);
+    }
+
+    void write_receipt(const CommitReceipt& receipt) noexcept {
+        const std::size_t base = region_offset(Region::Integrity);
+        std::fill(bytes_.begin() + static_cast<std::ptrdiff_t>(base), bytes_.end(), 0U);
+        write_u64_unchecked(base + 0U, receipt.prior_digest);
+        write_u64_unchecked(base + 8U, receipt.candidate_digest);
+        write_u64_unchecked(base + 16U, receipt.result_digest);
+        write_u64_unchecked(base + 24U, receipt.microcode_digest);
+        write_u64_unchecked(base + 32U, receipt.epoch);
+        write_u16_unchecked(base + 40U, receipt.changed_regions);
+        write_u32_unchecked(base + 42U, receipt.semantic_gap_q24);
+        write_u32_unchecked(base + 46U, receipt.state_delta_q24);
+        bytes_[base + 50U] = receipt.accepted ? 1U : 0U;
+    }
+
+    CommitReceipt receipt() const noexcept {
+        const std::size_t base = region_offset(Region::Integrity);
+        CommitReceipt result;
+        result.prior_digest = read_u64_unchecked(base + 0U);
+        result.candidate_digest = read_u64_unchecked(base + 8U);
+        result.result_digest = read_u64_unchecked(base + 16U);
+        result.microcode_digest = read_u64_unchecked(base + 24U);
+        result.epoch = read_u64_unchecked(base + 32U);
+        result.changed_regions = read_u16_unchecked(base + 40U);
+        result.semantic_gap_q24 = read_u32_unchecked(base + 42U);
+        result.state_delta_q24 = read_u32_unchecked(base + 46U);
+        result.accepted = bytes_[base + 50U] != 0U;
+        return result;
+    }
+
+    static std::uint16_t changed_region_bitmap(
+        const std::array<std::uint8_t, kContainerBytes>& before,
+        const std::array<std::uint8_t, kContainerBytes>& after) noexcept {
+        std::uint16_t bitmap = 0U;
+        for (std::size_t r = 0U; r < kRegions.size(); ++r) {
+            const RegionSpec& spec = kRegions[r];
+            bool changed = false;
+            for (std::size_t i = 0U; i < spec.size; ++i) {
+                if (before[spec.offset + i] != after[spec.offset + i]) {
+                    changed = true;
+                    break;
+                }
+            }
+            if (changed) bitmap = static_cast<std::uint16_t>(bitmap | static_cast<std::uint16_t>(1U << r));
+        }
+        return bitmap;
+    }
+
+    static double normalized_delta(
+        const std::array<std::uint8_t, kContainerBytes>& before,
+        const std::array<std::uint8_t, kContainerBytes>& after) noexcept {
+        std::size_t changed = 0U;
+        for (std::size_t i = 0U; i < kContainerBytes; ++i) {
+            if (before[i] != after[i]) ++changed;
+        }
+        return static_cast<double>(changed) / static_cast<double>(kContainerBytes);
+    }
+
+    static std::size_t torus_index(int x, int y, int z) noexcept {
+        constexpr int edge = 8;
+        const auto wrap = [](int value) noexcept {
+            constexpr int local_edge = 8;
+            int result = value % local_edge;
+            if (result < 0) result += local_edge;
+            return static_cast<std::size_t>(result);
+        };
+        const std::size_t wx = wrap(x);
+        const std::size_t wy = wrap(y);
+        const std::size_t wz = wrap(z);
+        (void)edge;
+        return (wz * 8U + wy) * 8U + wx;
+    }
+
+private:
+    std::array<std::uint8_t, kContainerBytes> bytes_{};
+
+    static void check_bounds(std::size_t offset, std::size_t size) {
+        if (offset > kContainerBytes || size > kContainerBytes - offset) {
+            throw std::out_of_range("DM8KB container-local access outside 8192-byte boundary");
+        }
+    }
+
+    void write_u16(std::size_t offset, std::uint16_t value) {
+        check_bounds(offset, 2U);
+        write_u16_unchecked(offset, value);
+    }
+
+    void write_u16_unchecked(std::size_t offset, std::uint16_t value) noexcept {
+        bytes_[offset] = static_cast<std::uint8_t>(value & 0xFFU);
+        bytes_[offset + 1U] = static_cast<std::uint8_t>((value >> 8U) & 0xFFU);
+    }
+
+    std::uint16_t read_u16_unchecked(std::size_t offset) const noexcept {
+        return static_cast<std::uint16_t>(bytes_[offset]) |
+               static_cast<std::uint16_t>(static_cast<std::uint16_t>(bytes_[offset + 1U]) << 8U);
+    }
+
+    void write_u32_unchecked(std::size_t offset, std::uint32_t value) noexcept {
+        for (std::size_t i = 0U; i < 4U; ++i) {
+            bytes_[offset + i] = static_cast<std::uint8_t>((value >> (8U * i)) & 0xFFU);
+        }
+    }
+
+    std::uint32_t read_u32_unchecked(std::size_t offset) const noexcept {
+        std::uint32_t value = 0U;
+        for (std::size_t i = 0U; i < 4U; ++i) {
+            value |= static_cast<std::uint32_t>(bytes_[offset + i]) << (8U * i);
+        }
+        return value;
+    }
+
+    void write_u64_unchecked(std::size_t offset, std::uint64_t value) noexcept {
+        for (std::size_t i = 0U; i < 8U; ++i) {
+            bytes_[offset + i] = static_cast<std::uint8_t>((value >> (8U * i)) & 0xFFULL);
+        }
+    }
+
+    std::uint64_t read_u64_unchecked(std::size_t offset) const noexcept {
+        std::uint64_t value = 0ULL;
+        for (std::size_t i = 0U; i < 8U; ++i) {
+            value |= static_cast<std::uint64_t>(bytes_[offset + i]) << (8U * i);
+        }
+        return value;
+    }
+};
+
+inline std::uint32_t q24(double value) noexcept {
+    const double clamped = std::clamp(value, 0.0, 255.9999999403953552);
+    return static_cast<std::uint32_t>(clamped * 16777216.0);
+}
+
+} // namespace jarvisx::dm8kb

--- a/cpp_runtime/include/jarvisx/dm8kb_container.hpp
+++ b/cpp_runtime/include/jarvisx/dm8kb_container.hpp
@@ -4,7 +4,6 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -79,7 +78,7 @@ struct CommitReceipt {
 };
 
 inline std::uint64_t fnv1a64(const std::uint8_t* data, std::size_t size) noexcept {
-    std::uint64_t hash = 1469598103934665603ULL;
+    std::uint64_t hash = 14695981039346656037ULL;
     for (std::size_t i = 0U; i < size; ++i) {
         hash ^= static_cast<std::uint64_t>(data[i]);
         hash *= 1099511628211ULL;
@@ -92,7 +91,7 @@ public:
     Container() { reset(); }
 
     void reset() noexcept {
-        bytes_.fill(0U);
+        bytes_.fill(std::uint8_t{0U});
         constexpr std::array<std::uint8_t, 8U> magic{{
             'D', 'M', '8', 'K', 'B', '1', 0U, 0U,
         }};
@@ -125,7 +124,8 @@ public:
         }
         const std::size_t offset = region_offset(region);
         std::fill(bytes_.begin() + static_cast<std::ptrdiff_t>(offset),
-                  bytes_.begin() + static_cast<std::ptrdiff_t>(offset + region_size(region)), 0U);
+                  bytes_.begin() + static_cast<std::ptrdiff_t>(offset + region_size(region)),
+                  std::uint8_t{0U});
         if (size != 0U) {
             std::copy_n(data, static_cast<std::ptrdiff_t>(size),
                         bytes_.begin() + static_cast<std::ptrdiff_t>(offset));
@@ -190,7 +190,7 @@ public:
 
     void write_receipt(const CommitReceipt& receipt) noexcept {
         const std::size_t base = region_offset(Region::Integrity);
-        std::fill(bytes_.begin() + static_cast<std::ptrdiff_t>(base), bytes_.end(), 0U);
+        std::fill(bytes_.begin() + static_cast<std::ptrdiff_t>(base), bytes_.end(), std::uint8_t{0U});
         write_u64_unchecked(base + 0U, receipt.prior_digest);
         write_u64_unchecked(base + 8U, receipt.candidate_digest);
         write_u64_unchecked(base + 16U, receipt.result_digest);
@@ -246,17 +246,15 @@ public:
     }
 
     static std::size_t torus_index(int x, int y, int z) noexcept {
-        constexpr int edge = 8;
         const auto wrap = [](int value) noexcept {
-            constexpr int local_edge = 8;
-            int result = value % local_edge;
-            if (result < 0) result += local_edge;
+            constexpr int edge = 8;
+            int result = value % edge;
+            if (result < 0) result += edge;
             return static_cast<std::size_t>(result);
         };
         const std::size_t wx = wrap(x);
         const std::size_t wy = wrap(y);
         const std::size_t wz = wrap(z);
-        (void)edge;
         return (wz * 8U + wy) * 8U + wx;
     }
 

--- a/cpp_runtime/include/jarvisx/pixels_to_bits_codec.hpp
+++ b/cpp_runtime/include/jarvisx/pixels_to_bits_codec.hpp
@@ -1,0 +1,832 @@
+#pragma once
+
+#include "jarvisx/dm8kb_container.hpp"
+#include "jarvisx/intelligence_media_processor.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jarvisx::pixels {
+
+constexpr std::uint16_t kMaxPixel10 = 1023U;
+constexpr std::size_t kChannels = 3U;
+constexpr std::size_t kPixelTileEdge = 8U;
+constexpr std::size_t kPixelsPerTile = kPixelTileEdge * kPixelTileEdge;
+
+struct Frame10 {
+    std::uint32_t width{};
+    std::uint32_t height{};
+    std::vector<std::uint16_t> rgb;
+
+    void validate() const {
+        if (width == 0U || height == 0U) throw std::invalid_argument("pixel frame dimensions must be positive");
+        const std::uint64_t samples = static_cast<std::uint64_t>(width) *
+                                      static_cast<std::uint64_t>(height) *
+                                      static_cast<std::uint64_t>(kChannels);
+        if (samples > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            throw std::overflow_error("pixel frame exceeds host addressable size");
+        }
+        if (rgb.size() != static_cast<std::size_t>(samples)) {
+            throw std::invalid_argument("pixel frame RGB sample count mismatch");
+        }
+        for (const std::uint16_t value : rgb) {
+            if (value > kMaxPixel10) throw std::invalid_argument("pixel sample exceeds 10-bit range");
+        }
+    }
+
+    std::uint16_t at(std::uint32_t x, std::uint32_t y, std::size_t channel) const {
+        if (x >= width || y >= height || channel >= kChannels) {
+            throw std::out_of_range("pixel coordinate outside frame");
+        }
+        const std::size_t index =
+            (static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+             static_cast<std::size_t>(x)) * kChannels + channel;
+        return rgb[index];
+    }
+
+    void set(std::uint32_t x, std::uint32_t y, std::size_t channel, std::uint16_t value) {
+        if (x >= width || y >= height || channel >= kChannels || value > kMaxPixel10) {
+            throw std::out_of_range("invalid 10-bit pixel write");
+        }
+        const std::size_t index =
+            (static_cast<std::size_t>(y) * static_cast<std::size_t>(width) +
+             static_cast<std::size_t>(x)) * kChannels + channel;
+        rgb[index] = value;
+    }
+};
+
+struct RawProfile {
+    std::uint32_t width{};
+    std::uint32_t height{};
+    std::uint32_t fps{};
+    std::uint64_t pixels{};
+    std::uint64_t raw_bits_per_frame{};
+    std::uint64_t packed_bytes_per_frame{};
+    double packed_gbytes_per_second{};
+    double frame_budget_ms{};
+};
+
+inline RawProfile raw_profile(std::uint32_t width, std::uint32_t height, std::uint32_t fps) {
+    if (width == 0U || height == 0U || fps == 0U) throw std::invalid_argument("profile dimensions/fps must be positive");
+    RawProfile profile;
+    profile.width = width;
+    profile.height = height;
+    profile.fps = fps;
+    profile.pixels = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height);
+    profile.raw_bits_per_frame = profile.pixels * 30ULL;
+    profile.packed_bytes_per_frame = (profile.raw_bits_per_frame + 7ULL) / 8ULL;
+    profile.packed_gbytes_per_second =
+        static_cast<double>(profile.packed_bytes_per_frame) * static_cast<double>(fps) / 1.0e9;
+    profile.frame_budget_ms = 1000.0 / static_cast<double>(fps);
+    return profile;
+}
+
+inline RawProfile uhd8k120_profile() { return raw_profile(7680U, 4320U, 120U); }
+
+class ByteWriter {
+public:
+    void u8(std::uint8_t value) { bytes_.push_back(value); }
+
+    void u16(std::uint16_t value) {
+        u8(static_cast<std::uint8_t>(value & 0xFFU));
+        u8(static_cast<std::uint8_t>((value >> 8U) & 0xFFU));
+    }
+
+    void u32(std::uint32_t value) {
+        for (std::size_t i = 0U; i < 4U; ++i) {
+            u8(static_cast<std::uint8_t>((value >> (8U * i)) & 0xFFU));
+        }
+    }
+
+    void u64(std::uint64_t value) {
+        for (std::size_t i = 0U; i < 8U; ++i) {
+            u8(static_cast<std::uint8_t>((value >> (8U * i)) & 0xFFULL));
+        }
+    }
+
+    void append(const std::vector<std::uint8_t>& values) {
+        bytes_.insert(bytes_.end(), values.begin(), values.end());
+    }
+
+    void append(const std::uint8_t* values, std::size_t size) {
+        if (size != 0U) bytes_.insert(bytes_.end(), values, values + size);
+    }
+
+    const std::vector<std::uint8_t>& bytes() const noexcept { return bytes_; }
+    std::vector<std::uint8_t> take() { return std::move(bytes_); }
+
+private:
+    std::vector<std::uint8_t> bytes_;
+};
+
+class ByteReader {
+public:
+    explicit ByteReader(const std::vector<std::uint8_t>& bytes) : bytes_(bytes) {}
+
+    std::uint8_t u8() {
+        require(1U);
+        return bytes_[offset_++];
+    }
+
+    std::uint16_t u16() {
+        const std::uint16_t a = static_cast<std::uint16_t>(u8());
+        const std::uint16_t b = static_cast<std::uint16_t>(u8());
+        return static_cast<std::uint16_t>(a | static_cast<std::uint16_t>(b << 8U));
+    }
+
+    std::uint32_t u32() {
+        std::uint32_t value = 0U;
+        for (std::size_t i = 0U; i < 4U; ++i) value |= static_cast<std::uint32_t>(u8()) << (8U * i);
+        return value;
+    }
+
+    std::uint64_t u64() {
+        std::uint64_t value = 0ULL;
+        for (std::size_t i = 0U; i < 8U; ++i) value |= static_cast<std::uint64_t>(u8()) << (8U * i);
+        return value;
+    }
+
+    std::vector<std::uint8_t> bytes(std::size_t count) {
+        require(count);
+        std::vector<std::uint8_t> result(
+            bytes_.begin() + static_cast<std::ptrdiff_t>(offset_),
+            bytes_.begin() + static_cast<std::ptrdiff_t>(offset_ + count));
+        offset_ += count;
+        return result;
+    }
+
+    std::size_t offset() const noexcept { return offset_; }
+    std::size_t remaining() const noexcept { return bytes_.size() - offset_; }
+
+private:
+    const std::vector<std::uint8_t>& bytes_;
+    std::size_t offset_{};
+
+    void require(std::size_t count) const {
+        if (count > bytes_.size() - offset_) throw std::runtime_error("truncated pixels-to-bits stream");
+    }
+};
+
+class BitWriter {
+public:
+    void write(std::uint32_t value, std::uint8_t bits) {
+        if (bits > 32U) throw std::invalid_argument("bit width above 32");
+        for (std::uint8_t bit = 0U; bit < bits; ++bit) {
+            if ((used_bits_ & 7U) == 0U) bytes_.push_back(0U);
+            const std::uint8_t one = static_cast<std::uint8_t>((value >> bit) & 1U);
+            bytes_.back() = static_cast<std::uint8_t>(
+                bytes_.back() | static_cast<std::uint8_t>(one << (used_bits_ & 7U)));
+            ++used_bits_;
+        }
+    }
+
+    const std::vector<std::uint8_t>& bytes() const noexcept { return bytes_; }
+
+private:
+    std::vector<std::uint8_t> bytes_;
+    std::uint32_t used_bits_{};
+};
+
+class BitReader {
+public:
+    explicit BitReader(const std::vector<std::uint8_t>& bytes) : bytes_(bytes) {}
+
+    std::uint32_t read(std::uint8_t bits) {
+        if (bits > 32U) throw std::invalid_argument("bit width above 32");
+        if (static_cast<std::uint64_t>(bit_offset_) + static_cast<std::uint64_t>(bits) >
+            static_cast<std::uint64_t>(bytes_.size()) * 8ULL) {
+            throw std::runtime_error("truncated packed residual bits");
+        }
+        std::uint32_t value = 0U;
+        for (std::uint8_t bit = 0U; bit < bits; ++bit) {
+            const std::size_t byte_index = bit_offset_ >> 3U;
+            const std::uint8_t bit_index = static_cast<std::uint8_t>(bit_offset_ & 7U);
+            const std::uint32_t one = static_cast<std::uint32_t>((bytes_[byte_index] >> bit_index) & 1U);
+            value |= one << bit;
+            ++bit_offset_;
+        }
+        return value;
+    }
+
+private:
+    const std::vector<std::uint8_t>& bytes_;
+    std::size_t bit_offset_{};
+};
+
+inline std::uint32_t zigzag_encode(int value) noexcept {
+    if (value >= 0) return static_cast<std::uint32_t>(value) * 2U;
+    return static_cast<std::uint32_t>(-value) * 2U - 1U;
+}
+
+inline int zigzag_decode(std::uint32_t value) noexcept {
+    if ((value & 1U) == 0U) return static_cast<int>(value >> 1U);
+    return -static_cast<int>((value + 1U) >> 1U);
+}
+
+inline std::uint8_t required_bits(std::uint32_t value) noexcept {
+    std::uint8_t bits = 0U;
+    while (value != 0U) {
+        ++bits;
+        value >>= 1U;
+    }
+    return bits;
+}
+
+inline int quantize_difference(int difference, int step) noexcept {
+    if (step <= 1) return difference;
+    const int half = step / 2;
+    if (difference >= 0) return (difference + half) / step;
+    return -((-difference + half) / step);
+}
+
+inline std::uint16_t clamp_pixel10(int value) noexcept {
+    return static_cast<std::uint16_t>(std::clamp(value, 0, static_cast<int>(kMaxPixel10)));
+}
+
+inline std::pair<std::uint8_t, std::uint8_t> morton_xy(std::uint8_t code) noexcept {
+    std::uint8_t x = 0U;
+    std::uint8_t y = 0U;
+    for (std::uint8_t bit = 0U; bit < 3U; ++bit) {
+        x = static_cast<std::uint8_t>(x | static_cast<std::uint8_t>(((code >> (2U * bit)) & 1U) << bit));
+        y = static_cast<std::uint8_t>(y | static_cast<std::uint8_t>(((code >> (2U * bit + 1U)) & 1U) << bit));
+    }
+    return {x, y};
+}
+
+struct TileCandidate {
+    std::uint16_t tile_x{};
+    std::uint16_t tile_y{};
+    std::uint8_t valid_w{};
+    std::uint8_t valid_h{};
+    std::uint8_t shift{};
+    std::array<std::uint16_t, kChannels> bases{};
+    std::array<std::uint8_t, kChannels> widths{};
+    std::vector<std::uint8_t> residual_payload;
+    std::vector<std::uint8_t> record;
+    double mse{};
+    double psnr_db{std::numeric_limits<double>::infinity()};
+};
+
+struct CodecConfig {
+    bool lossless{};
+    std::uint8_t max_shift{4U};
+    double max_tile_mse{20.0};
+    double min_tile_psnr_db{47.0};
+    std::uint32_t fps{120U};
+    bool persistent_adaptation{};
+    std::size_t instruction_limit{4096U};
+
+    void validate() const {
+        if (max_shift > 8U) throw std::invalid_argument("max_shift must be <= 8");
+        if (!std::isfinite(max_tile_mse) || max_tile_mse < 0.0) {
+            throw std::invalid_argument("max_tile_mse must be finite and non-negative");
+        }
+        if (!std::isfinite(min_tile_psnr_db) || min_tile_psnr_db < 0.0) {
+            throw std::invalid_argument("min_tile_psnr_db must be finite and non-negative");
+        }
+        if (fps == 0U) throw std::invalid_argument("fps must be positive");
+        if (instruction_limit == 0U) throw std::invalid_argument("instruction_limit must be positive");
+    }
+};
+
+struct CodecMetrics {
+    std::uint64_t tiles{};
+    std::uint64_t raw_bits{};
+    std::uint64_t encoded_bits{};
+    double compression_ratio{};
+    double mse{};
+    double psnr_db{std::numeric_limits<double>::infinity()};
+    double hbar_semantic_visual{};
+    double average_tile_shift{};
+    double average_vcl_entropy{};
+    double average_active_nodes{};
+    double average_container_delta{};
+    std::uint64_t evolution_commits{};
+    std::uint64_t evolution_rollbacks{};
+    double frame_budget_ms{};
+};
+
+struct EncodeResult {
+    std::vector<std::uint8_t> bitstream;
+    Frame10 reconstructed;
+    CodecMetrics metrics;
+    dm8kb::Container final_container;
+};
+
+class PixelsToBitsCodec {
+public:
+    explicit PixelsToBitsCodec(CodecConfig config = {}) : config_(config) {
+        config_.validate();
+        reset_runtime();
+    }
+
+    void reset_runtime() {
+        container_ = dm8kb::Container{};
+        control_tile_ = media8::VCLTile8{};
+        container_.set_microcode(media8::default_media_program());
+    }
+
+    EncodeResult encode(const Frame10& frame) {
+        frame.validate();
+        if (!config_.persistent_adaptation) reset_runtime();
+
+        ByteWriter output;
+        constexpr std::array<std::uint8_t, 8U> magic{{'D', 'M', 'P', 'X', 'B', 'T', '1', 0U}};
+        output.append(magic.data(), magic.size());
+        output.u16(1U);
+        output.u32(frame.width);
+        output.u32(frame.height);
+        output.u16(static_cast<std::uint16_t>(std::min<std::uint32_t>(config_.fps, 65535U)));
+        output.u8(static_cast<std::uint8_t>(kChannels));
+        output.u8(10U);
+        output.u8(static_cast<std::uint8_t>(kPixelTileEdge));
+        output.u8(config_.lossless ? 1U : 0U);
+        output.u8(config_.max_shift);
+        output.u8(0U);
+
+        const std::uint32_t tiles_x = (frame.width + 7U) / 8U;
+        const std::uint32_t tiles_y = (frame.height + 7U) / 8U;
+        const std::uint64_t tile_count64 = static_cast<std::uint64_t>(tiles_x) * static_cast<std::uint64_t>(tiles_y);
+        if (tile_count64 > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) {
+            throw std::overflow_error("too many pixel tiles for v1 stream");
+        }
+        output.u32(static_cast<std::uint32_t>(tile_count64));
+        output.u64(static_cast<std::uint64_t>(frame.width) * static_cast<std::uint64_t>(frame.height) * 30ULL);
+
+        CodecMetrics metrics;
+        metrics.tiles = tile_count64;
+        metrics.raw_bits = static_cast<std::uint64_t>(frame.width) * static_cast<std::uint64_t>(frame.height) * 30ULL;
+        metrics.frame_budget_ms = 1000.0 / static_cast<double>(config_.fps);
+        double shift_sum = 0.0;
+        double entropy_sum = 0.0;
+        double active_sum = 0.0;
+        double container_delta_sum = 0.0;
+        std::uint64_t evolution_commits = 0ULL;
+        std::uint64_t evolution_rollbacks = 0ULL;
+
+        for (std::uint32_t ty = 0U; ty < tiles_y; ++ty) {
+            for (std::uint32_t tx = 0U; tx < tiles_x; ++tx) {
+                const std::uint32_t x0 = tx * 8U;
+                const std::uint32_t y0 = ty * 8U;
+                const std::uint8_t valid_w = static_cast<std::uint8_t>(std::min<std::uint32_t>(8U, frame.width - x0));
+                const std::uint8_t valid_h = static_cast<std::uint8_t>(std::min<std::uint32_t>(8U, frame.height - y0));
+
+                const auto container_before = container_.snapshot();
+                const media8::AdaptiveSnapshot adaptive_before = control_tile_.adaptive_snapshot();
+                const media8::TileMetrics control_metrics = execute_control_tile(frame, x0, y0, valid_w, valid_h);
+
+                TileCandidate candidate = select_candidate(frame, tx, ty, valid_w, valid_h);
+                const bool quality_ok = candidate.mse <= config_.max_tile_mse + 1.0e-12 &&
+                                        candidate.psnr_db + 1.0e-12 >= config_.min_tile_psnr_db;
+                if (!quality_ok) {
+                    control_tile_.restore_adaptive(adaptive_before);
+                    container_.restore(container_before);
+                    throw std::runtime_error("lossless fallback failed quality gate");
+                }
+
+                synchronize_container(frame, x0, y0, valid_w, valid_h, candidate, control_metrics,
+                                      container_before, true);
+
+                if (candidate.record.size() > static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max())) {
+                    throw std::overflow_error("tile record exceeds v1 length field");
+                }
+                output.u16(static_cast<std::uint16_t>(candidate.record.size()));
+                output.append(candidate.record);
+
+                shift_sum += static_cast<double>(candidate.shift);
+                entropy_sum += control_metrics.normalized_entropy;
+                active_sum += static_cast<double>(control_metrics.active_nodes);
+                container_delta_sum += dm8kb::Container::normalized_delta(container_before, container_.snapshot());
+                evolution_commits += control_metrics.evolution_commits;
+                evolution_rollbacks += control_metrics.evolution_rollbacks;
+            }
+        }
+
+        std::vector<std::uint8_t> stream = output.take();
+        const std::uint64_t stream_digest = dm8kb::fnv1a64(stream.data(), stream.size());
+        ByteWriter with_digest;
+        with_digest.append(stream);
+        with_digest.u64(stream_digest);
+        stream = with_digest.take();
+
+        Frame10 reconstructed = decode(stream);
+        metrics.encoded_bits = static_cast<std::uint64_t>(stream.size()) * 8ULL;
+        metrics.compression_ratio = metrics.encoded_bits == 0ULL ? 0.0 :
+            static_cast<double>(metrics.raw_bits) / static_cast<double>(metrics.encoded_bits);
+        metrics.mse = frame_mse(frame, reconstructed);
+        metrics.psnr_db = psnr(metrics.mse);
+        metrics.hbar_semantic_visual = std::sqrt(metrics.mse) / static_cast<double>(kMaxPixel10);
+        const double tiles = static_cast<double>(metrics.tiles);
+        metrics.average_tile_shift = shift_sum / tiles;
+        metrics.average_vcl_entropy = entropy_sum / tiles;
+        metrics.average_active_nodes = active_sum / tiles;
+        metrics.average_container_delta = container_delta_sum / tiles;
+        metrics.evolution_commits = evolution_commits;
+        metrics.evolution_rollbacks = evolution_rollbacks;
+
+        EncodeResult result;
+        result.bitstream = std::move(stream);
+        result.reconstructed = std::move(reconstructed);
+        result.metrics = metrics;
+        result.final_container = container_;
+        return result;
+    }
+
+    static Frame10 decode(const std::vector<std::uint8_t>& bitstream) {
+        if (bitstream.size() < 8U + 2U + 4U + 4U + 2U + 6U + 4U + 8U + 8U) {
+            throw std::runtime_error("pixels-to-bits stream too small");
+        }
+        const std::size_t payload_size = bitstream.size() - 8U;
+        const std::uint64_t expected_digest = read_tail_u64(bitstream);
+        const std::uint64_t actual_digest = dm8kb::fnv1a64(bitstream.data(), payload_size);
+        if (expected_digest != actual_digest) throw std::runtime_error("pixels-to-bits stream digest mismatch");
+
+        std::vector<std::uint8_t> payload(bitstream.begin(), bitstream.end() - 8);
+        ByteReader input(payload);
+        constexpr std::array<std::uint8_t, 8U> magic{{'D', 'M', 'P', 'X', 'B', 'T', '1', 0U}};
+        for (const std::uint8_t expected : magic) {
+            if (input.u8() != expected) throw std::runtime_error("unsupported pixels-to-bits magic");
+        }
+        if (input.u16() != 1U) throw std::runtime_error("unsupported pixels-to-bits version");
+        const std::uint32_t width = input.u32();
+        const std::uint32_t height = input.u32();
+        (void)input.u16();
+        if (input.u8() != static_cast<std::uint8_t>(kChannels)) throw std::runtime_error("unsupported channel count");
+        if (input.u8() != 10U) throw std::runtime_error("unsupported bit depth");
+        if (input.u8() != static_cast<std::uint8_t>(kPixelTileEdge)) throw std::runtime_error("unsupported tile edge");
+        (void)input.u8();
+        (void)input.u8();
+        (void)input.u8();
+        const std::uint32_t tile_count = input.u32();
+        const std::uint64_t raw_bits = input.u64();
+        const std::uint64_t expected_raw_bits = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height) * 30ULL;
+        if (raw_bits != expected_raw_bits) throw std::runtime_error("pixels-to-bits raw size metadata mismatch");
+
+        const std::uint64_t sample_count64 = static_cast<std::uint64_t>(width) *
+                                             static_cast<std::uint64_t>(height) *
+                                             static_cast<std::uint64_t>(kChannels);
+        if (sample_count64 > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            throw std::overflow_error("decoded frame exceeds host addressable size");
+        }
+        Frame10 frame;
+        frame.width = width;
+        frame.height = height;
+        frame.rgb.assign(static_cast<std::size_t>(sample_count64), 0U);
+
+        const std::uint32_t tiles_x = (width + 7U) / 8U;
+        const std::uint32_t tiles_y = (height + 7U) / 8U;
+        if (static_cast<std::uint64_t>(tile_count) !=
+            static_cast<std::uint64_t>(tiles_x) * static_cast<std::uint64_t>(tiles_y)) {
+            throw std::runtime_error("pixels-to-bits tile count mismatch");
+        }
+
+        for (std::uint32_t tile = 0U; tile < tile_count; ++tile) {
+            const std::size_t record_size = static_cast<std::size_t>(input.u16());
+            const std::vector<std::uint8_t> record = input.bytes(record_size);
+            decode_tile_record(record, frame);
+        }
+        if (input.remaining() != 0U) throw std::runtime_error("unexpected trailing pixels-to-bits payload");
+        frame.validate();
+        return frame;
+    }
+
+    const dm8kb::Container& container() const noexcept { return container_; }
+
+private:
+    CodecConfig config_;
+    dm8kb::Container container_;
+    media8::VCLTile8 control_tile_;
+
+    static std::uint64_t read_tail_u64(const std::vector<std::uint8_t>& values) noexcept {
+        const std::size_t base = values.size() - 8U;
+        std::uint64_t value = 0ULL;
+        for (std::size_t i = 0U; i < 8U; ++i) {
+            value |= static_cast<std::uint64_t>(values[base + i]) << (8U * i);
+        }
+        return value;
+    }
+
+    static std::vector<std::pair<std::uint8_t, std::uint8_t>> valid_morton_positions(
+        std::uint8_t valid_w, std::uint8_t valid_h) {
+        std::vector<std::pair<std::uint8_t, std::uint8_t>> positions;
+        positions.reserve(static_cast<std::size_t>(valid_w) * static_cast<std::size_t>(valid_h));
+        for (std::uint8_t code = 0U; code < 64U; ++code) {
+            const auto xy = morton_xy(code);
+            if (xy.first < valid_w && xy.second < valid_h) positions.push_back(xy);
+        }
+        return positions;
+    }
+
+    TileCandidate build_candidate(const Frame10& frame, std::uint32_t tx, std::uint32_t ty,
+                                  std::uint8_t valid_w, std::uint8_t valid_h, std::uint8_t shift) const {
+        TileCandidate candidate;
+        if (tx > 65535U || ty > 65535U) throw std::overflow_error("tile coordinate exceeds v1 record");
+        candidate.tile_x = static_cast<std::uint16_t>(tx);
+        candidate.tile_y = static_cast<std::uint16_t>(ty);
+        candidate.valid_w = valid_w;
+        candidate.valid_h = valid_h;
+        candidate.shift = shift;
+
+        const std::uint32_t x0 = tx * 8U;
+        const std::uint32_t y0 = ty * 8U;
+        const auto positions = valid_morton_positions(valid_w, valid_h);
+        if (positions.empty()) throw std::runtime_error("empty pixel tile");
+
+        std::array<std::vector<int>, kChannels> residuals;
+        std::array<std::uint32_t, kChannels> max_zigzag{};
+        double squared_error = 0.0;
+        const int step = 1 << shift;
+
+        for (std::size_t channel = 0U; channel < kChannels; ++channel) {
+            const auto first = positions.front();
+            const std::uint16_t base = frame.at(x0 + first.first, y0 + first.second, channel);
+            candidate.bases[channel] = base;
+            int reconstructed_previous = static_cast<int>(base);
+            residuals[channel].reserve(positions.size() - 1U);
+            for (std::size_t index = 1U; index < positions.size(); ++index) {
+                const auto xy = positions[index];
+                const int source = static_cast<int>(frame.at(x0 + xy.first, y0 + xy.second, channel));
+                const int difference = source - reconstructed_previous;
+                const int q = quantize_difference(difference, step);
+                const int reconstructed = static_cast<int>(clamp_pixel10(reconstructed_previous + q * step));
+                residuals[channel].push_back(q);
+                max_zigzag[channel] = std::max(max_zigzag[channel], zigzag_encode(q));
+                const double error = static_cast<double>(source - reconstructed);
+                squared_error += error * error;
+                reconstructed_previous = reconstructed;
+            }
+            candidate.widths[channel] = required_bits(max_zigzag[channel]);
+        }
+
+        const std::size_t sample_count = positions.size() * kChannels;
+        candidate.mse = sample_count == 0U ? 0.0 : squared_error / static_cast<double>(sample_count);
+        candidate.psnr_db = psnr(candidate.mse);
+
+        BitWriter packed;
+        for (std::size_t channel = 0U; channel < kChannels; ++channel) {
+            const std::uint8_t width = candidate.widths[channel];
+            for (const int residual : residuals[channel]) {
+                if (width != 0U) packed.write(zigzag_encode(residual), width);
+            }
+        }
+        candidate.residual_payload = packed.bytes();
+
+        ByteWriter record;
+        record.u16(candidate.tile_x);
+        record.u16(candidate.tile_y);
+        record.u8(candidate.valid_w);
+        record.u8(candidate.valid_h);
+        record.u8(candidate.shift);
+        for (const std::uint8_t width : candidate.widths) record.u8(width);
+        for (const std::uint16_t base : candidate.bases) record.u16(base);
+        if (candidate.residual_payload.size() > static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max())) {
+            throw std::overflow_error("packed tile residual payload exceeds v1 size field");
+        }
+        record.u16(static_cast<std::uint16_t>(candidate.residual_payload.size()));
+        record.append(candidate.residual_payload);
+        std::vector<std::uint8_t> without_digest = record.take();
+        const std::uint64_t digest = dm8kb::fnv1a64(without_digest.data(), without_digest.size());
+        ByteWriter complete;
+        complete.append(without_digest);
+        complete.u64(digest);
+        candidate.record = complete.take();
+        return candidate;
+    }
+
+    TileCandidate select_candidate(const Frame10& frame, std::uint32_t tx, std::uint32_t ty,
+                                   std::uint8_t valid_w, std::uint8_t valid_h) const {
+        TileCandidate best = build_candidate(frame, tx, ty, valid_w, valid_h, 0U);
+        if (config_.lossless) return best;
+
+        for (std::uint8_t shift = 1U; shift <= config_.max_shift; ++shift) {
+            TileCandidate candidate = build_candidate(frame, tx, ty, valid_w, valid_h, shift);
+            const bool quality_ok = candidate.mse <= config_.max_tile_mse + 1.0e-12 &&
+                                    candidate.psnr_db + 1.0e-12 >= config_.min_tile_psnr_db;
+            if (!quality_ok) continue;
+            if (candidate.record.size() < best.record.size() ||
+                (candidate.record.size() == best.record.size() && candidate.mse < best.mse)) {
+                best = std::move(candidate);
+            }
+        }
+        return best;
+    }
+
+    media8::TileMetrics execute_control_tile(const Frame10& frame, std::uint32_t x0, std::uint32_t y0,
+                                             std::uint8_t valid_w, std::uint8_t valid_h) {
+        std::array<std::uint8_t, media8::kTileNodes> projection{};
+        projection.fill(128U);
+        std::size_t cursor = 0U;
+        for (std::uint8_t y = 0U; y < valid_h; ++y) {
+            for (std::uint8_t x = 0U; x < valid_w; ++x) {
+                for (std::size_t channel = 0U; channel < kChannels; ++channel) {
+                    if (cursor >= projection.size()) break;
+                    const std::uint16_t sample = frame.at(x0 + x, y0 + y, channel);
+                    projection[cursor++] = static_cast<std::uint8_t>(sample >> 2U);
+                }
+            }
+        }
+        control_tile_.ingest_tile(projection);
+        media8::VCLBVM8 vm(control_tile_);
+        return vm.execute(container_.microcode(), config_.instruction_limit);
+    }
+
+    void synchronize_container(const Frame10& frame, std::uint32_t x0, std::uint32_t y0,
+                               std::uint8_t valid_w, std::uint8_t valid_h,
+                               const TileCandidate& candidate, const media8::TileMetrics& control_metrics,
+                               const std::array<std::uint8_t, dm8kb::kContainerBytes>& before,
+                               bool accepted) {
+        const std::uint64_t prior_digest = dm8kb::fnv1a64(before.data(), dm8kb::region_offset(dm8kb::Region::Integrity));
+
+        std::array<std::uint8_t, media8::kTileNodes> states{};
+        const auto& nodes = control_tile_.nodes();
+        for (std::size_t i = 0U; i < nodes.size(); ++i) states[i] = media8::centered_to_byte(nodes[i].state);
+        container_.write_region(dm8kb::Region::VclState, states.data(), states.size());
+
+        const media8::AdaptiveSnapshot adaptive = control_tile_.adaptive_snapshot();
+        std::array<std::uint8_t, media8::kTileNodes> theta{};
+        for (std::size_t i = 0U; i < theta.size(); ++i) theta[i] = static_cast<std::uint8_t>(adaptive.weights[i]);
+        container_.write_region(dm8kb::Region::Theta, theta.data(), theta.size());
+
+        std::array<std::uint8_t, 128U> masks{};
+        for (std::size_t i = 0U; i < nodes.size(); ++i) {
+            const std::size_t byte = i >> 3U;
+            const std::uint8_t bit = static_cast<std::uint8_t>(1U << (i & 7U));
+            if (nodes[i].logic_mask != 0U) masks[byte] = static_cast<std::uint8_t>(masks[byte] | bit);
+            if (nodes[i].control_flag != 0U) masks[64U + byte] = static_cast<std::uint8_t>(masks[64U + byte] | bit);
+        }
+        container_.write_region(dm8kb::Region::Masks, masks.data(), masks.size());
+
+        std::array<std::uint8_t, 512U> omega{};
+        for (std::size_t i = 0U; i < adaptive.omega.size(); ++i) {
+            const std::uint16_t value = static_cast<std::uint16_t>(adaptive.omega[i]);
+            omega[i * 2U] = static_cast<std::uint8_t>(value & 0xFFU);
+            omega[i * 2U + 1U] = static_cast<std::uint8_t>((value >> 8U) & 0xFFU);
+        }
+        container_.write_region(dm8kb::Region::Omega, omega.data(), omega.size());
+
+        ByteWriter residual;
+        const auto positions = valid_morton_positions(valid_w, valid_h);
+        const int step = 1 << candidate.shift;
+        for (std::size_t channel = 0U; channel < kChannels; ++channel) {
+            int previous = static_cast<int>(candidate.bases[channel]);
+            const auto first = positions.front();
+            (void)first;
+            for (std::size_t index = 1U; index < positions.size(); ++index) {
+                const auto xy = positions[index];
+                const int source = static_cast<int>(frame.at(x0 + xy.first, y0 + xy.second, channel));
+                const int q = quantize_difference(source - previous, step);
+                const int reconstructed = static_cast<int>(clamp_pixel10(previous + q * step));
+                const int error = source - reconstructed;
+                residual.u16(static_cast<std::uint16_t>(static_cast<std::int16_t>(error)));
+                previous = reconstructed;
+            }
+        }
+        container_.write_region(dm8kb::Region::Residual, residual.bytes());
+
+        ByteWriter features;
+        features.u32(x0);
+        features.u32(y0);
+        features.u8(valid_w);
+        features.u8(valid_h);
+        features.u8(candidate.shift);
+        features.u8(accepted ? 1U : 0U);
+        features.u32(dm8kb::q24(candidate.mse));
+        features.u32(dm8kb::q24(candidate.mse == 0.0 ? 0.0 : std::sqrt(candidate.mse) / 1023.0));
+        features.u32(dm8kb::q24(control_metrics.normalized_entropy));
+        features.u16(static_cast<std::uint16_t>(std::min<std::size_t>(control_metrics.active_nodes, 65535U)));
+        container_.write_region(dm8kb::Region::Features, features.bytes());
+        container_.stage_shadow(candidate.record);
+
+        const std::uint64_t candidate_digest = container_.digest();
+        if (accepted) container_.increment_epoch();
+        const auto after = container_.snapshot();
+        const double state_delta = dm8kb::Container::normalized_delta(before, after);
+
+        dm8kb::CommitReceipt receipt;
+        receipt.prior_digest = prior_digest;
+        receipt.candidate_digest = candidate_digest;
+        receipt.result_digest = container_.digest();
+        receipt.microcode_digest = container_.microcode_digest();
+        receipt.epoch = container_.epoch();
+        receipt.changed_regions = dm8kb::Container::changed_region_bitmap(before, after);
+        receipt.semantic_gap_q24 = dm8kb::q24(candidate.mse == 0.0 ? 0.0 : std::sqrt(candidate.mse) / 1023.0);
+        receipt.state_delta_q24 = dm8kb::q24(state_delta);
+        receipt.accepted = accepted;
+        container_.write_receipt(receipt);
+    }
+
+    static void decode_tile_record(const std::vector<std::uint8_t>& record, Frame10& frame) {
+        if (record.size() < 2U + 2U + 1U + 1U + 1U + 3U + 6U + 2U + 8U) {
+            throw std::runtime_error("pixel tile record too small");
+        }
+        const std::size_t digest_offset = record.size() - 8U;
+        std::uint64_t expected_digest = 0ULL;
+        for (std::size_t i = 0U; i < 8U; ++i) {
+            expected_digest |= static_cast<std::uint64_t>(record[digest_offset + i]) << (8U * i);
+        }
+        const std::uint64_t actual_digest = dm8kb::fnv1a64(record.data(), digest_offset);
+        if (expected_digest != actual_digest) throw std::runtime_error("pixel tile digest mismatch");
+
+        std::vector<std::uint8_t> body(record.begin(), record.begin() + static_cast<std::ptrdiff_t>(digest_offset));
+        ByteReader input(body);
+        const std::uint16_t tx = input.u16();
+        const std::uint16_t ty = input.u16();
+        const std::uint8_t valid_w = input.u8();
+        const std::uint8_t valid_h = input.u8();
+        const std::uint8_t shift = input.u8();
+        if (valid_w == 0U || valid_w > 8U || valid_h == 0U || valid_h > 8U || shift > 8U) {
+            throw std::runtime_error("invalid pixel tile geometry/shift");
+        }
+        std::array<std::uint8_t, kChannels> widths{};
+        for (std::uint8_t& width : widths) {
+            width = input.u8();
+            if (width > 11U) throw std::runtime_error("invalid residual bit width");
+        }
+        std::array<std::uint16_t, kChannels> bases{};
+        for (std::uint16_t& base : bases) {
+            base = input.u16();
+            if (base > kMaxPixel10) throw std::runtime_error("invalid 10-bit tile base");
+        }
+        const std::size_t payload_size = static_cast<std::size_t>(input.u16());
+        const std::vector<std::uint8_t> residual_payload = input.bytes(payload_size);
+        if (input.remaining() != 0U) throw std::runtime_error("unexpected tile record bytes");
+
+        const std::uint32_t x0 = static_cast<std::uint32_t>(tx) * 8U;
+        const std::uint32_t y0 = static_cast<std::uint32_t>(ty) * 8U;
+        if (x0 >= frame.width || y0 >= frame.height ||
+            x0 + valid_w > frame.width || y0 + valid_h > frame.height) {
+            throw std::runtime_error("tile record outside decoded frame");
+        }
+
+        const auto positions = valid_morton_positions(valid_w, valid_h);
+        const int step = 1 << shift;
+        BitReader packed(residual_payload);
+        for (std::size_t channel = 0U; channel < kChannels; ++channel) {
+            int previous = static_cast<int>(bases[channel]);
+            const auto first = positions.front();
+            frame.set(x0 + first.first, y0 + first.second, channel, bases[channel]);
+            const std::uint8_t width = widths[channel];
+            for (std::size_t index = 1U; index < positions.size(); ++index) {
+                const int q = width == 0U ? 0 : zigzag_decode(packed.read(width));
+                const std::uint16_t reconstructed = clamp_pixel10(previous + q * step);
+                const auto xy = positions[index];
+                frame.set(x0 + xy.first, y0 + xy.second, channel, reconstructed);
+                previous = static_cast<int>(reconstructed);
+            }
+        }
+    }
+
+    static double frame_mse(const Frame10& left, const Frame10& right) {
+        left.validate();
+        right.validate();
+        if (left.width != right.width || left.height != right.height || left.rgb.size() != right.rgb.size()) {
+            throw std::invalid_argument("frame MSE geometry mismatch");
+        }
+        if (left.rgb.empty()) return 0.0;
+        long double squared = 0.0L;
+        for (std::size_t i = 0U; i < left.rgb.size(); ++i) {
+            const long double delta = static_cast<long double>(left.rgb[i]) - static_cast<long double>(right.rgb[i]);
+            squared += delta * delta;
+        }
+        return static_cast<double>(squared / static_cast<long double>(left.rgb.size()));
+    }
+
+    static double psnr(double mse) noexcept {
+        if (mse <= 0.0) return std::numeric_limits<double>::infinity();
+        const double peak = static_cast<double>(kMaxPixel10);
+        return 10.0 * std::log10((peak * peak) / mse);
+    }
+};
+
+inline Frame10 make_gradient_frame(std::uint32_t width, std::uint32_t height) {
+    if (width == 0U || height == 0U) throw std::invalid_argument("gradient dimensions must be positive");
+    const std::uint64_t count64 = static_cast<std::uint64_t>(width) * static_cast<std::uint64_t>(height) * 3ULL;
+    if (count64 > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        throw std::overflow_error("gradient frame too large");
+    }
+    Frame10 frame;
+    frame.width = width;
+    frame.height = height;
+    frame.rgb.assign(static_cast<std::size_t>(count64), 0U);
+    for (std::uint32_t y = 0U; y < height; ++y) {
+        for (std::uint32_t x = 0U; x < width; ++x) {
+            const std::uint16_t r = width <= 1U ? 0U : static_cast<std::uint16_t>((static_cast<std::uint64_t>(x) * 1023ULL) / static_cast<std::uint64_t>(width - 1U));
+            const std::uint16_t g = height <= 1U ? 0U : static_cast<std::uint16_t>((static_cast<std::uint64_t>(y) * 1023ULL) / static_cast<std::uint64_t>(height - 1U));
+            const std::uint16_t b = static_cast<std::uint16_t>((static_cast<std::uint32_t>(r) + static_cast<std::uint32_t>(g)) / 2U);
+            frame.set(x, y, 0U, r);
+            frame.set(x, y, 1U, g);
+            frame.set(x, y, 2U, b);
+        }
+    }
+    return frame;
+}
+
+} // namespace jarvisx::pixels

--- a/cpp_runtime/src/pixels_to_bits_main.cpp
+++ b/cpp_runtime/src/pixels_to_bits_main.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>

--- a/cpp_runtime/src/pixels_to_bits_main.cpp
+++ b/cpp_runtime/src/pixels_to_bits_main.cpp
@@ -1,0 +1,265 @@
+#include "jarvisx/pixels_to_bits_codec.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::filesystem::path input{};
+    std::filesystem::path encoded{"dr-moagi-pixels-to-bits.dmpb"};
+    std::filesystem::path decoded{"dr-moagi-pixels-to-bits-decoded.ppm"};
+    std::uint32_t width{64U};
+    std::uint32_t height{64U};
+    std::uint32_t fps{120U};
+    std::uint8_t max_shift{4U};
+    double max_mse{20.0};
+    double min_psnr{47.0};
+    bool lossless{};
+    bool quiet{};
+    bool report_8k120{true};
+};
+
+std::uint64_t parse_u64(const std::string& value, const char* flag) {
+    std::size_t consumed = 0U;
+    const std::uint64_t result = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) throw std::invalid_argument(std::string("invalid integer for ") + flag);
+    return result;
+}
+
+double parse_double(const std::string& value, const char* flag) {
+    std::size_t consumed = 0U;
+    const double result = std::stod(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(result)) {
+        throw std::invalid_argument(std::string("invalid number for ") + flag);
+    }
+    return result;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto next = [&](int& index, const char* flag) {
+        if (index + 1 >= argc) throw std::invalid_argument(std::string("missing value after ") + flag);
+        return std::string(argv[++index]);
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--input") {
+            options.input = next(index, "--input");
+        } else if (argument == "--encoded") {
+            options.encoded = next(index, "--encoded");
+        } else if (argument == "--decoded") {
+            options.decoded = next(index, "--decoded");
+        } else if (argument == "--width") {
+            const auto value = parse_u64(next(index, "--width"), "--width");
+            if (value > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) throw std::out_of_range("width too large");
+            options.width = static_cast<std::uint32_t>(value);
+        } else if (argument == "--height") {
+            const auto value = parse_u64(next(index, "--height"), "--height");
+            if (value > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) throw std::out_of_range("height too large");
+            options.height = static_cast<std::uint32_t>(value);
+        } else if (argument == "--fps") {
+            const auto value = parse_u64(next(index, "--fps"), "--fps");
+            if (value == 0ULL || value > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) throw std::out_of_range("fps out of range");
+            options.fps = static_cast<std::uint32_t>(value);
+        } else if (argument == "--max-shift") {
+            const auto value = parse_u64(next(index, "--max-shift"), "--max-shift");
+            if (value > 8ULL) throw std::out_of_range("max-shift must be <= 8");
+            options.max_shift = static_cast<std::uint8_t>(value);
+        } else if (argument == "--max-mse") {
+            options.max_mse = parse_double(next(index, "--max-mse"), "--max-mse");
+        } else if (argument == "--min-psnr") {
+            options.min_psnr = parse_double(next(index, "--min-psnr"), "--min-psnr");
+        } else if (argument == "--lossless") {
+            options.lossless = true;
+        } else if (argument == "--quiet") {
+            options.quiet = true;
+        } else if (argument == "--no-8k120-report") {
+            options.report_8k120 = false;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: DrMoagi-Pixels-to-Bits [options]\n"
+                << "  --input FILE       P6 PPM source (8-bit or <=10-bit maxval)\n"
+                << "  --encoded FILE     output DM-PXBT v1 bitstream\n"
+                << "  --decoded FILE     reconstructed 10-bit PPM\n"
+                << "  --width N          generated gradient width (default 64)\n"
+                << "  --height N         generated gradient height (default 64)\n"
+                << "  --fps N            target frame rate for budget telemetry\n"
+                << "  --lossless         exact 10-bit round-trip mode\n"
+                << "  --max-shift N      maximum predictive quantization shift [0,8]\n"
+                << "  --max-mse X        per-tile Lambda MSE ceiling\n"
+                << "  --min-psnr X       per-tile Lambda PSNR floor in dB\n"
+                << "  --no-8k120-report  suppress canonical 7680x4320@120 profile\n"
+                << "  --quiet            suppress telemetry\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+std::string ppm_token(std::istream& input) {
+    std::string token;
+    char ch = '\0';
+    while (input.get(ch)) {
+        if (ch == '#') {
+            input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            continue;
+        }
+        if (!std::isspace(static_cast<unsigned char>(ch))) {
+            token.push_back(ch);
+            break;
+        }
+    }
+    while (input.get(ch)) {
+        if (ch == '#') {
+            input.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            break;
+        }
+        if (std::isspace(static_cast<unsigned char>(ch))) break;
+        token.push_back(ch);
+    }
+    if (token.empty()) throw std::runtime_error("truncated PPM header");
+    return token;
+}
+
+jarvisx::pixels::Frame10 read_ppm10(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) throw std::runtime_error("cannot open input PPM: " + path.string());
+    if (ppm_token(input) != "P6") throw std::runtime_error("only binary P6 PPM is supported");
+    const std::uint64_t width64 = parse_u64(ppm_token(input), "PPM width");
+    const std::uint64_t height64 = parse_u64(ppm_token(input), "PPM height");
+    const std::uint64_t maxval64 = parse_u64(ppm_token(input), "PPM maxval");
+    if (width64 == 0ULL || height64 == 0ULL ||
+        width64 > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) ||
+        height64 > static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max())) {
+        throw std::runtime_error("PPM dimensions out of range");
+    }
+    if (maxval64 == 0ULL || maxval64 > 1023ULL) throw std::runtime_error("PPM maxval must be in [1,1023]");
+
+    jarvisx::pixels::Frame10 frame;
+    frame.width = static_cast<std::uint32_t>(width64);
+    frame.height = static_cast<std::uint32_t>(height64);
+    const std::uint64_t samples64 = width64 * height64 * 3ULL;
+    if (samples64 > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) throw std::overflow_error("PPM too large");
+    frame.rgb.resize(static_cast<std::size_t>(samples64));
+
+    const bool wide = maxval64 > 255ULL;
+    for (std::size_t i = 0U; i < frame.rgb.size(); ++i) {
+        std::uint16_t source = 0U;
+        if (wide) {
+            const int high = input.get();
+            const int low = input.get();
+            if (high < 0 || low < 0) throw std::runtime_error("truncated PPM pixel data");
+            source = static_cast<std::uint16_t>((static_cast<std::uint16_t>(high) << 8U) |
+                                                static_cast<std::uint16_t>(low));
+        } else {
+            const int byte = input.get();
+            if (byte < 0) throw std::runtime_error("truncated PPM pixel data");
+            source = static_cast<std::uint16_t>(byte);
+        }
+        if (source > maxval64) throw std::runtime_error("PPM sample exceeds maxval");
+        frame.rgb[i] = static_cast<std::uint16_t>(
+            (static_cast<std::uint64_t>(source) * 1023ULL + maxval64 / 2ULL) / maxval64);
+    }
+    frame.validate();
+    return frame;
+}
+
+void write_ppm10(const std::filesystem::path& path, const jarvisx::pixels::Frame10& frame) {
+    frame.validate();
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output) throw std::runtime_error("cannot create decoded PPM: " + path.string());
+    output << "P6\n" << frame.width << ' ' << frame.height << "\n1023\n";
+    for (const std::uint16_t value : frame.rgb) {
+        const char high = static_cast<char>((value >> 8U) & 0xFFU);
+        const char low = static_cast<char>(value & 0xFFU);
+        output.put(high);
+        output.put(low);
+    }
+    if (!output) throw std::runtime_error("failed writing decoded PPM");
+}
+
+void write_bytes(const std::filesystem::path& path, const std::vector<std::uint8_t>& bytes) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output) throw std::runtime_error("cannot create encoded stream: " + path.string());
+    if (!bytes.empty()) {
+        output.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+    if (!output) throw std::runtime_error("failed writing encoded stream");
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        const jarvisx::pixels::Frame10 frame = options.input.empty()
+            ? jarvisx::pixels::make_gradient_frame(options.width, options.height)
+            : read_ppm10(options.input);
+
+        jarvisx::pixels::CodecConfig config;
+        config.lossless = options.lossless;
+        config.max_shift = options.max_shift;
+        config.max_tile_mse = options.lossless ? 0.0 : options.max_mse;
+        config.min_tile_psnr_db = options.lossless ? 0.0 : options.min_psnr;
+        config.fps = options.fps;
+
+        jarvisx::pixels::PixelsToBitsCodec codec(config);
+        const auto begin = std::chrono::steady_clock::now();
+        const auto result = codec.encode(frame);
+        const auto end = std::chrono::steady_clock::now();
+        const double elapsed_ms = std::chrono::duration<double, std::milli>(end - begin).count();
+
+        write_bytes(options.encoded, result.bitstream);
+        write_ppm10(options.decoded, result.reconstructed);
+
+        if (!options.quiet) {
+            std::cout << "DM-vOmegaXi+ Pixels-to-Bits reference\n"
+                      << "frame=" << frame.width << 'x' << frame.height
+                      << " RGB10 fps_target=" << options.fps << '\n'
+                      << "tiles=" << result.metrics.tiles
+                      << " raw_bits=" << result.metrics.raw_bits
+                      << " encoded_bits=" << result.metrics.encoded_bits
+                      << " ratio=" << result.metrics.compression_ratio << "x\n"
+                      << "mse=" << result.metrics.mse
+                      << " psnr_db=" << result.metrics.psnr_db
+                      << " hbar_visual=" << result.metrics.hbar_semantic_visual << '\n'
+                      << "avg_shift=" << result.metrics.average_tile_shift
+                      << " avg_vcl_entropy=" << result.metrics.average_vcl_entropy
+                      << " avg_active_nodes=" << result.metrics.average_active_nodes
+                      << " avg_container_delta=" << result.metrics.average_container_delta << '\n'
+                      << "elapsed_ms=" << elapsed_ms
+                      << " target_budget_ms=" << result.metrics.frame_budget_ms
+                      << " software_meets_target=" << (elapsed_ms <= result.metrics.frame_budget_ms ? "yes" : "no") << '\n'
+                      << "container_bytes=" << jarvisx::dm8kb::kContainerBytes
+                      << " epoch=" << result.final_container.epoch()
+                      << " accepted_receipt=" << (result.final_container.receipt().accepted ? "yes" : "no") << '\n'
+                      << "encoded=" << options.encoded.string() << '\n'
+                      << "decoded=" << options.decoded.string() << '\n';
+            if (options.report_8k120) {
+                const auto profile = jarvisx::pixels::uhd8k120_profile();
+                std::cout << "8k120_raw_pixels=" << profile.pixels
+                          << " raw_bits_per_frame=" << profile.raw_bits_per_frame
+                          << " packed_bytes_per_frame=" << profile.packed_bytes_per_frame
+                          << " packed_GBps=" << profile.packed_gbytes_per_second
+                          << " frame_budget_ms=" << profile.frame_budget_ms << '\n';
+            }
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "DrMoagi Pixels-to-Bits failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/pixels_to_bits_tests.cpp
+++ b/cpp_runtime/tests/pixels_to_bits_tests.cpp
@@ -1,0 +1,152 @@
+#include "jarvisx/pixels_to_bits_codec.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+
+void test_exact_8kb_layout_and_bounds() {
+    static_assert(jarvisx::dm8kb::layout_is_exact(), "layout must be exact");
+    jarvisx::dm8kb::Container container;
+    assert(container.bytes().size() == 8192U);
+    assert(jarvisx::dm8kb::region_offset(jarvisx::dm8kb::Region::Integrity) == 0x1F00U);
+    assert(jarvisx::dm8kb::region_size(jarvisx::dm8kb::Region::Integrity) == 256U);
+
+    bool rejected = false;
+    try {
+        container.write(8192U, 1U);
+    } catch (const std::out_of_range&) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+void test_toroidal_indexing() {
+    using jarvisx::dm8kb::Container;
+    assert(Container::torus_index(0, 0, 0) == 0U);
+    assert(Container::torus_index(8, 0, 0) == 0U);
+    assert(Container::torus_index(-1, 0, 0) == 7U);
+    assert(Container::torus_index(0, -1, 0) == 56U);
+    assert(Container::torus_index(0, 0, -1) == 448U);
+    assert(Container::torus_index(8, 8, 8) == 0U);
+}
+
+void test_8k120_profile_arithmetic() {
+    const auto profile = jarvisx::pixels::uhd8k120_profile();
+    assert(profile.pixels == 33177600ULL);
+    assert(profile.raw_bits_per_frame == 995328000ULL);
+    assert(profile.packed_bytes_per_frame == 124416000ULL);
+    assert(std::fabs(profile.packed_gbytes_per_second - 14.92992) < 1.0e-9);
+    assert(std::fabs(profile.frame_budget_ms - (1000.0 / 120.0)) < 1.0e-12);
+}
+
+void test_lossless_roundtrip_partial_tiles() {
+    const auto frame = jarvisx::pixels::make_gradient_frame(13U, 10U);
+    jarvisx::pixels::CodecConfig config;
+    config.lossless = true;
+    config.max_tile_mse = 0.0;
+    config.min_tile_psnr_db = 0.0;
+    jarvisx::pixels::PixelsToBitsCodec codec(config);
+    const auto result = codec.encode(frame);
+
+    assert(result.reconstructed.width == frame.width);
+    assert(result.reconstructed.height == frame.height);
+    assert(result.reconstructed.rgb == frame.rgb);
+    assert(result.metrics.mse == 0.0);
+    assert(std::isinf(result.metrics.psnr_db));
+    assert(result.metrics.hbar_semantic_visual == 0.0);
+    assert(result.final_container.bytes().size() == 8192U);
+    assert(result.final_container.receipt().accepted);
+    assert(result.final_container.epoch() == result.metrics.tiles);
+
+    const auto decoded_again = jarvisx::pixels::PixelsToBitsCodec::decode(result.bitstream);
+    assert(decoded_again.rgb == frame.rgb);
+}
+
+void test_near_lossless_quality_gate_and_compression() {
+    const auto frame = jarvisx::pixels::make_gradient_frame(32U, 24U);
+    jarvisx::pixels::CodecConfig config;
+    config.lossless = false;
+    config.max_shift = 4U;
+    config.max_tile_mse = 100.0;
+    config.min_tile_psnr_db = 40.0;
+    jarvisx::pixels::PixelsToBitsCodec codec(config);
+    const auto result = codec.encode(frame);
+
+    assert(result.metrics.mse <= 100.0 + 1.0e-9);
+    assert(result.metrics.psnr_db >= 40.0 - 1.0e-9);
+    assert(result.metrics.compression_ratio > 1.0);
+    assert(result.metrics.average_tile_shift > 0.0);
+    assert(result.metrics.hbar_semantic_visual >= 0.0);
+    assert(result.metrics.hbar_semantic_visual < 0.02);
+}
+
+void test_deterministic_stream() {
+    const auto frame = jarvisx::pixels::make_gradient_frame(16U, 16U);
+    jarvisx::pixels::CodecConfig config;
+    config.max_shift = 3U;
+    config.max_tile_mse = 80.0;
+    config.min_tile_psnr_db = 40.0;
+    jarvisx::pixels::PixelsToBitsCodec left(config);
+    jarvisx::pixels::PixelsToBitsCodec right(config);
+    const auto a = left.encode(frame);
+    const auto b = right.encode(frame);
+    assert(a.bitstream == b.bitstream);
+    assert(a.reconstructed.rgb == b.reconstructed.rgb);
+    assert(a.final_container.bytes() == b.final_container.bytes());
+}
+
+void test_corruption_fails_closed() {
+    const auto frame = jarvisx::pixels::make_gradient_frame(8U, 8U);
+    jarvisx::pixels::CodecConfig config;
+    config.lossless = true;
+    config.max_tile_mse = 0.0;
+    config.min_tile_psnr_db = 0.0;
+    jarvisx::pixels::PixelsToBitsCodec codec(config);
+    auto result = codec.encode(frame);
+    assert(result.bitstream.size() > 24U);
+    result.bitstream[20U] = static_cast<std::uint8_t>(result.bitstream[20U] ^ 0x01U);
+
+    bool rejected = false;
+    try {
+        (void)jarvisx::pixels::PixelsToBitsCodec::decode(result.bitstream);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+void test_shadow_and_receipt_are_bounded() {
+    jarvisx::dm8kb::Container container;
+    container.set_microcode(jarvisx::media8::default_media_program());
+    std::vector<std::uint8_t> candidate(1024U, 0xA5U);
+    container.stage_shadow(candidate);
+    assert(container.shadow_size() == 1024U);
+
+    bool rejected = false;
+    try {
+        container.stage_shadow(std::vector<std::uint8_t>(1025U, 0U));
+    } catch (const std::out_of_range&) {
+        rejected = true;
+    }
+    assert(rejected);
+}
+
+} // namespace
+
+int main() {
+    test_exact_8kb_layout_and_bounds();
+    test_toroidal_indexing();
+    test_8k120_profile_arithmetic();
+    test_lossless_roundtrip_partial_tiles();
+    test_near_lossless_quality_gate_and_compression();
+    test_deterministic_stream();
+    test_corruption_fails_closed();
+    test_shadow_and_receipt_are_bounded();
+    std::cout << "DM-vOmegaXi+ pixels-to-bits tests passed\n";
+    return 0;
+}

--- a/docs/PIXELS_TO_BITS_8K120_REFERENCE.md
+++ b/docs/PIXELS_TO_BITS_8K120_REFERENCE.md
@@ -1,0 +1,258 @@
+# Dr Moagi Pixels-to-Bits Mapping Framework — End-to-End Reference
+
+## Status
+
+This document describes the executable software reference for the pixels-to-bits mapping layer governed by the canonical `DM-vOmegaXi+` 8192-byte container contract.
+
+It implements a real round-trippable 10-bit RGB bitstream and uses the existing VCL-BVM-8 / DM-IMP execution core as the bounded inward control/adaptation layer.
+
+It does **not** claim that an arbitrary 8K RGB10 frame fits losslessly inside 8KB. The 8KB container is the reusable execution, latent, residual, microcode and transactional workspace. Encoded frame information is carried by the external `DM-PXBT` bitstream.
+
+It also does not assert measured 8K120 throughput, sub-nanosecond silicon timing, TSV/eSRAM realization, external SOTA or patentability.
+
+## 1. Raw 8K120 arithmetic
+
+For RGB10 7680 x 4320:
+
+```text
+pixels/frame       = 33,177,600
+bits/pixel         = 30
+raw bits/frame     = 995,328,000
+packed bytes/frame = 124,416,000
+120 Hz packed rate = 14.92992 GB/s
+frame budget       = 8.333333... ms
+```
+
+These values are exposed by `uhd8k120_profile()` without allocating an 8K frame.
+
+## 2. Executable pipeline
+
+```text
+RGB10 frame
+   |
+   v
+8x8 pixel micro-tiles
+   |
+   +----> 512-byte VCL projection
+   |          |
+   |          v
+   |     VCL-BVM-8 / Psi-Phi-Omega-Theta control path
+   |          |
+   |          v
+   |     8192-byte DM container + commit receipt
+   |
+   v
+Morton-ordered per-channel predictive residuals
+   |
+   v
+candidate quantization shifts 0..N
+   |
+   v
+Lambda quality gate (tile MSE + tile PSNR)
+   |
+   v
+variable-bit residual packing
+   |
+   v
+DM-PXBT v1 bitstream
+   |
+   v
+bit fetch -> predictor reconstruction -> RGB10 frame
+```
+
+The actual frame codec is independently decodable. It does not require the original pixels or an unstored neural latent state to reconstruct the frame.
+
+## 3. Lossless and near-lossless modes
+
+### Lossless
+
+`shift = 0` stores exact predictive differences. Reconstruction satisfies:
+
+```text
+P_hat == P
+MSE   == 0
+PSNR  == infinity
+hbar_semantic_visual == 0
+```
+
+The bitstream may expand on high-entropy inputs; no universal compression claim is made.
+
+### Near-lossless
+
+For each tile the encoder evaluates quantization shifts from 0 through `max_shift`.
+
+For step `s = 2^shift`:
+
+```text
+q       = round((pixel - reconstructed_predictor) / s)
+P_hat   = clamp10(reconstructed_predictor + q*s)
+```
+
+A candidate is admissible only when:
+
+```text
+MSE_tile  <= max_tile_mse
+PSNR_tile >= min_tile_psnr_db
+```
+
+Among admissible candidates the smallest encoded record wins. Exact shift-0 coding is always available as the fidelity fallback.
+
+## 4. 3D / Morton mapping
+
+Pixels inside each 8x8 tile are visited in 2D Morton/Z-order. The local DM container separately exposes a canonical toroidal `8x8x8` address mapping:
+
+```text
+x' = x mod 8
+y' = y mod 8
+z' = z mod 8
+```
+
+including correct wrapping for negative coordinates.
+
+This is logical topology. Physical TSV toroidal routing remains a hardware workstream.
+
+## 5. DM-PXBT v1 stream
+
+The global stream contains:
+
+- magic `DMPXBT1`;
+- version;
+- width / height;
+- target FPS;
+- RGB channel count;
+- 10-bit source depth;
+- 8x8 tile edge;
+- mode and max-shift metadata;
+- tile count;
+- raw source bit count;
+- length-prefixed tile records;
+- final deterministic stream digest.
+
+Each tile record contains:
+
+- tile X/Y;
+- valid edge dimensions;
+- selected shift;
+- three residual bit widths;
+- three 10-bit predictor bases;
+- packed per-channel residual payload;
+- tile digest.
+
+Malformed, truncated or corrupted streams fail closed.
+
+## 6. Exact 8192-byte container integration
+
+`dm8kb_container.hpp` implements the canonical state map exactly:
+
+```text
+CONTROL    128 B
+VCL_STATE  512 B
+THETA      512 B
+MASKS      128 B
+OMEGA      512 B
+MICROCODE 1024 B
+RESIDUAL  2048 B
+FEATURES  2048 B
+SHADOW    1024 B
+INTEGRITY  256 B
+----------------
+TOTAL     8192 B
+```
+
+Every tile executes the canonical VCL program on an 8-bit projection of the RGB10 samples. The resulting state, adaptive weights, masks, Omega values, residual telemetry and candidate record are synchronized into the container.
+
+The `SHADOW` region holds the candidate tile record before commit. The `INTEGRITY` region records:
+
+- prior state digest;
+- candidate digest;
+- result digest;
+- microcode digest;
+- epoch;
+- changed-region bitmap;
+- semantic-gap telemetry;
+- state-delta telemetry;
+- accepted/rejected state.
+
+The container digest deliberately excludes `INTEGRITY`, allowing receipts to describe authoritative state without self-referential digest recursion.
+
+## 7. Semantic gap
+
+Frame-level visual semantic residual is currently the normalized RMSE reference metric:
+
+```text
+hbar_semantic_visual = sqrt(MSE) / 1023
+```
+
+This is a measurable reference quantity, not a universal physical constant. Additional perceptual/task metrics belong in the benchmark workstream.
+
+## 8. Executable target
+
+CMake target:
+
+```text
+jarvisx-pixels-to-bits
+```
+
+Windows executable:
+
+```text
+DrMoagi-Pixels-to-Bits.exe
+```
+
+Generated deterministic gradient, near-lossless:
+
+```powershell
+.\DrMoagi-Pixels-to-Bits.exe `
+  --width 1920 `
+  --height 1080 `
+  --fps 120 `
+  --max-shift 4 `
+  --max-mse 20 `
+  --min-psnr 47 `
+  --encoded frame.dmpb `
+  --decoded frame.ppm
+```
+
+Exact lossless:
+
+```powershell
+.\DrMoagi-Pixels-to-Bits.exe `
+  --input source.ppm `
+  --lossless `
+  --encoded source-lossless.dmpb `
+  --decoded restored.ppm
+```
+
+Input PPM is binary P6 with maxval in `[1,1023]`. 8-bit PPM input is scaled into the canonical RGB10 domain; decoded PPM is emitted with maxval `1023`.
+
+## 9. Verification
+
+The regression suite checks:
+
+1. exact 8192-byte memory layout;
+2. hard container-local bounds;
+3. toroidal address wrapping;
+4. exact 8K120 raw arithmetic;
+5. lossless round-trip including partial edge tiles;
+6. quality-gated near-lossless reconstruction;
+7. deterministic bitstream and final container state;
+8. corruption detection / fail-closed decode;
+9. bounded 1024-byte shadow staging;
+10. executable CLI smoke path.
+
+The existing C++ workflow compiles and runs the complete suite on GCC, Clang with sanitizers, and MSVC.
+
+## 10. Evidence boundary
+
+The software reference establishes functional semantics and deterministic bitstream behavior.
+
+The following remain separate evidence gates:
+
+- actual 8K120 wall-clock throughput and latency;
+- GPU/NPU/SIMD comparison and external SOTA;
+- FPGA/ASIC Fmax, timing closure and energy;
+- TSV/eSRAM/3D-stacked implementation;
+- codec perceptual benchmarks such as SSIM/MS-SSIM/VMAF;
+- formal patentability/legal conclusions.
+
+Those are tracked under the existing commercialization and hardware/benchmark workstreams.


### PR DESCRIPTION
## Summary

Implements the end-to-end software reference for the Dr Moagi Pixels-to-Bits Mapping Framework on top of the canonical 8192-byte DM-vOmegaXi+ container and existing VCL-BVM-8 media processor.

### End-to-end path
`RGB10 pixels -> 8x8 tiles -> VCL/DM 8KB control container -> Morton predictive residuals -> Lambda quality gate -> DM-PXBT bitstream -> independent decode -> RGB10 reconstruction`

### Runtime
- exact 8192-byte container implementation with canonical region map, hard bounds, toroidal indexing, shadow staging, digests and commit receipts;
- real versioned `DM-PXBT v1` decodable bitstream;
- exact lossless 10-bit predictive mode;
- quality-gated near-lossless mode that searches per-tile quantization shifts and falls back to exact coding;
- per-tile Morton/Z-order mapping and variable-bit residual packing;
- stream/tile integrity digests and fail-closed corruption handling;
- VCL-BVM-8 control execution per pixel tile, with Theta/Omega/masks/residual/features synchronized into the 8KB container;
- measurable visual semantic residual `sqrt(MSE)/1023`;
- 8K RGB10 @ 120 Hz raw arithmetic/profile without pretending the full frame resides in 8KB.

### CLI
Adds `DrMoagi-Pixels-to-Bits` with P6 PPM ingress, DM-PXBT output, decoded 10-bit PPM output, lossless/near-lossless controls, and target frame-budget telemetry.

### Verification
Adds regression coverage for exact 8KB layout, bounds, toroidal wrapping, 8K120 arithmetic, lossless partial-tile roundtrip, near-lossless quality/compression, deterministic replay, corruption rejection and shadow limits. Adds CMake/CTest smoke coverage and a dedicated Windows MSVC packaging workflow.

### Claim boundary
This is a bounded deterministic software reference. It does not claim measured 8K120 realtime performance, sub-nanosecond silicon timing, TSV/eSRAM realization, external SOTA, or patentability. Those remain separate benchmark/hardware/IP evidence gates.

Tracks canonical container conformance work in #184 and feeds benchmark/hardware workstreams #178/#179.