### PR TITLE
Implement 128-bit VMAD kinetic world-engine layer

### DIFF
--- a/.github/workflows/world-engine-windows.yml
+++ b/.github/workflows/world-engine-windows.yml
@@ -1,0 +1,88 @@
+name: Dr Moagi VMAD128 World Engine Windows
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/src/world_engine_main.cpp"
+      - "cpp_runtime/tests/world_engine_vmad_tests.cpp"
+      - "cpp_runtime/world_engine.cmake"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/VMAD128_WORLD_ENGINE.md"
+      - ".github/workflows/world-engine-windows.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/src/world_engine_main.cpp"
+      - "cpp_runtime/tests/world_engine_vmad_tests.cpp"
+      - "cpp_runtime/world_engine.cmake"
+      - "cpp_runtime/CMakeLists.txt"
+      - "docs/VMAD128_WORLD_ENGINE.md"
+      - ".github/workflows/world-engine-windows.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: world-engine-windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-test-package:
+    name: Windows x64 / MSVC
+    runs-on: windows-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Configure CMake
+        shell: pwsh
+        run: >-
+          cmake -S cpp_runtime -B build/world-engine
+          -A x64
+          -DJARVISX_BUILD_GL_VISUALIZER=OFF
+          -DJARVISX_ENABLE_SANITIZERS=OFF
+
+      - name: Build world-engine and regressions
+        shell: pwsh
+        run: |
+          cmake --build build/world-engine --config Release --target jarvisx-world-engine --parallel 2
+          cmake --build build/world-engine --config Release --target jarvisx-world-engine-tests --parallel 2
+
+      - name: Run focused tests
+        shell: pwsh
+        run: |
+          ctest --test-dir build/world-engine -C Release -R "world-engine-(runtime-smoke|regressions)" --output-on-failure
+
+      - name: Execute kinetic reference profile
+        shell: pwsh
+        run: |
+          $exe = "build/world-engine/Release/DrMoagi-World-Engine.exe"
+          & $exe --state-dir build/world-engine/reference-state
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stage package and checksum
+        shell: pwsh
+        run: |
+          $stage = "build/world-engine/package"
+          New-Item -ItemType Directory -Force -Path $stage | Out-Null
+          Copy-Item "build/world-engine/Release/DrMoagi-World-Engine.exe" "$stage/DrMoagi-World-Engine.exe"
+          Copy-Item "docs/VMAD128_WORLD_ENGINE.md" "$stage/README.md"
+          $hash = (Get-FileHash "$stage/DrMoagi-World-Engine.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  DrMoagi-World-Engine.exe" | Set-Content -Encoding ascii "$stage/SHA256SUMS.txt"
+          Compress-Archive -Path "$stage/*" -DestinationPath "build/world-engine/DrMoagi-World-Engine-Windows-x64.zip" -Force
+
+      - name: Upload Windows package
+        uses: actions/upload-artifact@v4
+        with:
+          name: DrMoagi-World-Engine-Windows-x64
+          path: |
+            build/world-engine/package/DrMoagi-World-Engine.exe
+            build/world-engine/package/README.md
+            build/world-engine/package/SHA256SUMS.txt
+            build/world-engine/DrMoagi-World-Engine-Windows-x64.zip
+          if-no-files-found: error
+          retention-days: 30

--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -273,3 +273,5 @@ jarvisx_harden(jarvisx-pixels-to-bits-tests)
 
 add_test(NAME pixels-to-bits-regressions COMMAND jarvisx-pixels-to-bits-tests)
 set_tests_properties(pixels-to-bits-regressions PROPERTIES TIMEOUT 120)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/world_engine.cmake)

--- a/cpp_runtime/include/jarvisx/world_engine_vmad.hpp
+++ b/cpp_runtime/include/jarvisx/world_engine_vmad.hpp
@@ -1,0 +1,508 @@
+#pragma once
+
+#include "jarvisx/intelligence_vm3d.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace jarvisx::world {
+
+constexpr std::uint64_t kVmadCoordExtent = 1ULL << 33U;
+constexpr std::uint64_t kVmadCoordMask = kVmadCoordExtent - 1ULL;
+constexpr std::size_t kVectorRegisterCount = 512U;
+constexpr std::size_t kVectorBytes = 64U;
+constexpr std::size_t kScalarRegisterCount = 512U;
+constexpr std::size_t kVmadRegisterCount = 32U;
+constexpr std::size_t kMaxTransferBytes = 4096U;
+constexpr std::size_t kDefaultTileBytes = 1024U;
+
+struct Vmad128 {
+    std::uint64_t hi{};
+    std::uint64_t lo{};
+
+    static Vmad128 pack(std::uint16_t region, std::uint8_t modality, std::uint16_t attributes,
+                        std::uint64_t x, std::uint64_t y, std::uint64_t z) {
+        if (region >= 4096U) throw std::out_of_range("VMAD region exceeds 12 bits");
+        if (attributes >= 512U) throw std::out_of_range("VMAD attributes exceed 9 bits");
+        if (x >= kVmadCoordExtent || y >= kVmadCoordExtent || z >= kVmadCoordExtent) {
+            throw std::out_of_range("VMAD coordinate exceeds 33-bit domain");
+        }
+        Vmad128 value;
+        const std::uint64_t y_low31 = y & ((1ULL << 31U) - 1ULL);
+        const std::uint64_t y_high2 = y >> 31U;
+        value.lo = z | (y_low31 << 33U);
+        value.hi = y_high2 |
+                   (x << 2U) |
+                   (static_cast<std::uint64_t>(attributes) << 35U) |
+                   (static_cast<std::uint64_t>(modality) << 44U) |
+                   (static_cast<std::uint64_t>(region) << 52U);
+        return value;
+    }
+
+    std::uint16_t region() const noexcept {
+        return static_cast<std::uint16_t>((hi >> 52U) & 0x0fffULL);
+    }
+
+    std::uint8_t modality() const noexcept {
+        return static_cast<std::uint8_t>((hi >> 44U) & 0xffULL);
+    }
+
+    std::uint16_t attributes() const noexcept {
+        return static_cast<std::uint16_t>((hi >> 35U) & 0x01ffULL);
+    }
+
+    std::uint64_t x() const noexcept { return (hi >> 2U) & kVmadCoordMask; }
+
+    std::uint64_t y() const noexcept {
+        const std::uint64_t low31 = (lo >> 33U) & ((1ULL << 31U) - 1ULL);
+        const std::uint64_t high2 = hi & 0x3ULL;
+        return low31 | (high2 << 31U);
+    }
+
+    std::uint64_t z() const noexcept { return lo & kVmadCoordMask; }
+
+    intelligence3d::Coord3 coord() const noexcept { return {x(), y(), z()}; }
+
+    bool operator==(const Vmad128& other) const noexcept {
+        return hi == other.hi && lo == other.lo;
+    }
+};
+
+inline std::uint64_t wrap_coord(std::uint64_t base, std::int64_t delta) noexcept {
+    constexpr std::int64_t extent = static_cast<std::int64_t>(kVmadCoordExtent);
+    const std::int64_t reduced = delta % extent;
+    std::int64_t result = static_cast<std::int64_t>(base) + reduced;
+    result %= extent;
+    if (result < 0) result += extent;
+    return static_cast<std::uint64_t>(result);
+}
+
+inline Vmad128 vmad_offset(const Vmad128& base, std::int64_t dx, std::int64_t dy, std::int64_t dz) {
+    return Vmad128::pack(base.region(), base.modality(), base.attributes(),
+                         wrap_coord(base.x(), dx), wrap_coord(base.y(), dy), wrap_coord(base.z(), dz));
+}
+
+inline Vmad128 vmad_advance_linear(const Vmad128& base, std::uint64_t bytes) {
+    const std::uint64_t z_total = base.z() + bytes;
+    const std::uint64_t z = z_total & kVmadCoordMask;
+    const std::uint64_t carry_y = z_total >> 33U;
+    const std::uint64_t y_total = base.y() + carry_y;
+    const std::uint64_t y = y_total & kVmadCoordMask;
+    const std::uint64_t carry_x = y_total >> 33U;
+    const std::uint64_t x = (base.x() + carry_x) & kVmadCoordMask;
+    return Vmad128::pack(base.region(), base.modality(), base.attributes(), x, y, z);
+}
+
+enum class MicroOpcode : std::uint8_t {
+    Nop = 0x00,
+    LoadVmad = 0x01,
+    TileInVec = 0x10,
+    StoreVec = 0x11,
+    EncLatVol = 0x20,
+    FuseAttn = 0x30,
+    DecPixVol = 0x40,
+    CalcDelta = 0x50,
+    ProposeBias = 0x60,
+    Validate = 0x70,
+    CommitIf = 0x71,
+    Halt = 0xff,
+};
+
+enum class KineticStage : std::uint8_t {
+    Ingest = 0U,
+    Reduce = 1U,
+    Fuse = 2U,
+    Reconstruct = 3U,
+    Feedback = 4U,
+};
+
+struct MicroOp {
+    MicroOpcode opcode{MicroOpcode::Nop};
+    std::uint16_t dst{};
+    std::uint16_t src0{};
+    std::uint16_t src1{};
+    std::uint8_t vmad_reg{};
+    std::uint32_t imm24{};
+
+    std::uint64_t encode() const {
+        if (dst >= 512U || src0 >= 512U || src1 >= 512U) {
+            throw std::out_of_range("micro-op register field exceeds 9 bits");
+        }
+        if (vmad_reg >= 32U) throw std::out_of_range("micro-op VMAD field exceeds 5 bits");
+        if (imm24 >= (1U << 24U)) throw std::out_of_range("micro-op immediate exceeds 24 bits");
+        return (static_cast<std::uint64_t>(static_cast<std::uint8_t>(opcode)) << 56U) |
+               (static_cast<std::uint64_t>(dst) << 47U) |
+               (static_cast<std::uint64_t>(src0) << 38U) |
+               (static_cast<std::uint64_t>(src1) << 29U) |
+               (static_cast<std::uint64_t>(vmad_reg) << 24U) |
+               static_cast<std::uint64_t>(imm24);
+    }
+
+    static MicroOp decode(std::uint64_t word) noexcept {
+        MicroOp op;
+        op.opcode = static_cast<MicroOpcode>(static_cast<std::uint8_t>((word >> 56U) & 0xffULL));
+        op.dst = static_cast<std::uint16_t>((word >> 47U) & 0x01ffULL);
+        op.src0 = static_cast<std::uint16_t>((word >> 38U) & 0x01ffULL);
+        op.src1 = static_cast<std::uint16_t>((word >> 29U) & 0x01ffULL);
+        op.vmad_reg = static_cast<std::uint8_t>((word >> 24U) & 0x1fULL);
+        op.imm24 = static_cast<std::uint32_t>(word & 0x00ffffffULL);
+        return op;
+    }
+};
+
+struct WorldProgram {
+    std::vector<Vmad128> descriptors;
+    std::vector<std::uint64_t> words;
+};
+
+struct KineticStats {
+    std::uint64_t issued_micro_ops{};
+    std::uint64_t logical_issue_cycles{};
+    std::uint64_t estimated_pipeline_latency_cycles{};
+    std::uint64_t bytes_ingested{};
+    std::uint64_t bytes_stored{};
+    std::uint64_t commits{};
+    std::uint64_t rollbacks{};
+    std::array<std::uint64_t, 5U> stage_issues{};
+};
+
+class WorldEngine128 {
+public:
+    using VectorRegister = std::array<std::uint8_t, kVectorBytes>;
+
+    explicit WorldEngine128(intelligence3d::VirtualVolume3D& volume) : volume_(volume) {
+        if (volume_.axis_extent() < kVmadCoordExtent) {
+            throw std::invalid_argument("WorldEngine128 requires a virtual volume with at least 2^33 coordinates per axis");
+        }
+    }
+
+    void reset() noexcept {
+        for (auto& reg : vectors_) reg.fill(0U);
+        scalars_.fill(0ULL);
+        vmads_.fill(Vmad128{});
+        authoritative_bias_.fill(0);
+        candidate_bias_.fill(0);
+        candidate_valid_ = false;
+        last_delta_mean_ = 0U;
+        stats_ = KineticStats{};
+    }
+
+    const VectorRegister& vector_register(std::size_t index) const {
+        if (index >= vectors_.size()) throw std::out_of_range("vector register out of range");
+        return vectors_[index];
+    }
+
+    void set_vector_register(std::size_t index, const VectorRegister& value) {
+        if (index >= vectors_.size()) throw std::out_of_range("vector register out of range");
+        vectors_[index] = value;
+    }
+
+    std::uint64_t scalar_register(std::size_t index) const {
+        if (index >= scalars_.size()) throw std::out_of_range("scalar register out of range");
+        return scalars_[index];
+    }
+
+    const std::array<std::int16_t, kVectorBytes>& biases() const noexcept { return authoritative_bias_; }
+    const KineticStats& stats() const noexcept { return stats_; }
+    std::uint32_t last_delta_mean() const noexcept { return last_delta_mean_; }
+
+    void run(const WorldProgram& program, std::uint64_t max_steps = 100000ULL) {
+        if (program.words.empty()) throw std::invalid_argument("world program must not be empty");
+        if (max_steps == 0ULL) throw std::invalid_argument("max_steps must be positive");
+        std::uint64_t steps = 0ULL;
+        for (const std::uint64_t word : program.words) {
+            if (++steps > max_steps) throw std::runtime_error("world program exceeded max_steps");
+            const MicroOp op = MicroOp::decode(word);
+            ++stats_.issued_micro_ops;
+            ++stats_.logical_issue_cycles;
+            if (execute(op, program)) break;
+        }
+        stats_.estimated_pipeline_latency_cycles =
+            stats_.logical_issue_cycles == 0ULL ? 0ULL : stats_.logical_issue_cycles + 4ULL;
+    }
+
+private:
+    intelligence3d::VirtualVolume3D& volume_;
+    std::array<VectorRegister, kVectorRegisterCount> vectors_{};
+    std::array<std::uint64_t, kScalarRegisterCount> scalars_{};
+    std::array<Vmad128, kVmadRegisterCount> vmads_{};
+    std::array<std::int16_t, kVectorBytes> authoritative_bias_{};
+    std::array<std::int16_t, kVectorBytes> candidate_bias_{};
+    bool candidate_valid_{};
+    std::uint32_t last_delta_mean_{};
+    KineticStats stats_{};
+
+    static std::size_t transfer_size(std::uint32_t imm24) {
+        const std::size_t bytes = imm24 == 0U ? kDefaultTileBytes : static_cast<std::size_t>(imm24);
+        if (bytes == 0U || bytes > kMaxTransferBytes) {
+            throw std::runtime_error("world-engine transfer exceeds bounded payload size");
+        }
+        return bytes;
+    }
+
+    static std::size_t register_span(std::size_t bytes) noexcept {
+        return (bytes + kVectorBytes - 1U) / kVectorBytes;
+    }
+
+    static void validate_vector_span(std::uint16_t base, std::size_t bytes) {
+        const std::size_t span = register_span(bytes);
+        if (static_cast<std::size_t>(base) + span > kVectorRegisterCount) {
+            throw std::runtime_error("vector register span exceeds V0-V511");
+        }
+    }
+
+    static void validate_vector(std::uint16_t index) {
+        if (index >= kVectorRegisterCount) throw std::runtime_error("vector register exceeds V0-V511");
+    }
+
+    static void validate_scalar(std::uint16_t index) {
+        if (index >= kScalarRegisterCount) throw std::runtime_error("scalar register exceeds R0-R511");
+    }
+
+    static std::uint8_t clamp_byte(std::int64_t value) noexcept {
+        return static_cast<std::uint8_t>(std::clamp<std::int64_t>(value, 0LL, 255LL));
+    }
+
+    static std::int16_t clamp_bias(std::int64_t value) noexcept {
+        return static_cast<std::int16_t>(std::clamp<std::int64_t>(value, -127LL, 127LL));
+    }
+
+    std::uint8_t vector_byte(std::uint16_t base, std::size_t offset) const {
+        const std::size_t reg = static_cast<std::size_t>(base) + offset / kVectorBytes;
+        return vectors_[reg][offset % kVectorBytes];
+    }
+
+    void set_vector_byte(std::uint16_t base, std::size_t offset, std::uint8_t value) {
+        const std::size_t reg = static_cast<std::size_t>(base) + offset / kVectorBytes;
+        vectors_[reg][offset % kVectorBytes] = value;
+    }
+
+    intelligence3d::Coord3 checked_coord(const Vmad128& address) const {
+        const intelligence3d::Coord3 coord = address.coord();
+        if (coord.x >= volume_.axis_extent() || coord.y >= volume_.axis_extent() ||
+            coord.z >= volume_.axis_extent()) {
+            throw std::runtime_error("VMAD lies outside configured sparse volume");
+        }
+        return coord;
+    }
+
+    void note_stage(KineticStage stage) noexcept {
+        ++stats_.stage_issues[static_cast<std::size_t>(stage)];
+    }
+
+    bool execute(const MicroOp& op, const WorldProgram& program) {
+        switch (op.opcode) {
+            case MicroOpcode::Nop:
+                return false;
+            case MicroOpcode::LoadVmad:
+                if (op.vmad_reg >= kVmadRegisterCount) throw std::runtime_error("VMAD register exceeds A0-A31");
+                if (op.imm24 >= program.descriptors.size()) throw std::runtime_error("VMAD descriptor index out of range");
+                vmads_[op.vmad_reg] = program.descriptors[op.imm24];
+                return false;
+            case MicroOpcode::TileInVec:
+                ingest(op);
+                return false;
+            case MicroOpcode::StoreVec:
+                store(op);
+                return false;
+            case MicroOpcode::EncLatVol:
+                encode_latent(op);
+                return false;
+            case MicroOpcode::FuseAttn:
+                fuse_attention(op);
+                return false;
+            case MicroOpcode::DecPixVol:
+                decode_expand(op);
+                return false;
+            case MicroOpcode::CalcDelta:
+                calculate_delta(op);
+                return false;
+            case MicroOpcode::ProposeBias:
+                propose_bias(op);
+                return false;
+            case MicroOpcode::Validate:
+                validate_candidate(op);
+                return false;
+            case MicroOpcode::CommitIf:
+                commit_if(op);
+                return false;
+            case MicroOpcode::Halt:
+                return true;
+            default:
+                throw std::runtime_error("unknown world-engine micro-opcode");
+        }
+    }
+
+    void ingest(const MicroOp& op) {
+        if (op.vmad_reg >= kVmadRegisterCount) throw std::runtime_error("VMAD register exceeds A0-A31");
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector_span(op.dst, bytes);
+        const Vmad128 base = vmads_[op.vmad_reg];
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            const Vmad128 address = vmad_advance_linear(base, static_cast<std::uint64_t>(i));
+            set_vector_byte(op.dst, i, volume_.read(checked_coord(address)));
+        }
+        stats_.bytes_ingested += static_cast<std::uint64_t>(bytes);
+        note_stage(KineticStage::Ingest);
+    }
+
+    void store(const MicroOp& op) {
+        if (op.vmad_reg >= kVmadRegisterCount) throw std::runtime_error("VMAD register exceeds A0-A31");
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector_span(op.src0, bytes);
+        const Vmad128 base = vmads_[op.vmad_reg];
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            const Vmad128 address = vmad_advance_linear(base, static_cast<std::uint64_t>(i));
+            volume_.write(checked_coord(address), vector_byte(op.src0, i));
+        }
+        stats_.bytes_stored += static_cast<std::uint64_t>(bytes);
+        note_stage(KineticStage::Reconstruct);
+    }
+
+    void encode_latent(const MicroOp& op) {
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector_span(op.src0, bytes);
+        validate_vector(op.dst);
+        vectors_[op.dst].fill(0U);
+        for (std::size_t latent = 0U; latent < 32U; ++latent) {
+            std::uint64_t sum = 0ULL;
+            std::size_t count = 0U;
+            for (std::size_t i = latent; i < bytes; i += 32U) {
+                sum += static_cast<std::uint64_t>(vector_byte(op.src0, i));
+                ++count;
+            }
+            const std::int64_t average = count == 0U ? 0LL :
+                static_cast<std::int64_t>((sum + static_cast<std::uint64_t>(count / 2U)) /
+                                          static_cast<std::uint64_t>(count));
+            vectors_[op.dst][latent] = clamp_byte(average + authoritative_bias_[latent]);
+        }
+        note_stage(KineticStage::Reduce);
+    }
+
+    void fuse_attention(const MicroOp& op) {
+        validate_vector(op.dst);
+        validate_vector(op.src0);
+        validate_vector(op.src1);
+        std::int64_t dot = 0LL;
+        for (std::size_t i = 0U; i < kVectorBytes; ++i) {
+            const std::int64_t a = static_cast<std::int64_t>(vectors_[op.src0][i]) - 128LL;
+            const std::int64_t b = static_cast<std::int64_t>(vectors_[op.src1][i]) - 128LL;
+            dot += a * b;
+        }
+        const std::int64_t alpha64 = std::clamp<std::int64_t>(128LL + dot / 16384LL, 32LL, 223LL);
+        const std::uint32_t alpha = static_cast<std::uint32_t>(alpha64);
+        for (std::size_t i = 0U; i < kVectorBytes; ++i) {
+            const std::uint32_t a = vectors_[op.src0][i];
+            const std::uint32_t b = vectors_[op.src1][i];
+            const std::uint32_t mixed = alpha * a + (255U - alpha) * b + 127U;
+            vectors_[op.dst][i] = static_cast<std::uint8_t>(mixed / 255U);
+        }
+        note_stage(KineticStage::Fuse);
+    }
+
+    void decode_expand(const MicroOp& op) {
+        if (op.vmad_reg >= kVmadRegisterCount) throw std::runtime_error("VMAD register exceeds A0-A31");
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector(op.src0);
+        validate_vector_span(op.dst, bytes);
+        const Vmad128 base = vmads_[op.vmad_reg];
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            const std::size_t latent = i % 32U;
+            const std::size_t next = (latent + 1U) % 32U;
+            const std::uint32_t expanded =
+                (3U * static_cast<std::uint32_t>(vectors_[op.src0][latent]) +
+                 static_cast<std::uint32_t>(vectors_[op.src0][next]) + 2U) / 4U;
+            const std::uint8_t value = static_cast<std::uint8_t>(expanded);
+            set_vector_byte(op.dst, i, value);
+            const Vmad128 address = vmad_advance_linear(base, static_cast<std::uint64_t>(i));
+            volume_.write(checked_coord(address), value);
+        }
+        stats_.bytes_stored += static_cast<std::uint64_t>(bytes);
+        note_stage(KineticStage::Reconstruct);
+    }
+
+    void calculate_delta(const MicroOp& op) {
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector_span(op.src0, bytes);
+        validate_vector_span(op.src1, bytes);
+        validate_vector_span(op.dst, bytes);
+        std::uint64_t score = 0ULL;
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            const std::int64_t source = static_cast<std::int64_t>(vector_byte(op.src0, i));
+            const std::int64_t reconstructed = static_cast<std::int64_t>(vector_byte(op.src1, i));
+            const std::int64_t delta = source - reconstructed;
+            score += static_cast<std::uint64_t>(delta < 0 ? -delta : delta);
+            const std::int64_t bounded = std::clamp<std::int64_t>(delta, -127LL, 127LL);
+            set_vector_byte(op.dst, i, static_cast<std::uint8_t>(bounded + 128LL));
+        }
+        last_delta_mean_ = static_cast<std::uint32_t>(score / static_cast<std::uint64_t>(bytes));
+        note_stage(KineticStage::Feedback);
+    }
+
+    void propose_bias(const MicroOp& op) {
+        const std::size_t bytes = transfer_size(op.imm24);
+        validate_vector_span(op.src0, bytes);
+        for (std::size_t lane = 0U; lane < kVectorBytes; ++lane) {
+            std::int64_t sum = 0LL;
+            std::size_t count = 0U;
+            for (std::size_t i = lane; i < bytes; i += kVectorBytes) {
+                sum += static_cast<std::int64_t>(vector_byte(op.src0, i)) - 128LL;
+                ++count;
+            }
+            const std::int64_t mean = count == 0U ? 0LL : sum / static_cast<std::int64_t>(count);
+            candidate_bias_[lane] = clamp_bias(static_cast<std::int64_t>(authoritative_bias_[lane]) + mean / 8LL);
+        }
+        candidate_valid_ = true;
+        note_stage(KineticStage::Feedback);
+    }
+
+    void validate_candidate(const MicroOp& op) {
+        validate_scalar(op.dst);
+        const std::uint32_t threshold = op.imm24;
+        scalars_[op.dst] = candidate_valid_ && last_delta_mean_ <= threshold ? 1ULL : 0ULL;
+        note_stage(KineticStage::Feedback);
+    }
+
+    void commit_if(const MicroOp& op) {
+        validate_scalar(op.src0);
+        const bool accept = scalars_[op.src0] != 0ULL && candidate_valid_;
+        if (accept) {
+            authoritative_bias_ = candidate_bias_;
+            ++stats_.commits;
+        } else {
+            ++stats_.rollbacks;
+        }
+        candidate_bias_ = authoritative_bias_;
+        candidate_valid_ = false;
+        note_stage(KineticStage::Feedback);
+    }
+};
+
+inline WorldProgram make_world_demo_program(const Vmad128& source, const Vmad128& output) {
+    WorldProgram program;
+    program.descriptors = {source, output};
+    const auto emit = [&](MicroOpcode opcode, std::uint16_t dst, std::uint16_t src0,
+                          std::uint16_t src1, std::uint8_t address_reg, std::uint32_t imm24) {
+        program.words.push_back(MicroOp{opcode, dst, src0, src1, address_reg, imm24}.encode());
+    };
+    emit(MicroOpcode::LoadVmad, 0U, 0U, 0U, 0U, 0U);
+    emit(MicroOpcode::LoadVmad, 0U, 0U, 0U, 1U, 1U);
+    emit(MicroOpcode::TileInVec, 2U, 0U, 0U, 0U, 1024U);
+    emit(MicroOpcode::EncLatVol, 32U, 2U, 0U, 0U, 1024U);
+    emit(MicroOpcode::FuseAttn, 40U, 32U, 32U, 0U, 0U);
+    emit(MicroOpcode::DecPixVol, 64U, 40U, 0U, 1U, 1024U);
+    emit(MicroOpcode::CalcDelta, 96U, 2U, 64U, 0U, 1024U);
+    emit(MicroOpcode::ProposeBias, 0U, 96U, 0U, 0U, 1024U);
+    emit(MicroOpcode::Validate, 20U, 0U, 0U, 0U, 255U);
+    emit(MicroOpcode::CommitIf, 0U, 20U, 0U, 0U, 0U);
+    emit(MicroOpcode::Halt, 0U, 0U, 0U, 0U, 0U);
+    return program;
+}
+
+} // namespace jarvisx::world

--- a/cpp_runtime/src/world_engine_main.cpp
+++ b/cpp_runtime/src/world_engine_main.cpp
@@ -1,0 +1,93 @@
+#include "jarvisx/world_engine_vmad.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::filesystem::path state_dir{"jarvisx-world-state"};
+    bool quiet{};
+};
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--state-dir") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --state-dir");
+            options.state_dir = argv[++i];
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout << "Usage: DrMoagi-World-Engine [--state-dir PATH] [--quiet]\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + arg);
+        }
+    }
+    return options;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        std::filesystem::remove_all(options.state_dir);
+
+        jarvisx::intelligence3d::VirtualVolume3D volume({
+            jarvisx::world::kVmadCoordExtent,
+            32U,
+            2ULL * 1024ULL * 1024ULL,
+            options.state_dir / "pages",
+        });
+
+        const auto source = jarvisx::world::Vmad128::pack(1U, 1U, 0U, 12U, 34U, 56U);
+        const auto output = jarvisx::world::Vmad128::pack(2U, 1U, 0U, 20U, 40U, 60U);
+
+        for (std::size_t i = 0U; i < jarvisx::world::kDefaultTileBytes; ++i) {
+            const auto address = jarvisx::world::vmad_advance_linear(source, static_cast<std::uint64_t>(i));
+            const std::uint8_t value = static_cast<std::uint8_t>((i * 37U + (i >> 3U)) & 0xffU);
+            volume.write(address.coord(), value);
+        }
+
+        jarvisx::world::WorldEngine128 engine(volume);
+        const auto program = jarvisx::world::make_world_demo_program(source, output);
+        engine.run(program, 1000ULL);
+        volume.flush();
+
+        if (!options.quiet) {
+            const auto& stats = engine.stats();
+            std::cout << "DM-vOmegaXi+ VMAD128 kinetic world-engine reference\n"
+                      << "vmad_bits=128 coord_bits=33 axis_extent=" << jarvisx::world::kVmadCoordExtent << '\n'
+                      << "vector_registers=" << jarvisx::world::kVectorRegisterCount
+                      << " vector_bytes=" << jarvisx::world::kVectorBytes
+                      << " scalar_registers=" << jarvisx::world::kScalarRegisterCount
+                      << " vmad_registers=" << jarvisx::world::kVmadRegisterCount << '\n'
+                      << "micro_ops=" << stats.issued_micro_ops
+                      << " issue_cycles=" << stats.logical_issue_cycles
+                      << " estimated_pipeline_latency_cycles=" << stats.estimated_pipeline_latency_cycles << '\n'
+                      << "bytes_ingested=" << stats.bytes_ingested
+                      << " bytes_stored=" << stats.bytes_stored
+                      << " commits=" << stats.commits
+                      << " rollbacks=" << stats.rollbacks
+                      << " delta_mean=" << engine.last_delta_mean() << '\n'
+                      << "stage_ingest=" << stats.stage_issues[0]
+                      << " stage_reduce=" << stats.stage_issues[1]
+                      << " stage_fuse=" << stats.stage_issues[2]
+                      << " stage_reconstruct=" << stats.stage_issues[3]
+                      << " stage_feedback=" << stats.stage_issues[4] << '\n'
+                      << "claim_boundary=software_reference_no_photonic_or_subnanosecond_timing_claim\n";
+        }
+
+        std::filesystem::remove_all(options.state_dir);
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "DrMoagi World Engine failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/src/world_engine_main.cpp
+++ b/cpp_runtime/src/world_engine_main.cpp
@@ -1,6 +1,7 @@
 #include "jarvisx/world_engine_vmad.hpp"
 
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>

--- a/cpp_runtime/tests/world_engine_vmad_tests.cpp
+++ b/cpp_runtime/tests/world_engine_vmad_tests.cpp
@@ -1,0 +1,164 @@
+#include "jarvisx/world_engine_vmad.hpp"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+std::filesystem::path test_dir(const char* name) {
+    return std::filesystem::temp_directory_path() / (std::string("jarvisx-world-") + name);
+}
+
+void test_vmad_pack_roundtrip() {
+    const auto address = jarvisx::world::Vmad128::pack(
+        4095U, 255U, 511U,
+        jarvisx::world::kVmadCoordExtent - 1ULL,
+        jarvisx::world::kVmadCoordExtent - 2ULL,
+        jarvisx::world::kVmadCoordExtent - 3ULL);
+    require(address.region() == 4095U, "VMAD region roundtrip failed");
+    require(address.modality() == 255U, "VMAD modality roundtrip failed");
+    require(address.attributes() == 511U, "VMAD attributes roundtrip failed");
+    require(address.x() == jarvisx::world::kVmadCoordExtent - 1ULL, "VMAD X roundtrip failed");
+    require(address.y() == jarvisx::world::kVmadCoordExtent - 2ULL, "VMAD Y roundtrip failed");
+    require(address.z() == jarvisx::world::kVmadCoordExtent - 3ULL, "VMAD Z roundtrip failed");
+
+    const auto wrapped = jarvisx::world::vmad_offset(address, 1, 2, 3);
+    require(wrapped.x() == 0ULL && wrapped.y() == 0ULL && wrapped.z() == 0ULL,
+            "VMAD toroidal offset failed");
+
+    bool rejected = false;
+    try {
+        (void)jarvisx::world::Vmad128::pack(0U, 0U, 0U, jarvisx::world::kVmadCoordExtent, 0U, 0U);
+    } catch (const std::out_of_range&) {
+        rejected = true;
+    }
+    require(rejected, "VMAD accepted a coordinate outside the 33-bit domain");
+}
+
+void test_micro_op_roundtrip() {
+    const jarvisx::world::MicroOp original{
+        jarvisx::world::MicroOpcode::CalcDelta, 511U, 510U, 509U, 31U, 0x00abcdefU,
+    };
+    const auto decoded = jarvisx::world::MicroOp::decode(original.encode());
+    require(decoded.opcode == original.opcode, "micro-op opcode roundtrip failed");
+    require(decoded.dst == original.dst && decoded.src0 == original.src0 && decoded.src1 == original.src1,
+            "micro-op register roundtrip failed");
+    require(decoded.vmad_reg == original.vmad_reg, "micro-op VMAD register roundtrip failed");
+    require(decoded.imm24 == original.imm24, "micro-op immediate roundtrip failed");
+}
+
+void test_sparse_ingest_and_pipeline() {
+    const auto dir = test_dir("pipeline");
+    std::filesystem::remove_all(dir);
+    jarvisx::intelligence3d::VirtualVolume3D volume({
+        jarvisx::world::kVmadCoordExtent, 32U, 2ULL * 1024ULL * 1024ULL, dir / "pages",
+    });
+    const auto source = jarvisx::world::Vmad128::pack(1U, 1U, 0U, 5U, 7U, 11U);
+    const auto output = jarvisx::world::Vmad128::pack(2U, 1U, 0U, 17U, 19U, 23U);
+    for (std::size_t i = 0U; i < 1024U; ++i) {
+        const auto address = jarvisx::world::vmad_advance_linear(source, static_cast<std::uint64_t>(i));
+        volume.write(address.coord(), static_cast<std::uint8_t>((i * 13U + 17U) & 0xffU));
+    }
+
+    jarvisx::world::WorldEngine128 engine(volume);
+    engine.run(jarvisx::world::make_world_demo_program(source, output), 1000ULL);
+    const auto& stats = engine.stats();
+    require(stats.bytes_ingested == 1024ULL, "pipeline did not ingest one 1024-byte quantum");
+    require(stats.bytes_stored == 1024ULL, "pipeline did not reconstruct one 1024-byte quantum");
+    require(stats.commits == 1ULL && stats.rollbacks == 0ULL, "pipeline candidate did not commit");
+    require(stats.stage_issues[0] >= 1ULL, "ingest stage was not exercised");
+    require(stats.stage_issues[1] >= 1ULL, "reduce stage was not exercised");
+    require(stats.stage_issues[2] >= 1ULL, "fusion stage was not exercised");
+    require(stats.stage_issues[3] >= 1ULL, "reconstruction stage was not exercised");
+    require(stats.stage_issues[4] >= 1ULL, "feedback stage was not exercised");
+    require(stats.estimated_pipeline_latency_cycles == stats.logical_issue_cycles + 4ULL,
+            "pipeline latency accounting is inconsistent");
+    require(volume.read(output.coord()) <= 255U, "reconstructed output byte is invalid");
+    std::filesystem::remove_all(dir);
+}
+
+jarvisx::world::WorldProgram adaptation_program(std::uint32_t threshold) {
+    jarvisx::world::WorldProgram program;
+    const auto emit = [&](jarvisx::world::MicroOpcode opcode, std::uint16_t dst, std::uint16_t src0,
+                          std::uint16_t src1, std::uint32_t imm24) {
+        program.words.push_back(jarvisx::world::MicroOp{opcode, dst, src0, src1, 0U, imm24}.encode());
+    };
+    emit(jarvisx::world::MicroOpcode::CalcDelta, 2U, 0U, 1U, 64U);
+    emit(jarvisx::world::MicroOpcode::ProposeBias, 0U, 2U, 0U, 64U);
+    emit(jarvisx::world::MicroOpcode::Validate, 7U, 0U, 0U, threshold);
+    emit(jarvisx::world::MicroOpcode::CommitIf, 0U, 7U, 0U, 0U);
+    emit(jarvisx::world::MicroOpcode::Halt, 0U, 0U, 0U, 0U);
+    return program;
+}
+
+void test_candidate_commit_and_rollback() {
+    const auto dir = test_dir("transaction");
+    std::filesystem::remove_all(dir);
+    jarvisx::intelligence3d::VirtualVolume3D volume({
+        jarvisx::world::kVmadCoordExtent, 32U, 1024ULL * 1024ULL, dir / "pages",
+    });
+    jarvisx::world::WorldEngine128 engine(volume);
+
+    jarvisx::world::WorldEngine128::VectorRegister high{};
+    jarvisx::world::WorldEngine128::VectorRegister low{};
+    high.fill(255U);
+    low.fill(0U);
+    engine.set_vector_register(0U, high);
+    engine.set_vector_register(1U, low);
+    const auto before = engine.biases();
+
+    engine.run(adaptation_program(0U), 100ULL);
+    require(engine.stats().rollbacks == 1ULL, "failed quality gate did not roll back candidate");
+    require(engine.biases() == before, "rollback mutated authoritative bias state");
+
+    engine.run(adaptation_program(255U), 100ULL);
+    require(engine.stats().commits == 1ULL, "validated candidate did not commit");
+    require(engine.biases() != before, "commit did not change authoritative bias state");
+    std::filesystem::remove_all(dir);
+}
+
+void test_transfer_bound() {
+    const auto dir = test_dir("bounds");
+    std::filesystem::remove_all(dir);
+    jarvisx::intelligence3d::VirtualVolume3D volume({
+        jarvisx::world::kVmadCoordExtent, 32U, 1024ULL * 1024ULL, dir / "pages",
+    });
+    jarvisx::world::WorldEngine128 engine(volume);
+    jarvisx::world::WorldProgram program;
+    program.descriptors.push_back(jarvisx::world::Vmad128::pack(0U, 0U, 0U, 0U, 0U, 0U));
+    program.words.push_back(jarvisx::world::MicroOp{jarvisx::world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 0U, 0U}.encode());
+    program.words.push_back(jarvisx::world::MicroOp{jarvisx::world::MicroOpcode::TileInVec, 0U, 0U, 0U, 0U, 4097U}.encode());
+    bool rejected = false;
+    try {
+        engine.run(program, 10ULL);
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    require(rejected, "world engine accepted an oversized transfer");
+    std::filesystem::remove_all(dir);
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_vmad_pack_roundtrip();
+        test_micro_op_roundtrip();
+        test_sparse_ingest_and_pipeline();
+        test_candidate_commit_and_rollback();
+        test_transfer_bound();
+        std::cout << "world-engine VMAD128 regressions passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "world-engine VMAD128 regression failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/world_engine_vmad_tests.cpp
+++ b/cpp_runtime/tests/world_engine_vmad_tests.cpp
@@ -81,7 +81,8 @@ void test_sparse_ingest_and_pipeline() {
     require(stats.stage_issues[4] >= 1ULL, "feedback stage was not exercised");
     require(stats.estimated_pipeline_latency_cycles == stats.logical_issue_cycles + 4ULL,
             "pipeline latency accounting is inconsistent");
-    require(volume.read(output.coord()) <= 255U, "reconstructed output byte is invalid");
+    require(volume.read(output.coord()) == engine.vector_register(64U)[0],
+            "decoded vector and sparse output volume diverged");
     std::filesystem::remove_all(dir);
 }
 

--- a/cpp_runtime/world_engine.cmake
+++ b/cpp_runtime/world_engine.cmake
@@ -1,0 +1,23 @@
+add_executable(jarvisx-world-engine
+    src/world_engine_main.cpp
+)
+set_target_properties(jarvisx-world-engine PROPERTIES OUTPUT_NAME "DrMoagi-World-Engine")
+jarvisx_include_runtime(jarvisx-world-engine)
+jarvisx_harden(jarvisx-world-engine)
+
+add_test(
+    NAME world-engine-runtime-smoke
+    COMMAND jarvisx-world-engine
+        --state-dir ${CMAKE_CURRENT_BINARY_DIR}/world-engine-smoke
+        --quiet
+)
+set_tests_properties(world-engine-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-world-engine-tests
+    tests/world_engine_vmad_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-world-engine-tests)
+jarvisx_harden(jarvisx-world-engine-tests)
+
+add_test(NAME world-engine-regressions COMMAND jarvisx-world-engine-tests)
+set_tests_properties(world-engine-regressions PROPERTIES TIMEOUT 120)

--- a/docs/VMAD128_WORLD_ENGINE.md
+++ b/docs/VMAD128_WORLD_ENGINE.md
@@ -1,0 +1,132 @@
+# DM-vOmegaXi+ VMAD128 Kinetic World Engine
+
+Status: software reference implementation
+
+This layer extends the existing sparse `VirtualVolume3D` substrate with a typed 128-bit volumetric address descriptor and a separate 64-bit micro-op execution format. It does **not** replace or alter the existing `JX3DVM1` bytecode wire format.
+
+## 1. VMAD128 layout
+
+The canonical descriptor is:
+
+| Bits | Field | Width |
+|---|---|---:|
+| 127:116 | region | 12 |
+| 115:108 | modality | 8 |
+| 107:99 | attributes | 9 |
+| 98:66 | X | 33 |
+| 65:33 | Y | 33 |
+| 32:0 | Z | 33 |
+
+Each coordinate lies in `[0, 2^33)`. The conceptual byte volume is therefore `2^99` addressable byte sites. The implementation remains sparse: untouched coordinates are not materialized as resident memory.
+
+Periodic addressing uses modulo-`2^33` coordinate arithmetic. Sequential payload transfer advances Z first, then Y, then X.
+
+## 2. Register banks
+
+The reference machine exposes:
+
+- 512 vector registers `V0..V511`, each 64 bytes (512 bits), for 32 KiB of vector-register state;
+- 512 scalar registers `R0..R511`;
+- 32 VMAD registers `A0..A31`.
+
+A 1024-byte ingress quantum occupies exactly 16 vector registers.
+
+## 3. 64-bit micro-op
+
+Each micro-op is encoded as:
+
+```text
+63          56 55      47 46      38 37      29 28   24 23               0
++-------------+----------+----------+----------+-------+-------------------+
+| opcode (8)  | dst (9)  | src0(9)  | src1(9)  | A(5)  | immediate (24)   |
++-------------+----------+----------+----------+-------+-------------------+
+```
+
+A 128-bit VMAD is never embedded inside the 64-bit instruction. `LOAD_VMAD` loads one descriptor from the program descriptor table into `A0..A31`.
+
+Implemented reference micro-ops:
+
+- `LOAD_VMAD`
+- `TILE_IN_VEC`
+- `STORE_VEC`
+- `ENC_LAT_VOL`
+- `FUSE_ATTN`
+- `DEC_PIX_VOL`
+- `CALC_DELTA`
+- `PROPOSE_BIAS`
+- `VALIDATE`
+- `COMMIT_IF`
+- `HALT`
+
+Payload movement is explicitly bounded to 4096 bytes per micro-op. The canonical demo uses 1024-byte quanta.
+
+## 4. Five-stage kinetic model
+
+The logical stages are:
+
+1. ingestion;
+2. latent reduction;
+3. cross-modal/fixed-point fusion;
+4. reconstruction/store;
+5. inward feedback and transactional adaptation.
+
+The software reference accounts for one issued micro-op per logical issue cycle and reports an estimated five-stage pipeline-fill latency of `issued + 4` cycles. This is architectural accounting only; it is not a measured clock frequency or physical silicon latency.
+
+## 5. Deterministic transforms
+
+`ENC_LAT_VOL` reduces a bounded byte block into a 32-byte latent vector using deterministic grouped averaging plus the currently authoritative local bias state.
+
+`FUSE_ATTN` computes a centered fixed-point dot product between two 64-byte vector registers and derives a bounded blend coefficient. This provides deterministic cross-stream fusion without claiming a photonic matrix implementation.
+
+`DEC_PIX_VOL` expands the 32-byte latent state into a bounded output payload and writes it to both vector registers and the sparse VMAD-addressed volume.
+
+`CALC_DELTA` computes source-minus-reconstruction deltas, stores a centered signed-byte representation, and records mean absolute byte error.
+
+## 6. Inward transactional adaptation
+
+The adaptation sequence is:
+
+```text
+CALC_DELTA -> PROPOSE_BIAS -> VALIDATE -> COMMIT_IF
+```
+
+`PROPOSE_BIAS` writes only a shadow candidate. `VALIDATE` places the gate result in a scalar register. `COMMIT_IF` is the only operation permitted to promote the candidate into authoritative bias state.
+
+Therefore the invariant is:
+
+```text
+no authoritative adaptive state changes before validation
+```
+
+A rejected candidate restores the existing authoritative bias state unchanged.
+
+## 7. Sparse world-state semantics
+
+VMAD region/modality/attribute fields are typed metadata at this layer. Physical residency is still provided by `VirtualVolume3D`, whose pages are lazily materialized and spilled through the existing sparse backing store.
+
+This implementation proves the software addressing and execution semantics; it does not claim that `2^99` bytes are physically resident.
+
+## 8. Claim boundary
+
+Implemented and testable:
+
+- exact 128-bit VMAD packing/unpacking;
+- 33-bit X/Y/Z domain;
+- toroidal coordinate wrapping;
+- 64-bit micro-op encoding/decoding;
+- 512 vector + 512 scalar + 32 VMAD register architecture;
+- bounded sparse ingress/output;
+- deterministic reduction/fusion/reconstruction;
+- candidate/validate/commit rollback discipline;
+- five-stage logical pipeline telemetry.
+
+Not established by this software reference:
+
+- silicon-photonic routing latency;
+- TSV/eSRAM realization;
+- sub-nanosecond or sub-picosecond timing;
+- physical energy efficiency;
+- external SOTA performance;
+- patentability.
+
+Those remain separate hardware and benchmarking evidence gates.


### PR DESCRIPTION
## Summary

Implements the next software-conformant slice of the production-scale DM-vOmegaXi+ world-engine architecture without altering the existing JX3DVM1 wire format.

### Architecture
- typed 128-bit VMAD: 12-bit region, 8-bit modality, 9-bit attributes, 33-bit X/Y/Z;
- `2^99` conceptual byte-address volume over the existing sparse `VirtualVolume3D` substrate;
- modulo-`2^33` toroidal coordinate semantics;
- 512 x 64-byte vector registers, 512 scalar registers, 32 VMAD registers;
- 64-bit micro-op format `(OP,D,S0,S1,A,IMM24)`;
- descriptor-table VMAD loading so 128-bit addresses are never embedded in 64-bit opcodes.

### Kinetic execution
- bounded `TILE_IN_VEC` / `STORE_VEC` transfers;
- deterministic `ENC_LAT_VOL` 1024-byte -> 32-byte latent reduction;
- fixed-point `FUSE_ATTN` cross-stream fusion;
- `DEC_PIX_VOL` expansion into vector + sparse VMAD-addressed output state;
- `CALC_DELTA` byte error field;
- `PROPOSE_BIAS -> VALIDATE -> COMMIT_IF` candidate-first inward adaptation;
- five-stage logical pipeline accounting with throughput/latency kept distinct.

### Verification
Adds regressions for:
- VMAD field roundtrip and 33-bit bounds;
- toroidal wrapping;
- 64-bit micro-op encode/decode;
- 1024-byte sparse ingestion/reconstruction;
- stage coverage and pipeline-fill accounting;
- reject-without-mutation and validated commit;
- oversized transfer fail-closed behavior.

Adds `DrMoagi-World-Engine` CLI, CMake/CTest integration, documentation, and a Windows x64 MSVC packaging workflow.

### Claim boundary
This is a deterministic software reference. It does not establish silicon-photonic latency, TSV/eSRAM realization, sub-nanosecond timing, physical energy efficiency, SOTA superiority, or patentability.

Closes #188 when all cross-platform promotion gates pass.