### PR TITLE
Permeate recursive cube interpreter through VMAD128 world engine

### DIFF
--- a/.github/workflows/world-engine-windows.yml
+++ b/.github/workflows/world-engine-windows.yml
@@ -4,20 +4,28 @@ on:
   push:
     paths:
       - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp"
       - "cpp_runtime/src/world_engine_main.cpp"
+      - "cpp_runtime/src/recursive_cube_main.cpp"
       - "cpp_runtime/tests/world_engine_vmad_tests.cpp"
+      - "cpp_runtime/tests/recursive_cube_interpreter_tests.cpp"
       - "cpp_runtime/world_engine.cmake"
       - "cpp_runtime/CMakeLists.txt"
       - "docs/VMAD128_WORLD_ENGINE.md"
+      - "docs/RECURSIVE_CUBE_INTERPRETER.md"
       - ".github/workflows/world-engine-windows.yml"
   pull_request:
     paths:
       - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp"
       - "cpp_runtime/src/world_engine_main.cpp"
+      - "cpp_runtime/src/recursive_cube_main.cpp"
       - "cpp_runtime/tests/world_engine_vmad_tests.cpp"
+      - "cpp_runtime/tests/recursive_cube_interpreter_tests.cpp"
       - "cpp_runtime/world_engine.cmake"
       - "cpp_runtime/CMakeLists.txt"
       - "docs/VMAD128_WORLD_ENGINE.md"
+      - "docs/RECURSIVE_CUBE_INTERPRETER.md"
       - ".github/workflows/world-engine-windows.yml"
   workflow_dispatch:
 
@@ -46,16 +54,18 @@ jobs:
           -DJARVISX_BUILD_GL_VISUALIZER=OFF
           -DJARVISX_ENABLE_SANITIZERS=OFF
 
-      - name: Build world-engine and regressions
+      - name: Build world-engine, recursive cube, and regressions
         shell: pwsh
         run: |
           cmake --build build/world-engine --config Release --target jarvisx-world-engine --parallel 2
           cmake --build build/world-engine --config Release --target jarvisx-world-engine-tests --parallel 2
+          cmake --build build/world-engine --config Release --target jarvisx-recursive-cube --parallel 2
+          cmake --build build/world-engine --config Release --target jarvisx-recursive-cube-tests --parallel 2
 
       - name: Run focused tests
         shell: pwsh
         run: |
-          ctest --test-dir build/world-engine -C Release -R "world-engine-(runtime-smoke|regressions)" --output-on-failure
+          ctest --test-dir build/world-engine -C Release -R "(world-engine|recursive-cube)-(runtime-smoke|regressions)" --output-on-failure
 
       - name: Execute kinetic reference profile
         shell: pwsh
@@ -64,15 +74,28 @@ jobs:
           & $exe --state-dir build/world-engine/reference-state
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-      - name: Stage package and checksum
+      - name: Execute recursive cube reference profile
+        shell: pwsh
+        run: |
+          $exe = "build/world-engine/Release/DrMoagi-Recursive-Cube.exe"
+          & $exe --tiles 32 --levels 2 --state-dir build/world-engine/recursive-reference-state
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Stage package and checksums
         shell: pwsh
         run: |
           $stage = "build/world-engine/package"
           New-Item -ItemType Directory -Force -Path $stage | Out-Null
           Copy-Item "build/world-engine/Release/DrMoagi-World-Engine.exe" "$stage/DrMoagi-World-Engine.exe"
-          Copy-Item "docs/VMAD128_WORLD_ENGINE.md" "$stage/README.md"
-          $hash = (Get-FileHash "$stage/DrMoagi-World-Engine.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
-          "$hash  DrMoagi-World-Engine.exe" | Set-Content -Encoding ascii "$stage/SHA256SUMS.txt"
+          Copy-Item "build/world-engine/Release/DrMoagi-Recursive-Cube.exe" "$stage/DrMoagi-Recursive-Cube.exe"
+          Copy-Item "docs/VMAD128_WORLD_ENGINE.md" "$stage/VMAD128_WORLD_ENGINE.md"
+          Copy-Item "docs/RECURSIVE_CUBE_INTERPRETER.md" "$stage/RECURSIVE_CUBE_INTERPRETER.md"
+          $worldHash = (Get-FileHash "$stage/DrMoagi-World-Engine.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          $cubeHash = (Get-FileHash "$stage/DrMoagi-Recursive-Cube.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
+          @(
+            "$worldHash  DrMoagi-World-Engine.exe",
+            "$cubeHash  DrMoagi-Recursive-Cube.exe"
+          ) | Set-Content -Encoding ascii "$stage/SHA256SUMS.txt"
           Compress-Archive -Path "$stage/*" -DestinationPath "build/world-engine/DrMoagi-World-Engine-Windows-x64.zip" -Force
 
       - name: Upload Windows package
@@ -81,7 +104,9 @@ jobs:
           name: DrMoagi-World-Engine-Windows-x64
           path: |
             build/world-engine/package/DrMoagi-World-Engine.exe
-            build/world-engine/package/README.md
+            build/world-engine/package/DrMoagi-Recursive-Cube.exe
+            build/world-engine/package/VMAD128_WORLD_ENGINE.md
+            build/world-engine/package/RECURSIVE_CUBE_INTERPRETER.md
             build/world-engine/package/SHA256SUMS.txt
             build/world-engine/DrMoagi-World-Engine-Windows-x64.zip
           if-no-files-found: error

--- a/cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp
+++ b/cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp
@@ -1,0 +1,544 @@
+#pragma once
+
+#include "jarvisx/world_engine_vmad.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace jarvisx::cube {
+
+constexpr std::array<std::uint8_t, 8U> kCubeMagic{{'D','M','C','U','B','E','1',0U}};
+constexpr std::uint16_t kCubeVersion = 1U;
+constexpr std::size_t kCubeHeaderBytes = 16U;
+constexpr std::size_t kCubeCommandBytes = 96U;
+constexpr std::size_t kCubeDigestBytes = 8U;
+constexpr std::size_t kCubeTileBytes = world::kDefaultTileBytes;
+constexpr std::size_t kCubeLatentBytes = 32U;
+
+inline std::uint64_t fnv1a64(const std::uint8_t* data, std::size_t size) noexcept {
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (std::size_t i = 0U; i < size; ++i) {
+        hash ^= static_cast<std::uint64_t>(data[i]);
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+enum class CubeOpcode : std::uint8_t {
+    EncodeRefine = 0x10,
+    Decode = 0x20,
+    Halt = 0xff,
+};
+
+struct CubeCommand {
+    CubeOpcode opcode{CubeOpcode::Halt};
+    std::uint8_t level{};
+    std::uint16_t flags{};
+    std::uint32_t tile_count{};
+    std::uint32_t max_passes{};
+    std::uint32_t epsilon{};
+    world::Vmad128 source{};
+    world::Vmad128 latent{};
+    world::Vmad128 output{};
+    world::Vmad128 shadow_latent{};
+    world::Vmad128 shadow_output{};
+};
+
+struct CubeInterpreterConfig {
+    std::uint64_t logical_extent{1000ULL * 1000ULL * 1000ULL};
+    std::uint32_t max_commands{4096U};
+    std::uint32_t max_tiles_per_command{1U << 20U};
+    std::uint32_t max_passes_per_tile{64U};
+    std::uint64_t max_total_tile_ops{1ULL << 22U};
+
+    void validate() const {
+        if (logical_extent == 0ULL || logical_extent > world::kVmadCoordExtent) {
+            throw std::invalid_argument("cube logical extent must lie in [1, 2^33]");
+        }
+        if (max_commands == 0U || max_tiles_per_command == 0U || max_passes_per_tile == 0U ||
+            max_total_tile_ops == 0ULL) {
+            throw std::invalid_argument("cube interpreter limits must be positive");
+        }
+    }
+};
+
+class ByteWriter {
+public:
+    void u8(std::uint8_t value) { bytes_.push_back(value); }
+    void u16(std::uint16_t value) {
+        u8(static_cast<std::uint8_t>(value & 0xffU));
+        u8(static_cast<std::uint8_t>((value >> 8U) & 0xffU));
+    }
+    void u32(std::uint32_t value) {
+        for (unsigned i = 0U; i < 4U; ++i) u8(static_cast<std::uint8_t>((value >> (8U * i)) & 0xffU));
+    }
+    void u64(std::uint64_t value) {
+        for (unsigned i = 0U; i < 8U; ++i) u8(static_cast<std::uint8_t>((value >> (8U * i)) & 0xffULL));
+    }
+    void vmad(const world::Vmad128& value) { u64(value.hi); u64(value.lo); }
+    void append(const std::uint8_t* data, std::size_t size) {
+        bytes_.insert(bytes_.end(), data, data + static_cast<std::ptrdiff_t>(size));
+    }
+    void append(const std::vector<std::uint8_t>& data) { bytes_.insert(bytes_.end(), data.begin(), data.end()); }
+    std::vector<std::uint8_t> take() { return std::move(bytes_); }
+private:
+    std::vector<std::uint8_t> bytes_;
+};
+
+class ByteReader {
+public:
+    explicit ByteReader(const std::vector<std::uint8_t>& bytes) : bytes_(bytes) {}
+    std::uint8_t u8() { require(1U); return bytes_[offset_++]; }
+    std::uint16_t u16() {
+        const std::uint16_t a = u8();
+        const std::uint16_t b = u8();
+        return static_cast<std::uint16_t>(a | static_cast<std::uint16_t>(b << 8U));
+    }
+    std::uint32_t u32() {
+        std::uint32_t value = 0U;
+        for (unsigned i = 0U; i < 4U; ++i) value |= static_cast<std::uint32_t>(u8()) << (8U * i);
+        return value;
+    }
+    std::uint64_t u64() {
+        std::uint64_t value = 0ULL;
+        for (unsigned i = 0U; i < 8U; ++i) value |= static_cast<std::uint64_t>(u8()) << (8U * i);
+        return value;
+    }
+    world::Vmad128 vmad() { return world::Vmad128{u64(), u64()}; }
+    std::size_t remaining() const noexcept { return bytes_.size() - offset_; }
+private:
+    const std::vector<std::uint8_t>& bytes_;
+    std::size_t offset_{};
+    void require(std::size_t count) const {
+        if (count > bytes_.size() - offset_) throw std::runtime_error("truncated recursive-cube execution buffer");
+    }
+};
+
+inline void append_command(ByteWriter& writer, const CubeCommand& command) {
+    writer.u8(static_cast<std::uint8_t>(command.opcode));
+    writer.u8(command.level);
+    writer.u16(command.flags);
+    writer.u32(command.tile_count);
+    writer.u32(command.max_passes);
+    writer.u32(command.epsilon);
+    writer.vmad(command.source);
+    writer.vmad(command.latent);
+    writer.vmad(command.output);
+    writer.vmad(command.shadow_latent);
+    writer.vmad(command.shadow_output);
+}
+
+inline CubeCommand read_command(ByteReader& reader) {
+    CubeCommand command;
+    command.opcode = static_cast<CubeOpcode>(reader.u8());
+    command.level = reader.u8();
+    command.flags = reader.u16();
+    command.tile_count = reader.u32();
+    command.max_passes = reader.u32();
+    command.epsilon = reader.u32();
+    command.source = reader.vmad();
+    command.latent = reader.vmad();
+    command.output = reader.vmad();
+    command.shadow_latent = reader.vmad();
+    command.shadow_output = reader.vmad();
+    return command;
+}
+
+inline std::vector<std::uint8_t> serialize_execution_buffer(const std::vector<CubeCommand>& commands) {
+    if (commands.empty() || commands.size() > static_cast<std::size_t>(std::numeric_limits<std::uint16_t>::max())) {
+        throw std::invalid_argument("recursive-cube command count must fit uint16 and be non-zero");
+    }
+    ByteWriter writer;
+    writer.append(kCubeMagic.data(), kCubeMagic.size());
+    writer.u16(kCubeVersion);
+    writer.u16(static_cast<std::uint16_t>(commands.size()));
+    writer.u32(0U);
+    for (const auto& command : commands) append_command(writer, command);
+    std::vector<std::uint8_t> body = writer.take();
+    const std::uint64_t digest = fnv1a64(body.data(), body.size());
+    ByteWriter complete;
+    complete.append(body);
+    complete.u64(digest);
+    return complete.take();
+}
+
+inline bool same_line_overlap(const world::Vmad128& a, std::uint64_t a_bytes,
+                              const world::Vmad128& b, std::uint64_t b_bytes) noexcept {
+    if (a.x() != b.x() || a.y() != b.y()) return false;
+    const std::uint64_t a_end = a.z() + a_bytes;
+    const std::uint64_t b_end = b.z() + b_bytes;
+    return a.z() < b_end && b.z() < a_end;
+}
+
+inline void validate_span(const world::Vmad128& base, std::uint64_t bytes,
+                          const CubeInterpreterConfig& config) {
+    if (base.x() >= config.logical_extent || base.y() >= config.logical_extent || base.z() >= config.logical_extent) {
+        throw std::runtime_error("cube VMAD lies outside configured logical extent");
+    }
+    if (bytes > config.logical_extent || base.z() > config.logical_extent - bytes) {
+        throw std::runtime_error("cube VMAD span crosses configured logical extent");
+    }
+}
+
+inline std::vector<CubeCommand> parse_execution_buffer(const std::vector<std::uint8_t>& bytes,
+                                                        const CubeInterpreterConfig& config) {
+    config.validate();
+    if (bytes.size() < kCubeHeaderBytes + kCubeCommandBytes + kCubeDigestBytes) {
+        throw std::runtime_error("recursive-cube execution buffer too small");
+    }
+    const std::size_t payload_size = bytes.size() - kCubeDigestBytes;
+    std::uint64_t expected_digest = 0ULL;
+    for (std::size_t i = 0U; i < 8U; ++i) {
+        expected_digest |= static_cast<std::uint64_t>(bytes[payload_size + i]) << (8U * i);
+    }
+    if (fnv1a64(bytes.data(), payload_size) != expected_digest) {
+        throw std::runtime_error("recursive-cube execution buffer digest mismatch");
+    }
+    std::vector<std::uint8_t> payload(bytes.begin(), bytes.begin() + static_cast<std::ptrdiff_t>(payload_size));
+    ByteReader reader(payload);
+    for (const auto expected : kCubeMagic) {
+        if (reader.u8() != expected) throw std::runtime_error("invalid recursive-cube execution-buffer magic");
+    }
+    if (reader.u16() != kCubeVersion) throw std::runtime_error("unsupported recursive-cube execution-buffer version");
+    const std::uint16_t count = reader.u16();
+    if (reader.u32() != 0U) throw std::runtime_error("recursive-cube header reserved field must be zero");
+    if (count == 0U || count > config.max_commands) throw std::runtime_error("recursive-cube command count exceeds limit");
+    const std::size_t expected_size = kCubeHeaderBytes + static_cast<std::size_t>(count) * kCubeCommandBytes;
+    if (payload.size() != expected_size) throw std::runtime_error("recursive-cube execution-buffer size mismatch");
+
+    std::vector<CubeCommand> commands;
+    commands.reserve(count);
+    std::uint64_t total_tile_ops = 0ULL;
+    bool halted = false;
+    for (std::uint16_t index = 0U; index < count; ++index) {
+        CubeCommand command = read_command(reader);
+        if (halted) throw std::runtime_error("recursive-cube command appears after HALT");
+        if (command.flags != 0U) throw std::runtime_error("recursive-cube command flags are reserved");
+        switch (command.opcode) {
+            case CubeOpcode::EncodeRefine: {
+                if (command.tile_count == 0U || command.tile_count > config.max_tiles_per_command) {
+                    throw std::runtime_error("recursive-cube encode tile count exceeds limit");
+                }
+                if (command.max_passes == 0U || command.max_passes > config.max_passes_per_tile) {
+                    throw std::runtime_error("recursive-cube refinement pass count exceeds limit");
+                }
+                if (command.epsilon > 255U) throw std::runtime_error("recursive-cube epsilon exceeds byte delta range");
+                const std::uint64_t tile_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+                const std::uint64_t latent_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeLatentBytes;
+                validate_span(command.source, tile_bytes, config);
+                validate_span(command.latent, latent_bytes, config);
+                validate_span(command.output, tile_bytes, config);
+                validate_span(command.shadow_latent, latent_bytes, config);
+                validate_span(command.shadow_output, tile_bytes, config);
+                const std::array<std::pair<world::Vmad128, std::uint64_t>, 5U> spans{{
+                    {command.source, tile_bytes}, {command.latent, latent_bytes}, {command.output, tile_bytes},
+                    {command.shadow_latent, latent_bytes}, {command.shadow_output, tile_bytes},
+                }};
+                for (std::size_t a = 0U; a < spans.size(); ++a) {
+                    for (std::size_t b = a + 1U; b < spans.size(); ++b) {
+                        if (same_line_overlap(spans[a].first, spans[a].second, spans[b].first, spans[b].second)) {
+                            throw std::runtime_error("recursive-cube encode spans overlap in sparse world state");
+                        }
+                    }
+                }
+                total_tile_ops += static_cast<std::uint64_t>(command.tile_count) * command.max_passes;
+                break;
+            }
+            case CubeOpcode::Decode: {
+                if (command.tile_count == 0U || command.tile_count > config.max_tiles_per_command) {
+                    throw std::runtime_error("recursive-cube decode tile count exceeds limit");
+                }
+                const std::uint64_t source_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeLatentBytes;
+                const std::uint64_t output_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+                validate_span(command.source, source_bytes, config);
+                validate_span(command.output, output_bytes, config);
+                if (same_line_overlap(command.source, source_bytes, command.output, output_bytes)) {
+                    throw std::runtime_error("recursive-cube decode source/output overlap");
+                }
+                total_tile_ops += command.tile_count;
+                break;
+            }
+            case CubeOpcode::Halt:
+                if (index + 1U != count) throw std::runtime_error("recursive-cube HALT must be final command");
+                halted = true;
+                break;
+            default:
+                throw std::runtime_error("unknown recursive-cube opcode");
+        }
+        if (total_tile_ops > config.max_total_tile_ops) {
+            throw std::runtime_error("recursive-cube execution exceeds total tile-operation limit");
+        }
+        commands.push_back(command);
+    }
+    if (!halted) throw std::runtime_error("recursive-cube execution buffer missing HALT");
+    if (reader.remaining() != 0U) throw std::runtime_error("recursive-cube parser left trailing payload");
+    return commands;
+}
+
+struct CubeCommandMetrics {
+    CubeOpcode opcode{CubeOpcode::Halt};
+    std::uint8_t level{};
+    std::uint64_t tiles{};
+    std::uint64_t passes{};
+    std::uint64_t accepted_passes{};
+    std::uint64_t rejected_passes{};
+    std::uint64_t converged_tiles{};
+    std::uint64_t input_bytes{};
+    std::uint64_t latent_bytes{};
+    std::uint64_t output_bytes{};
+    double mean_final_delta{};
+};
+
+struct CubeRunMetrics {
+    bool execution_buffer_validated{};
+    std::uint64_t commands_executed{};
+    std::uint64_t tiles_processed{};
+    std::uint64_t total_passes{};
+    std::uint64_t accepted_passes{};
+    std::uint64_t rejected_passes{};
+    std::uint64_t converged_tiles{};
+    std::uint64_t encoded_input_bytes{};
+    std::uint64_t latent_bytes_committed{};
+    std::uint64_t decoded_output_bytes{};
+    std::vector<CubeCommandMetrics> commands;
+};
+
+class RecursiveCubeInterpreter {
+public:
+    RecursiveCubeInterpreter(intelligence3d::VirtualVolume3D& volume,
+                             CubeInterpreterConfig config = {})
+        : volume_(volume), engine_(volume), config_(config) {
+        config_.validate();
+        if (volume_.axis_extent() < world::kVmadCoordExtent) {
+            throw std::invalid_argument("recursive cube requires VMAD128-compatible virtual volume");
+        }
+    }
+
+    CubeRunMetrics run(const std::vector<std::uint8_t>& execution_buffer) {
+        const std::vector<CubeCommand> commands = parse_execution_buffer(execution_buffer, config_);
+        CubeRunMetrics metrics;
+        metrics.execution_buffer_validated = true;
+        for (const auto& command : commands) {
+            if (command.opcode == CubeOpcode::Halt) break;
+            CubeCommandMetrics local;
+            local.opcode = command.opcode;
+            local.level = command.level;
+            local.tiles = command.tile_count;
+            if (command.opcode == CubeOpcode::EncodeRefine) execute_encode(command, local);
+            else execute_decode(command, local);
+            ++metrics.commands_executed;
+            metrics.tiles_processed += local.tiles;
+            metrics.total_passes += local.passes;
+            metrics.accepted_passes += local.accepted_passes;
+            metrics.rejected_passes += local.rejected_passes;
+            metrics.converged_tiles += local.converged_tiles;
+            metrics.encoded_input_bytes += local.input_bytes;
+            metrics.latent_bytes_committed += local.latent_bytes;
+            metrics.decoded_output_bytes += local.output_bytes;
+            metrics.commands.push_back(local);
+        }
+        return metrics;
+    }
+
+    const world::WorldEngine128& engine() const noexcept { return engine_; }
+
+private:
+    intelligence3d::VirtualVolume3D& volume_;
+    world::WorldEngine128 engine_;
+    CubeInterpreterConfig config_;
+
+    static void emit(world::WorldProgram& program, world::MicroOpcode opcode, std::uint16_t dst,
+                     std::uint16_t src0, std::uint16_t src1, std::uint8_t vmad_reg, std::uint32_t imm24) {
+        program.words.push_back(world::MicroOp{opcode, dst, src0, src1, vmad_reg, imm24}.encode());
+    }
+
+    world::WorldProgram candidate_program(const world::Vmad128& source,
+                                          const world::Vmad128& shadow_latent,
+                                          const world::Vmad128& shadow_output,
+                                          std::uint32_t threshold) const {
+        world::WorldProgram program;
+        program.descriptors = {source, shadow_latent, shadow_output};
+        emit(program, world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 0U, 0U);
+        emit(program, world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 1U, 1U);
+        emit(program, world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 2U, 2U);
+        emit(program, world::MicroOpcode::TileInVec, 2U, 0U, 0U, 0U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::EncLatVol, 32U, 2U, 0U, 0U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::StoreVec, 0U, 32U, 0U, 1U, static_cast<std::uint32_t>(kCubeLatentBytes));
+        emit(program, world::MicroOpcode::FuseAttn, 40U, 32U, 32U, 0U, 0U);
+        emit(program, world::MicroOpcode::DecPixVol, 64U, 40U, 0U, 2U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::CalcDelta, 96U, 2U, 64U, 0U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::ProposeBias, 0U, 96U, 0U, 0U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::Validate, 20U, 0U, 0U, 0U, threshold);
+        emit(program, world::MicroOpcode::Halt, 0U, 0U, 0U, 0U, 0U);
+        return program;
+    }
+
+    static world::WorldProgram commit_program(bool accept) {
+        world::WorldProgram program;
+        const std::uint16_t gate = accept ? 20U : 511U;
+        emit(program, world::MicroOpcode::CommitIf, 0U, gate, 0U, 0U, 0U);
+        emit(program, world::MicroOpcode::Halt, 0U, 0U, 0U, 0U, 0U);
+        return program;
+    }
+
+    world::WorldProgram decode_program(const world::Vmad128& source, const world::Vmad128& output) const {
+        world::WorldProgram program;
+        program.descriptors = {source, output};
+        emit(program, world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 0U, 0U);
+        emit(program, world::MicroOpcode::LoadVmad, 0U, 0U, 0U, 1U, 1U);
+        emit(program, world::MicroOpcode::TileInVec, 32U, 0U, 0U, 0U, static_cast<std::uint32_t>(kCubeLatentBytes));
+        emit(program, world::MicroOpcode::DecPixVol, 64U, 32U, 0U, 1U, static_cast<std::uint32_t>(kCubeTileBytes));
+        emit(program, world::MicroOpcode::Halt, 0U, 0U, 0U, 0U, 0U);
+        return program;
+    }
+
+    void copy_span(const world::Vmad128& source, const world::Vmad128& destination, std::size_t bytes) {
+        std::vector<std::uint8_t> staged(bytes, 0U);
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            staged[i] = volume_.read(world::vmad_advance_linear(source, static_cast<std::uint64_t>(i)).coord());
+        }
+        for (std::size_t i = 0U; i < bytes; ++i) {
+            volume_.write(world::vmad_advance_linear(destination, static_cast<std::uint64_t>(i)).coord(), staged[i]);
+        }
+    }
+
+    void execute_encode(const CubeCommand& command, CubeCommandMetrics& metrics) {
+        long double delta_sum = 0.0L;
+        for (std::uint32_t tile = 0U; tile < command.tile_count; ++tile) {
+            const auto source = world::vmad_advance_linear(command.source, static_cast<std::uint64_t>(tile) * kCubeTileBytes);
+            const auto latent = world::vmad_advance_linear(command.latent, static_cast<std::uint64_t>(tile) * kCubeLatentBytes);
+            const auto output = world::vmad_advance_linear(command.output, static_cast<std::uint64_t>(tile) * kCubeTileBytes);
+            const auto shadow_latent = world::vmad_advance_linear(command.shadow_latent, static_cast<std::uint64_t>(tile) * kCubeLatentBytes);
+            const auto shadow_output = world::vmad_advance_linear(command.shadow_output, static_cast<std::uint64_t>(tile) * kCubeTileBytes);
+            std::uint32_t previous_delta = 256U;
+            std::uint32_t final_delta = 255U;
+            bool converged = false;
+            for (std::uint32_t pass = 0U; pass < command.max_passes; ++pass) {
+                const std::uint32_t threshold = std::min<std::uint32_t>(255U, previous_delta);
+                engine_.run(candidate_program(source, shadow_latent, shadow_output, threshold), 64ULL);
+                final_delta = engine_.last_delta_mean();
+                const bool lambda_gate = engine_.scalar_register(20U) != 0ULL;
+                const bool improved = pass == 0U || final_delta < previous_delta;
+                const bool accept = lambda_gate && improved;
+                ++metrics.passes;
+                if (accept) {
+                    copy_span(shadow_latent, latent, kCubeLatentBytes);
+                    copy_span(shadow_output, output, kCubeTileBytes);
+                    engine_.run(commit_program(true), 8ULL);
+                    ++metrics.accepted_passes;
+                    previous_delta = final_delta;
+                    if (final_delta <= command.epsilon) {
+                        converged = true;
+                        break;
+                    }
+                } else {
+                    engine_.run(commit_program(false), 8ULL);
+                    ++metrics.rejected_passes;
+                    break;
+                }
+            }
+            if (converged) ++metrics.converged_tiles;
+            delta_sum += static_cast<long double>(final_delta);
+        }
+        metrics.input_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+        metrics.latent_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeLatentBytes;
+        metrics.output_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+        metrics.mean_final_delta = command.tile_count == 0U ? 0.0 :
+            static_cast<double>(delta_sum / static_cast<long double>(command.tile_count));
+    }
+
+    void execute_decode(const CubeCommand& command, CubeCommandMetrics& metrics) {
+        for (std::uint32_t tile = 0U; tile < command.tile_count; ++tile) {
+            const auto source = world::vmad_advance_linear(command.source, static_cast<std::uint64_t>(tile) * kCubeLatentBytes);
+            const auto output = world::vmad_advance_linear(command.output, static_cast<std::uint64_t>(tile) * kCubeTileBytes);
+            engine_.run(decode_program(source, output), 16ULL);
+        }
+        metrics.input_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeLatentBytes;
+        metrics.output_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+    }
+};
+
+struct CubeDemoPlan {
+    std::vector<std::uint8_t> execution_buffer;
+    world::Vmad128 source{};
+    world::Vmad128 final_output{};
+    std::uint32_t base_tiles{};
+    std::uint8_t levels{};
+};
+
+inline world::Vmad128 demo_address(std::uint16_t region, std::uint64_t z) {
+    return world::Vmad128::pack(region, 0U, 0U, 0U, 0U, z);
+}
+
+inline CubeDemoPlan make_demo_plan(std::uint32_t base_tiles = 32U, std::uint8_t levels = 2U,
+                                   std::uint64_t logical_extent = 1000ULL * 1000ULL * 1000ULL) {
+    if (base_tiles == 0U || levels == 0U || levels > 8U) throw std::invalid_argument("invalid recursive-cube demo geometry");
+    std::uint64_t cursor = 0ULL;
+    const auto allocate = [&](std::uint16_t region, std::uint64_t bytes, std::uint64_t& mutable_cursor) {
+        if (bytes > logical_extent || mutable_cursor > logical_extent - bytes) {
+            throw std::overflow_error("recursive-cube demo layout exceeds logical extent");
+        }
+        const auto address = demo_address(region, mutable_cursor);
+        mutable_cursor += bytes + 4096ULL;
+        if (mutable_cursor > logical_extent) throw std::overflow_error("recursive-cube demo padding exceeds logical extent");
+        return address;
+    };
+
+    CubeDemoPlan plan;
+    plan.base_tiles = base_tiles;
+    plan.levels = levels;
+    plan.source = allocate(1U, static_cast<std::uint64_t>(base_tiles) * kCubeTileBytes, cursor);
+
+    std::vector<CubeCommand> commands;
+    std::vector<world::Vmad128> level_latents;
+    std::vector<std::uint32_t> level_tiles;
+    world::Vmad128 source = plan.source;
+    std::uint32_t tiles = base_tiles;
+    for (std::uint8_t level = 0U; level < levels; ++level) {
+        const std::uint64_t latent_bytes = static_cast<std::uint64_t>(tiles) * kCubeLatentBytes;
+        const std::uint64_t tile_bytes = static_cast<std::uint64_t>(tiles) * kCubeTileBytes;
+        CubeCommand command;
+        command.opcode = CubeOpcode::EncodeRefine;
+        command.level = level;
+        command.tile_count = tiles;
+        command.max_passes = 4U;
+        command.epsilon = 8U;
+        command.source = source;
+        command.latent = allocate(static_cast<std::uint16_t>(100U + level), latent_bytes, cursor);
+        command.output = allocate(static_cast<std::uint16_t>(200U + level), tile_bytes, cursor);
+        command.shadow_latent = allocate(static_cast<std::uint16_t>(300U + level), latent_bytes, cursor);
+        command.shadow_output = allocate(static_cast<std::uint16_t>(400U + level), tile_bytes, cursor);
+        commands.push_back(command);
+        level_latents.push_back(command.latent);
+        level_tiles.push_back(tiles);
+        source = command.latent;
+        tiles = (tiles + 31U) / 32U;
+    }
+
+    world::Vmad128 decode_source = level_latents.back();
+    for (std::size_t reverse = level_latents.size(); reverse-- > 0U;) {
+        CubeCommand command;
+        command.opcode = CubeOpcode::Decode;
+        command.level = static_cast<std::uint8_t>(reverse);
+        command.tile_count = level_tiles[reverse];
+        command.max_passes = 1U;
+        command.source = decode_source;
+        const std::uint64_t output_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
+        command.output = allocate(static_cast<std::uint16_t>(500U + reverse), output_bytes, cursor);
+        commands.push_back(command);
+        decode_source = command.output;
+        if (reverse == 0U) plan.final_output = command.output;
+    }
+
+    commands.push_back(CubeCommand{CubeOpcode::Halt});
+    plan.execution_buffer = serialize_execution_buffer(commands);
+    return plan;
+}
+
+} // namespace jarvisx::cube

--- a/cpp_runtime/src/recursive_cube_main.cpp
+++ b/cpp_runtime/src/recursive_cube_main.cpp
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
                       << "accepted_passes=" << metrics.accepted_passes
                       << " rejected_passes=" << metrics.rejected_passes
                       << " converged_tiles=" << metrics.converged_tiles << '\n'
-                      << "encoded_input_bytes=" << metrics.encoded_input_bytes
+                      << "aggregate_command_input_bytes=" << metrics.encoded_input_bytes
                       << " latent_bytes_committed=" << metrics.latent_bytes_committed
                       << " total_world_output_bytes=" << metrics.decoded_output_bytes << '\n'
                       << "recursive_output_mae=" << mean_absolute_error << '\n'

--- a/cpp_runtime/src/recursive_cube_main.cpp
+++ b/cpp_runtime/src/recursive_cube_main.cpp
@@ -1,6 +1,7 @@
 #include "jarvisx/recursive_cube_interpreter.hpp"
 
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
@@ -105,7 +106,7 @@ int main(int argc, char** argv) {
                       << " converged_tiles=" << metrics.converged_tiles << '\n'
                       << "encoded_input_bytes=" << metrics.encoded_input_bytes
                       << " latent_bytes_committed=" << metrics.latent_bytes_committed
-                      << " decoded_output_bytes=" << metrics.decoded_output_bytes << '\n'
+                      << " total_world_output_bytes=" << metrics.decoded_output_bytes << '\n'
                       << "recursive_output_mae=" << mean_absolute_error << '\n'
                       << "world_commits=" << interpreter.engine().stats().commits
                       << " world_rollbacks=" << interpreter.engine().stats().rollbacks << '\n'

--- a/cpp_runtime/src/recursive_cube_main.cpp
+++ b/cpp_runtime/src/recursive_cube_main.cpp
@@ -1,0 +1,121 @@
+#include "jarvisx/recursive_cube_interpreter.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::filesystem::path state_dir{"jarvisx-recursive-cube-state"};
+    std::uint32_t tiles{32U};
+    std::uint8_t levels{2U};
+    bool quiet{};
+};
+
+std::uint32_t parse_u32(const std::string& text, const char* name) {
+    std::size_t used = 0U;
+    const unsigned long value = std::stoul(text, &used, 10);
+    if (used != text.size() || value > 0xffffffffUL) throw std::invalid_argument(std::string("invalid ") + name);
+    return static_cast<std::uint32_t>(value);
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--state-dir") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --state-dir");
+            options.state_dir = argv[++i];
+        } else if (arg == "--tiles") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --tiles");
+            options.tiles = parse_u32(argv[++i], "tile count");
+        } else if (arg == "--levels") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --levels");
+            const std::uint32_t value = parse_u32(argv[++i], "level count");
+            if (value > 255U) throw std::invalid_argument("level count exceeds uint8");
+            options.levels = static_cast<std::uint8_t>(value);
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout << "Usage: DrMoagi-Recursive-Cube [--tiles N] [--levels N] [--state-dir PATH] [--quiet]\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + arg);
+        }
+    }
+    if (options.tiles == 0U || options.levels == 0U || options.levels > 8U) {
+        throw std::invalid_argument("tiles must be positive and levels must be in [1,8]");
+    }
+    return options;
+}
+
+std::uint8_t source_byte(std::uint64_t index) noexcept {
+    return static_cast<std::uint8_t>((index * 37ULL + (index >> 3U) + (index >> 11U)) & 0xffULL);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        std::filesystem::remove_all(options.state_dir);
+        jarvisx::intelligence3d::VirtualVolume3D volume({
+            jarvisx::world::kVmadCoordExtent,
+            32U,
+            8ULL * 1024ULL * 1024ULL,
+            options.state_dir / "pages",
+        });
+
+        const auto plan = jarvisx::cube::make_demo_plan(options.tiles, options.levels);
+        const std::uint64_t source_bytes = static_cast<std::uint64_t>(options.tiles) * jarvisx::cube::kCubeTileBytes;
+        for (std::uint64_t i = 0ULL; i < source_bytes; ++i) {
+            const auto address = jarvisx::world::vmad_advance_linear(plan.source, i);
+            volume.write(address.coord(), source_byte(i));
+        }
+
+        jarvisx::cube::RecursiveCubeInterpreter interpreter(volume);
+        const auto metrics = interpreter.run(plan.execution_buffer);
+        volume.flush();
+
+        long double absolute_error = 0.0L;
+        for (std::uint64_t i = 0ULL; i < source_bytes; ++i) {
+            const auto address = jarvisx::world::vmad_advance_linear(plan.final_output, i);
+            const int source = static_cast<int>(source_byte(i));
+            const int reconstructed = static_cast<int>(volume.read(address.coord()));
+            const int delta = source - reconstructed;
+            absolute_error += static_cast<long double>(delta < 0 ? -delta : delta);
+        }
+        const double mean_absolute_error = source_bytes == 0ULL ? 0.0 :
+            static_cast<double>(absolute_error / static_cast<long double>(source_bytes));
+
+        if (!options.quiet) {
+            std::cout << "DM-vOmegaXi+ recursive cube interpreter\n"
+                      << "execution_buffer=DMCUBE1 validated=" << (metrics.execution_buffer_validated ? 1 : 0) << '\n'
+                      << "logical_cube_extent=1000000000 sparse=1 vmad_bits=128\n"
+                      << "base_tiles=" << options.tiles << " levels=" << static_cast<unsigned>(options.levels)
+                      << " source_bytes=" << source_bytes << '\n'
+                      << "commands_executed=" << metrics.commands_executed
+                      << " tiles_processed=" << metrics.tiles_processed
+                      << " passes=" << metrics.total_passes << '\n'
+                      << "accepted_passes=" << metrics.accepted_passes
+                      << " rejected_passes=" << metrics.rejected_passes
+                      << " converged_tiles=" << metrics.converged_tiles << '\n'
+                      << "encoded_input_bytes=" << metrics.encoded_input_bytes
+                      << " latent_bytes_committed=" << metrics.latent_bytes_committed
+                      << " decoded_output_bytes=" << metrics.decoded_output_bytes << '\n'
+                      << "recursive_output_mae=" << mean_absolute_error << '\n'
+                      << "world_commits=" << interpreter.engine().stats().commits
+                      << " world_rollbacks=" << interpreter.engine().stats().rollbacks << '\n'
+                      << "claim_boundary=sparse_software_reference_no_sota_or_physical_timing_claim\n";
+        }
+
+        std::filesystem::remove_all(options.state_dir);
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "DrMoagi Recursive Cube failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
+++ b/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
@@ -94,15 +94,22 @@ void test_end_to_end_recursive_execution() {
 
     const auto plan = jarvisx::cube::make_demo_plan(4U, 1U);
     const std::uint64_t source_bytes = 4ULL * jarvisx::cube::kCubeTileBytes;
+    const std::uint64_t latent_bytes = 4ULL * jarvisx::cube::kCubeLatentBytes;
     seed(volume, plan.source, source_bytes);
 
     jarvisx::cube::RecursiveCubeInterpreter interpreter(volume);
     const auto metrics = interpreter.run(plan.execution_buffer);
     require(metrics.execution_buffer_validated, "recursive-cube execution buffer did not validate");
     require(metrics.commands_executed == 2ULL, "single-level plan should execute one inward and one outward command");
+    require(metrics.commands.size() == 2U, "recursive-cube command telemetry count mismatch");
     require(metrics.accepted_passes >= 4ULL, "each first tile candidate should pass the byte-range Lambda gate");
-    require(metrics.encoded_input_bytes == source_bytes, "recursive-cube encoded byte count mismatch");
-    require(metrics.latent_bytes_committed == 4ULL * jarvisx::cube::kCubeLatentBytes,
+    require(metrics.commands[0].input_bytes == source_bytes,
+            "recursive-cube inward command input byte count mismatch");
+    require(metrics.commands[1].input_bytes == latent_bytes,
+            "recursive-cube outward command latent input byte count mismatch");
+    require(metrics.encoded_input_bytes == source_bytes + latent_bytes,
+            "recursive-cube aggregate command-input byte count mismatch");
+    require(metrics.latent_bytes_committed == latent_bytes,
             "recursive-cube committed latent byte count mismatch");
     require(interpreter.engine().stats().commits == metrics.accepted_passes,
             "world-engine commit telemetry diverges from recursive interpreter");

--- a/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
+++ b/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
@@ -1,0 +1,153 @@
+#include "jarvisx/recursive_cube_interpreter.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+void require(bool condition, const std::string& message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+std::filesystem::path test_dir(const char* name) {
+    return std::filesystem::temp_directory_path() / (std::string("jarvisx-recursive-cube-") + name);
+}
+
+std::uint8_t sample(std::uint64_t index) noexcept {
+    return static_cast<std::uint8_t>((index * 29ULL + (index >> 4U) + 7ULL) & 0xffULL);
+}
+
+void seed(jarvisx::intelligence3d::VirtualVolume3D& volume,
+          const jarvisx::world::Vmad128& base, std::uint64_t bytes) {
+    for (std::uint64_t i = 0ULL; i < bytes; ++i) {
+        volume.write(jarvisx::world::vmad_advance_linear(base, i).coord(), sample(i));
+    }
+}
+
+void test_execution_buffer_validation() {
+    const auto plan = jarvisx::cube::make_demo_plan(32U, 2U);
+    const auto commands = jarvisx::cube::parse_execution_buffer(plan.execution_buffer, {});
+    require(commands.size() == 5U, "two-level recursive-cube plan should contain four actions plus HALT");
+    require(commands.front().opcode == jarvisx::cube::CubeOpcode::EncodeRefine,
+            "recursive-cube plan does not begin with inward encoding");
+    require(commands[2].opcode == jarvisx::cube::CubeOpcode::Decode,
+            "recursive-cube plan does not turn outward after hierarchy construction");
+    require(commands.back().opcode == jarvisx::cube::CubeOpcode::Halt,
+            "recursive-cube plan missing terminal HALT");
+
+    auto corrupted = plan.execution_buffer;
+    corrupted[20] ^= 0x5aU;
+    bool rejected = false;
+    try {
+        (void)jarvisx::cube::parse_execution_buffer(corrupted, {});
+    } catch (const std::runtime_error&) {
+        rejected = true;
+    }
+    require(rejected, "corrupted recursive-cube execution buffer was accepted");
+}
+
+void test_overlap_and_step_limits() {
+    jarvisx::cube::CubeCommand command;
+    command.opcode = jarvisx::cube::CubeOpcode::EncodeRefine;
+    command.tile_count = 1U;
+    command.max_passes = 1U;
+    command.epsilon = 8U;
+    command.source = jarvisx::cube::demo_address(1U, 1000U);
+    command.latent = jarvisx::cube::demo_address(2U, 1000U);
+    command.output = jarvisx::cube::demo_address(3U, 5000U);
+    command.shadow_latent = jarvisx::cube::demo_address(4U, 9000U);
+    command.shadow_output = jarvisx::cube::demo_address(5U, 13000U);
+    std::vector<jarvisx::cube::CubeCommand> commands{command, jarvisx::cube::CubeCommand{jarvisx::cube::CubeOpcode::Halt}};
+    bool overlap_rejected = false;
+    try {
+        (void)jarvisx::cube::parse_execution_buffer(jarvisx::cube::serialize_execution_buffer(commands), {});
+    } catch (const std::runtime_error&) {
+        overlap_rejected = true;
+    }
+    require(overlap_rejected, "overlapping recursive-cube source/latent spans were accepted");
+
+    const auto plan = jarvisx::cube::make_demo_plan(4U, 1U);
+    jarvisx::cube::CubeInterpreterConfig config;
+    config.max_total_tile_ops = 1ULL;
+    bool bound_rejected = false;
+    try {
+        (void)jarvisx::cube::parse_execution_buffer(plan.execution_buffer, config);
+    } catch (const std::runtime_error&) {
+        bound_rejected = true;
+    }
+    require(bound_rejected, "recursive-cube total tile-operation guard did not fire");
+}
+
+void test_end_to_end_recursive_execution() {
+    const auto dir = test_dir("e2e");
+    std::filesystem::remove_all(dir);
+    jarvisx::intelligence3d::VirtualVolume3D volume({
+        jarvisx::world::kVmadCoordExtent,
+        32U,
+        4ULL * 1024ULL * 1024ULL,
+        dir / "pages",
+    });
+
+    const auto plan = jarvisx::cube::make_demo_plan(4U, 1U);
+    const std::uint64_t source_bytes = 4ULL * jarvisx::cube::kCubeTileBytes;
+    seed(volume, plan.source, source_bytes);
+
+    jarvisx::cube::RecursiveCubeInterpreter interpreter(volume);
+    const auto metrics = interpreter.run(plan.execution_buffer);
+    require(metrics.execution_buffer_validated, "recursive-cube execution buffer did not validate");
+    require(metrics.commands_executed == 2ULL, "single-level plan should execute one inward and one outward command");
+    require(metrics.accepted_passes >= 4ULL, "each first tile candidate should pass the byte-range Lambda gate");
+    require(metrics.encoded_input_bytes == source_bytes, "recursive-cube encoded byte count mismatch");
+    require(metrics.latent_bytes_committed == 4ULL * jarvisx::cube::kCubeLatentBytes,
+            "recursive-cube committed latent byte count mismatch");
+    require(interpreter.engine().stats().commits == metrics.accepted_passes,
+            "world-engine commit telemetry diverges from recursive interpreter");
+
+    std::uint64_t nonzero = 0ULL;
+    for (std::uint64_t i = 0ULL; i < source_bytes; ++i) {
+        if (volume.read(jarvisx::world::vmad_advance_linear(plan.final_output, i).coord()) != 0U) ++nonzero;
+    }
+    require(nonzero != 0ULL, "recursive outward decode produced an empty final world state");
+    std::filesystem::remove_all(dir);
+}
+
+void test_data_is_not_implicitly_executable() {
+    const auto dir = test_dir("data-not-code");
+    std::filesystem::remove_all(dir);
+    jarvisx::intelligence3d::VirtualVolume3D volume({
+        jarvisx::world::kVmadCoordExtent,
+        32U,
+        1024ULL * 1024ULL,
+        dir / "pages",
+    });
+    const auto plan = jarvisx::cube::make_demo_plan(1U, 1U);
+    for (std::size_t i = 0U; i < jarvisx::cube::kCubeMagic.size(); ++i) {
+        volume.write(jarvisx::world::vmad_advance_linear(plan.source, static_cast<std::uint64_t>(i)).coord(),
+                     jarvisx::cube::kCubeMagic[i]);
+    }
+    jarvisx::cube::RecursiveCubeInterpreter interpreter(volume);
+    const auto metrics = interpreter.run(plan.execution_buffer);
+    require(metrics.commands_executed == 2ULL,
+            "payload bytes altered interpreter control flow; decoded data must not auto-execute");
+    std::filesystem::remove_all(dir);
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_execution_buffer_validation();
+        test_overlap_and_step_limits();
+        test_end_to_end_recursive_execution();
+        test_data_is_not_implicitly_executable();
+        std::cout << "recursive-cube interpreter regressions passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "recursive-cube interpreter regression failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/world_engine.cmake
+++ b/cpp_runtime/world_engine.cmake
@@ -21,3 +21,29 @@ jarvisx_harden(jarvisx-world-engine-tests)
 
 add_test(NAME world-engine-regressions COMMAND jarvisx-world-engine-tests)
 set_tests_properties(world-engine-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-recursive-cube
+    src/recursive_cube_main.cpp
+)
+set_target_properties(jarvisx-recursive-cube PROPERTIES OUTPUT_NAME "DrMoagi-Recursive-Cube")
+jarvisx_include_runtime(jarvisx-recursive-cube)
+jarvisx_harden(jarvisx-recursive-cube)
+
+add_test(
+    NAME recursive-cube-runtime-smoke
+    COMMAND jarvisx-recursive-cube
+        --tiles 4
+        --levels 1
+        --state-dir ${CMAKE_CURRENT_BINARY_DIR}/recursive-cube-smoke
+        --quiet
+)
+set_tests_properties(recursive-cube-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-recursive-cube-tests
+    tests/recursive_cube_interpreter_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-recursive-cube-tests)
+jarvisx_harden(jarvisx-recursive-cube-tests)
+
+add_test(NAME recursive-cube-regressions COMMAND jarvisx-recursive-cube-tests)
+set_tests_properties(recursive-cube-regressions PROPERTIES TIMEOUT 120)

--- a/docs/RECURSIVE_CUBE_INTERPRETER.md
+++ b/docs/RECURSIVE_CUBE_INTERPRETER.md
@@ -1,0 +1,207 @@
+# DM-vOmegaXi+ Recursive Cube Interpreter
+
+Status: deterministic software reference layered on VMAD128 World Engine
+
+The Recursive Cube Interpreter turns the inward/outward cube abstraction into a bounded executable hierarchy. It does not allocate a literal `1GB x 1GB x 1GB` physical cube. The canonical logical cube extent is `1,000,000,000` byte coordinates per axis inside the existing `2^33`-per-axis VMAD128 sparse address domain.
+
+## 1. Operational recurrence
+
+The interpreter executes:
+
+```text
+sparse source bytes
+  -> 1024-byte tile
+  -> ENC_LAT_VOL
+  -> 32-byte latent
+  -> shadow latent/output
+  -> CALC_DELTA
+  -> PROPOSE_BIAS
+  -> VALIDATE
+  -> authoritative commit or rollback
+  -> next recursive level
+  -> outward latent decode
+  -> final sparse world output
+```
+
+The governing transition is:
+
+```text
+Describe -> Encode -> Reconstruct -> Compare -> Propose -> Validate -> Commit/Rollback -> Recurse
+```
+
+Accepted refinement is non-worsening at the VMAD byte-delta level, and repeated refinement is bounded by both an epsilon target and a maximum pass count. There is no unbounded `while(true)` execution path.
+
+## 2. DMCUBE1 execution buffer
+
+Control flow is carried in a dedicated execution buffer, not inferred from decoded data.
+
+Header:
+
+| Field | Bytes |
+|---|---:|
+| magic `DMCUBE1\0` | 8 |
+| version | 2 |
+| command count | 2 |
+| reserved | 4 |
+
+Every command is exactly 96 bytes:
+
+| Field | Bytes |
+|---|---:|
+| opcode | 1 |
+| hierarchy level | 1 |
+| flags | 2 |
+| tile count | 4 |
+| maximum passes | 4 |
+| epsilon | 4 |
+| source VMAD128 | 16 |
+| authoritative latent VMAD128 | 16 |
+| authoritative output VMAD128 | 16 |
+| shadow latent VMAD128 | 16 |
+| shadow output VMAD128 | 16 |
+
+An 8-byte FNV-1a digest terminates the entire buffer.
+
+Implemented cube opcodes:
+
+- `0x10 ENCODE_REFINE`
+- `0x20 DECODE`
+- `0xFF HALT`
+
+Unknown opcodes, invalid magic/version, digest corruption, overlapping transaction spans, out-of-cube addresses, excessive tile counts, excessive refinement counts, missing `HALT`, commands after `HALT`, and aggregate step-budget overflow all fail closed before execution.
+
+## 3. Inward tile transaction
+
+For each 1024-byte source tile, the interpreter composes the existing VMAD128 micro-ops:
+
+```text
+LOAD_VMAD     source
+LOAD_VMAD     shadow_latent
+LOAD_VMAD     shadow_output
+TILE_IN_VEC   1024 B
+ENC_LAT_VOL   1024 B -> 32 B
+STORE_VEC     32 B shadow latent
+FUSE_ATTN     deterministic fixed-point fusion
+DEC_PIX_VOL   32 B -> 1024 B shadow output
+CALC_DELTA    source - reconstruction
+PROPOSE_BIAS  shadow candidate
+VALIDATE      previous-delta threshold
+HALT
+```
+
+No authoritative latent or output bytes are written by this candidate program.
+
+If Lambda accepts the candidate, the interpreter first stages the complete shadow spans in host memory, copies them to the authoritative latent/output VMAD ranges, and then executes `COMMIT_IF` for the adaptive bias candidate.
+
+If the candidate fails Lambda or fails to improve after the first accepted pass, `COMMIT_IF` is issued against a reserved zero gate and the adaptive candidate is rolled back. Authoritative latent/output spans remain unchanged.
+
+This preserves the operational invariant:
+
+```text
+candidate -> validate -> commit/rollback
+```
+
+The software reference is transactionally ordered but is not yet a crash-atomic persistent store; WAL/journaling remains a separate hardening boundary.
+
+## 4. Recursive hierarchy
+
+The byte hierarchy uses the already implemented `1024 -> 32` latent contraction, giving a 32:1 byte reduction per level.
+
+For level `l`:
+
+```text
+N_l source tiles -> N_l latent vectors
+N_(l+1) = ceil(N_l / 32)
+```
+
+Thirty-two 32-byte child latent vectors form the 1024-byte source quantum for the next level. Missing tail bytes are sparse zero/default state.
+
+Conceptually:
+
+```text
+V0 --encode--> V1 --encode--> ... --encode--> VL
+ |                                         |
+ +<--decode--- ... <---------decode--------+
+```
+
+The outward pass starts from the highest committed latent stream and repeatedly expands each 32-byte latent vector into a 1024-byte lower-level representation until the final base-world output is produced.
+
+## 5. Fixed-point rule
+
+Let `d_t` be the mean absolute byte reconstruction delta for one tile.
+
+The first candidate is admissible when the lower VMAD engine validates `d_t <= 255`. Subsequent passes must satisfy strict improvement:
+
+```text
+d_(t+1) < d_t
+```
+
+Refinement stops when either:
+
+```text
+d_t <= epsilon
+```
+
+or no strict improvement occurs, or `max_passes` is reached.
+
+Thus the machine implements bounded admissible refinement rather than claiming infinite computation or guaranteed zero error.
+
+## 6. Data/code separation
+
+Decoded output is data. It is never interpreted as executable control merely because it contains opcode-like bytes or the `DMCUBE1` magic.
+
+Only a separately supplied execution buffer that passes full `DMCUBE1` validation controls the interpreter. This is the executable form of:
+
+```text
+decoded bytes != executable instructions
+```
+
+unless they are explicitly staged as a control buffer and pass all validation gates.
+
+## 7. CLI
+
+CMake target:
+
+```text
+jarvisx-recursive-cube
+```
+
+Windows executable:
+
+```text
+DrMoagi-Recursive-Cube.exe
+```
+
+Example:
+
+```powershell
+.\DrMoagi-Recursive-Cube.exe --tiles 32 --levels 2 --state-dir .\cube-state
+```
+
+The demo seeds deterministic sparse bytes, constructs a disjoint recursive VMAD layout, executes the validated hierarchy, unfolds it outward, and reports execution-buffer validation, tile/pass counts, accepted/rejected refinements, committed latent bytes, world output bytes, recursive output MAE, and lower-engine commit/rollback counts.
+
+## 8. Production claim boundary
+
+Implemented and testable:
+
+- sparse virtual cube semantics;
+- VMAD128 addressing inherited from the World Engine;
+- integrity-protected recursive execution buffer;
+- explicit data/code separation;
+- bounded multilevel encoding and outward decoding;
+- candidate-first shadow latent/output state;
+- Lambda-gated adaptive commit/rollback;
+- finite convergence/step guards;
+- deterministic telemetry and cross-platform regression tests.
+
+Not established by this software reference:
+
+- literal `1GB^3` resident physical memory;
+- one physical processor per byte cell;
+- silicon-photonic or TSV timing;
+- sub-nanosecond pipeline execution;
+- physical energy efficiency;
+- SOTA superiority;
+- patentability.
+
+Those claims remain separate evidence gates.


### PR DESCRIPTION
## Summary

Permeates the recursive cube abstraction into the merged VMAD128 World Engine as a bounded, validated hierarchical interpreter rather than a separate conceptual runtime.

### DMCUBE1 control plane
- integrity-protected execution-buffer magic/version/digest;
- fixed 96-byte commands carrying source, latent, output, shadow-latent and shadow-output VMAD128 descriptors;
- `ENCODE_REFINE`, `DECODE`, `HALT` cube opcodes;
- fail-closed validation for unknown opcodes, corruption, overlap, bounds, command count, tile count, pass count, step budget and HALT placement;
- decoded data is never implicitly treated as executable control.

### Recursive inward/outward execution
- composes the existing `TILE_IN_VEC -> ENC_LAT_VOL -> FUSE_ATTN -> DEC_PIX_VOL -> CALC_DELTA -> PROPOSE_BIAS -> VALIDATE` primitives;
- candidate latent and reconstruction bytes land only in shadow VMAD ranges;
- authoritative latent/output bytes are copied only after Lambda acceptance;
- adaptive bias state is promoted only through the existing `COMMIT_IF` gate;
- later passes require strict byte-delta improvement and stop on epsilon, no-improvement, or max-pass bounds;
- 1024-byte -> 32-byte hierarchy supports recursive 32:1 byte contraction and outward expansion.

### Runtime surfaces
- adds `DrMoagi-Recursive-Cube` CLI;
- adds smoke and regression tests;
- adds normative documentation;
- extends the existing VMAD128 Windows workflow/package to build and ship both `DrMoagi-World-Engine.exe` and `DrMoagi-Recursive-Cube.exe`.

### Claim boundary
This is a sparse deterministic software reference. It does not claim literal `1GB^3` resident memory, one physical processor per byte, silicon-photonic/TSV timing, sub-nanosecond execution, SOTA superiority, or patentability.

Closes #190 when all exact-head promotion gates pass.