### PR TITLE
feat(cpp): permeate symmetry 3D performance envelope

### DIFF
--- a/.github/workflows/cpp-self-editor3d.yml
+++ b/.github/workflows/cpp-self-editor3d.yml
@@ -58,3 +58,18 @@ jobs:
 
       - name: Test
         run: ctest --test-dir build/self-editor3d -C Release --output-on-failure
+
+      - name: Quick performance envelope
+        if: matrix.compiler == 'gcc'
+        run: >-
+          ./build/self-editor3d/jarvisx-symmetry-benchmark3d
+          --quick
+          --output build/self-editor3d/symmetry3d-benchmark-gcc.csv
+
+      - name: Upload performance envelope
+        if: matrix.compiler == 'gcc'
+        uses: actions/upload-artifact@v4
+        with:
+          name: symmetry3d-performance-envelope-gcc
+          path: build/self-editor3d/symmetry3d-benchmark-gcc.csv
+          if-no-files-found: error

--- a/cpp_runtime/self_editor3d/CMakeLists.txt
+++ b/cpp_runtime/self_editor3d/CMakeLists.txt
@@ -47,6 +47,21 @@ add_executable(jarvisx-symmetry-loop3d
 target_link_libraries(jarvisx-symmetry-loop3d PRIVATE jarvisx-symmetry-loop3d-core)
 jarvisx_selfedit_harden(jarvisx-symmetry-loop3d)
 
+add_library(jarvisx-symmetry-benchmark3d-core STATIC
+    src/symmetry_benchmark3d.cpp
+)
+target_include_directories(jarvisx-symmetry-benchmark3d-core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+target_link_libraries(jarvisx-symmetry-benchmark3d-core PUBLIC jarvisx-symmetry-loop3d-core)
+jarvisx_selfedit_harden(jarvisx-symmetry-benchmark3d-core)
+
+add_executable(jarvisx-symmetry-benchmark3d
+    src/symmetry_benchmark3d_main.cpp
+)
+target_link_libraries(jarvisx-symmetry-benchmark3d PRIVATE jarvisx-symmetry-benchmark3d-core)
+jarvisx_selfedit_harden(jarvisx-symmetry-benchmark3d)
+
 enable_testing()
 
 add_executable(jarvisx-self-editor3d-tests
@@ -66,3 +81,12 @@ jarvisx_selfedit_harden(jarvisx-symmetry-loop3d-tests)
 
 add_test(NAME symmetry-loop3d-regressions COMMAND jarvisx-symmetry-loop3d-tests)
 set_tests_properties(symmetry-loop3d-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-symmetry-benchmark3d-tests
+    tests/symmetry_benchmark3d_tests.cpp
+)
+target_link_libraries(jarvisx-symmetry-benchmark3d-tests PRIVATE jarvisx-symmetry-benchmark3d-core)
+jarvisx_selfedit_harden(jarvisx-symmetry-benchmark3d-tests)
+
+add_test(NAME symmetry-benchmark3d-regressions COMMAND jarvisx-symmetry-benchmark3d-tests)
+set_tests_properties(symmetry-benchmark3d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/self_editor3d/README.md
+++ b/cpp_runtime/self_editor3d/README.md
@@ -81,7 +81,7 @@ Safety invariants:
 
 ## Closed 3D symmetry autoencoding loop
 
-The same subsystem now includes an executable mathematical closure of the three-plane pixel autoencoder. For an `n×n` frame `X`, the fixed encoder is
+The same subsystem includes an executable mathematical closure of the three-plane pixel autoencoder. For an `n×n` frame `X`, the fixed encoder is
 
 ```text
 E(X) = [ X, H(X), V(X) ]
@@ -120,6 +120,39 @@ Run the reference fixture:
 
 The regression suite proves the exact baseline invariant `D(E(X)) = X`, `P^3 = I`, the supplied fixture's decoded period-two orbit under exact cyclic transport, row-stochastic learnable transport, material objective reduction from the cyclic initialization, and convergence of the optimized feedback loop back to the invariant frame.
 
+## Performance envelope
+
+The runtime now includes `jarvisx-symmetry-benchmark3d`, a deterministic benchmark harness for fidelity, robustness, convergence and runtime telemetry.
+
+Full default sweep:
+
+```bash
+./build/self-editor3d/jarvisx-symmetry-benchmark3d \
+  --sizes 8,16,32,64,128,256 \
+  --noise 0,0.05,0.10,0.20,0.30,0.40 \
+  --repeats 5 \
+  --output symmetry3d-benchmark.csv
+```
+
+Quick CI-sized sweep:
+
+```bash
+./build/self-editor3d/jarvisx-symmetry-benchmark3d \
+  --quick \
+  --output symmetry3d-benchmark.csv
+```
+
+The benchmark records reconstruction MSE, binary accuracy, theoretical bit error where defined, feedback steps, fixed-point residual, optimization objective reduction, optimization/inference latency, throughput, estimated working-set bytes and latent expansion ratio.
+
+Two noise domains are kept separate:
+
+- `input-common`: corruption occurs before encoding, so all three symmetry copies inherit the same error and majority voting cannot remove it;
+- `latent-independent`: the clean three-plane code is formed first, then layers fail independently. Exact majority decoding has theoretical BER `3p² - 2p³`.
+
+The three-plane representation reports a latent expansion ratio of `3.0`; it is a redundancy mechanism, not a compression result. Dense-AE and CNN-AE labels are intentionally absent until real matched implementations exist. See [`docs/CPP_3D_SYMMETRY_PERFORMANCE.md`](../../docs/CPP_3D_SYMMETRY_PERFORMANCE.md) for the benchmark protocol and interpretation rules.
+
 ## Regression coverage
 
-The CTest suite verifies workspace containment, ambiguous-anchor rejection, no-op rejection, recursive folding to a `1³` core, objective reduction, source canonicalization, fixed-point convergence, exact symmetry reconstruction, latent cyclic order, stochastic transport normalization, and closed-loop parameter/state convergence. GitHub Actions builds and tests the subsystem on GCC, Clang with sanitizers, and MSVC.
+The CTest suite verifies workspace containment, ambiguous-anchor rejection, no-op rejection, recursive folding to a `1³` core, objective reduction, source canonicalization, fixed-point convergence, exact symmetry reconstruction, latent cyclic order, stochastic transport normalization, closed-loop parameter/state convergence, deterministic corruption replay, the analytical three-copy majority BER, independent-latent robustness gain, benchmark matrix integrity and CSV emission.
+
+GitHub Actions builds and tests the subsystem on GCC, Clang with ASan/UBSan and MSVC. The GCC Release leg additionally emits a quick benchmark CSV artifact; sanitizer timing is not used as performance telemetry.

--- a/cpp_runtime/self_editor3d/include/jarvisx/symmetry_benchmark3d.hpp
+++ b/cpp_runtime/self_editor3d/include/jarvisx/symmetry_benchmark3d.hpp
@@ -39,6 +39,9 @@ struct BenchmarkRow {
     double initial_objective{};
     double final_objective{};
     double objective_reduction_fraction{};
+    std::size_t optimization_sweeps{};
+    std::size_t accepted_moves{};
+    double optimization_latency_us{};
     double latency_us{};
     double throughput_mpix_s{};
     std::size_t estimated_working_set_bytes{};

--- a/cpp_runtime/self_editor3d/include/jarvisx/symmetry_benchmark3d.hpp
+++ b/cpp_runtime/self_editor3d/include/jarvisx/symmetry_benchmark3d.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "jarvisx/symmetry_loop3d.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace jarvisx {
+namespace symmetry3d {
+namespace bench {
+
+enum class NoiseDomain {
+    InputCommon,
+    LatentIndependent,
+};
+
+struct BenchmarkConfig {
+    std::vector<std::size_t> sizes{8, 16, 32, 64, 128, 256};
+    std::vector<double> noise_levels{0.0, 0.05, 0.10, 0.20, 0.30, 0.40};
+    std::size_t repeats{5};
+    std::uint64_t seed{0x4d4f414749334455ULL};
+    LoopConfig loop{};
+};
+
+struct BenchmarkRow {
+    std::string model;
+    std::string noise_domain;
+    std::size_t n{};
+    double noise_probability{};
+    std::size_t repeat{};
+    double mse{};
+    double bit_accuracy{};
+    double theoretical_bit_error{};
+    std::size_t feedback_steps{};
+    double fixed_point_mse{};
+    double initial_objective{};
+    double final_objective{};
+    double objective_reduction_fraction{};
+    double latency_us{};
+    double throughput_mpix_s{};
+    std::size_t estimated_working_set_bytes{};
+    double latent_expansion_ratio{};
+};
+
+struct BenchmarkSummary {
+    std::size_t row_count{};
+    double mean_mse{};
+    double mean_bit_accuracy{};
+    double mean_latency_us{};
+    double mean_throughput_mpix_s{};
+};
+
+Grid make_reference_pattern(std::size_t n, std::uint64_t seed);
+Grid corrupt_grid(const Grid& source, double probability, std::uint64_t seed);
+Tensor3 corrupt_latent_independently(const Tensor3& latent,
+                                     double probability,
+                                     std::uint64_t seed);
+
+double grid_mse(const Grid& a, const Grid& b);
+double bit_accuracy(const Grid& predicted, const Grid& reference, double threshold = 0.5);
+double majority_vote_bit_error(double independent_flip_probability);
+
+class BenchmarkRunner {
+public:
+    explicit BenchmarkRunner(BenchmarkConfig config = {});
+
+    std::vector<BenchmarkRow> run() const;
+    BenchmarkSummary summarize(const std::vector<BenchmarkRow>& rows) const;
+    void write_csv(const std::filesystem::path& path,
+                   const std::vector<BenchmarkRow>& rows) const;
+
+private:
+    BenchmarkConfig config_;
+
+    std::vector<BenchmarkRow> run_size(std::size_t n) const;
+};
+
+std::string noise_domain_name(NoiseDomain domain);
+
+}  // namespace bench
+}  // namespace symmetry3d
+}  // namespace jarvisx

--- a/cpp_runtime/self_editor3d/src/symmetry_benchmark3d.cpp
+++ b/cpp_runtime/self_editor3d/src/symmetry_benchmark3d.cpp
@@ -1,0 +1,399 @@
+#include "jarvisx/symmetry_benchmark3d.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <stdexcept>
+
+namespace jarvisx {
+namespace symmetry3d {
+namespace bench {
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+std::uint64_t splitmix64(std::uint64_t& state) {
+    std::uint64_t z = (state += 0x9e3779b97f4a7c15ULL);
+    z = (z ^ (z >> 30U)) * 0xbf58476d1ce4e5b9ULL;
+    z = (z ^ (z >> 27U)) * 0x94d049bb133111ebULL;
+    return z ^ (z >> 31U);
+}
+
+double uniform01(std::uint64_t& state) {
+    const std::uint64_t bits = splitmix64(state) >> 11U;
+    return static_cast<double>(bits) * (1.0 / 9007199254740992.0);
+}
+
+std::uint64_t mix_seed(std::uint64_t seed,
+                       std::size_t n,
+                       std::size_t noise_index,
+                       std::size_t repeat,
+                       std::uint64_t tag) {
+    std::uint64_t state = seed ^ tag;
+    state ^= static_cast<std::uint64_t>(n) * 0x9e3779b185ebca87ULL;
+    state ^= static_cast<std::uint64_t>(noise_index + 1U) * 0xc2b2ae3d27d4eb4fULL;
+    state ^= static_cast<std::uint64_t>(repeat + 1U) * 0x165667b19e3779f9ULL;
+    return splitmix64(state);
+}
+
+double elapsed_us(Clock::time_point begin, Clock::time_point end) {
+    return std::chrono::duration<double, std::micro>(end - begin).count();
+}
+
+double throughput_mpix(std::size_t pixels, double latency_us) {
+    if (!(latency_us > 0.0)) {
+        return 0.0;
+    }
+    return static_cast<double>(pixels) / latency_us;
+}
+
+double objective_reduction(double initial, double final_value) {
+    if (!(initial > 0.0)) {
+        return 0.0;
+    }
+    return (initial - final_value) / initial;
+}
+
+BenchmarkRow base_row(const std::string& model,
+                      NoiseDomain domain,
+                      std::size_t n,
+                      double noise_probability,
+                      std::size_t repeat,
+                      double theoretical_error) {
+    BenchmarkRow row;
+    row.model = model;
+    row.noise_domain = noise_domain_name(domain);
+    row.n = n;
+    row.noise_probability = noise_probability;
+    row.repeat = repeat;
+    row.theoretical_bit_error = theoretical_error;
+    return row;
+}
+
+void fill_quality(BenchmarkRow& row,
+                  const Grid& predicted,
+                  const Grid& reference,
+                  double latency_us) {
+    row.mse = grid_mse(predicted, reference);
+    row.bit_accuracy = bit_accuracy(predicted, reference);
+    row.latency_us = latency_us;
+    row.throughput_mpix_s = throughput_mpix(reference.size(), latency_us);
+}
+
+}  // namespace
+
+Grid make_reference_pattern(std::size_t n, std::uint64_t seed) {
+    if (n == 0) {
+        throw std::invalid_argument("reference pattern side must be positive");
+    }
+    Grid grid(n * n, 0.0);
+    const std::size_t phase = static_cast<std::size_t>(seed % 11ULL);
+    const double center = (static_cast<double>(n) - 1.0) * 0.5;
+    const double radius = std::max(1.0, static_cast<double>(n) * 0.28);
+    const double radius2 = radius * radius;
+
+    for (std::size_t i = 0; i < n; ++i) {
+        for (std::size_t j = 0; j < n; ++j) {
+            const bool checker = (((i / 2U) + (j / 2U) + phase) & 1U) != 0U;
+            const bool diagonal = ((i + 2U * j + phase) % 7U) < 3U;
+            const double di = static_cast<double>(i) - center;
+            const double dj = static_cast<double>(j) - center;
+            const double d2 = di * di + dj * dj;
+            const bool disk = d2 <= radius2;
+            const bool value = checker ^ diagonal ^ disk;
+            grid[i * n + j] = value ? 1.0 : 0.0;
+        }
+    }
+    return grid;
+}
+
+Grid corrupt_grid(const Grid& source, double probability, std::uint64_t seed) {
+    if (source.empty()) {
+        throw std::invalid_argument("cannot corrupt an empty grid");
+    }
+    if (probability < 0.0 || probability > 1.0 || !std::isfinite(probability)) {
+        throw std::invalid_argument("noise probability must be in [0,1]");
+    }
+    Grid out = source;
+    std::uint64_t state = seed;
+    for (double& value : out) {
+        if (uniform01(state) < probability) {
+            value = value >= 0.5 ? 0.0 : 1.0;
+        }
+    }
+    return out;
+}
+
+Tensor3 corrupt_latent_independently(const Tensor3& latent,
+                                     double probability,
+                                     std::uint64_t seed) {
+    if (latent.n == 0) {
+        throw std::invalid_argument("cannot corrupt an empty latent tensor");
+    }
+    Tensor3 out = latent;
+    for (std::size_t k = 0; k < 3; ++k) {
+        out.layer[k] = corrupt_grid(
+            latent.layer[k],
+            probability,
+            seed ^ (0xd6e8feb86659fd93ULL * static_cast<std::uint64_t>(k + 1U)));
+    }
+    return out;
+}
+
+double grid_mse(const Grid& a, const Grid& b) {
+    if (a.empty() || a.size() != b.size()) {
+        throw std::invalid_argument("grid_mse requires equal non-empty grids");
+    }
+    double total = 0.0;
+    for (std::size_t p = 0; p < a.size(); ++p) {
+        const double d = a[p] - b[p];
+        total += d * d;
+    }
+    return total / static_cast<double>(a.size());
+}
+
+double bit_accuracy(const Grid& predicted, const Grid& reference, double threshold) {
+    if (predicted.empty() || predicted.size() != reference.size()) {
+        throw std::invalid_argument("bit_accuracy requires equal non-empty grids");
+    }
+    std::size_t correct = 0;
+    for (std::size_t p = 0; p < predicted.size(); ++p) {
+        const bool a = predicted[p] >= threshold;
+        const bool b = reference[p] >= threshold;
+        if (a == b) {
+            ++correct;
+        }
+    }
+    return static_cast<double>(correct) / static_cast<double>(predicted.size());
+}
+
+double majority_vote_bit_error(double independent_flip_probability) {
+    const double p = independent_flip_probability;
+    if (p < 0.0 || p > 1.0 || !std::isfinite(p)) {
+        throw std::invalid_argument("flip probability must be in [0,1]");
+    }
+    return 3.0 * p * p - 2.0 * p * p * p;
+}
+
+std::string noise_domain_name(NoiseDomain domain) {
+    switch (domain) {
+        case NoiseDomain::InputCommon:
+            return "input-common";
+        case NoiseDomain::LatentIndependent:
+            return "latent-independent";
+    }
+    throw std::invalid_argument("unknown noise domain");
+}
+
+BenchmarkRunner::BenchmarkRunner(BenchmarkConfig config) : config_(std::move(config)) {
+    if (config_.sizes.empty() || config_.noise_levels.empty() || config_.repeats == 0) {
+        throw std::invalid_argument("benchmark requires sizes, noise levels and repeats");
+    }
+    for (std::size_t n : config_.sizes) {
+        if (n == 0) {
+            throw std::invalid_argument("benchmark grid sides must be positive");
+        }
+    }
+    for (double p : config_.noise_levels) {
+        if (p < 0.0 || p > 1.0 || !std::isfinite(p)) {
+            throw std::invalid_argument("benchmark noise levels must be in [0,1]");
+        }
+    }
+}
+
+std::vector<BenchmarkRow> BenchmarkRunner::run_size(std::size_t n) const {
+    const std::size_t pixels = n * n;
+    const std::size_t scalar_bytes = pixels * sizeof(double);
+    const Grid reference = make_reference_pattern(n, config_.seed ^ static_cast<std::uint64_t>(n));
+    SymmetryCodec codec(n);
+    ClosedLoopOptimizer optimizer(n, config_.loop);
+
+    const auto optimize_begin = Clock::now();
+    const OptimizationReport optimized = optimizer.optimize(reference, Transport3::cyclic_inward());
+    const auto optimize_end = Clock::now();
+    const double optimization_latency = elapsed_us(optimize_begin, optimize_end);
+    const double reduction = objective_reduction(
+        optimized.initial_loss.objective,
+        optimized.final_loss.objective);
+    const Tensor3 clean_latent = codec.encode(reference);
+
+    std::vector<BenchmarkRow> rows;
+    rows.reserve(config_.noise_levels.size() * config_.repeats * 6U);
+
+    for (std::size_t noise_index = 0; noise_index < config_.noise_levels.size(); ++noise_index) {
+        const double p = config_.noise_levels[noise_index];
+        for (std::size_t repeat = 0; repeat < config_.repeats; ++repeat) {
+            const std::uint64_t common_seed = mix_seed(
+                config_.seed, n, noise_index, repeat, 0x434f4d4d4f4eULL);
+            const Grid common_noisy = corrupt_grid(reference, p, common_seed);
+
+            {
+                BenchmarkRow row = base_row("identity", NoiseDomain::InputCommon, n, p, repeat, p);
+                const auto begin = Clock::now();
+                const Grid predicted = common_noisy;
+                const auto end = Clock::now();
+                fill_quality(row, predicted, reference, elapsed_us(begin, end));
+                row.estimated_working_set_bytes = 2U * scalar_bytes;
+                row.latent_expansion_ratio = 1.0;
+                rows.push_back(row);
+            }
+
+            {
+                BenchmarkRow row = base_row("symmetry-exact", NoiseDomain::InputCommon, n, p, repeat, p);
+                const auto begin = Clock::now();
+                const Grid predicted = codec.decode_majority(codec.encode(common_noisy));
+                const auto end = Clock::now();
+                fill_quality(row, predicted, reference, elapsed_us(begin, end));
+                row.estimated_working_set_bytes = 4U * scalar_bytes;
+                row.latent_expansion_ratio = 3.0;
+                rows.push_back(row);
+            }
+
+            {
+                BenchmarkRow row = base_row(
+                    "symmetry-closed-loop", NoiseDomain::InputCommon, n, p, repeat, -1.0);
+                const auto begin = Clock::now();
+                const FeedbackReport feedback = optimizer.close_feedback(
+                    common_noisy, reference, optimized.transport);
+                const auto end = Clock::now();
+                fill_quality(row, feedback.final_binary_state, reference, elapsed_us(begin, end));
+                row.feedback_steps = feedback.steps;
+                row.fixed_point_mse = feedback.fixed_point_mse;
+                row.initial_objective = optimized.initial_loss.objective;
+                row.final_objective = optimized.final_loss.objective;
+                row.objective_reduction_fraction = reduction;
+                row.optimization_sweeps = optimized.sweeps;
+                row.accepted_moves = optimized.accepted_moves;
+                row.optimization_latency_us = optimization_latency;
+                row.estimated_working_set_bytes = 8U * scalar_bytes + 9U * sizeof(double);
+                row.latent_expansion_ratio = 3.0;
+                rows.push_back(row);
+            }
+
+            const std::uint64_t latent_seed = mix_seed(
+                config_.seed, n, noise_index, repeat, 0x4c4154454e54ULL);
+            const Tensor3 latent_noisy = corrupt_latent_independently(clean_latent, p, latent_seed);
+
+            {
+                BenchmarkRow row = base_row(
+                    "single-copy", NoiseDomain::LatentIndependent, n, p, repeat, p);
+                const auto begin = Clock::now();
+                const Grid predicted = latent_noisy.layer[0];
+                const auto end = Clock::now();
+                fill_quality(row, predicted, reference, elapsed_us(begin, end));
+                row.estimated_working_set_bytes = 2U * scalar_bytes;
+                row.latent_expansion_ratio = 1.0;
+                rows.push_back(row);
+            }
+
+            {
+                BenchmarkRow row = base_row(
+                    "symmetry-majority", NoiseDomain::LatentIndependent, n, p, repeat,
+                    majority_vote_bit_error(p));
+                const auto begin = Clock::now();
+                const Grid predicted = codec.decode_majority(latent_noisy);
+                const auto end = Clock::now();
+                fill_quality(row, predicted, reference, elapsed_us(begin, end));
+                row.estimated_working_set_bytes = 4U * scalar_bytes;
+                row.latent_expansion_ratio = 3.0;
+                rows.push_back(row);
+            }
+
+            {
+                BenchmarkRow row = base_row(
+                    "symmetry-learned-transport", NoiseDomain::LatentIndependent, n, p, repeat, -1.0);
+                const auto begin = Clock::now();
+                const Tensor3 transported = codec.apply_transport(latent_noisy, optimized.transport);
+                const Grid soft = codec.decode_soft(transported);
+                const Grid predicted = codec.hard_threshold(soft, config_.loop.hard_threshold);
+                const auto end = Clock::now();
+                fill_quality(row, predicted, reference, elapsed_us(begin, end));
+                row.initial_objective = optimized.initial_loss.objective;
+                row.final_objective = optimized.final_loss.objective;
+                row.objective_reduction_fraction = reduction;
+                row.optimization_sweeps = optimized.sweeps;
+                row.accepted_moves = optimized.accepted_moves;
+                row.optimization_latency_us = optimization_latency;
+                row.estimated_working_set_bytes = 7U * scalar_bytes + 9U * sizeof(double);
+                row.latent_expansion_ratio = 3.0;
+                rows.push_back(row);
+            }
+        }
+    }
+    return rows;
+}
+
+std::vector<BenchmarkRow> BenchmarkRunner::run() const {
+    std::vector<BenchmarkRow> rows;
+    for (std::size_t n : config_.sizes) {
+        std::vector<BenchmarkRow> size_rows = run_size(n);
+        rows.insert(rows.end(), size_rows.begin(), size_rows.end());
+    }
+    return rows;
+}
+
+BenchmarkSummary BenchmarkRunner::summarize(const std::vector<BenchmarkRow>& rows) const {
+    BenchmarkSummary summary;
+    summary.row_count = rows.size();
+    if (rows.empty()) {
+        return summary;
+    }
+    for (const BenchmarkRow& row : rows) {
+        summary.mean_mse += row.mse;
+        summary.mean_bit_accuracy += row.bit_accuracy;
+        summary.mean_latency_us += row.latency_us;
+        summary.mean_throughput_mpix_s += row.throughput_mpix_s;
+    }
+    const double count = static_cast<double>(rows.size());
+    summary.mean_mse /= count;
+    summary.mean_bit_accuracy /= count;
+    summary.mean_latency_us /= count;
+    summary.mean_throughput_mpix_s /= count;
+    return summary;
+}
+
+void BenchmarkRunner::write_csv(const std::filesystem::path& path,
+                                const std::vector<BenchmarkRow>& rows) const {
+    if (path.has_parent_path()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    std::ofstream out(path);
+    if (!out) {
+        throw std::runtime_error("failed to open benchmark CSV for writing");
+    }
+    out << "model,noise_domain,n,noise_probability,repeat,mse,bit_accuracy,"
+           "theoretical_bit_error,feedback_steps,fixed_point_mse,initial_objective,"
+           "final_objective,objective_reduction_fraction,optimization_sweeps,accepted_moves,"
+           "optimization_latency_us,latency_us,throughput_mpix_s,estimated_working_set_bytes,"
+           "latent_expansion_ratio\n";
+    out << std::setprecision(17);
+    for (const BenchmarkRow& row : rows) {
+        out << row.model << ','
+            << row.noise_domain << ','
+            << row.n << ','
+            << row.noise_probability << ','
+            << row.repeat << ','
+            << row.mse << ','
+            << row.bit_accuracy << ','
+            << row.theoretical_bit_error << ','
+            << row.feedback_steps << ','
+            << row.fixed_point_mse << ','
+            << row.initial_objective << ','
+            << row.final_objective << ','
+            << row.objective_reduction_fraction << ','
+            << row.optimization_sweeps << ','
+            << row.accepted_moves << ','
+            << row.optimization_latency_us << ','
+            << row.latency_us << ','
+            << row.throughput_mpix_s << ','
+            << row.estimated_working_set_bytes << ','
+            << row.latent_expansion_ratio << '\n';
+    }
+}
+
+}  // namespace bench
+}  // namespace symmetry3d
+}  // namespace jarvisx

--- a/cpp_runtime/self_editor3d/src/symmetry_benchmark3d_main.cpp
+++ b/cpp_runtime/self_editor3d/src/symmetry_benchmark3d_main.cpp
@@ -1,0 +1,115 @@
+#include "jarvisx/symmetry_benchmark3d.hpp"
+
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::size_t> parse_sizes(const std::string& text) {
+    std::vector<std::size_t> out;
+    std::stringstream stream(text);
+    std::string token;
+    while (std::getline(stream, token, ',')) {
+        if (token.empty()) {
+            throw std::invalid_argument("empty size token");
+        }
+        out.push_back(static_cast<std::size_t>(std::stoull(token)));
+    }
+    if (out.empty()) {
+        throw std::invalid_argument("sizes list is empty");
+    }
+    return out;
+}
+
+std::vector<double> parse_noise(const std::string& text) {
+    std::vector<double> out;
+    std::stringstream stream(text);
+    std::string token;
+    while (std::getline(stream, token, ',')) {
+        if (token.empty()) {
+            throw std::invalid_argument("empty noise token");
+        }
+        out.push_back(std::stod(token));
+    }
+    if (out.empty()) {
+        throw std::invalid_argument("noise list is empty");
+    }
+    return out;
+}
+
+void usage() {
+    std::cout
+        << "Jarvis-X 3D symmetry performance envelope\n\n"
+        << "Usage:\n"
+        << "  jarvisx-symmetry-benchmark3d [options]\n\n"
+        << "Options:\n"
+        << "  --quick                  Small deterministic smoke benchmark\n"
+        << "  --sizes CSV              Grid sides, default 8,16,32,64,128,256\n"
+        << "  --noise CSV              Flip probabilities, default 0,.05,.1,.2,.3,.4\n"
+        << "  --repeats N              Repetitions per point, default 5\n"
+        << "  --output PATH            CSV output, default symmetry3d-benchmark.csv\n"
+        << "  --help                    Show this message\n";
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    try {
+        jarvisx::symmetry3d::bench::BenchmarkConfig config;
+        std::string output = "symmetry3d-benchmark.csv";
+
+        for (int i = 1; i < argc; ++i) {
+            const std::string arg = argv[i];
+            if (arg == "--help") {
+                usage();
+                return EXIT_SUCCESS;
+            }
+            if (arg == "--quick") {
+                config.sizes = {8, 16, 32};
+                config.noise_levels = {0.0, 0.10, 0.30};
+                config.repeats = 2;
+                config.loop.max_optimization_sweeps = 32;
+                continue;
+            }
+            if (arg == "--sizes" || arg == "--noise" || arg == "--repeats" || arg == "--output") {
+                if (i + 1 >= argc) {
+                    throw std::invalid_argument("missing value for " + arg);
+                }
+                const std::string value = argv[++i];
+                if (arg == "--sizes") {
+                    config.sizes = parse_sizes(value);
+                } else if (arg == "--noise") {
+                    config.noise_levels = parse_noise(value);
+                } else if (arg == "--repeats") {
+                    config.repeats = static_cast<std::size_t>(std::stoull(value));
+                } else {
+                    output = value;
+                }
+                continue;
+            }
+            throw std::invalid_argument("unknown argument: " + arg);
+        }
+
+        jarvisx::symmetry3d::bench::BenchmarkRunner runner(config);
+        const auto rows = runner.run();
+        runner.write_csv(output, rows);
+        const auto summary = runner.summarize(rows);
+
+        std::cout << "rows=" << summary.row_count << '\n'
+                  << "mean_mse=" << summary.mean_mse << '\n'
+                  << "mean_bit_accuracy=" << summary.mean_bit_accuracy << '\n'
+                  << "mean_latency_us=" << summary.mean_latency_us << '\n'
+                  << "mean_throughput_mpix_s=" << summary.mean_throughput_mpix_s << '\n'
+                  << "csv=" << output << '\n'
+                  << "note=timing is machine-dependent; correctness metrics are deterministic\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& error) {
+        std::cerr << "error: " << error.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/cpp_runtime/self_editor3d/tests/symmetry_benchmark3d_tests.cpp
+++ b/cpp_runtime/self_editor3d/tests/symmetry_benchmark3d_tests.cpp
@@ -1,0 +1,145 @@
+#include "jarvisx/symmetry_benchmark3d.hpp"
+
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace jarvisx::symmetry3d;
+using namespace jarvisx::symmetry3d::bench;
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) {
+        throw std::runtime_error(message);
+    }
+}
+
+bool same_grid(const Grid& a, const Grid& b) {
+    return a == b;
+}
+
+void test_theoretical_majority_error() {
+    require(std::abs(majority_vote_bit_error(0.0)) < 1.0e-15,
+            "zero latent noise must have zero theoretical BER");
+    require(std::abs(majority_vote_bit_error(0.2) - 0.104) < 1.0e-12,
+            "three-copy majority BER formula is incorrect");
+    require(std::abs(majority_vote_bit_error(0.5) - 0.5) < 1.0e-12,
+            "majority BER must be 0.5 at p=0.5");
+}
+
+void test_corruption_is_deterministic() {
+    const Grid source = make_reference_pattern(32, 1234);
+    const Grid a = corrupt_grid(source, 0.2, 99);
+    const Grid b = corrupt_grid(source, 0.2, 99);
+    const Grid c = corrupt_grid(source, 0.2, 100);
+    require(same_grid(a, b), "corruption must replay exactly for the same seed");
+    require(!same_grid(a, c), "different corruption seeds should produce different fixtures");
+    require(same_grid(source, corrupt_grid(source, 0.0, 99)),
+            "zero corruption must preserve the source exactly");
+}
+
+void test_independent_latent_redundancy_improves_recovery() {
+    const std::size_t n = 128;
+    const double p = 0.2;
+    const Grid reference = make_reference_pattern(n, 777);
+    SymmetryCodec codec(n);
+    const Tensor3 clean = codec.encode(reference);
+
+    double single_error = 0.0;
+    double majority_error = 0.0;
+    for (std::uint64_t seed = 1; seed <= 4; ++seed) {
+        const Tensor3 noisy = corrupt_latent_independently(clean, p, seed * 1009ULL);
+        single_error += 1.0 - bit_accuracy(noisy.layer[0], reference);
+        majority_error += 1.0 - bit_accuracy(codec.decode_majority(noisy), reference);
+    }
+    single_error /= 4.0;
+    majority_error /= 4.0;
+
+    require(majority_error < single_error,
+            "independent three-copy majority decoding must beat a single noisy copy at p=0.2");
+    require(std::abs(majority_error - majority_vote_bit_error(p)) < 0.02,
+            "empirical majority BER deviates unexpectedly from the theoretical repetition-code BER");
+}
+
+void test_benchmark_matrix_and_csv() {
+    BenchmarkConfig config;
+    config.sizes = {8};
+    config.noise_levels = {0.0, 0.2};
+    config.repeats = 1;
+    config.loop.max_optimization_sweeps = 16;
+    config.loop.max_feedback_steps = 16;
+
+    BenchmarkRunner runner(config);
+    const auto rows = runner.run();
+    require(rows.size() == 12,
+            "one size x two noise levels x two domains x three models must produce 12 rows");
+
+    bool saw_common_exact = false;
+    bool saw_latent_majority = false;
+    bool saw_closed = false;
+    for (const BenchmarkRow& row : rows) {
+        require(row.n == 8, "benchmark row has wrong grid size");
+        require(row.bit_accuracy >= 0.0 && row.bit_accuracy <= 1.0,
+                "bit accuracy must remain in [0,1]");
+        require(row.mse >= 0.0, "MSE must be non-negative");
+        require(row.latency_us >= 0.0, "latency must be non-negative");
+        require(row.throughput_mpix_s >= 0.0, "throughput must be non-negative");
+        require(row.estimated_working_set_bytes > 0, "working-set estimate must be positive");
+
+        if (row.model == "symmetry-exact" && row.noise_domain == "input-common") {
+            saw_common_exact = true;
+        }
+        if (row.model == "symmetry-majority" && row.noise_domain == "latent-independent") {
+            saw_latent_majority = true;
+        }
+        if (row.model == "symmetry-closed-loop" && row.noise_domain == "input-common") {
+            saw_closed = true;
+            require(row.final_objective <= row.initial_objective,
+                    "closed-loop benchmark must not report an objective regression");
+            require(row.latent_expansion_ratio == 3.0,
+                    "symmetry latent representation must report threefold scalar expansion");
+        }
+    }
+    require(saw_common_exact && saw_latent_majority && saw_closed,
+            "benchmark matrix is missing required models or noise domains");
+
+    const BenchmarkSummary summary = runner.summarize(rows);
+    require(summary.row_count == rows.size(), "summary row count mismatch");
+
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "jarvisx-symmetry-benchmark3d-test.csv";
+    runner.write_csv(path, rows);
+    std::ifstream input(path);
+    require(static_cast<bool>(input), "benchmark CSV was not created");
+    std::string header;
+    std::getline(input, header);
+    require(header.find("bit_accuracy") != std::string::npos,
+            "benchmark CSV header is missing bit accuracy");
+    require(header.find("optimization_latency_us") != std::string::npos,
+            "benchmark CSV header is missing optimization latency");
+    require(header.find("latent_expansion_ratio") != std::string::npos,
+            "benchmark CSV header is missing latent expansion ratio");
+    input.close();
+    std::filesystem::remove(path);
+}
+
+}  // namespace
+
+int main() {
+    try {
+        test_theoretical_majority_error();
+        test_corruption_is_deterministic();
+        test_independent_latent_redundancy_improves_recovery();
+        test_benchmark_matrix_and_csv();
+        std::cout << "symmetry-benchmark3d regressions: PASS\n";
+        return EXIT_SUCCESS;
+    } catch (const std::exception& ex) {
+        std::cerr << "symmetry-benchmark3d regressions: FAIL: " << ex.what() << '\n';
+        return EXIT_FAILURE;
+    }
+}

--- a/docs/CPP_3D_SYMMETRY_PERFORMANCE.md
+++ b/docs/CPP_3D_SYMMETRY_PERFORMANCE.md
@@ -1,0 +1,92 @@
+# C++ 3D Symmetry Performance Envelope
+
+This benchmark turns the closed three-plane symmetry autoencoder into a measurable engineering target. It deliberately separates deterministic correctness metrics from wall-clock telemetry, because GitHub-hosted runner timing is useful for smoke/regression tracking but is not a substitute for controlled hardware benchmarking.
+
+## Benchmark matrix
+
+The full default sweep is:
+
+- grid side `n`: `8,16,32,64,128,256`;
+- flip probability `p`: `0,0.05,0.10,0.20,0.30,0.40`;
+- repetitions per point: `5`;
+- deterministic fixture and corruption seeds.
+
+Run it with:
+
+```bash
+./build/self-editor3d/jarvisx-symmetry-benchmark3d \
+  --output symmetry3d-benchmark.csv
+```
+
+A smaller CI-oriented sweep is available with `--quick`.
+
+## Noise domains
+
+Two failure models are measured independently.
+
+### Common-mode input corruption
+
+The source is corrupted before encoding:
+
+```text
+X -> corrupt(X) -> [X', H(X'), V(X')]
+```
+
+All three latent layers therefore inherit the same incorrect source bit. Symmetry redundancy cannot vote away a common-mode error. The `identity`, `symmetry-exact`, and `symmetry-closed-loop` rows make this boundary measurable rather than assuming denoising capability.
+
+### Independent latent corruption
+
+The clean source is encoded first and each latent layer is then corrupted independently:
+
+```text
+X -> [X,H(X),V(X)] -> independent layer noise -> consensus decode
+```
+
+For independent binary flips with probability `p`, exact three-copy majority decoding has theoretical bit-error probability
+
+```text
+P_error = 3 p^2 (1-p) + p^3 = 3 p^2 - 2 p^3.
+```
+
+The benchmark records both empirical bit accuracy and this theoretical repetition-code error for the exact majority model.
+
+## Models currently measured
+
+- `identity`: corrupted input returned directly;
+- `symmetry-exact`: encode and aligned majority decode after common-mode corruption;
+- `symmetry-closed-loop`: learned transport plus recurrent feedback after common-mode corruption;
+- `single-copy`: one independently corrupted latent copy used as the baseline;
+- `symmetry-majority`: exact aligned majority vote across three independently corrupted latent layers;
+- `symmetry-learned-transport`: learned row-stochastic transport followed by aligned consensus decode.
+
+Dense-AE, CNN-AE and other learned baselines are **not** labeled or simulated by proxy in this harness. They should be added only as real implementations with matched training data, parameter budgets and evaluation protocol.
+
+## Recorded metrics
+
+Each CSV row records:
+
+- reconstruction MSE;
+- binary bit accuracy;
+- theoretical bit error where defined;
+- feedback convergence steps and fixed-point residual;
+- initial/final optimization objective and fractional reduction;
+- optimization sweeps and accepted coordinate moves;
+- optimization latency;
+- inference/feedback latency;
+- throughput in megapixels per second;
+- estimated working-set bytes;
+- latent scalar expansion ratio.
+
+The current three-plane code has a latent scalar expansion ratio of `3.0`; this is redundancy, not compression. Reporting it explicitly prevents a robustness code from being mischaracterized as a storage codec.
+
+## Interpretation rules
+
+1. Timing is machine-dependent. Compare timing only within controlled hardware/compiler configurations or as a coarse CI regression signal.
+2. Fidelity, deterministic replay, theoretical BER and invariant tests are platform-independent targets except for ordinary floating-point tolerance.
+3. Fixed-point convergence is not equivalent to correct reconstruction. `reference_mse`/bit accuracy must be considered alongside fixed-point residual.
+4. Common-mode and independent-layer corruption must never be pooled into one robustness number.
+5. Performance claims should report the complete matrix or a clearly declared subset, not a single favorable fixture.
+
+## CI
+
+The `C++ Inward 3D Self Editor` workflow builds and tests the benchmark on GCC, Clang with ASan/UBSan and MSVC. The GCC Release leg also runs the quick envelope and uploads `symmetry3d-performance-envelope-gcc` as a CSV artifact. Sanitizer timing is not used as performance telemetry.


### PR DESCRIPTION
## Summary

Permeates a deterministic performance envelope into the closed 3D symmetry autoencoder runtime.

### Metrics
- reconstruction MSE;
- binary bit accuracy;
- theoretical BER where defined;
- feedback convergence steps and fixed-point residual;
- initial/final objective and fractional reduction;
- optimization sweeps / accepted moves / optimization latency;
- inference or feedback latency;
- throughput in megapixels per second;
- estimated working-set bytes;
- latent scalar expansion ratio.

### Robustness protocol
The harness separates two noise domains instead of pooling them:

1. `input-common`: corruption happens before encoding, so all symmetry copies inherit the same incorrect bit and majority vote cannot correct it.
2. `latent-independent`: the clean three-plane code is created first and each layer is corrupted independently. For exact three-copy majority voting the theoretical BER is `3p^2 - 2p^3`.

This distinction prevents a redundancy mechanism from being credited for robustness it does not possess under common-mode corruption.

### Sweep
Default matrix:
- n = 8,16,32,64,128,256
- p = 0,.05,.10,.20,.30,.40
- 5 deterministic repeats

`--quick` provides a bounded CI smoke envelope.

### Baselines currently implemented
- identity / single-copy;
- exact symmetry encode/decode;
- closed-loop symmetry transport;
- exact three-copy latent majority;
- learned transport plus consensus.

Dense-AE and CNN-AE labels are intentionally **not** simulated by proxy. They should be added only as real implementations with matched data, parameter budgets and evaluation protocol.

### CI
- benchmark regression tests join the existing GCC / Clang+ASan/UBSan / MSVC matrix;
- GCC Release runs the quick envelope and uploads `symmetry3d-performance-envelope-gcc.csv`;
- sanitizer timing is excluded from performance telemetry.

### Interpretation
The three-plane representation reports latent expansion ratio `3.0`. It is currently a redundancy code, not a compression result. Fixed-point convergence is reported separately from reference fidelity so a stable but wrong state cannot be counted as success.