### PR TITLE
feat(cpp): permeate inward 3D self-editing engine

### DIFF
--- a/.github/workflows/cpp-self-editor3d.yml
+++ b/.github/workflows/cpp-self-editor3d.yml
@@ -1,0 +1,60 @@
+name: C++ Inward 3D Self Editor
+
+on:
+  push:
+    paths:
+      - "cpp_runtime/self_editor3d/**"
+      - ".github/workflows/cpp-self-editor3d.yml"
+  pull_request:
+    paths:
+      - "cpp_runtime/self_editor3d/**"
+      - ".github/workflows/cpp-self-editor3d.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cpp-self-editor3d-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            compiler: gcc
+            sanitizers: "OFF"
+          - os: ubuntu-latest
+            compiler: clang
+            sanitizers: "ON"
+          - os: windows-latest
+            compiler: msvc
+            sanitizers: "OFF"
+    runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} / ${{ matrix.compiler }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Select GCC
+        if: matrix.compiler == 'gcc'
+        run: echo "CXX=g++" >> "$GITHUB_ENV"
+
+      - name: Select Clang
+        if: matrix.compiler == 'clang'
+        run: echo "CXX=clang++" >> "$GITHUB_ENV"
+
+      - name: Configure
+        run: >-
+          cmake -S cpp_runtime/self_editor3d -B build/self-editor3d
+          -DCMAKE_BUILD_TYPE=Release
+          -DJARVISX_SELFEDIT_ENABLE_SANITIZERS=${{ matrix.sanitizers }}
+
+      - name: Build
+        run: cmake --build build/self-editor3d --config Release --parallel 2
+
+      - name: Test
+        run: ctest --test-dir build/self-editor3d -C Release --output-on-failure

--- a/cpp_runtime/self_editor3d/CMakeLists.txt
+++ b/cpp_runtime/self_editor3d/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 3.16)
+project(jarvisx_self_editor3d LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(JARVISX_SELFEDIT_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+
+function(jarvisx_selfedit_harden target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4 /permissive-)
+    else()
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
+        if(JARVISX_SELFEDIT_ENABLE_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+            target_compile_options(${target} PRIVATE -fsanitize=address,undefined -fno-omit-frame-pointer)
+            target_link_options(${target} PRIVATE -fsanitize=address,undefined)
+        endif()
+    endif()
+endfunction()
+
+add_library(jarvisx-self-editor3d-core STATIC
+    src/self_editor3d.cpp
+)
+target_include_directories(jarvisx-self-editor3d-core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+jarvisx_selfedit_harden(jarvisx-self-editor3d-core)
+
+add_executable(jarvisx-self-editor3d
+    src/main.cpp
+)
+target_link_libraries(jarvisx-self-editor3d PRIVATE jarvisx-self-editor3d-core)
+jarvisx_selfedit_harden(jarvisx-self-editor3d)
+
+enable_testing()
+
+add_executable(jarvisx-self-editor3d-tests
+    tests/self_editor3d_tests.cpp
+)
+target_link_libraries(jarvisx-self-editor3d-tests PRIVATE jarvisx-self-editor3d-core)
+jarvisx_selfedit_harden(jarvisx-self-editor3d-tests)
+
+add_test(NAME self-editor3d-regressions COMMAND jarvisx-self-editor3d-tests)
+set_tests_properties(self-editor3d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/self_editor3d/README.md
+++ b/cpp_runtime/self_editor3d/README.md
@@ -1,0 +1,84 @@
+# Jarvis-X Inward 3D C++ Self-Editing Engine
+
+This subsystem gives the C++ runtime a bounded source-editing and self-refinement kernel. It maps active C/C++ source bytes into a cubic voxel field, recursively pools `2×2×2` neighborhoods into a `1³` latent core, ranks a conservative mutation set, applies one mutation transactionally, validates it, and either accepts the next source state or restores the rollback anchor.
+
+It does **not** autonomously invent arbitrary native code, bypass repository controls, or persist failed mutations. The built-in autonomous mutation policy is intentionally semantics-conservative: trailing whitespace removal, excessive blank-line collapse, and canonical final-newline insertion. Exact replacement and insertion primitives are exposed for higher-level tooling, but ambiguous anchors and no-op edits are rejected.
+
+## Inward recurrence
+
+```text
+source tree
+  -> byte voxels V(x,y,z)
+  -> recursive 2x2x2 pooling
+  -> 1^3 core
+  -> ranked admissible mutation
+  -> transactional source edit
+  -> optional compile/test validator
+  -> objective gate
+  -> accept next state OR rollback
+  -> repeat to fixed point
+```
+
+The optimizer reports source-volume metrics and minimizes a bounded objective over trailing whitespace, excessive vertical whitespace, missing final newlines, and the measured structural hotspot field. A candidate is accepted only when validation succeeds and the objective does not increase.
+
+## Build and test
+
+```bash
+cmake -S cpp_runtime/self_editor3d -B build/self-editor3d -DCMAKE_BUILD_TYPE=Release
+cmake --build build/self-editor3d --config Release --parallel
+ctest --test-dir build/self-editor3d -C Release --output-on-failure
+```
+
+## Inspect the 3D source state
+
+```bash
+./build/self-editor3d/jarvisx-self-editor3d analyze-3d cpp_runtime
+./build/self-editor3d/jarvisx-self-editor3d field-3d cpp_runtime
+./build/self-editor3d/jarvisx-self-editor3d propose-3d cpp_runtime
+```
+
+`field-3d` prints the inward side sequence for every source file, for example `24^3 -> 12^3 -> 6^3 -> 3^3 -> 2^3 -> 1^3`, together with the final core energies.
+
+## Bounded self-optimization
+
+Run without a validator only for source-canonicalization experiments:
+
+```bash
+./build/self-editor3d/jarvisx-self-editor3d optimize-3d cpp_runtime 16
+```
+
+For repository self-refinement, pass a compile/test command so every proposed mutation must survive validation before it can remain authoritative:
+
+```bash
+./build/self-editor3d/jarvisx-self-editor3d optimize-3d cpp_runtime 16 \
+  "cmake --build ../build/cpp-runtime --config Release"
+```
+
+The validation command is explicitly supplied by the operator and is executed from the selected workspace root. It is not synthesized by the autonomous mutation policy.
+
+## Transactional editing primitives
+
+```bash
+./build/self-editor3d/jarvisx-self-editor3d replace \
+  cpp_runtime src/example.cpp "old_exact_text" "new_exact_text" \
+  "cmake --build ../build/cpp-runtime --config Release"
+
+./build/self-editor3d/jarvisx-self-editor3d insert-after \
+  cpp_runtime src/example.cpp "unique_anchor" "inserted_text" \
+  "cmake --build ../build/cpp-runtime --config Release"
+```
+
+Safety invariants:
+
+- edits are confined to the selected workspace after canonical path resolution;
+- absolute paths and path escapes are rejected;
+- exact replacement/insertion anchors must occur exactly once;
+- no-op transactions do not commit;
+- writes use a temporary file followed by rename;
+- failed compile/test validation restores the pre-edit bytes;
+- objective-regressing autonomous mutations are rolled back;
+- the refinement loop terminates when no admissible mutations remain or the pass budget is exhausted.
+
+## Regression coverage
+
+The CTest suite verifies workspace containment, ambiguous-anchor rejection, no-op rejection, recursive folding to a `1³` core, objective reduction, source canonicalization, and fixed-point convergence. GitHub Actions builds and tests the subsystem on GCC, Clang with sanitizers, and MSVC.

--- a/cpp_runtime/self_editor3d/include/jarvisx/self_editor3d.hpp
+++ b/cpp_runtime/self_editor3d/include/jarvisx/self_editor3d.hpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace jarvisx {
+namespace selfedit {
+
+struct FileState {
+    std::filesystem::path path;
+    std::string content;
+    std::uint64_t fingerprint{};
+};
+
+struct Edit {
+    enum class Kind { ReplaceOnce, InsertAfter, ReplaceRange };
+    Kind kind{Kind::ReplaceOnce};
+    std::filesystem::path file;
+    std::string needle;
+    std::string replacement;
+    std::size_t begin{};
+    std::size_t end{};
+};
+
+struct EditResult {
+    bool ok{false};
+    std::string message;
+    std::vector<std::filesystem::path> changed_files;
+};
+
+class Workspace {
+public:
+    explicit Workspace(std::filesystem::path root);
+
+    const std::filesystem::path& root() const noexcept { return root_; }
+    std::filesystem::path resolve(const std::filesystem::path& relative) const;
+    std::vector<std::filesystem::path> cpp_files() const;
+    FileState read(const std::filesystem::path& relative) const;
+
+private:
+    std::filesystem::path root_;
+};
+
+class Transaction {
+public:
+    explicit Transaction(const Workspace& workspace);
+
+    void add(Edit edit);
+    EditResult apply();
+    void rollback() noexcept;
+    bool committed() const noexcept { return committed_; }
+
+private:
+    const Workspace& workspace_;
+    std::vector<Edit> edits_;
+    std::vector<FileState> before_;
+    bool committed_{false};
+
+    static std::string apply_one(std::string current, const Edit& edit);
+    static void atomic_write(const std::filesystem::path& path, std::string_view content);
+};
+
+struct ValidationResult {
+    bool ok{false};
+    int exit_code{-1};
+    std::string command;
+};
+
+class Validator {
+public:
+    explicit Validator(std::filesystem::path workspace_root);
+    ValidationResult run(const std::string& command) const;
+
+private:
+    std::filesystem::path root_;
+};
+
+class SelfRefiningEditor {
+public:
+    explicit SelfRefiningEditor(std::filesystem::path root);
+
+    EditResult replace_once(const std::filesystem::path& file,
+                            std::string needle,
+                            std::string replacement,
+                            const std::optional<std::string>& validation_command = std::nullopt);
+
+    EditResult insert_after(const std::filesystem::path& file,
+                            std::string anchor,
+                            std::string text,
+                            const std::optional<std::string>& validation_command = std::nullopt);
+
+    const Workspace& workspace() const noexcept { return workspace_; }
+
+private:
+    Workspace workspace_;
+    Validator validator_;
+};
+
+struct Voxel3D {
+    float byte_value{};
+    float syntax_energy{};
+    float whitespace_energy{};
+    float alpha_energy{};
+    float digit_energy{};
+    float newline_energy{};
+    float hotspot{};
+    std::size_t source_index{static_cast<std::size_t>(-1)};
+};
+
+struct InwardLevel3D {
+    std::size_t side{};
+    std::vector<Voxel3D> voxels;
+};
+
+struct SourceField3D {
+    std::filesystem::path file;
+    std::size_t source_bytes{};
+    std::vector<InwardLevel3D> levels;
+    Voxel3D core;
+};
+
+struct WorkspaceMetrics3D {
+    std::size_t files{};
+    std::size_t bytes{};
+    std::size_t lines{};
+    std::size_t trailing_whitespace_bytes{};
+    std::size_t excessive_blank_lines{};
+    std::size_t tab_bytes{};
+    std::size_t missing_final_newline_files{};
+    double mean_hotspot{};
+    double objective{};
+};
+
+struct Mutation3D {
+    std::filesystem::path file;
+    Edit edit;
+    double predicted_gain{};
+    std::string rationale;
+};
+
+struct OptimizationPass3D {
+    bool changed{false};
+    bool accepted{false};
+    std::string message;
+    std::optional<Mutation3D> mutation;
+    WorkspaceMetrics3D before;
+    WorkspaceMetrics3D after;
+};
+
+struct OptimizationReport3D {
+    std::vector<OptimizationPass3D> passes;
+    WorkspaceMetrics3D initial;
+    WorkspaceMetrics3D final;
+};
+
+class Inward3DEncoder {
+public:
+    SourceField3D encode(const FileState& source) const;
+
+private:
+    static Voxel3D voxelize(unsigned char byte, std::size_t source_index) noexcept;
+    static Voxel3D pool8(const std::vector<Voxel3D>& children) noexcept;
+};
+
+class Inward3DSelfOptimizer {
+public:
+    explicit Inward3DSelfOptimizer(std::filesystem::path root);
+
+    WorkspaceMetrics3D analyze() const;
+    std::vector<SourceField3D> encode_workspace() const;
+    std::vector<Mutation3D> propose() const;
+
+    OptimizationReport3D optimize(
+        std::size_t max_passes,
+        const std::optional<std::string>& validation_command = std::nullopt);
+
+private:
+    Workspace workspace_;
+    Validator validator_;
+    Inward3DEncoder encoder_;
+
+    static double objective(const WorkspaceMetrics3D& metrics) noexcept;
+    static std::vector<Mutation3D> propose_for_file(const FileState& state,
+                                                    const SourceField3D& field);
+};
+
+std::uint64_t fingerprint(std::string_view data) noexcept;
+
+} // namespace selfedit
+} // namespace jarvisx

--- a/cpp_runtime/self_editor3d/src/main.cpp
+++ b/cpp_runtime/self_editor3d/src/main.cpp
@@ -1,0 +1,168 @@
+#include "jarvisx/self_editor3d.hpp"
+
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using jarvisx::selfedit::WorkspaceMetrics3D;
+
+void usage() {
+    std::cout
+        << "Jarvis-X Inward 3D C++ Self-Editing Engine\n\n"
+        << "Usage:\n"
+        << "  jarvisx-self-editor3d scan <workspace>\n"
+        << "  jarvisx-self-editor3d analyze-3d <workspace>\n"
+        << "  jarvisx-self-editor3d field-3d <workspace>\n"
+        << "  jarvisx-self-editor3d propose-3d <workspace>\n"
+        << "  jarvisx-self-editor3d optimize-3d <workspace> <max-passes> [validation-command]\n"
+        << "  jarvisx-self-editor3d replace <workspace> <file> <needle> <replacement> [validation-command]\n"
+        << "  jarvisx-self-editor3d insert-after <workspace> <file> <anchor> <text> [validation-command]\n\n"
+        << "Safe self-fold example:\n"
+        << "  jarvisx-self-editor3d optimize-3d cpp_runtime 16 \"cmake --build ../build/cpp-runtime --config Release\"\n";
+}
+
+std::optional<std::string> arg_optional(int argc, char** argv, int index) {
+    if (argc > index) return std::string(argv[index]);
+    return std::nullopt;
+}
+
+std::size_t parse_size(const char* text) {
+    const auto value = std::stoull(text);
+    if (value > 10000ULL) throw std::runtime_error("max-passes must be <= 10000");
+    return static_cast<std::size_t>(value);
+}
+
+void print_metrics(const WorkspaceMetrics3D& m) {
+    std::cout << std::fixed << std::setprecision(8)
+              << "files=" << m.files
+              << " bytes=" << m.bytes
+              << " lines=" << m.lines
+              << " trailing_ws=" << m.trailing_whitespace_bytes
+              << " excessive_blank=" << m.excessive_blank_lines
+              << " tabs=" << m.tab_bytes
+              << " missing_final_newline=" << m.missing_final_newline_files
+              << " mean_hotspot=" << m.mean_hotspot
+              << " objective=" << m.objective << '\n';
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        if (argc < 3) {
+            usage();
+            return 1;
+        }
+
+        const std::string command = argv[1];
+        const std::filesystem::path root = argv[2];
+
+        if (command == "analyze-3d" || command == "field-3d" ||
+            command == "propose-3d" || command == "optimize-3d") {
+            jarvisx::selfedit::Inward3DSelfOptimizer inward(root);
+
+            if (command == "analyze-3d") {
+                print_metrics(inward.analyze());
+                return 0;
+            }
+
+            if (command == "field-3d") {
+                for (const auto& field : inward.encode_workspace()) {
+                    std::cout << field.file.generic_string()
+                              << " bytes=" << field.source_bytes
+                              << " levels=" << field.levels.size() << " sides=";
+                    for (std::size_t i = 0; i < field.levels.size(); ++i) {
+                        if (i) std::cout << "->";
+                        std::cout << field.levels[i].side << '^' << 3;
+                    }
+                    std::cout << " core=[byte=" << field.core.byte_value
+                              << ", syntax=" << field.core.syntax_energy
+                              << ", whitespace=" << field.core.whitespace_energy
+                              << ", hotspot=" << field.core.hotspot << "]\n";
+                }
+                return 0;
+            }
+
+            if (command == "propose-3d") {
+                const auto mutations = inward.propose();
+                if (mutations.empty()) {
+                    std::cout << "fixed point: no admissible mutations\n";
+                    return 0;
+                }
+                for (const auto& m : mutations) {
+                    std::cout << m.file.generic_string()
+                              << " range=[" << m.edit.begin << ',' << m.edit.end << ")"
+                              << " gain=" << m.predicted_gain
+                              << " :: " << m.rationale << '\n';
+                }
+                return 0;
+            }
+
+            if (argc < 4) {
+                usage();
+                return 1;
+            }
+            const auto max_passes = parse_size(argv[3]);
+            const auto report = inward.optimize(max_passes, arg_optional(argc, argv, 4));
+            std::cout << "INITIAL ";
+            print_metrics(report.initial);
+            for (std::size_t i = 0; i < report.passes.size(); ++i) {
+                const auto& pass = report.passes[i];
+                std::cout << "PASS " << (i + 1) << ' '
+                          << (pass.accepted ? "ACCEPT " : "REJECT ")
+                          << pass.message;
+                if (pass.mutation) {
+                    std::cout << " :: " << pass.mutation->file.generic_string()
+                              << " :: " << pass.mutation->rationale;
+                }
+                std::cout << '\n';
+            }
+            std::cout << "FINAL   ";
+            print_metrics(report.final);
+            return 0;
+        }
+
+        jarvisx::selfedit::SelfRefiningEditor engine(root);
+
+        if (command == "scan") {
+            for (const auto& file : engine.workspace().cpp_files()) {
+                const auto state = engine.workspace().read(file);
+                std::cout << file.generic_string()
+                          << " bytes=" << state.content.size()
+                          << " fingerprint=" << state.fingerprint << '\n';
+            }
+            return 0;
+        }
+
+        if (command == "replace") {
+            if (argc < 6) {
+                usage();
+                return 1;
+            }
+            const auto result = engine.replace_once(argv[3], argv[4], argv[5], arg_optional(argc, argv, 6));
+            std::cout << (result.ok ? "OK: " : "ERROR: ") << result.message << '\n';
+            return result.ok ? 0 : 2;
+        }
+
+        if (command == "insert-after") {
+            if (argc < 6) {
+                usage();
+                return 1;
+            }
+            const auto result = engine.insert_after(argv[3], argv[4], argv[5], arg_optional(argc, argv, 6));
+            std::cout << (result.ok ? "OK: " : "ERROR: ") << result.message << '\n';
+            return result.ok ? 0 : 2;
+        }
+
+        usage();
+        return 1;
+    } catch (const std::exception& e) {
+        std::cerr << "fatal: " << e.what() << '\n';
+        return 3;
+    }
+}

--- a/cpp_runtime/self_editor3d/src/self_editor3d.cpp
+++ b/cpp_runtime/self_editor3d/src/self_editor3d.cpp
@@ -1,0 +1,629 @@
+#include "jarvisx/self_editor3d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace fs = std::filesystem;
+
+namespace jarvisx {
+namespace selfedit {
+namespace {
+
+bool is_contained_path(const fs::path& root, const fs::path& candidate) {
+    auto root_it = root.begin();
+    auto candidate_it = candidate.begin();
+    for (; root_it != root.end(); ++root_it, ++candidate_it) {
+        if (candidate_it == candidate.end() || *root_it != *candidate_it) return false;
+    }
+    return true;
+}
+
+std::size_t cube_side_for(std::size_t n) {
+    if (n == 0) return 1;
+    auto side = static_cast<std::size_t>(std::ceil(std::cbrt(static_cast<double>(n))));
+    while (static_cast<long double>(side) * static_cast<long double>(side) *
+           static_cast<long double>(side) < static_cast<long double>(n)) {
+        ++side;
+    }
+    return std::max<std::size_t>(1, side);
+}
+
+std::size_t index3(std::size_t x, std::size_t y, std::size_t z, std::size_t side) {
+    return (z * side + y) * side + x;
+}
+
+bool is_syntax(unsigned char c) noexcept {
+    constexpr std::string_view syntax = "{}[]();,:<>+-=*/%&|!^~?.#\\\"'";
+    return syntax.find(static_cast<char>(c)) != std::string_view::npos;
+}
+
+std::size_t count_lines(std::string_view s) noexcept {
+    if (s.empty()) return 0;
+    return 1 + static_cast<std::size_t>(std::count(s.begin(), s.end(), '\n'));
+}
+
+struct TextPenalties {
+    std::size_t trailing{};
+    std::size_t excessive_blank{};
+    std::size_t tabs{};
+};
+
+TextPenalties inspect_text(std::string_view s) {
+    TextPenalties p;
+    p.tabs = static_cast<std::size_t>(std::count(s.begin(), s.end(), '\t'));
+
+    std::size_t line_start = 0;
+    std::size_t consecutive_blank = 0;
+    while (line_start < s.size()) {
+        auto line_end = s.find('\n', line_start);
+        if (line_end == std::string_view::npos) line_end = s.size();
+
+        std::size_t trimmed = line_end;
+        while (trimmed > line_start && (s[trimmed - 1] == ' ' || s[trimmed - 1] == '\t')) {
+            --trimmed;
+        }
+        p.trailing += line_end - trimmed;
+
+        const bool blank = trimmed == line_start;
+        if (blank) {
+            ++consecutive_blank;
+            if (consecutive_blank > 2) ++p.excessive_blank;
+        } else {
+            consecutive_blank = 0;
+        }
+
+        if (line_end == s.size()) break;
+        line_start = line_end + 1;
+    }
+    return p;
+}
+
+} // namespace
+
+std::uint64_t fingerprint(std::string_view data) noexcept {
+    constexpr std::uint64_t offset = 1469598103934665603ULL;
+    constexpr std::uint64_t prime = 1099511628211ULL;
+    std::uint64_t hash = offset;
+    for (unsigned char c : data) {
+        hash ^= static_cast<std::uint64_t>(c);
+        hash *= prime;
+    }
+    return hash;
+}
+
+Workspace::Workspace(fs::path root) : root_(fs::weakly_canonical(std::move(root))) {
+    if (!fs::exists(root_) || !fs::is_directory(root_)) {
+        throw std::runtime_error("workspace root is not a directory: " + root_.string());
+    }
+}
+
+fs::path Workspace::resolve(const fs::path& relative) const {
+    if (relative.is_absolute()) {
+        throw std::runtime_error("absolute edit paths are not allowed: " + relative.string());
+    }
+    const auto candidate = fs::weakly_canonical(root_ / relative);
+    if (!is_contained_path(root_, candidate)) {
+        throw std::runtime_error("path escapes workspace: " + relative.string());
+    }
+    return candidate;
+}
+
+std::vector<fs::path> Workspace::cpp_files() const {
+    std::vector<fs::path> out;
+    fs::recursive_directory_iterator it(root_), end;
+    while (it != end) {
+        const auto& entry = *it;
+        if (entry.is_directory()) {
+            const auto name = entry.path().filename().string();
+            if (name == ".git" || name == "build" || name == "out" || name == ".cache") {
+                it.disable_recursion_pending();
+            }
+        } else if (entry.is_regular_file()) {
+            const auto ext = entry.path().extension().string();
+            if (ext == ".cpp" || ext == ".cc" || ext == ".cxx" || ext == ".hpp" || ext == ".h") {
+                out.push_back(fs::relative(entry.path(), root_));
+            }
+        }
+        ++it;
+    }
+    std::sort(out.begin(), out.end());
+    return out;
+}
+
+FileState Workspace::read(const fs::path& relative) const {
+    const auto path = resolve(relative);
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("cannot read file: " + path.string());
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    FileState state{relative, buffer.str(), 0};
+    state.fingerprint = fingerprint(state.content);
+    return state;
+}
+
+Transaction::Transaction(const Workspace& workspace) : workspace_(workspace) {}
+
+void Transaction::add(Edit edit) {
+    if (committed_) throw std::runtime_error("cannot add edits after commit");
+    edits_.push_back(std::move(edit));
+}
+
+std::string Transaction::apply_one(std::string current, const Edit& edit) {
+    switch (edit.kind) {
+        case Edit::Kind::ReplaceOnce: {
+            if (edit.needle.empty()) throw std::runtime_error("replace target must not be empty");
+            const auto pos = current.find(edit.needle);
+            if (pos == std::string::npos) throw std::runtime_error("replace target not found");
+            if (current.find(edit.needle, pos + edit.needle.size()) != std::string::npos) {
+                throw std::runtime_error("replace target is ambiguous; expected exactly one match");
+            }
+            current.replace(pos, edit.needle.size(), edit.replacement);
+            return current;
+        }
+        case Edit::Kind::InsertAfter: {
+            if (edit.needle.empty()) throw std::runtime_error("insert anchor must not be empty");
+            const auto pos = current.find(edit.needle);
+            if (pos == std::string::npos) throw std::runtime_error("insert anchor not found");
+            if (current.find(edit.needle, pos + edit.needle.size()) != std::string::npos) {
+                throw std::runtime_error("insert anchor is ambiguous; expected exactly one match");
+            }
+            current.insert(pos + edit.needle.size(), edit.replacement);
+            return current;
+        }
+        case Edit::Kind::ReplaceRange: {
+            if (edit.begin > edit.end || edit.end > current.size()) {
+                throw std::runtime_error("invalid replacement range");
+            }
+            current.replace(edit.begin, edit.end - edit.begin, edit.replacement);
+            return current;
+        }
+    }
+    throw std::runtime_error("unknown edit kind");
+}
+
+void Transaction::atomic_write(const fs::path& path, std::string_view content) {
+    const fs::path tmp = path.string() + ".jarvisx-selfedit.tmp";
+    {
+        std::ofstream out(tmp, std::ios::binary | std::ios::trunc);
+        if (!out) throw std::runtime_error("cannot open temp file: " + tmp.string());
+        out.write(content.data(), static_cast<std::streamsize>(content.size()));
+        if (!out) throw std::runtime_error("failed writing temp file: " + tmp.string());
+    }
+
+    std::error_code ec;
+    fs::rename(tmp, path, ec);
+    if (ec) {
+        std::error_code remove_ec;
+        fs::remove(path, remove_ec);
+        ec.clear();
+        fs::rename(tmp, path, ec);
+    }
+    if (ec) {
+        std::error_code cleanup_ec;
+        fs::remove(tmp, cleanup_ec);
+        throw std::runtime_error("atomic rename failed: " + ec.message());
+    }
+}
+
+EditResult Transaction::apply() {
+    if (committed_) return {false, "transaction already committed", {}};
+    if (edits_.empty()) return {false, "no edits supplied", {}};
+
+    try {
+        std::unordered_map<std::string, std::string> staged;
+        std::unordered_map<std::string, fs::path> relpaths;
+
+        for (const auto& edit : edits_) {
+            const auto key = edit.file.generic_string();
+            auto staged_it = staged.find(key);
+            if (staged_it == staged.end()) {
+                auto state = workspace_.read(edit.file);
+                before_.push_back(state);
+                staged.emplace(key, state.content);
+                relpaths.emplace(key, edit.file);
+                staged_it = staged.find(key);
+            }
+            staged_it->second = apply_one(std::move(staged_it->second), edit);
+        }
+
+        std::unordered_map<std::string, std::string> originals;
+        for (const auto& state : before_) {
+            originals.emplace(state.path.generic_string(), state.content);
+        }
+
+        std::vector<fs::path> changed;
+        for (const auto& pair : staged) {
+            const auto& key = pair.first;
+            const auto& content = pair.second;
+            if (content == originals.at(key)) continue;
+            atomic_write(workspace_.resolve(relpaths.at(key)), content);
+            changed.push_back(relpaths.at(key));
+        }
+        if (changed.empty()) {
+            before_.clear();
+            return {false, "edit produced no source change", {}};
+        }
+        committed_ = true;
+        return {true, "edits committed", std::move(changed)};
+    } catch (const std::exception& e) {
+        rollback();
+        return {false, e.what(), {}};
+    }
+}
+
+void Transaction::rollback() noexcept {
+    for (const auto& state : before_) {
+        try {
+            atomic_write(workspace_.resolve(state.path), state.content);
+        } catch (...) {
+        }
+    }
+    committed_ = false;
+}
+
+Validator::Validator(fs::path workspace_root) : root_(fs::weakly_canonical(std::move(workspace_root))) {}
+
+ValidationResult Validator::run(const std::string& command) const {
+    if (command.empty()) return {true, 0, command};
+#if defined(_WIN32)
+    const std::string wrapped = "cd /d \"" + root_.string() + "\" && " + command;
+#else
+    const std::string wrapped = "cd \"" + root_.string() + "\" && " + command;
+#endif
+    const int rc = std::system(wrapped.c_str());
+    return {rc == 0, rc, command};
+}
+
+SelfRefiningEditor::SelfRefiningEditor(fs::path root)
+    : workspace_(std::move(root)), validator_(workspace_.root()) {}
+
+EditResult SelfRefiningEditor::replace_once(const fs::path& file,
+                                            std::string needle,
+                                            std::string replacement,
+                                            const std::optional<std::string>& validation_command) {
+    Transaction tx(workspace_);
+    tx.add(Edit{Edit::Kind::ReplaceOnce, file, std::move(needle), std::move(replacement), 0, 0});
+    auto result = tx.apply();
+    if (!result.ok) return result;
+
+    if (validation_command) {
+        const auto validation = validator_.run(*validation_command);
+        if (!validation.ok) {
+            tx.rollback();
+            return {false, "validation failed; edit rolled back", {}};
+        }
+    }
+    return result;
+}
+
+EditResult SelfRefiningEditor::insert_after(const fs::path& file,
+                                            std::string anchor,
+                                            std::string text,
+                                            const std::optional<std::string>& validation_command) {
+    Transaction tx(workspace_);
+    tx.add(Edit{Edit::Kind::InsertAfter, file, std::move(anchor), std::move(text), 0, 0});
+    auto result = tx.apply();
+    if (!result.ok) return result;
+
+    if (validation_command) {
+        const auto validation = validator_.run(*validation_command);
+        if (!validation.ok) {
+            tx.rollback();
+            return {false, "validation failed; edit rolled back", {}};
+        }
+    }
+    return result;
+}
+
+Voxel3D Inward3DEncoder::voxelize(unsigned char byte, std::size_t source_index) noexcept {
+    const float value = static_cast<float>(byte) / 255.0F;
+    const float syntax = is_syntax(byte) ? 1.0F : 0.0F;
+    const float whitespace = (byte == ' ' || byte == '\t' || byte == '\r') ? 1.0F : 0.0F;
+    const float alpha = std::isalpha(byte) != 0 ? 1.0F : 0.0F;
+    const float digit = std::isdigit(byte) != 0 ? 1.0F : 0.0F;
+    const float newline = byte == '\n' ? 1.0F : 0.0F;
+    const float hotspot = 0.34F * syntax + 0.22F * whitespace + 0.18F * newline
+                        + 0.14F * digit + 0.12F * std::abs(value - 0.5F);
+    return {value, syntax, whitespace, alpha, digit, newline, hotspot, source_index};
+}
+
+Voxel3D Inward3DEncoder::pool8(const std::vector<Voxel3D>& children) noexcept {
+    if (children.empty()) return {};
+    Voxel3D out{};
+    float max_hotspot = -1.0F;
+    for (const auto& v : children) {
+        out.byte_value += v.byte_value;
+        out.syntax_energy += v.syntax_energy;
+        out.whitespace_energy += v.whitespace_energy;
+        out.alpha_energy += v.alpha_energy;
+        out.digit_energy += v.digit_energy;
+        out.newline_energy += v.newline_energy;
+        out.hotspot += v.hotspot;
+        if (v.hotspot > max_hotspot && v.source_index != static_cast<std::size_t>(-1)) {
+            max_hotspot = v.hotspot;
+            out.source_index = v.source_index;
+        }
+    }
+    const float inv = 1.0F / static_cast<float>(children.size());
+    out.byte_value *= inv;
+    out.syntax_energy *= inv;
+    out.whitespace_energy *= inv;
+    out.alpha_energy *= inv;
+    out.digit_energy *= inv;
+    out.newline_energy *= inv;
+    out.hotspot *= inv;
+    return out;
+}
+
+SourceField3D Inward3DEncoder::encode(const FileState& source) const {
+    SourceField3D field;
+    field.file = source.path;
+    field.source_bytes = source.content.size();
+
+    const std::size_t side = cube_side_for(source.content.size());
+    InwardLevel3D base;
+    base.side = side;
+    base.voxels.resize(side * side * side);
+
+    for (std::size_t i = 0; i < source.content.size(); ++i) {
+        base.voxels[i] = voxelize(static_cast<unsigned char>(source.content[i]), i);
+    }
+    field.levels.push_back(std::move(base));
+
+    while (field.levels.back().side > 1) {
+        const auto& prev = field.levels.back();
+        const std::size_t next_side = (prev.side + 1) / 2;
+        InwardLevel3D next;
+        next.side = next_side;
+        next.voxels.resize(next_side * next_side * next_side);
+
+        for (std::size_t z = 0; z < next_side; ++z) {
+            for (std::size_t y = 0; y < next_side; ++y) {
+                for (std::size_t x = 0; x < next_side; ++x) {
+                    std::vector<Voxel3D> children;
+                    children.reserve(8);
+                    for (std::size_t dz = 0; dz < 2; ++dz) {
+                        for (std::size_t dy = 0; dy < 2; ++dy) {
+                            for (std::size_t dx = 0; dx < 2; ++dx) {
+                                const auto px = x * 2 + dx;
+                                const auto py = y * 2 + dy;
+                                const auto pz = z * 2 + dz;
+                                if (px < prev.side && py < prev.side && pz < prev.side) {
+                                    children.push_back(prev.voxels[index3(px, py, pz, prev.side)]);
+                                }
+                            }
+                        }
+                    }
+                    next.voxels[index3(x, y, z, next_side)] = pool8(children);
+                }
+            }
+        }
+        field.levels.push_back(std::move(next));
+    }
+
+    field.core = field.levels.back().voxels.front();
+    return field;
+}
+
+Inward3DSelfOptimizer::Inward3DSelfOptimizer(fs::path root)
+    : workspace_(std::move(root)), validator_(workspace_.root()) {}
+
+std::vector<SourceField3D> Inward3DSelfOptimizer::encode_workspace() const {
+    std::vector<SourceField3D> fields;
+    const auto files = workspace_.cpp_files();
+    fields.reserve(files.size());
+    for (const auto& file : files) {
+        fields.push_back(encoder_.encode(workspace_.read(file)));
+    }
+    return fields;
+}
+
+double Inward3DSelfOptimizer::objective(const WorkspaceMetrics3D& m) noexcept {
+    if (m.bytes == 0) return 0.0;
+    const double bytes = static_cast<double>(m.bytes);
+    const double trailing = static_cast<double>(m.trailing_whitespace_bytes) / bytes;
+    const double blanks = static_cast<double>(m.excessive_blank_lines) /
+                          static_cast<double>(std::max<std::size_t>(1, m.lines));
+    const double termination = static_cast<double>(m.missing_final_newline_files) /
+                               static_cast<double>(std::max<std::size_t>(1, m.files));
+    return 4.0 * trailing + 2.5 * blanks + 0.25 * termination + 0.15 * m.mean_hotspot;
+}
+
+WorkspaceMetrics3D Inward3DSelfOptimizer::analyze() const {
+    WorkspaceMetrics3D m;
+    double hotspot_sum = 0.0;
+    std::size_t hotspot_count = 0;
+
+    for (const auto& file : workspace_.cpp_files()) {
+        const auto state = workspace_.read(file);
+        const auto penalties = inspect_text(state.content);
+        const auto field = encoder_.encode(state);
+
+        ++m.files;
+        m.bytes += state.content.size();
+        m.lines += count_lines(state.content);
+        m.trailing_whitespace_bytes += penalties.trailing;
+        m.excessive_blank_lines += penalties.excessive_blank;
+        m.tab_bytes += penalties.tabs;
+        if (!state.content.empty() && state.content.back() != '\n') {
+            ++m.missing_final_newline_files;
+        }
+
+        for (const auto& v : field.levels.front().voxels) {
+            if (v.source_index != static_cast<std::size_t>(-1)) {
+                hotspot_sum += v.hotspot;
+                ++hotspot_count;
+            }
+        }
+    }
+
+    m.mean_hotspot = hotspot_count == 0 ? 0.0 : hotspot_sum / static_cast<double>(hotspot_count);
+    m.objective = objective(m);
+    return m;
+}
+
+std::vector<Mutation3D> Inward3DSelfOptimizer::propose_for_file(const FileState& state,
+                                                                 const SourceField3D& field) {
+    std::vector<Mutation3D> out;
+    const auto& s = state.content;
+
+    std::size_t line_start = 0;
+    while (line_start <= s.size()) {
+        auto line_end = s.find('\n', line_start);
+        if (line_end == std::string::npos) line_end = s.size();
+        std::size_t trimmed = line_end;
+        while (trimmed > line_start && (s[trimmed - 1] == ' ' || s[trimmed - 1] == '\t')) --trimmed;
+        if (trimmed < line_end) {
+            Edit edit;
+            edit.kind = Edit::Kind::ReplaceRange;
+            edit.file = state.path;
+            edit.begin = trimmed;
+            edit.end = line_end;
+            out.push_back({state.path, std::move(edit),
+                           static_cast<double>(line_end - trimmed),
+                           "remove trailing whitespace from a 3D hotspot line"});
+        }
+        if (line_end == s.size()) break;
+        line_start = line_end + 1;
+    }
+
+    std::size_t blank_line_start = 0;
+    std::size_t consecutive_blank = 0;
+    while (blank_line_start < s.size()) {
+        auto blank_line_end = s.find('\n', blank_line_start);
+        const bool has_newline = blank_line_end != std::string::npos;
+        if (!has_newline) blank_line_end = s.size();
+
+        std::size_t trimmed = blank_line_end;
+        while (trimmed > blank_line_start &&
+               (s[trimmed - 1] == ' ' || s[trimmed - 1] == '\t' || s[trimmed - 1] == '\r')) {
+            --trimmed;
+        }
+        const bool blank = trimmed == blank_line_start;
+        if (blank) {
+            ++consecutive_blank;
+            if (consecutive_blank > 2) {
+                const std::size_t erase_end = has_newline ? blank_line_end + 1 : blank_line_end;
+                if (erase_end > blank_line_start) {
+                    Edit edit;
+                    edit.kind = Edit::Kind::ReplaceRange;
+                    edit.file = state.path;
+                    edit.begin = blank_line_start;
+                    edit.end = erase_end;
+                    out.push_back({state.path, std::move(edit), 1.0,
+                                   "collapse excessive vertical whitespace in the inward source field"});
+                }
+                break;
+            }
+        } else {
+            consecutive_blank = 0;
+        }
+
+        if (!has_newline) break;
+        blank_line_start = blank_line_end + 1;
+    }
+
+    if (!s.empty() && s.back() != '\n') {
+        Edit edit;
+        edit.kind = Edit::Kind::ReplaceRange;
+        edit.file = state.path;
+        edit.begin = s.size();
+        edit.end = s.size();
+        edit.replacement = "\n";
+        out.push_back({state.path, std::move(edit), 0.5,
+                       "canonicalize source termination for deterministic self-rewrites"});
+    }
+
+    const double core_bias = 1.0 + static_cast<double>(field.core.hotspot);
+    for (auto& mutation : out) mutation.predicted_gain *= core_bias;
+    return out;
+}
+
+std::vector<Mutation3D> Inward3DSelfOptimizer::propose() const {
+    std::vector<Mutation3D> all;
+    for (const auto& file : workspace_.cpp_files()) {
+        const auto state = workspace_.read(file);
+        const auto field = encoder_.encode(state);
+        auto local = propose_for_file(state, field);
+        all.insert(all.end(), std::make_move_iterator(local.begin()), std::make_move_iterator(local.end()));
+    }
+
+    std::sort(all.begin(), all.end(), [](const Mutation3D& a, const Mutation3D& b) {
+        if (a.predicted_gain != b.predicted_gain) return a.predicted_gain > b.predicted_gain;
+        if (a.file != b.file) return a.file.generic_string() < b.file.generic_string();
+        return a.edit.begin < b.edit.begin;
+    });
+    return all;
+}
+
+OptimizationReport3D Inward3DSelfOptimizer::optimize(
+    std::size_t max_passes,
+    const std::optional<std::string>& validation_command) {
+
+    OptimizationReport3D report;
+    report.initial = analyze();
+
+    for (std::size_t pass = 0; pass < max_passes; ++pass) {
+        OptimizationPass3D result;
+        result.before = analyze();
+
+        const auto candidates = propose();
+        if (candidates.empty()) {
+            result.message = "fixed point reached: no admissible source mutations remain";
+            result.after = result.before;
+            report.passes.push_back(std::move(result));
+            break;
+        }
+
+        result.mutation = candidates.front();
+        result.changed = true;
+
+        Transaction tx(workspace_);
+        tx.add(result.mutation->edit);
+        const auto applied = tx.apply();
+        if (!applied.ok) {
+            result.message = "mutation rejected during transaction: " + applied.message;
+            result.after = analyze();
+            report.passes.push_back(std::move(result));
+            continue;
+        }
+
+        if (validation_command) {
+            const auto validation = validator_.run(*validation_command);
+            if (!validation.ok) {
+                tx.rollback();
+                result.message = "mutation failed compile/test validation and was rolled back";
+                result.after = analyze();
+                report.passes.push_back(std::move(result));
+                continue;
+            }
+        }
+
+        result.after = analyze();
+        constexpr double epsilon = 1e-12;
+        if (result.after.objective > result.before.objective + epsilon) {
+            tx.rollback();
+            result.after = analyze();
+            result.message = "mutation increased the 3D objective and was rolled back";
+            report.passes.push_back(std::move(result));
+            continue;
+        }
+
+        result.accepted = true;
+        result.message = "mutation accepted into the next inward source state";
+        report.passes.push_back(std::move(result));
+    }
+
+    report.final = analyze();
+    return report;
+}
+
+} // namespace selfedit
+} // namespace jarvisx

--- a/cpp_runtime/self_editor3d/tests/self_editor3d_tests.cpp
+++ b/cpp_runtime/self_editor3d/tests/self_editor3d_tests.cpp
@@ -1,0 +1,109 @@
+#include "jarvisx/self_editor3d.hpp"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace fs = std::filesystem;
+using namespace jarvisx::selfedit;
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+struct TempWorkspace {
+    fs::path root;
+
+    TempWorkspace() {
+        const auto tick = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+        root = fs::temp_directory_path() / ("jarvisx-selfedit-" + std::to_string(tick));
+        fs::create_directories(root / "src");
+    }
+
+    ~TempWorkspace() {
+        std::error_code ec;
+        fs::remove_all(root, ec);
+    }
+
+    void write(const fs::path& relative, const std::string& text) const {
+        fs::create_directories((root / relative).parent_path());
+        std::ofstream out(root / relative, std::ios::binary | std::ios::trunc);
+        if (!out) throw std::runtime_error("failed to create fixture");
+        out << text;
+    }
+};
+
+void test_transaction_guards() {
+    TempWorkspace fixture;
+    fixture.write("src/a.cpp", "int x = 1;\nint x2 = 1;\n");
+    Workspace workspace(fixture.root);
+
+    bool escaped = false;
+    try {
+        (void)workspace.resolve("../outside.cpp");
+    } catch (const std::exception&) {
+        escaped = true;
+    }
+    require(escaped, "workspace escape must be rejected");
+
+    Transaction ambiguous(workspace);
+    ambiguous.add(Edit{Edit::Kind::ReplaceOnce, "src/a.cpp", "= 1", "= 2", 0, 0});
+    require(!ambiguous.apply().ok, "ambiguous replace must be rejected");
+
+    Transaction noop(workspace);
+    noop.add(Edit{Edit::Kind::ReplaceRange, "src/a.cpp", {}, {}, 0, 0});
+    require(!noop.apply().ok, "no-op edit must not commit");
+}
+
+void test_inward_fold_and_optimization() {
+    TempWorkspace fixture;
+    fixture.write("src/dirty.cpp",
+                  "#include <iostream>   \n"
+                  "\n"
+                  "\n"
+                  "\n"
+                  "int main() {\t\n"
+                  "    std::cout << 42;    \n"
+                  "}");
+
+    Workspace workspace(fixture.root);
+    Inward3DEncoder encoder;
+    const auto field = encoder.encode(workspace.read("src/dirty.cpp"));
+    require(!field.levels.empty(), "3D field must contain at least one level");
+    require(field.levels.back().side == 1, "3D fold must terminate at a 1^3 core");
+    require(field.source_bytes > 0, "source bytes must be represented");
+
+    Inward3DSelfOptimizer optimizer(fixture.root);
+    const auto before = optimizer.analyze();
+    require(before.trailing_whitespace_bytes > 0, "fixture must have trailing whitespace");
+    require(before.excessive_blank_lines > 0, "fixture must have excessive blank lines");
+    require(before.missing_final_newline_files == 1, "fixture must lack a final newline");
+
+    const auto report = optimizer.optimize(32);
+    require(report.final.objective <= report.initial.objective, "optimization objective must not increase");
+    require(report.final.trailing_whitespace_bytes == 0, "optimizer must remove trailing whitespace");
+    require(report.final.excessive_blank_lines == 0, "optimizer must collapse excessive blank lines");
+    require(report.final.missing_final_newline_files == 0, "optimizer must canonicalize source termination");
+
+    const auto proposals = optimizer.propose();
+    require(proposals.empty(), "clean fixture should converge to a fixed point");
+}
+
+} // namespace
+
+int main() {
+    try {
+        test_transaction_guards();
+        test_inward_fold_and_optimization();
+        std::cout << "self_editor3d_regressions: PASS\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "self_editor3d_regressions: FAIL: " << e.what() << '\n';
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Permeates the bounded inward 3D C++ self-editing engine into `cpp_runtime` as an isolated, reviewable subsystem.

### Runtime
- maps C/C++ source bytes into a cubic voxel field;
- recursively pools `2x2x2` neighborhoods to a `1^3` latent core;
- ranks conservative source mutations using the inward field;
- applies edits transactionally with workspace path containment;
- rejects ambiguous exact anchors and no-op mutations;
- optionally runs an operator-supplied compile/test validator;
- rolls back failed validation or objective-regressing mutations;
- repeats until a fixed point or bounded pass limit.

### Autonomous mutation boundary
The built-in optimizer is intentionally semantics-conservative: trailing whitespace removal, excessive blank-line collapse, and canonical final-newline insertion. Arbitrary semantic code generation is not performed by this layer.

### Validation
- C++17 local build completed with `-Wall -Wextra -Wpedantic -Wconversion -Wshadow`;
- regression suite passes locally;
- regression coverage includes path escape rejection, ambiguous edit rejection, no-op rejection, recursive fold to `1^3`, objective reduction, canonicalization, and fixed-point convergence;
- adds dedicated GitHub Actions matrix for GCC, Clang + ASan/UBSan, and MSVC.

### Layout
- `cpp_runtime/self_editor3d/include/jarvisx/self_editor3d.hpp`
- `cpp_runtime/self_editor3d/src/self_editor3d.cpp`
- `cpp_runtime/self_editor3d/src/main.cpp`
- `cpp_runtime/self_editor3d/tests/self_editor3d_tests.cpp`
- `cpp_runtime/self_editor3d/CMakeLists.txt`
- `cpp_runtime/self_editor3d/README.md`
- `.github/workflows/cpp-self-editor3d.yml`

The subsystem is deliberately standalone inside `cpp_runtime` so it can be validated independently without destabilizing the existing root CMake graph.