### PR TITLE
feat(java): evolve Dr Moagi into general multimodal platform

### DIFF
--- a/.github/workflows/dr-moagi-platform-java.yml
+++ b/.github/workflows/dr-moagi-platform-java.yml
@@ -1,0 +1,41 @@
+name: Dr Moagi Java Platform
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/dr-moagi-platform-java/**'
+      - '.github/workflows/dr-moagi-platform-java.yml'
+  pull_request:
+    paths:
+      - 'apps/dr-moagi-platform-java/**'
+      - '.github/workflows/dr-moagi-platform-java.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  java17:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Compile
+        working-directory: apps/dr-moagi-platform-java
+        run: |
+          mkdir -p build
+          javac --release 17 -Xlint:all -Werror -d build src/DrMoagiPlatform.java test/DrMoagiPlatformTest.java
+      - name: Regression tests
+        working-directory: apps/dr-moagi-platform-java
+        run: java -ea -cp build DrMoagiPlatformTest
+      - name: CLI smoke test
+        working-directory: apps/dr-moagi-platform-java
+        run: |
+          printf '/compute sqrt(81) + 5 * 2\n/data 1,2,3,4\n/status\n/exit\n' | java -cp build DrMoagiPlatform | tee smoke.log
+          grep -F '[COMPUTE]' smoke.log
+          grep -F '[DATA]' smoke.log
+          grep -F 'DR MOAGI PLATFORM STATUS' smoke.log

--- a/.github/workflows/dr-moagi-runtime-fabric.yml
+++ b/.github/workflows/dr-moagi-runtime-fabric.yml
@@ -1,0 +1,85 @@
+name: Dr Moagi Runtime Fabric
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/dr-moagi-platform-java/**'
+      - 'apps/dmvann-chat/**'
+      - 'apps/dr-moagi-cognitive/**'
+      - 'apps/dr-moagi-geometry/**'
+      - 'apps/qsol-graphics-codec/**'
+      - 'apps/moagi-field-sim/**'
+      - 'cpp_runtime/self_editor3d/**'
+      - 'tools/verify-dr-moagi-runtime-fabric.mjs'
+      - 'docs/DR_MOAGI_RUNTIME_FABRIC.md'
+      - '.github/workflows/dr-moagi-runtime-fabric.yml'
+  pull_request:
+    paths:
+      - 'apps/dr-moagi-platform-java/**'
+      - 'apps/dmvann-chat/**'
+      - 'apps/dr-moagi-cognitive/**'
+      - 'apps/dr-moagi-geometry/**'
+      - 'apps/qsol-graphics-codec/**'
+      - 'apps/moagi-field-sim/**'
+      - 'cpp_runtime/self_editor3d/**'
+      - 'tools/verify-dr-moagi-runtime-fabric.mjs'
+      - 'docs/DR_MOAGI_RUNTIME_FABRIC.md'
+      - '.github/workflows/dr-moagi-runtime-fabric.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  contract-and-js:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Validate runtime fabric contract
+        run: node tools/verify-dr-moagi-runtime-fabric.mjs
+      - name: DMVANN deterministic tests
+        run: node --test apps/dmvann-chat/test_core.mjs
+      - name: Cognitive control-plane tests
+        run: node --test apps/dr-moagi-cognitive/test_core.mjs
+      - name: Geometry optimizer tests
+        run: node --test apps/dr-moagi-geometry/test_core.mjs
+
+  java-kernel:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Compile and test Java platform
+        working-directory: apps/dr-moagi-platform-java
+        run: |
+          mkdir -p build
+          javac --release 17 -Xlint:all -Werror -d build src/DrMoagiPlatform.java test/DrMoagiPlatformTest.java
+          java -ea -cp build DrMoagiPlatformTest
+
+  graphics-codec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: QSOL codec self-test
+        run: dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- --self-test
+
+  native-3d:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S cpp_runtime/self_editor3d -B build/self-editor3d -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build/self-editor3d --config Release --parallel
+      - name: Test
+        run: ctest --test-dir build/self-editor3d -C Release --output-on-failure

--- a/apps/dr-moagi-platform-java/README.md
+++ b/apps/dr-moagi-platform-java/README.md
@@ -1,0 +1,126 @@
+# Dr Moagi General Multimodal Platform — Java 17
+
+A dependency-free Java 17 reference platform that evolves the original `DrMoagiEngine` into a capability-routed, recurrent multimodal computing kernel.
+
+## What is operational
+
+- **One recurrent kernel for seven surfaces:** chat, image, audio, video, code, data and compute.
+- **4×4×4 toroidal latent field:** 64 state cells with periodic boundary conditions; boundary values fold back into the opposite face.
+- **Turn-wise encoding:** each transcript turn contributes its own spatial feature field instead of repeatedly applying one whole-transcript feature vector.
+- **Kinetic relaxation:** Euler integration updates the field toward the current encoded target with local neighbour coupling and a reconstruction-error force.
+- **Authoritative telemetry:** loss is evaluated after the state update, so reported loss describes the state actually returned by the step.
+- **Capability registry:** built-in adapters can be replaced by `ServiceLoader<DrMoagiPlatform.SurfaceAdapter>` implementations without modifying the kernel.
+- **Offline compute:** `/compute` evaluates arithmetic with a safe parser; it does not execute shell commands or arbitrary code.
+- **Offline data analytics:** `/data` computes count, sum, mean, min, max and population variance from numeric input.
+- **Provider bridges:** an optional OpenAI-compatible text endpoint can drive chat/code; generic JSON HTTP endpoints can drive image/audio/video.
+- **No embedded secrets:** provider configuration is read from environment variables.
+
+## Mathematical kernel
+
+For latent cell `i`, the periodic 3D neighbourhood mean is
+
+```text
+n_i = mean(s_(i±x), s_(i±y), s_(i±z))
+```
+
+The decoded local state and error are
+
+```text
+d_i = tanh(s_i + beta * (n_i - s_i))
+e_i = z_i - d_i
+```
+
+and the explicit Euler update is
+
+```text
+F_i = alpha * (z_i - s_i)
+    + beta  * (n_i - s_i)
+    - gamma * s_i
+    + eta   * e_i
+
+s_i(t + dt) = clamp(s_i(t) + dt * F_i, -1, 1)
+```
+
+The step loss is evaluated on the **updated** field:
+
+```text
+L = mean_i (z_i - decode(s_next)_i)^2
+```
+
+This is a nonlinear recurrent state optimizer. It deliberately does **not** claim that fixed kernel parameters are being learned; trainable parameter optimisation can be added as a separate layer without conflating state relaxation and gradient learning.
+
+## Build and run
+
+```bash
+cd apps/dr-moagi-platform-java
+mkdir -p build
+javac --release 17 -d build src/DrMoagiPlatform.java test/DrMoagiPlatformTest.java
+java -cp build DrMoagiPlatformTest
+java -cp build DrMoagiPlatform
+```
+
+Example session:
+
+```text
+/compute sqrt(81) + max(3,5) * 2^3
+/data 10, 20, 30, 40
+/image volumetric torus with inward flow
+/code design a bounded work queue
+/status
+```
+
+## Optional external text provider
+
+```bash
+export MOAGI_TEXT_ENDPOINT='https://provider.example/v1/chat/completions'
+export MOAGI_API_KEY='...'
+export MOAGI_MODEL='model-name'
+java -cp build DrMoagiPlatform
+```
+
+The adapter uses an OpenAI-compatible **chat-completions-style** JSON contract. The platform itself does not depend on any vendor SDK.
+
+## Optional media providers
+
+Configure any subset:
+
+```bash
+export MOAGI_IMAGE_ENDPOINT='https://renderer.example/image'
+export MOAGI_AUDIO_ENDPOINT='https://renderer.example/audio'
+export MOAGI_VIDEO_ENDPOINT='https://renderer.example/video'
+```
+
+The platform posts this contract:
+
+```json
+{
+  "mode": "image",
+  "prompt": "...",
+  "latent": [0.0, 0.0],
+  "signature": "DM3D-..."
+}
+```
+
+The endpoint may return any UTF-8 response body. Production media systems can replace this generic bridge with a provider-specific `SurfaceAdapter`.
+
+## Extension contract
+
+Implement:
+
+```java
+public final class MyImageAdapter implements DrMoagiPlatform.SurfaceAdapter {
+  public DrMoagiPlatform.Surface surface() {
+    return DrMoagiPlatform.Surface.IMAGE;
+  }
+
+  public String execute(DrMoagiPlatform.PlatformRequest request) {
+    return "rendered artifact reference";
+  }
+}
+```
+
+Register the implementation using Java `ServiceLoader` metadata under `META-INF/services/DrMoagiPlatform$SurfaceAdapter`. Service-loaded adapters are registered after built-ins and therefore can override a built-in surface cleanly.
+
+## Boundary of the reference implementation
+
+This PR establishes the **platform kernel and adapter ABI**, not a claim that one local Java file itself contains production image synthesis, speech synthesis, video generation, a compiler, or a foundation model. Those capabilities are deliberately attached through adapters so they can be benchmarked, replaced and scaled independently.

--- a/apps/dr-moagi-platform-java/runtime-fabric.json
+++ b/apps/dr-moagi-platform-java/runtime-fabric.json
@@ -1,0 +1,72 @@
+{
+  "schema": "jarvisx.dr-moagi-runtime-fabric/v1",
+  "platform": {
+    "id": "dr-moagi-platform-java",
+    "path": "apps/dr-moagi-platform-java",
+    "role": "recurrent-multimodal-kernel",
+    "surfaces": ["chat", "image", "audio", "video", "code", "data", "compute"]
+  },
+  "policy": {
+    "routing": "explicit-capability",
+    "defaultAuthority": "specialist-runtime",
+    "networkAuthority": "opt-in-by-environment",
+    "hostExecutionAuthority": "none-from-fabric",
+    "provisionalIsAuthoritative": false
+  },
+  "runtimes": [
+    {
+      "id": "dmvann-chat",
+      "path": "apps/dmvann-chat",
+      "role": "chat-and-model-proxy",
+      "capabilities": ["chat", "control-field", "model-proxy", "http"],
+      "transport": {"kind": "http-optional", "endpointEnv": "MOAGI_DMVANN_ENDPOINT", "healthPath": "/healthz", "routePath": "/api/chat"},
+      "requiredFiles": ["README.md", "core.mjs", "server.mjs", "test_core.mjs"],
+      "authorityBoundary": "Remote model inference remains server-side, opt-in and credential-isolated."
+    },
+    {
+      "id": "dr-moagi-cognitive",
+      "path": "apps/dr-moagi-cognitive",
+      "role": "browser-control-plane",
+      "capabilities": ["control", "visualization", "session", "firmware-client"],
+      "transport": {"kind": "browser"},
+      "requiredFiles": ["README.md", "core.mjs", "index.html", "test_core.mjs"],
+      "authorityBoundary": "Browser state cannot bypass firmware verification or receive signing keys."
+    },
+    {
+      "id": "dr-moagi-geometry",
+      "path": "apps/dr-moagi-geometry",
+      "role": "bounded-3d-geometry-optimizer",
+      "capabilities": ["geometry", "3d", "optimization", "visualization"],
+      "transport": {"kind": "browser"},
+      "requiredFiles": ["README.md", "core.mjs", "index.html", "test_core.mjs"],
+      "authorityBoundary": "Only measured parameter candidates may be promoted; topology gates remain authoritative."
+    },
+    {
+      "id": "qsol-graphics-codec",
+      "path": "apps/qsol-graphics-codec",
+      "role": "3d-scene-codec",
+      "capabilities": ["graphics-state", "3d", "codec", "animation", "binary"],
+      "transport": {"kind": "dotnet-cli"},
+      "requiredFiles": ["README.md", "QSol.GraphicsCodec.csproj"],
+      "authorityBoundary": "Codec fidelity is bounded by measured reconstruction error; it is not a renderer."
+    },
+    {
+      "id": "moagi-field-sim",
+      "path": "apps/moagi-field-sim",
+      "role": "physical-latent-policy-simulator",
+      "capabilities": ["simulation", "field", "policy", "visualization"],
+      "transport": {"kind": "browser"},
+      "requiredFiles": ["README.md", "index.html"],
+      "authorityBoundary": "Synthetic policy output has no broker, exchange or production transmission authority."
+    },
+    {
+      "id": "cpp-self-editor3d",
+      "path": "cpp_runtime/self_editor3d",
+      "role": "bounded-native-self-refinement",
+      "capabilities": ["code-refinement", "3d", "autoencoding", "benchmark", "native"],
+      "transport": {"kind": "native-cli"},
+      "requiredFiles": ["README.md", "CMakeLists.txt", "src/symmetry_loop3d.cpp", "tests/symmetry_loop3d_tests.cpp"],
+      "authorityBoundary": "Edits remain workspace-confined, transactional and validator-gated with rollback."
+    }
+  ]
+}

--- a/apps/dr-moagi-platform-java/src/DrMoagiPlatform.java
+++ b/apps/dr-moagi-platform-java/src/DrMoagiPlatform.java
@@ -1,0 +1,824 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Scanner;
+import java.util.ServiceLoader;
+
+/**
+ * Dr Moagi Platform v0.5.0
+ *
+ * A dependency-free Java 17 multimodal computing kernel.
+ *
+ * Pipeline:
+ *   request -> turn-wise encoder -> 3D toroidal latent field
+ *   -> recurrent kinetic relaxation -> capability router
+ *   -> chat/image/audio/video/code/data/compute surface
+ *   -> telemetry -> recurrent transcript state
+ *
+ * External providers are optional. The local runtime remains useful offline.
+ */
+public final class DrMoagiPlatform {
+  static final int SIDE = 4;
+  static final int VOLUME = SIDE * SIDE * SIDE;
+  static final double CONVERGENCE_EPSILON = 0.002;
+
+  private DrMoagiPlatform() {}
+
+  public static void main(String[] args) {
+    Platform platform = Platform.bootstrap();
+    System.out.println("DR MOAGI / GENERAL MULTIMODAL PLATFORM v0.5.0");
+    System.out.println("Java 17 | latent=4x4x4 torus | dependency-free");
+    System.out.println("Commands: /chat /image /audio /video /code /data /compute /status /reset /help /exit\n");
+
+    try (Scanner scanner = new Scanner(new BufferedReader(new InputStreamReader(System.in)))) {
+      while (true) {
+        System.out.print("you> ");
+        if (!scanner.hasNextLine()) break;
+        String line = scanner.nextLine().trim();
+        if (line.isBlank()) continue;
+        if (line.equalsIgnoreCase("/exit")) break;
+        if (line.equalsIgnoreCase("/help")) {
+          System.out.println(helpText());
+          continue;
+        }
+        if (line.equalsIgnoreCase("/status")) {
+          System.out.println(platform.status());
+          continue;
+        }
+        if (line.equalsIgnoreCase("/reset")) {
+          platform.reset();
+          System.out.println("moagi> State reset.\n");
+          continue;
+        }
+
+        ParsedInput input = ParsedInput.parse(line);
+        PlatformResponse response = platform.process(input.prompt(), input.surface());
+        System.out.println("\nmoagi> " + response.output());
+        System.out.printf(Locale.ROOT,
+            "      signature=%s loss=%.6f steps=%d energy=%.6f mode=%s%n%n",
+            response.telemetry().signature(),
+            response.telemetry().loss(),
+            response.telemetry().steps(),
+            response.telemetry().energy(),
+            response.surface().label);
+      }
+    }
+  }
+
+  static String helpText() {
+    return """
+        Surfaces
+          /chat <prompt>       conversational reasoning surface
+          /image <prompt>      image renderer adapter surface
+          /audio <prompt>      audio renderer adapter surface
+          /video <prompt>      video renderer adapter surface
+          /code <prompt>       code-generation/review surface
+          /data <numbers>      local numeric analytics surface
+          /compute <expr>      safe local arithmetic surface
+
+        Control
+          /status              kernel/capability telemetry
+          /reset               clear transcript and latent state
+          /help                show this help
+          /exit                stop the runtime
+
+        External model configuration (optional)
+          MOAGI_TEXT_ENDPOINT  OpenAI-compatible chat-completions endpoint
+          MOAGI_API_KEY        bearer token
+          MOAGI_MODEL          model identifier
+
+        External media endpoint configuration (optional)
+          MOAGI_IMAGE_ENDPOINT
+          MOAGI_AUDIO_ENDPOINT
+          MOAGI_VIDEO_ENDPOINT
+
+        Media endpoints receive JSON: {mode,prompt,latent,signature} and may return any UTF-8 body.
+        """;
+  }
+
+  enum Surface {
+    CHAT("chat"), IMAGE("image"), AUDIO("audio"), VIDEO("video"),
+    CODE("code"), DATA("data"), COMPUTE("compute");
+
+    final String label;
+    Surface(String label) { this.label = label; }
+
+    static Surface fromCommand(String command) {
+      return switch (command.toLowerCase(Locale.ROOT)) {
+        case "/image" -> IMAGE;
+        case "/audio" -> AUDIO;
+        case "/video" -> VIDEO;
+        case "/code" -> CODE;
+        case "/data" -> DATA;
+        case "/compute" -> COMPUTE;
+        default -> CHAT;
+      };
+    }
+  }
+
+  record ParsedInput(Surface surface, String prompt) {
+    static ParsedInput parse(String line) {
+      if (!line.startsWith("/")) return new ParsedInput(Surface.CHAT, line);
+      int split = line.indexOf(' ');
+      String command = split < 0 ? line : line.substring(0, split);
+      Surface surface = Surface.fromCommand(command);
+      String prompt = split < 0 ? "Describe the current state." : line.substring(split + 1).trim();
+      return new ParsedInput(surface, prompt.isBlank() ? "Describe the current state." : prompt);
+    }
+  }
+
+  record Turn(String role, String content, Surface surface, Instant timestamp) {}
+
+  record Telemetry(double loss, int steps, double energy, String signature) {}
+
+  record PlatformRequest(
+      String prompt,
+      Surface surface,
+      List<Turn> transcript,
+      double[] latent,
+      Telemetry telemetry) {
+    PlatformRequest {
+      latent = latent.clone();
+      transcript = List.copyOf(transcript);
+    }
+  }
+
+  record PlatformResponse(String output, Surface surface, Telemetry telemetry) {}
+
+  public interface SurfaceAdapter {
+    Surface surface();
+    String execute(PlatformRequest request);
+    default String name() { return getClass().getSimpleName(); }
+  }
+
+  interface LanguageModel {
+    String complete(PlatformRequest request, String instruction);
+    String name();
+  }
+
+  static final class Platform {
+    private final TurnEncoder encoder;
+    private final KineticDynamics dynamics;
+    private final CapabilityRegistry registry;
+    private final List<Turn> transcript = new ArrayList<>();
+    private double[] latent = new double[VOLUME];
+
+    Platform(TurnEncoder encoder, KineticDynamics dynamics, CapabilityRegistry registry) {
+      this.encoder = Objects.requireNonNull(encoder);
+      this.dynamics = Objects.requireNonNull(dynamics);
+      this.registry = Objects.requireNonNull(registry);
+    }
+
+    static Platform bootstrap() {
+      LanguageModel languageModel = createLanguageModel(System.getenv());
+      CapabilityRegistry registry = new CapabilityRegistry();
+      registry.register(new ChatAdapter(languageModel));
+      registry.register(new CodeAdapter(languageModel));
+      registry.register(new DataAdapter());
+      registry.register(new ComputeAdapter());
+      registry.register(mediaAdapter(Surface.IMAGE, "MOAGI_IMAGE_ENDPOINT"));
+      registry.register(mediaAdapter(Surface.AUDIO, "MOAGI_AUDIO_ENDPOINT"));
+      registry.register(mediaAdapter(Surface.VIDEO, "MOAGI_VIDEO_ENDPOINT"));
+      ServiceLoader.load(SurfaceAdapter.class).forEach(registry::register);
+
+      return new Platform(
+          new TurnEncoder(0.78, 0.42),
+          new KineticDynamics(0.70, 0.16, 0.07, 0.40, 24, 0.12),
+          registry);
+    }
+
+    static LanguageModel createLanguageModel(Map<String, String> env) {
+      String endpoint = env.getOrDefault("MOAGI_TEXT_ENDPOINT", "").trim();
+      String apiKey = env.getOrDefault("MOAGI_API_KEY", "").trim();
+      String model = env.getOrDefault("MOAGI_MODEL", "").trim();
+      if (!endpoint.isBlank() && !apiKey.isBlank() && !model.isBlank()) {
+        return new OpenAICompatibleLanguageModel(endpoint, apiKey, model);
+      }
+      return new LocalLanguageModel();
+    }
+
+    static SurfaceAdapter mediaAdapter(Surface surface, String envKey) {
+      String endpoint = System.getenv().getOrDefault(envKey, "").trim();
+      return endpoint.isBlank()
+          ? new SpecMediaAdapter(surface)
+          : new HttpMediaAdapter(surface, endpoint, System.getenv().getOrDefault("MOAGI_API_KEY", ""));
+    }
+
+    synchronized PlatformResponse process(String prompt, Surface surface) {
+      Objects.requireNonNull(prompt);
+      Objects.requireNonNull(surface);
+      transcript.add(new Turn("user", prompt, surface, Instant.now()));
+
+      double[] target = encoder.encode(transcript);
+      double loss = Double.POSITIVE_INFINITY;
+      int steps = 0;
+      for (int i = 0; i < dynamics.maxSteps; i++) {
+        KineticStep step = dynamics.step(latent, target);
+        latent = step.state();
+        loss = step.loss();
+        steps++;
+        if (loss < CONVERGENCE_EPSILON) break;
+      }
+
+      Telemetry telemetry = telemetry(loss, steps, latent);
+      PlatformRequest request = new PlatformRequest(prompt, surface, transcript, latent, telemetry);
+      String output = registry.resolve(surface).execute(request);
+      transcript.add(new Turn("assistant", output, surface, Instant.now()));
+      return new PlatformResponse(output, surface, telemetry);
+    }
+
+    synchronized void reset() {
+      transcript.clear();
+      latent = new double[VOLUME];
+    }
+
+    synchronized String status() {
+      Telemetry t = telemetry(0.0, 0, latent);
+      return """
+          DR MOAGI PLATFORM STATUS
+            version: 0.5.0
+            java: %s
+            latent-field: %dx%dx%d (%d cells, toroidal)
+            transcript-turns: %d
+            energy: %.6f
+            signature: %s
+            capabilities: %s
+          """.formatted(
+          System.getProperty("java.version"), SIDE, SIDE, SIDE, VOLUME,
+          transcript.size(), t.energy(), t.signature(), registry.describe());
+    }
+  }
+
+  /** Turn-wise recurrent encoder. Each turn contributes its own spatial field. */
+  static final class TurnEncoder {
+    private final double decay;
+    private final double gain;
+
+    TurnEncoder(double decay, double gain) {
+      this.decay = decay;
+      this.gain = gain;
+    }
+
+    double[] encode(List<Turn> transcript) {
+      double[] state = new double[VOLUME];
+      for (Turn turn : transcript) {
+        double[] features = encodeTurn(turn);
+        for (int i = 0; i < VOLUME; i++) {
+          state[i] = Math.tanh(decay * state[i] + gain * features[i]);
+        }
+      }
+      return state;
+    }
+
+    private double[] encodeTurn(Turn turn) {
+      double[] field = new double[VOLUME];
+      String text = turn.content();
+      int rolling = 0x4d4f4147 ^ turn.surface().ordinal() * 0x9e3779b9;
+      int words = text.isBlank() ? 0 : text.trim().split("\\s+").length;
+      int vowels = 0;
+
+      for (int i = 0; i < text.length(); i++) {
+        char c = Character.toLowerCase(text.charAt(i));
+        if ("aeiou".indexOf(c) >= 0) vowels++;
+        rolling = 31 * rolling + c + i * 17;
+        int index = Math.floorMod(rolling, VOLUME);
+        double amplitude = ((c % 97) + 1) / 98.0;
+        field[index] += amplitude;
+        field[neighborIndex(index, 1, 0, 0)] += amplitude * 0.25;
+        field[neighborIndex(index, 0, 1, 0)] -= amplitude * 0.12;
+        field[neighborIndex(index, 0, 0, 1)] += amplitude * 0.08;
+      }
+
+      field[0] += Math.min(1.0, words / 64.0);
+      field[1] += Math.min(1.0, vowels / 64.0);
+      field[2] += turn.surface().ordinal() / (double) Math.max(1, Surface.values().length - 1);
+      field[3] += "assistant".equals(turn.role()) ? -0.35 : 0.35;
+
+      double max = 1.0;
+      for (double value : field) max = Math.max(max, Math.abs(value));
+      for (int i = 0; i < VOLUME; i++) field[i] = Math.tanh(field[i] / max * 2.0);
+      return field;
+    }
+  }
+
+  record KineticStep(double[] state, double loss) {
+    KineticStep { state = state.clone(); }
+  }
+
+  /** Euler integration on a periodic 3D field; boundaries fold back into the field. */
+  static final class KineticDynamics {
+    final double alpha, beta, gamma, eta, deltaT;
+    final int maxSteps;
+
+    KineticDynamics(double alpha, double beta, double gamma, double eta, int maxSteps, double deltaT) {
+      this.alpha = alpha;
+      this.beta = beta;
+      this.gamma = gamma;
+      this.eta = eta;
+      this.maxSteps = maxSteps;
+      this.deltaT = deltaT;
+    }
+
+    KineticStep step(double[] state, double[] target) {
+      if (state.length != VOLUME || target.length != VOLUME) {
+        throw new IllegalArgumentException("latent fields must contain " + VOLUME + " cells");
+      }
+      double[] next = new double[VOLUME];
+      for (int i = 0; i < VOLUME; i++) {
+        double neighbor = neighborMean(state, i);
+        double decoded = Math.tanh(state[i] + beta * (neighbor - state[i]));
+        double error = target[i] - decoded;
+        double force = alpha * (target[i] - state[i])
+            + beta * (neighbor - state[i])
+            - gamma * state[i]
+            + eta * error;
+        next[i] = clamp(state[i] + deltaT * force, -1.0, 1.0);
+      }
+
+      // Loss is evaluated on the authoritative next state, not the pre-update state.
+      double loss = 0.0;
+      for (int i = 0; i < VOLUME; i++) {
+        double neighbor = neighborMean(next, i);
+        double decoded = Math.tanh(next[i] + beta * (neighbor - next[i]));
+        double error = target[i] - decoded;
+        loss += error * error;
+      }
+      return new KineticStep(next, loss / VOLUME);
+    }
+  }
+
+  static final class CapabilityRegistry {
+    private final EnumMap<Surface, SurfaceAdapter> adapters = new EnumMap<>(Surface.class);
+
+    synchronized void register(SurfaceAdapter adapter) {
+      adapters.put(adapter.surface(), Objects.requireNonNull(adapter));
+    }
+
+    synchronized SurfaceAdapter resolve(Surface surface) {
+      SurfaceAdapter adapter = adapters.get(surface);
+      if (adapter == null) throw new IllegalStateException("No adapter registered for " + surface.label);
+      return adapter;
+    }
+
+    synchronized String describe() {
+      return adapters.entrySet().stream()
+          .map(e -> e.getKey().label + "=" + e.getValue().name())
+          .sorted()
+          .reduce((a, b) -> a + ", " + b)
+          .orElse("none");
+    }
+  }
+
+  static final class ChatAdapter implements SurfaceAdapter {
+    private final LanguageModel model;
+    ChatAdapter(LanguageModel model) { this.model = model; }
+    public Surface surface() { return Surface.CHAT; }
+    public String execute(PlatformRequest request) {
+      return model.complete(request,
+          "Answer the user directly. Treat latent telemetry as state context, not as a claim of intelligence.");
+    }
+    public String name() { return "ChatAdapter(" + model.name() + ")"; }
+  }
+
+  static final class CodeAdapter implements SurfaceAdapter {
+    private final LanguageModel model;
+    CodeAdapter(LanguageModel model) { this.model = model; }
+    public Surface surface() { return Surface.CODE; }
+    public String execute(PlatformRequest request) {
+      return model.complete(request,
+          "Act as a software engineering surface. Produce precise implementation-oriented output, tests, and assumptions.");
+    }
+    public String name() { return "CodeAdapter(" + model.name() + ")"; }
+  }
+
+  static final class LocalLanguageModel implements LanguageModel {
+    public String complete(PlatformRequest request, String instruction) {
+      return "[LOCAL " + request.surface().label.toUpperCase(Locale.ROOT) + "] "
+          + "Request accepted through latent " + request.telemetry().signature() + ". "
+          + "No external language model is configured, so the dependency-free kernel is returning a deterministic "
+          + "runtime acknowledgement for: “" + request.prompt() + "”.";
+    }
+    public String name() { return "local"; }
+  }
+
+  /** Optional OpenAI-compatible chat-completions adapter. */
+  static final class OpenAICompatibleLanguageModel implements LanguageModel {
+    private final HttpClient client = HttpClient.newBuilder().build();
+    private final URI endpoint;
+    private final String apiKey;
+    private final String model;
+
+    OpenAICompatibleLanguageModel(String endpoint, String apiKey, String model) {
+      this.endpoint = URI.create(endpoint);
+      this.apiKey = apiKey;
+      this.model = model;
+    }
+
+    public String complete(PlatformRequest request, String instruction) {
+      String latent = compactLatent(request.latent(), 12);
+      String system = instruction + " Kernel signature=" + request.telemetry().signature()
+          + "; latent-sample=" + latent + ".";
+      String body = "{\"model\":\"" + jsonEscape(model) + "\",\"messages\":["
+          + "{\"role\":\"system\",\"content\":\"" + jsonEscape(system) + "\"},"
+          + "{\"role\":\"user\",\"content\":\"" + jsonEscape(request.prompt()) + "\"}]}";
+      HttpRequest httpRequest = HttpRequest.newBuilder(endpoint)
+          .header("Authorization", "Bearer " + apiKey)
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+          .build();
+      try {
+        HttpResponse<String> response = client.send(httpRequest, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+          return "Provider HTTP " + response.statusCode() + ": " + trimBody(response.body());
+        }
+        String content = extractJsonString(response.body(), "content");
+        return content == null ? "Provider returned no decodable text content: " + trimBody(response.body()) : content;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return "Provider request interrupted.";
+      } catch (IOException | IllegalArgumentException e) {
+        return "Provider error: " + e.getMessage();
+      }
+    }
+
+    public String name() { return "openai-compatible:" + model; }
+  }
+
+  static final class SpecMediaAdapter implements SurfaceAdapter {
+    private final Surface surface;
+    SpecMediaAdapter(Surface surface) { this.surface = surface; }
+    public Surface surface() { return surface; }
+    public String execute(PlatformRequest request) {
+      return "[" + surface.label.toUpperCase(Locale.ROOT) + " SPEC READY] "
+          + "signature=" + request.telemetry().signature()
+          + " prompt=“" + request.prompt() + "”. Configure MOAGI_"
+          + surface.label.toUpperCase(Locale.ROOT) + "_ENDPOINT to attach a renderer.";
+    }
+  }
+
+  /** Generic JSON media bridge owned by the platform contract. */
+  static final class HttpMediaAdapter implements SurfaceAdapter {
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final Surface surface;
+    private final URI endpoint;
+    private final String apiKey;
+
+    HttpMediaAdapter(Surface surface, String endpoint, String apiKey) {
+      this.surface = surface;
+      this.endpoint = URI.create(endpoint);
+      this.apiKey = apiKey == null ? "" : apiKey;
+    }
+
+    public Surface surface() { return surface; }
+
+    public String execute(PlatformRequest request) {
+      String body = "{\"mode\":\"" + surface.label + "\",\"prompt\":\""
+          + jsonEscape(request.prompt()) + "\",\"latent\":" + latentJson(request.latent())
+          + ",\"signature\":\"" + jsonEscape(request.telemetry().signature()) + "\"}";
+      HttpRequest.Builder builder = HttpRequest.newBuilder(endpoint)
+          .header("Content-Type", "application/json")
+          .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8));
+      if (!apiKey.isBlank()) builder.header("Authorization", "Bearer " + apiKey);
+      try {
+        HttpResponse<String> response = client.send(builder.build(), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        return "[" + surface.label.toUpperCase(Locale.ROOT) + " HTTP " + response.statusCode() + "] "
+            + trimBody(response.body());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return "Media request interrupted.";
+      } catch (IOException e) {
+        return "Media provider error: " + e.getMessage();
+      }
+    }
+  }
+
+  static final class DataAdapter implements SurfaceAdapter {
+    public Surface surface() { return Surface.DATA; }
+
+    public String execute(PlatformRequest request) {
+      String[] tokens = request.prompt().trim().split("[\\s,;]+");
+      List<Double> values = new ArrayList<>();
+      for (String token : tokens) {
+        if (token.isBlank()) continue;
+        try {
+          values.add(Double.parseDouble(token));
+        } catch (NumberFormatException ignored) {
+          // Non-numeric tokens are intentionally skipped in the local analytics surface.
+        }
+      }
+      if (values.isEmpty()) return "[DATA] No numeric values found.";
+      double sum = values.stream().mapToDouble(Double::doubleValue).sum();
+      double mean = sum / values.size();
+      double min = values.stream().mapToDouble(Double::doubleValue).min().orElse(Double.NaN);
+      double max = values.stream().mapToDouble(Double::doubleValue).max().orElse(Double.NaN);
+      double variance = values.stream().mapToDouble(v -> (v - mean) * (v - mean)).sum() / values.size();
+      return String.format(Locale.ROOT,
+          "[DATA] n=%d sum=%.8f mean=%.8f min=%.8f max=%.8f variance=%.8f signature=%s",
+          values.size(), sum, mean, min, max, variance, request.telemetry().signature());
+    }
+  }
+
+  static final class ComputeAdapter implements SurfaceAdapter {
+    public Surface surface() { return Surface.COMPUTE; }
+
+    public String execute(PlatformRequest request) {
+      try {
+        double result = new ExpressionParser(request.prompt()).parse();
+        return "[COMPUTE] " + request.prompt() + " = " + formatNumber(result)
+            + " signature=" + request.telemetry().signature();
+      } catch (RuntimeException e) {
+        return "[COMPUTE ERROR] " + e.getMessage()
+            + ". Supported: + - * / % ^ parentheses and sin cos tan sqrt abs log exp min max.";
+      }
+    }
+  }
+
+  /** Tiny safe arithmetic parser: no reflection, shell, filesystem, or process execution. */
+  static final class ExpressionParser {
+    private final String text;
+    private int pos;
+
+    ExpressionParser(String text) { this.text = text == null ? "" : text; }
+
+    double parse() {
+      double value = expression();
+      skip();
+      if (pos != text.length()) throw error("Unexpected token at position " + pos);
+      if (!Double.isFinite(value)) throw error("Result is not finite");
+      return value;
+    }
+
+    private double expression() {
+      double value = term();
+      while (true) {
+        skip();
+        if (eat('+')) value += term();
+        else if (eat('-')) value -= term();
+        else return value;
+      }
+    }
+
+    private double term() {
+      double value = power();
+      while (true) {
+        skip();
+        if (eat('*')) value *= power();
+        else if (eat('/')) value /= power();
+        else if (eat('%')) value %= power();
+        else return value;
+      }
+    }
+
+    private double power() {
+      double value = unary();
+      skip();
+      if (eat('^')) value = Math.pow(value, power());
+      return value;
+    }
+
+    private double unary() {
+      skip();
+      if (eat('+')) return unary();
+      if (eat('-')) return -unary();
+      return primary();
+    }
+
+    private double primary() {
+      skip();
+      if (eat('(')) {
+        double value = expression();
+        require(')');
+        return value;
+      }
+      if (pos < text.length() && Character.isLetter(text.charAt(pos))) {
+        String name = identifier().toLowerCase(Locale.ROOT);
+        if (name.equals("pi")) return Math.PI;
+        if (name.equals("e")) return Math.E;
+        require('(');
+        double a = expression();
+        skip();
+        Double b = null;
+        if (eat(',')) b = expression();
+        require(')');
+        return function(name, a, b);
+      }
+      return number();
+    }
+
+    private double function(String name, double a, Double b) {
+      return switch (name) {
+        case "sin" -> Math.sin(a);
+        case "cos" -> Math.cos(a);
+        case "tan" -> Math.tan(a);
+        case "sqrt" -> Math.sqrt(a);
+        case "abs" -> Math.abs(a);
+        case "log" -> Math.log(a);
+        case "exp" -> Math.exp(a);
+        case "min" -> Math.min(a, requireSecond(name, b));
+        case "max" -> Math.max(a, requireSecond(name, b));
+        default -> throw error("Unknown function " + name);
+      };
+    }
+
+    private static double requireSecond(String name, Double value) {
+      if (value == null) throw new IllegalArgumentException(name + " requires two arguments");
+      return value;
+    }
+
+    private String identifier() {
+      int start = pos;
+      while (pos < text.length() && Character.isLetter(text.charAt(pos))) pos++;
+      return text.substring(start, pos);
+    }
+
+    private double number() {
+      skip();
+      int start = pos;
+      boolean dot = false;
+      boolean exponent = false;
+      while (pos < text.length()) {
+        char c = text.charAt(pos);
+        if (Character.isDigit(c)) {
+          pos++;
+        } else if (c == '.' && !dot && !exponent) {
+          dot = true;
+          pos++;
+        } else if ((c == 'e' || c == 'E') && !exponent) {
+          exponent = true;
+          pos++;
+          if (pos < text.length() && (text.charAt(pos) == '+' || text.charAt(pos) == '-')) pos++;
+        } else break;
+      }
+      if (start == pos) throw error("Expected number at position " + pos);
+      return Double.parseDouble(text.substring(start, pos));
+    }
+
+    private void require(char c) {
+      skip();
+      if (!eat(c)) throw error("Expected '" + c + "' at position " + pos);
+    }
+
+    private boolean eat(char c) {
+      if (pos < text.length() && text.charAt(pos) == c) {
+        pos++;
+        return true;
+      }
+      return false;
+    }
+
+    private void skip() {
+      while (pos < text.length() && Character.isWhitespace(text.charAt(pos))) pos++;
+    }
+
+    private IllegalArgumentException error(String message) { return new IllegalArgumentException(message); }
+  }
+
+  static int index(int x, int y, int z) {
+    int xx = Math.floorMod(x, SIDE);
+    int yy = Math.floorMod(y, SIDE);
+    int zz = Math.floorMod(z, SIDE);
+    return (zz * SIDE + yy) * SIDE + xx;
+  }
+
+  static int neighborIndex(int i, int dx, int dy, int dz) {
+    int x = i % SIDE;
+    int y = (i / SIDE) % SIDE;
+    int z = i / (SIDE * SIDE);
+    return index(x + dx, y + dy, z + dz);
+  }
+
+  static double neighborMean(double[] field, int i) {
+    return (field[neighborIndex(i, 1, 0, 0)] + field[neighborIndex(i, -1, 0, 0)]
+        + field[neighborIndex(i, 0, 1, 0)] + field[neighborIndex(i, 0, -1, 0)]
+        + field[neighborIndex(i, 0, 0, 1)] + field[neighborIndex(i, 0, 0, -1)]) / 6.0;
+  }
+
+  static Telemetry telemetry(double loss, int steps, double[] latent) {
+    double energy = Arrays.stream(latent).map(v -> v * v).average().orElse(0.0);
+    return new Telemetry(loss, steps, energy, signature(latent));
+  }
+
+  static String signature(double[] latent) {
+    long hash = 0xcbf29ce484222325L;
+    for (double value : latent) {
+      long bits = Double.doubleToLongBits(Math.rint(value * 1_000_000.0) / 1_000_000.0);
+      hash ^= bits;
+      hash *= 0x100000001b3L;
+    }
+    return "DM3D-" + Long.toUnsignedString(hash, 16).toUpperCase(Locale.ROOT);
+  }
+
+  static String compactLatent(double[] latent, int count) {
+    StringBuilder out = new StringBuilder("[");
+    for (int i = 0; i < Math.min(count, latent.length); i++) {
+      if (i > 0) out.append(',');
+      out.append(String.format(Locale.ROOT, "%.4f", latent[i]));
+    }
+    if (latent.length > count) out.append(",…");
+    return out.append(']').toString();
+  }
+
+  static String latentJson(double[] latent) {
+    StringBuilder out = new StringBuilder("[");
+    for (int i = 0; i < latent.length; i++) {
+      if (i > 0) out.append(',');
+      out.append(String.format(Locale.ROOT, "%.8f", latent[i]));
+    }
+    return out.append(']').toString();
+  }
+
+  static String jsonEscape(String value) {
+    StringBuilder out = new StringBuilder(value.length() + 16);
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      switch (c) {
+        case '"' -> out.append("\\\"");
+        case '\\' -> out.append("\\\\");
+        case '\b' -> out.append("\\b");
+        case '\f' -> out.append("\\f");
+        case '\n' -> out.append("\\n");
+        case '\r' -> out.append("\\r");
+        case '\t' -> out.append("\\t");
+        default -> {
+          if (c < 0x20) out.append(String.format(Locale.ROOT, "\\u%04x", (int) c));
+          else out.append(c);
+        }
+      }
+    }
+    return out.toString();
+  }
+
+  static String extractJsonString(String json, String key) {
+    String needle = "\"" + key + "\"";
+    int keyPos = json.indexOf(needle);
+    while (keyPos >= 0) {
+      int colon = json.indexOf(':', keyPos + needle.length());
+      if (colon < 0) return null;
+      int quote = colon + 1;
+      while (quote < json.length() && Character.isWhitespace(json.charAt(quote))) quote++;
+      if (quote < json.length() && json.charAt(quote) == '"') {
+        StringBuilder out = new StringBuilder();
+        boolean escaped = false;
+        for (int i = quote + 1; i < json.length(); i++) {
+          char c = json.charAt(i);
+          if (escaped) {
+            switch (c) {
+              case '"', '\\', '/' -> out.append(c);
+              case 'b' -> out.append('\b');
+              case 'f' -> out.append('\f');
+              case 'n' -> out.append('\n');
+              case 'r' -> out.append('\r');
+              case 't' -> out.append('\t');
+              case 'u' -> {
+                if (i + 4 >= json.length()) return null;
+                String hex = json.substring(i + 1, i + 5);
+                try { out.append((char) Integer.parseInt(hex, 16)); }
+                catch (NumberFormatException e) { return null; }
+                i += 4;
+              }
+              default -> out.append(c);
+            }
+            escaped = false;
+          } else if (c == '\\') {
+            escaped = true;
+          } else if (c == '"') {
+            return out.toString();
+          } else {
+            out.append(c);
+          }
+        }
+        return null;
+      }
+      keyPos = json.indexOf(needle, keyPos + needle.length());
+    }
+    return null;
+  }
+
+  static String trimBody(String body) {
+    if (body == null) return "";
+    String normalized = body.replaceAll("\\s+", " ").trim();
+    return normalized.length() <= 800 ? normalized : normalized.substring(0, 800) + "…";
+  }
+
+  static double clamp(double value, double min, double max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  static String formatNumber(double value) {
+    if (Math.rint(value) == value && Math.abs(value) < 9e15) return Long.toString((long) value);
+    return String.format(Locale.ROOT, "%.12g", value);
+  }
+}

--- a/apps/dr-moagi-platform-java/test/DrMoagiPlatformTest.java
+++ b/apps/dr-moagi-platform-java/test/DrMoagiPlatformTest.java
@@ -1,0 +1,65 @@
+import java.util.List;
+
+public final class DrMoagiPlatformTest {
+  public static void main(String[] args) {
+    testToroidalIndexing();
+    testKineticStateIsFinite();
+    testArithmeticSurface();
+    testDataSurface();
+    testJsonEscaping();
+    testJsonExtraction();
+    System.out.println("DrMoagiPlatformTest: PASS");
+  }
+
+  static void testToroidalIndexing() {
+    check(DrMoagiPlatform.index(-1, 0, 0) == DrMoagiPlatform.index(3, 0, 0), "x wrap");
+    check(DrMoagiPlatform.index(0, 4, 0) == DrMoagiPlatform.index(0, 0, 0), "y wrap");
+    check(DrMoagiPlatform.index(0, 0, -1) == DrMoagiPlatform.index(0, 0, 3), "z wrap");
+  }
+
+  static void testKineticStateIsFinite() {
+    var encoder = new DrMoagiPlatform.TurnEncoder(0.78, 0.42);
+    var target = encoder.encode(List.of(
+        new DrMoagiPlatform.Turn("user", "encode this state", DrMoagiPlatform.Surface.CHAT, java.time.Instant.EPOCH)));
+    var dynamics = new DrMoagiPlatform.KineticDynamics(0.70, 0.16, 0.07, 0.40, 24, 0.12);
+    double[] state = new double[DrMoagiPlatform.VOLUME];
+    double firstLoss = dynamics.step(state, target).loss();
+    double lastLoss = firstLoss;
+    for (int i = 0; i < 24; i++) {
+      var step = dynamics.step(state, target);
+      state = step.state();
+      lastLoss = step.loss();
+      for (double v : state) check(Double.isFinite(v) && Math.abs(v) <= 1.0, "bounded state");
+    }
+    check(lastLoss < firstLoss, "kinetic relaxation should reduce loss for fixture");
+  }
+
+  static void testArithmeticSurface() {
+    var parser = new DrMoagiPlatform.ExpressionParser("sqrt(81) + max(3, 5) * 2^3");
+    check(Math.abs(parser.parse() - 49.0) < 1e-12, "arithmetic parser");
+  }
+
+  static void testDataSurface() {
+    var adapter = new DrMoagiPlatform.DataAdapter();
+    var telemetry = new DrMoagiPlatform.Telemetry(0, 0, 0, "TEST");
+    var request = new DrMoagiPlatform.PlatformRequest(
+        "1, 2, 3, 4", DrMoagiPlatform.Surface.DATA, List.of(), new double[DrMoagiPlatform.VOLUME], telemetry);
+    String output = adapter.execute(request);
+    check(output.contains("n=4") && output.contains("mean=2.50000000"), "data adapter");
+  }
+
+  static void testJsonEscaping() {
+    String escaped = DrMoagiPlatform.jsonEscape("a\"b\\c\n");
+    check(escaped.equals("a\\\"b\\\\c\\n"), "json escaping");
+  }
+
+  static void testJsonExtraction() {
+    String json = "{\"choices\":[{\"message\":{\"content\":\"hello \\\"world\\\"\\nnext\"}}]}";
+    String value = DrMoagiPlatform.extractJsonString(json, "content");
+    check("hello \"world\"\nnext".equals(value), "json extraction");
+  }
+
+  static void check(boolean condition, String message) {
+    if (!condition) throw new AssertionError(message);
+  }
+}

--- a/docs/DR_MOAGI_RUNTIME_FABRIC.md
+++ b/docs/DR_MOAGI_RUNTIME_FABRIC.md
@@ -1,0 +1,124 @@
+# Dr Moagi Runtime Fabric
+
+The runtime fabric federates the repository's specialist engines beneath the Java 17 multimodal kernel without collapsing their trust boundaries or pretending that every runtime is the same kind of model.
+
+## Operational topology
+
+```text
+                         +---------------------------+
+user / application ----> | Dr Moagi Java 17 kernel  |
+                         | recurrent 4x4x4 field     |
+                         +-------------+-------------+
+                                       |
+                         explicit capability routing
+                                       |
+       +---------------+---------------+----------------+---------------+
+       |               |               |                |               |
+       v               v               v                v               v
+ DMVANN Chat      Cognitive UI    Geometry core   QSOL 3D codec   Field simulator
+ chat / proxy     control plane    3D optimizer    scene state      policy semantics
+       |                                                               
+       +-------------------------+-------------------------------------+
+                                 |
+                                 v
+                        C++ self-editor3d
+                    bounded code refinement
+```
+
+The machine-readable contract is `apps/dr-moagi-platform-java/runtime-fabric.json`. `tools/verify-dr-moagi-runtime-fabric.mjs` fails CI if a registered runtime disappears, declares an unsafe repository path, duplicates an identifier/capability, omits an authority boundary, or attempts to grant implicit host execution.
+
+## Authority model
+
+The fabric is an **orchestration contract**, not a superuser process.
+
+- Specialist runtimes remain authoritative for their own measured invariants.
+- Network-backed routing is opt-in through environment configuration; endpoint values and credentials are never stored in the manifest.
+- The fabric itself grants no shell/process execution authority.
+- Browser-only runtimes remain browser-only unless a separate, reviewed service adapter is implemented.
+- Provisional state never becomes authoritative merely because another runtime requested it.
+- A codec is not relabelled as a renderer, a simulation is not relabelled as production execution, and internal optimization objectives are not relabelled as external benchmark wins.
+
+## Registered specialist domains
+
+### `dmvann-chat`
+
+Provides the repository's chat/control-field interface and optional server-side model proxy. Its Node runtime already exposes health/runtime/chat HTTP endpoints, so it is the first natural service bridge for the Java chat surface when an operator explicitly configures a trusted endpoint.
+
+### `dr-moagi-cognitive`
+
+Provides the production-oriented browser control plane: deterministic local state, visualization, session persistence, bounded command compilation, and verified firmware client operations. The browser cannot bypass firmware verification.
+
+### `dr-moagi-geometry`
+
+Owns bounded topology-preserving 3D geometry optimization. Candidate parameters remain provisional until measured geometry gates accept them.
+
+### `qsol-graphics-codec`
+
+Owns executable 3D scene-state encoding/decoding, quantization search, reconstruction-error gating, topology preservation, and animation-state persistence. It is intentionally renderer-agnostic.
+
+### `moagi-field-sim`
+
+Owns synthetic 3-bit physical/processing/microstructure state semantics and the generation/epoch commit barrier. It has no production market transmission authority.
+
+### `cpp-self-editor3d`
+
+Owns bounded native source refinement, recursive byte-to-voxel folding, closed-loop 3D symmetry autoencoding, and the associated deterministic benchmark harness. Source mutations remain workspace-confined, transactional, validator-gated, and rollback-capable.
+
+## Platform surfaces versus specialist domains
+
+The Java kernel exposes modality/task surfaces:
+
+```text
+chat | image | audio | video | code | data | compute
+```
+
+The runtime fabric exposes specialist domains:
+
+```text
+chat-proxy | control | geometry | graphics-state | field-simulation | code-refinement
+```
+
+These are deliberately orthogonal. For example, `qsol-graphics-codec` may provide geometry/animation state to an image or video renderer, but it is not itself claimed to synthesize photorealistic frames. Likewise, the C++ self-editor can validate bounded source refinements but does not automatically receive arbitrary code-generation authority from the Java `/code` surface.
+
+## Federated CI invariant
+
+`Dr Moagi Runtime Fabric` CI makes the federation executable as a repository contract. It:
+
+1. validates the manifest structurally and against the checked-out tree;
+2. recompiles/tests the Java platform kernel;
+3. runs the DMVANN, cognitive, and geometry deterministic Node tests;
+4. runs the QSOL graphics codec self-test;
+5. builds and executes the C++ self-editor3d CTest suite.
+
+This gives the platform a measurable integration invariant:
+
+```text
+platform-contract-valid
+AND specialist-invariants-pass
+=> fabric-compatible commit
+```
+
+It does **not** imply that all runtimes share memory, latency, deployment, or security context. Cross-runtime transport remains explicit and independently reviewable.
+
+## Next operational layer
+
+The next safe evolution is a versioned request/result envelope for service-capable runtimes:
+
+```text
+request_id
+surface / capability
+input content reference
+latent signature + bounded telemetry
+runtime target
+provisional result
+specialist validation evidence
+promotion decision
+```
+
+That envelope can support distributed workers, artifact stores, GPU renderers, model gateways, and persistent memory while retaining the central invariant:
+
+```text
+PROVISIONAL != AUTHORITATIVE
+```
+
+until the owning specialist validates and promotes the result.

--- a/tools/verify-dr-moagi-runtime-fabric.mjs
+++ b/tools/verify-dr-moagi-runtime-fabric.mjs
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const manifestPath = resolve(repoRoot, 'apps/dr-moagi-platform-java/runtime-fabric.json');
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+const fail = (message) => {
+  console.error(`runtime-fabric: ${message}`);
+  process.exitCode = 1;
+};
+
+if (manifest.schema !== 'jarvisx.dr-moagi-runtime-fabric/v1') fail('unsupported schema');
+if (!manifest.platform?.id || !Array.isArray(manifest.platform?.surfaces)) fail('invalid platform declaration');
+if (!Array.isArray(manifest.runtimes) || manifest.runtimes.length === 0) fail('runtime list is empty');
+
+const ids = new Set();
+for (const runtime of manifest.runtimes ?? []) {
+  if (!runtime.id || !/^[a-z0-9][a-z0-9-]*$/.test(runtime.id)) {
+    fail(`invalid runtime id: ${String(runtime.id)}`);
+    continue;
+  }
+  if (ids.has(runtime.id)) fail(`duplicate runtime id: ${runtime.id}`);
+  ids.add(runtime.id);
+
+  if (!runtime.path || runtime.path.startsWith('/') || runtime.path.includes('..')) {
+    fail(`${runtime.id}: unsafe path`);
+    continue;
+  }
+  const runtimePath = resolve(repoRoot, runtime.path);
+  if (!runtimePath.startsWith(repoRoot + '/')) fail(`${runtime.id}: path escapes repository`);
+  if (!existsSync(runtimePath) || !statSync(runtimePath).isDirectory()) fail(`${runtime.id}: runtime directory missing`);
+
+  if (!Array.isArray(runtime.capabilities) || runtime.capabilities.length === 0) {
+    fail(`${runtime.id}: capabilities missing`);
+  } else if (new Set(runtime.capabilities).size !== runtime.capabilities.length) {
+    fail(`${runtime.id}: duplicate capability`);
+  }
+
+  if (!runtime.transport?.kind) fail(`${runtime.id}: transport kind missing`);
+  if (!runtime.authorityBoundary?.trim()) fail(`${runtime.id}: authority boundary missing`);
+
+  for (const relative of runtime.requiredFiles ?? []) {
+    if (!relative || relative.startsWith('/') || relative.includes('..')) {
+      fail(`${runtime.id}: unsafe required file ${relative}`);
+      continue;
+    }
+    if (!existsSync(join(runtimePath, relative))) fail(`${runtime.id}: required file missing: ${relative}`);
+  }
+
+  const env = runtime.transport?.endpointEnv;
+  if (env && !/^MOAGI_[A-Z0-9_]+$/.test(env)) fail(`${runtime.id}: endpoint env must use MOAGI_* namespace`);
+}
+
+const surfaceSet = new Set(manifest.platform?.surfaces ?? []);
+if (surfaceSet.size !== (manifest.platform?.surfaces ?? []).length) fail('duplicate platform surface');
+if (manifest.policy?.hostExecutionAuthority !== 'none-from-fabric') fail('fabric must not grant implicit host execution');
+if (manifest.policy?.provisionalIsAuthoritative !== false) fail('provisional state must not be authoritative');
+
+if (!process.exitCode) {
+  console.log(`runtime-fabric: PASS (${ids.size} specialist runtimes, ${surfaceSet.size} platform surfaces)`);
+}


### PR DESCRIPTION
## Summary

Evolves the supplied Java 17 `DrMoagiEngine` concept into a general-purpose multimodal platform kernel and then permeates it across the repository as an explicit specialist-runtime federation.

### Platform kernel
- 4×4×4 toroidal latent field (64 cells) with periodic 3D neighbourhood coupling
- turn-wise recurrent encoding instead of replaying one whole-transcript feature vector
- explicit Euler kinetic relaxation with post-update authoritative loss telemetry
- deterministic latent signatures and energy/state telemetry
- synchronized recurrent transcript state

### Capability surfaces
- `/chat` — local or OpenAI-compatible text adapter
- `/image`, `/audio`, `/video` — local spec adapters or generic JSON HTTP renderer bridges
- `/code` — text-model-backed software engineering surface
- `/data` — local numeric summary statistics
- `/compute` — safe local arithmetic parser (no shell/process execution)
- `/status`, `/reset`, `/help`, `/exit` control plane

### Runtime fabric permeation
Adds `runtime-fabric.json` as a machine-readable federation over six existing specialist engines:
- DMVANN Chat — chat/control-field/model proxy
- Dr Moagi Cognitive — browser/firmware control plane
- Dr Moagi Geometry — bounded topology-preserving 3D optimizer
- QSOL Graphics Codec — measured 3D scene-state codec/animation pipeline
- Moagi Field Simulator — synthetic 3-bit policy/field semantics
- C++ self-editor3d — transactional native code refinement, symmetry autoencoding and benchmark core

The fabric preserves specialist authority boundaries. It grants no implicit shell/process authority, keeps network routing opt-in through environment configuration, and preserves `PROVISIONAL != AUTHORITATIVE` across runtime boundaries.

### Federation verification
- `tools/verify-dr-moagi-runtime-fabric.mjs` validates IDs, repository paths, required files, capabilities, endpoint-env namespaces, and authority declarations.
- `Dr Moagi Runtime Fabric` CI federates Java 17, Node 22, .NET 8 and C++/CTest validation in one integration gate.
- Existing specialist runtimes are not rewritten or relabelled; the platform integrates above their current invariants.

### Validation before push

```text
javac --release 17 -Xlint:all -Werror ...
DrMoagiPlatformTest: PASS
/compute sqrt(81) + max(3,5) * 2^3 -> 49
/data 1,2,3,4 -> n=4 mean=2.50000000 variance=1.25000000
/image ... -> renderer-spec fallback
/status -> capability and latent telemetry
runtime-fabric.json -> valid JSON
verify-dr-moagi-runtime-fabric.mjs -> syntax valid
```

The first platform commit passed Dr Moagi Java Platform, CodeQL and Jarvis-X CI before the federation commit was added. The second commit triggers those checks plus the new cross-language runtime-fabric integration workflow.

## Architectural boundary

This establishes a platform kernel, adapter ABI, machine-readable runtime federation and CI compatibility contract. It does not falsely represent the dependency-free Java kernel as containing a production foundation model, renderer, speech engine, video generator, exchange connector, or unrestricted autonomous code executor. Those systems remain independently implemented, validated, permissioned and replaceable behind explicit capability boundaries.
