### PR TITLE
Fix recursive cube authoritative telemetry

### DIFF
--- a/cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp
+++ b/cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp
@@ -306,6 +306,8 @@ struct CubeRunMetrics {
     std::uint64_t encoded_input_bytes{};
     std::uint64_t latent_bytes_committed{};
     std::uint64_t decoded_output_bytes{};
+    std::uint64_t aggregate_command_input_bytes{};
+    std::uint64_t aggregate_command_output_bytes{};
     std::vector<CubeCommandMetrics> commands;
 };
 
@@ -338,9 +340,14 @@ public:
             metrics.accepted_passes += local.accepted_passes;
             metrics.rejected_passes += local.rejected_passes;
             metrics.converged_tiles += local.converged_tiles;
-            metrics.encoded_input_bytes += local.input_bytes;
-            metrics.latent_bytes_committed += local.latent_bytes;
-            metrics.decoded_output_bytes += local.output_bytes;
+            metrics.aggregate_command_input_bytes += local.input_bytes;
+            metrics.aggregate_command_output_bytes += local.output_bytes;
+            if (command.opcode == CubeOpcode::EncodeRefine) {
+                metrics.encoded_input_bytes += local.input_bytes;
+                metrics.latent_bytes_committed += local.latent_bytes;
+            } else if (command.opcode == CubeOpcode::Decode) {
+                metrics.decoded_output_bytes += local.output_bytes;
+            }
             metrics.commands.push_back(local);
         }
         return metrics;
@@ -417,14 +424,15 @@ private:
             const auto shadow_latent = world::vmad_advance_linear(command.shadow_latent, static_cast<std::uint64_t>(tile) * kCubeLatentBytes);
             const auto shadow_output = world::vmad_advance_linear(command.shadow_output, static_cast<std::uint64_t>(tile) * kCubeTileBytes);
             std::uint32_t previous_delta = 256U;
-            std::uint32_t final_delta = 255U;
+            std::uint32_t last_accepted_delta = 255U;
+            bool accepted_any = false;
             bool converged = false;
             for (std::uint32_t pass = 0U; pass < command.max_passes; ++pass) {
                 const std::uint32_t threshold = std::min<std::uint32_t>(255U, previous_delta);
                 engine_.run(candidate_program(source, shadow_latent, shadow_output, threshold), 64ULL);
-                final_delta = engine_.last_delta_mean();
+                const std::uint32_t candidate_delta = engine_.last_delta_mean();
                 const bool lambda_gate = engine_.scalar_register(20U) != 0ULL;
-                const bool improved = pass == 0U || final_delta < previous_delta;
+                const bool improved = pass == 0U || candidate_delta < previous_delta;
                 const bool accept = lambda_gate && improved;
                 ++metrics.passes;
                 if (accept) {
@@ -432,8 +440,10 @@ private:
                     copy_span(shadow_output, output, kCubeTileBytes);
                     engine_.run(commit_program(true), 8ULL);
                     ++metrics.accepted_passes;
-                    previous_delta = final_delta;
-                    if (final_delta <= command.epsilon) {
+                    accepted_any = true;
+                    previous_delta = candidate_delta;
+                    last_accepted_delta = candidate_delta;
+                    if (candidate_delta <= command.epsilon) {
                         converged = true;
                         break;
                     }
@@ -444,7 +454,7 @@ private:
                 }
             }
             if (converged) ++metrics.converged_tiles;
-            delta_sum += static_cast<long double>(final_delta);
+            delta_sum += static_cast<long double>(accepted_any ? last_accepted_delta : 255U);
         }
         metrics.input_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeTileBytes;
         metrics.latent_bytes = static_cast<std::uint64_t>(command.tile_count) * kCubeLatentBytes;

--- a/cpp_runtime/src/recursive_cube_main.cpp
+++ b/cpp_runtime/src/recursive_cube_main.cpp
@@ -104,9 +104,11 @@ int main(int argc, char** argv) {
                       << "accepted_passes=" << metrics.accepted_passes
                       << " rejected_passes=" << metrics.rejected_passes
                       << " converged_tiles=" << metrics.converged_tiles << '\n'
-                      << "aggregate_command_input_bytes=" << metrics.encoded_input_bytes
+                      << "encoded_input_bytes=" << metrics.encoded_input_bytes
                       << " latent_bytes_committed=" << metrics.latent_bytes_committed
-                      << " total_world_output_bytes=" << metrics.decoded_output_bytes << '\n'
+                      << " decoded_output_bytes=" << metrics.decoded_output_bytes << '\n'
+                      << "aggregate_command_input_bytes=" << metrics.aggregate_command_input_bytes
+                      << " aggregate_command_output_bytes=" << metrics.aggregate_command_output_bytes << '\n'
                       << "recursive_output_mae=" << mean_absolute_error << '\n'
                       << "world_commits=" << interpreter.engine().stats().commits
                       << " world_rollbacks=" << interpreter.engine().stats().rollbacks << '\n'

--- a/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
+++ b/cpp_runtime/tests/recursive_cube_interpreter_tests.cpp
@@ -1,5 +1,6 @@
 #include "jarvisx/recursive_cube_interpreter.hpp"
 
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
@@ -93,6 +94,7 @@ void test_end_to_end_recursive_execution() {
     });
 
     const auto plan = jarvisx::cube::make_demo_plan(4U, 1U);
+    const auto commands = jarvisx::cube::parse_execution_buffer(plan.execution_buffer, {});
     const std::uint64_t source_bytes = 4ULL * jarvisx::cube::kCubeTileBytes;
     const std::uint64_t latent_bytes = 4ULL * jarvisx::cube::kCubeLatentBytes;
     seed(volume, plan.source, source_bytes);
@@ -107,12 +109,42 @@ void test_end_to_end_recursive_execution() {
             "recursive-cube inward command input byte count mismatch");
     require(metrics.commands[1].input_bytes == latent_bytes,
             "recursive-cube outward command latent input byte count mismatch");
-    require(metrics.encoded_input_bytes == source_bytes + latent_bytes,
-            "recursive-cube aggregate command-input byte count mismatch");
+    require(metrics.encoded_input_bytes == source_bytes,
+            "recursive-cube encoded input should count inward source bytes only");
     require(metrics.latent_bytes_committed == latent_bytes,
             "recursive-cube committed latent byte count mismatch");
+    require(metrics.decoded_output_bytes == source_bytes,
+            "recursive-cube decoded output should count outward output bytes only");
+    require(metrics.aggregate_command_input_bytes == source_bytes + latent_bytes,
+            "recursive-cube aggregate command input byte count mismatch");
+    require(metrics.aggregate_command_output_bytes == source_bytes + source_bytes,
+            "recursive-cube aggregate command output byte count mismatch");
     require(interpreter.engine().stats().commits == metrics.accepted_passes,
             "world-engine commit telemetry diverges from recursive interpreter");
+
+    long double authoritative_delta_sum = 0.0L;
+    const auto& inward = commands.front();
+    for (std::uint32_t tile = 0U; tile < inward.tile_count; ++tile) {
+        const auto source = jarvisx::world::vmad_advance_linear(
+            inward.source, static_cast<std::uint64_t>(tile) * jarvisx::cube::kCubeTileBytes);
+        const auto authoritative = jarvisx::world::vmad_advance_linear(
+            inward.output, static_cast<std::uint64_t>(tile) * jarvisx::cube::kCubeTileBytes);
+        std::uint64_t score = 0ULL;
+        for (std::size_t i = 0U; i < jarvisx::cube::kCubeTileBytes; ++i) {
+            const int left = static_cast<int>(volume.read(
+                jarvisx::world::vmad_advance_linear(source, static_cast<std::uint64_t>(i)).coord()));
+            const int right = static_cast<int>(volume.read(
+                jarvisx::world::vmad_advance_linear(authoritative, static_cast<std::uint64_t>(i)).coord()));
+            const int delta = left - right;
+            score += static_cast<std::uint64_t>(delta < 0 ? -delta : delta);
+        }
+        authoritative_delta_sum += static_cast<long double>(
+            score / static_cast<std::uint64_t>(jarvisx::cube::kCubeTileBytes));
+    }
+    const double authoritative_mean = static_cast<double>(
+        authoritative_delta_sum / static_cast<long double>(inward.tile_count));
+    require(std::abs(metrics.commands[0].mean_final_delta - authoritative_mean) < 1.0e-9,
+            "mean_final_delta does not describe authoritative committed reconstruction");
 
     std::uint64_t nonzero = 0ULL;
     for (std::uint64_t i = 0ULL; i < source_bytes; ++i) {


### PR DESCRIPTION
## Summary

Follow-up hardening for PR #191. Corrects two post-review telemetry issues without changing DMCUBE1 wire format or recursive execution semantics.

### Fixes
1. **Opcode-specific byte accounting**
   - `encoded_input_bytes` now counts `ENCODE_REFINE` source bytes only.
   - `latent_bytes_committed` counts committed inward latents only.
   - `decoded_output_bytes` now counts `DECODE` output bytes only.
   - new `aggregate_command_input_bytes` / `aggregate_command_output_bytes` retain full command-traffic accounting explicitly.

2. **Authoritative final-delta telemetry**
   - tracks `candidate_delta` separately from `last_accepted_delta`;
   - a rejected non-improving shadow pass can no longer overwrite the reported final committed delta;
   - `mean_final_delta` now describes the authoritative reconstruction actually committed.

### Regression hardening
- verifies opcode-specific and aggregate byte counters independently;
- independently recomputes integer mean absolute byte delta from source vs authoritative VMAD output and requires it to equal command `mean_final_delta`;
- preserves existing integrity, bounds, rollback, recursion and data/code-separation tests.

No architecture/claim expansion. This is a telemetry correctness hotfix for the merged recursive cube interpreter.