### PR TITLE
feat: permeate self-referential 3D phase runtime autotuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Compile Python sources
         run: python -m compileall -q src tests
 
+      - name: Compile optional self-referential runtime
+        run: python -m py_compile examples/self_referential_triton_engine.py
+
       - name: Reject syntax errors and undefined names
         run: flake8 src/jarvisx tests --select=E9,F63,F7,F82 --show-source --statistics
 

--- a/.github/workflows/phase3d-runtime.yml
+++ b/.github/workflows/phase3d-runtime.yml
@@ -42,6 +42,35 @@ jobs:
           examples/self_referential_triton_engine.py
           examples/dr_moagi_phase3d_runtime.py
 
+      - name: Verify Phase3D invariants
+        env:
+          PYTHONPATH: examples
+        run: |
+          python - <<'PY'
+          import math
+          import torch
+          from dr_moagi_phase3d_runtime import (
+              C_LIGHT,
+              PhaseFieldConfig,
+              RelativisticPhaseField3D,
+          )
+
+          config = PhaseFieldConfig(node_count=256)
+          assert math.isclose(config.equilibrium_radius_m, 3.0 ** (1.0 / 3.0), rel_tol=1e-12)
+
+          phase = RelativisticPhaseField3D(config, torch.device("cpu"))
+          assert phase.position.shape == (256, 3)
+          assert phase.momentum.shape == (256, 3)
+          before = phase.position.clone()
+          report = phase.step()
+          assert torch.isfinite(phase.position).all()
+          assert torch.isfinite(phase.momentum).all()
+          assert not torch.equal(before, phase.position)
+          assert report.max_velocity_m_s < C_LIGHT
+          assert math.isfinite(report.mechanical_energy_j)
+          assert math.isfinite(report.relative_energy_drift)
+          PY
+
       - name: Execute end-to-end CPU cycle
         run: >-
           python examples/dr_moagi_phase3d_runtime.py

--- a/.github/workflows/phase3d-runtime.yml
+++ b/.github/workflows/phase3d-runtime.yml
@@ -7,6 +7,7 @@ on:
       - "examples/dr_moagi_phase3d_runtime.py"
       - "examples/self_referential_triton_engine.py"
       - "docs/PHASE3D_END_TO_END_RUNTIME.md"
+      - "src/jarvisx/kinetic_runtime.py"
       - "pyproject.toml"
       - ".github/workflows/phase3d-runtime.yml"
   workflow_dispatch:
@@ -69,6 +70,41 @@ jobs:
           assert report.max_velocity_m_s < C_LIGHT
           assert math.isfinite(report.mechanical_energy_j)
           assert math.isfinite(report.relative_energy_drift)
+          PY
+
+      - name: Verify canonical runtime receipt
+        env:
+          PYTHONPATH: examples
+        run: |
+          python - <<'PY'
+          from dr_moagi_phase3d_runtime import (
+              Phase3DSelfOptimizingRuntime,
+              PhaseFieldConfig,
+              RuntimeConfig,
+          )
+
+          runtime = Phase3DSelfOptimizingRuntime(
+              PhaseFieldConfig(node_count=128),
+              device="cpu",
+              runtime_config=RuntimeConfig(chunk_size=1024, compile_mode="eager"),
+          )
+          runtime.autotuner.candidates = lambda incumbent: (incumbent,)
+          runtime.phase.step()
+          coords = runtime.phase.neural_coordinates()
+          runtime.train_geometry(coords, 1)
+          measured = runtime._benchmark_incumbent(coords)
+          assert measured.accepted
+          runtime.exec_state = measured.metrics
+          _reported, promoted, receipt = runtime._tune_runtime(coords)
+          assert not promoted
+          assert receipt.decision == "rollback"
+          assert receipt.receipt_hash != "0" * 64
+          assert receipt.stages[-2:] == ("journal", "reenter")
+          assert {item.name for item in receipt.validators} == {
+              "phase3d_semantic_equivalence",
+              "phase3d_memory_budget",
+              "phase3d_runtime_improvement",
+          }
           PY
 
       - name: Execute end-to-end CPU cycle

--- a/.github/workflows/phase3d-runtime.yml
+++ b/.github/workflows/phase3d-runtime.yml
@@ -1,0 +1,66 @@
+name: Phase3D End-to-End Runtime
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "examples/dr_moagi_phase3d_runtime.py"
+      - "examples/self_referential_triton_engine.py"
+      - "docs/PHASE3D_END_TO_END_RUNTIME.md"
+      - "pyproject.toml"
+      - ".github/workflows/phase3d-runtime.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: phase3d-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cpu-smoke:
+    name: PyTorch CPU smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install optional PyTorch runtime
+        run: python -m pip install -e ".[torch]"
+
+      - name: Compile Phase3D sources
+        run: >-
+          python -m py_compile
+          examples/self_referential_triton_engine.py
+          examples/dr_moagi_phase3d_runtime.py
+
+      - name: Execute end-to-end CPU cycle
+        run: >-
+          python examples/dr_moagi_phase3d_runtime.py
+          --device cpu
+          --compile-mode eager
+          --cycles 2
+          --nodes 512
+          --train-steps 1
+          --tune-every 0
+          --chunk-size 1024
+
+      - name: Execute damped phase cycle
+        run: >-
+          python examples/dr_moagi_phase3d_runtime.py
+          --device cpu
+          --compile-mode eager
+          --cycles 2
+          --nodes 256
+          --train-steps 1
+          --tune-every 0
+          --damping 50
+          --chunk-size 1024

--- a/.github/workflows/phase3d-runtime.yml
+++ b/.github/workflows/phase3d-runtime.yml
@@ -72,17 +72,20 @@ jobs:
           assert math.isfinite(report.relative_energy_drift)
           PY
 
-      - name: Verify canonical runtime receipt
+      - name: Verify canonical runtime receipts
         env:
           PYTHONPATH: examples
         run: |
           python - <<'PY'
           from dr_moagi_phase3d_runtime import (
+              BenchmarkResult,
+              ExecutionMetrics,
               Phase3DSelfOptimizingRuntime,
               PhaseFieldConfig,
               RuntimeConfig,
           )
 
+          # Rollback path: only the incumbent is available, so no promotion is legal.
           runtime = Phase3DSelfOptimizingRuntime(
               PhaseFieldConfig(node_count=128),
               device="cpu",
@@ -105,6 +108,37 @@ jobs:
               "phase3d_memory_budget",
               "phase3d_runtime_improvement",
           }
+
+          # Commit path: deterministic benchmark evidence makes the 2048 chunk
+          # candidate 2x faster while preserving semantics and memory budget.
+          committed = Phase3DSelfOptimizingRuntime(
+              PhaseFieldConfig(node_count=64),
+              device="cpu",
+              runtime_config=RuntimeConfig(chunk_size=1024, compile_mode="eager"),
+          )
+          committed.phase.step()
+          coords = committed.phase.neural_coordinates()
+          fast = RuntimeConfig(chunk_size=2048, compile_mode="eager")
+          committed.autotuner.candidates = lambda incumbent: (incumbent, fast)
+
+          def deterministic_benchmark(config, _coords, _metrics, _reference):
+              qps = 2_000_000.0 if config == fast else 1_000_000.0
+              return BenchmarkResult(
+                  config=config,
+                  metrics=ExecutionMetrics(qps, 1.0, 16.0),
+                  max_abs_error=0.0,
+                  accepted=True,
+                  effective_mode="eager",
+              )
+
+          committed.autotuner.benchmark = deterministic_benchmark
+          reported, promoted, receipt = committed._tune_runtime(coords)
+          assert promoted
+          assert receipt.decision == "commit"
+          assert committed.runtime_config == fast
+          assert reported.config == fast
+          assert receipt.receipt_hash != "0" * 64
+          assert receipt.previous_receipt_hash == "0" * 64
           PY
 
       - name: Execute end-to-end CPU cycle

--- a/.github/workflows/phase3d-runtime.yml
+++ b/.github/workflows/phase3d-runtime.yml
@@ -34,8 +34,10 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install optional PyTorch runtime
-        run: python -m pip install -e ".[torch]"
+      - name: Install CPU-only PyTorch runtime
+        run: |
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.4"
+          python -m pip install -e . --no-deps
 
       - name: Compile Phase3D sources
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ The project follows semantic versioning where practical during alpha development
 - exact 2,700-edge open-cube and 3,000-edge fully wrapped topology contracts;
 - analytic tied-edge gradients with central finite-difference verification;
 - transactional non-regressing adaptation and connectivity-preserving pruning;
-- machine-readable arithmetic telemetry and a bounded command-line example.
+- machine-readable arithmetic telemetry and a bounded command-line example;
+- self-referential PyTorch/Inductor 3D implicit-field example with normalized execution telemetry;
+- bounded measurement-driven runtime autotuning kept separate from differentiable geometry learning.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ The project follows semantic versioning where practical during alpha development
 - transactional non-regressing adaptation and connectivity-preserving pruning;
 - machine-readable arithmetic telemetry and a bounded command-line example;
 - self-referential PyTorch/Inductor 3D implicit-field example with normalized execution telemetry;
-- bounded measurement-driven runtime autotuning kept separate from differentiable geometry learning.
+- bounded measurement-driven runtime autotuning kept separate from differentiable geometry learning;
+- vectorized `N x 3` Phase3D runtime with true two-parameter torus initialization and relativistic momentum integration;
+- dimensionally explicit central potential, shell/energy telemetry, and measured node-update throughput;
+- end-to-end Phase3D-to-implicit-field runtime with semantic, memory-budget, and minimum-throughput-improvement promotion gates.
 
 ### Changed
 

--- a/docs/PHASE3D_END_TO_END_RUNTIME.md
+++ b/docs/PHASE3D_END_TO_END_RUNTIME.md
@@ -1,0 +1,411 @@
+# Dr Moagi Phase3D End-to-End Runtime
+
+## Status
+
+This specification operationalizes the latest DM-vOmegaXi+ iteration as one measurable 3D execution loop:
+
+```text
+3D phase-space state
+-> relativistic momentum update
+-> implicit shell representation
+-> differentiable geometry learning
+-> measured runtime benchmark
+-> bounded device/runtime search
+-> semantic + resource promotion gate
+-> next cycle
+```
+
+The executable reference is:
+
+```text
+examples/dr_moagi_phase3d_runtime.py
+```
+
+It extends, rather than replaces, the self-referential PyTorch/Inductor runtime defined in `SELF_REFERENTIAL_TRITON_RUNTIME.md`.
+
+## 1. Separation of authorities
+
+The runtime deliberately keeps three optimization domains separate.
+
+### Phase dynamics
+
+The authoritative physical state is
+
+\[
+K_t=(X_t,P_t,M),
+\]
+
+where `X` is an `N x 3` position tensor, `P` is relativistic momentum, and `M` is the per-node mass tensor.
+
+The neural model does not directly write to `X` or `P`.
+
+### Neural representation
+
+The implicit field parameters are
+
+\[
+\Theta_t.
+\]
+
+They are updated only through a differentiable signed-distance objective.
+
+### Runtime mechanics
+
+The execution configuration is
+
+\[
+C_t=(\text{chunk size},\text{compile mode},\ldots).
+\]
+
+It is updated only from measured benchmark evidence after semantic and resource checks.
+
+Therefore
+
+\[
+\boxed{
+\text{phase evolution}\neq\text{gradient learning}\neq\text{runtime tuning}
+}
+\]
+
+while all three participate in the same outer recurrence.
+
+## 2. True 3D toroidal initialization
+
+The prior single-index construction coupled the two toroidal angles and sampled a one-dimensional closed curve. Phase3D instead creates independent angular grids
+
+\[
+\theta_i\in[0,2\pi),
+\qquad
+\phi_j\in[0,2\pi)
+\]
+
+and samples
+
+\[
+\rho=R+a\cos\phi,
+\]
+
+\[
+x=\rho\cos\theta,
+\qquad
+y=\rho\sin\theta,
+\qquad z=a\sin\phi.
+\]
+
+The resulting state samples a genuine two-parameter torus surface before being flattened into an `N x 3` tensor for parallel execution.
+
+## 3. Dimensionally explicit radial field
+
+The conservative force is
+
+\[
+F_r(r)=\frac{A}{r^2}-kr,
+\]
+
+where
+
+\[
+[A]=\mathrm{N\,m^2},
+\qquad
+[k]=\mathrm{N/m}.
+\]
+
+The potential is
+
+\[
+U(r)=\frac{A}{r}+\frac12kr^2.
+\]
+
+The equilibrium shell satisfies
+
+\[
+F_r(r_*)=0,
+\]
+
+therefore
+
+\[
+\boxed{r_*=(A/k)^{1/3}}.
+\]
+
+With the reference values
+
+\[
+A=15\times10^6\ \mathrm{N\,m^2},
+\qquad
+k=5\times10^6\ \mathrm{N/m},
+\]
+
+we obtain
+
+\[
+r_*=\sqrt[3]{3}\approx1.44225\ \mathrm{m}.
+\]
+
+Optional damping is represented as
+
+\[
+\frac{dP}{dt}=F(X)-\zeta P.
+\]
+
+When `zeta = 0`, the shell is a stable conservative equilibrium and phase points oscillate around it. When `zeta > 0`, the shell becomes dissipatively attracting.
+
+## 4. Relativistic momentum integration
+
+The runtime does not use Newtonian `F = ma` followed by an artificial light-speed clamp.
+
+Instead it evolves momentum:
+
+\[
+P_{t+1}=P_t+F(X_t)\Delta t.
+\]
+
+The Lorentz factor is recovered from momentum:
+
+\[
+\gamma_{t+1}
+=
+\sqrt{1+\frac{\|P_{t+1}\|^2}{m^2c^2}}.
+\]
+
+Velocity is then
+
+\[
+V_{t+1}
+=
+\frac{P_{t+1}}{\gamma_{t+1}m},
+\]
+
+and position advances semi-implicitly:
+
+\[
+X_{t+1}=X_t+V_{t+1}\Delta t.
+\]
+
+This construction enforces
+
+\[
+\|V\|<c
+\]
+
+without manual clipping.
+
+## 5. Energy telemetry
+
+The stable relativistic kinetic-energy expression is
+
+\[
+K
+=
+\frac{p^2}{m(\gamma+1)},
+\]
+
+summed over nodes.
+
+The mechanical energy is
+
+\[
+E_{mech}=K+U.
+\]
+
+The runtime records
+
+\[
+\delta_E
+=
+\frac{E_t-E_0}{|E_0|}.
+\]
+
+For `damping = 0`, this is an integrator-conservation diagnostic. For non-zero damping, a declining mechanical energy is expected and must not be misclassified as numerical failure.
+
+## 6. Neural shell representation
+
+The current phase coordinates are passed to the implicit field as
+
+\[
+X_t\in\mathbb R^{1\times N\times3}.
+\]
+
+The supervision target is the analytic equilibrium-shell signed distance
+
+\[
+d^*(x)=\|x\|_2-r_*.
+\]
+
+The field receives normalized execution telemetry as context, but its weights are updated only by the differentiable geometry loss:
+
+\[
+\Theta_{t+1}
+=
+\Theta_t-\eta\nabla_\Theta
+L_{geometry}.
+\]
+
+Measured wall-clock latency and throughput remain outside autograd.
+
+## 7. Runtime autotuning and promotion
+
+For the current phase coordinates and one frozen telemetry snapshot, the runtime evaluates a bounded neighborhood of execution configurations.
+
+Each candidate is:
+
+1. selected or compiled;
+2. warmed up outside the timed interval;
+3. measured using synchronized execution;
+4. compared against the eager semantic reference;
+5. rejected if semantic error exceeds tolerance;
+6. rejected if peak allocated memory exceeds the configured budget;
+7. promoted only when throughput exceeds the incumbent by the configured minimum relative improvement.
+
+Thus the device-side promotion rule is approximately
+
+\[
+C_{t+1}=C^{best}
+\]
+
+only if
+
+\[
+E_{semantic}\le\epsilon_s,
+\]
+
+\[
+M_{peak}\le M_{budget},
+\]
+
+and
+
+\[
+q(C^{best})\ge
+(1+\rho)q(C_t).
+\]
+
+Otherwise
+
+\[
+C_{t+1}=C_t.
+\]
+
+## 8. Measurement contract
+
+The runtime reports two independent measured throughput classes:
+
+### Phase throughput
+
+\[
+q_{phase}
+=
+\frac{N}{\Delta t_{wall}}
+\]
+
+in node updates per second.
+
+### Neural/runtime throughput
+
+\[
+q_{field}
+=
+\frac{N_{queries}}{\Delta t_{wall}}
+\]
+
+in implicit-field queries per second.
+
+No artificial `10^12` or other symbolic multiplier is applied to either measurement.
+
+The console also reports:
+
+```text
+phase node updates/s
+phase latency
+mean radius
+shell RMSE
+maximum velocity
+relative mechanical-energy drift
+geometry loss
+geometry RMSE
+implicit-field queries/s
+implicit-field latency
+peak allocated memory
+compiler/runtime mode
+chunk size
+runtime promotion decision
+```
+
+## 9. Full recurrence
+
+One complete cycle is
+
+\[
+\boxed{
+\begin{aligned}
+F_t &= -\nabla_X U(X_t)-\zeta P_t,\\
+P_{t+1} &= P_t+F_t\Delta t,\\
+X_{t+1} &= X_t+\frac{P_{t+1}}{\gamma_{t+1}M}\Delta t,\\
+Z_t &= E_{\Theta_t}(X_{t+1},\mathcal T_t),\\
+\widehat d_t &= D_{\Theta_t}(Z_t),\\
+\Theta_{t+1} &= \Theta_t-\eta\nabla_\Theta L_t,\\
+\mathcal T_{t+1} &= \operatorname{PROFILE}(\Theta_{t+1},C_t),\\
+C^{trial}_{t+1} &= \operatorname{SEARCH}(C_t,\mathcal T_{t+1}),\\
+C_{t+1} &= \operatorname{VERIFY/PROMOTE}(C_t,C^{trial}_{t+1}).
+\end{aligned}
+}
+\]
+
+The combined runtime state is
+
+\[
+\mathcal S_t=(K_t,\Theta_t,C_t,\mathcal T_t)
+\]
+
+with recurrence
+
+\[
+\boxed{\mathcal S_{t+1}=\mathcal M(\mathcal S_t)}.
+\]
+
+## 10. Execution
+
+Install optional PyTorch support:
+
+```bash
+pip install -e '.[torch]'
+```
+
+CPU reference:
+
+```bash
+python examples/dr_moagi_phase3d_runtime.py \
+  --device cpu \
+  --cycles 5 \
+  --nodes 16384 \
+  --compile-mode eager
+```
+
+CUDA/Inductor reference:
+
+```bash
+python examples/dr_moagi_phase3d_runtime.py \
+  --device cuda \
+  --cycles 20 \
+  --nodes 65536 \
+  --compile-mode default \
+  --tune-every 2 \
+  --peak-memory-mb 8192
+```
+
+Dissipative shell experiment:
+
+```bash
+python examples/dr_moagi_phase3d_runtime.py \
+  --device cuda \
+  --cycles 200 \
+  --damping 50
+```
+
+## 11. Claim boundary
+
+This runtime is an executable research architecture, not evidence of new physical law, quantum mechanics, or state-of-the-art hardware performance.
+
+`torch.compile`/Inductor can generate Triton-backed CUDA kernels where supported; the reference does not contain a hand-written Triton kernel.
+
+External performance claims require matched hardware, workloads, baselines, statistical treatment, and reproducible benchmark provenance.

--- a/docs/PHASE3D_END_TO_END_RUNTIME.md
+++ b/docs/PHASE3D_END_TO_END_RUNTIME.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This specification operationalizes the latest DM-vOmegaXi+ iteration as one measurable 3D execution loop:
+This specification operationalizes the current DM-vOmegaXi+ iteration as one measurable 3D execution loop:
 
 ```text
 3D phase-space state
@@ -11,7 +11,10 @@ This specification operationalizes the latest DM-vOmegaXi+ iteration as one meas
 -> differentiable geometry learning
 -> measured runtime benchmark
 -> bounded device/runtime search
--> semantic + resource promotion gate
+-> canonical kinetic transaction
+-> semantic/resource/performance validation
+-> commit or rollback
+-> hash-chained receipt
 -> next cycle
 ```
 
@@ -21,7 +24,7 @@ The executable reference is:
 examples/dr_moagi_phase3d_runtime.py
 ```
 
-It extends, rather than replaces, the self-referential PyTorch/Inductor runtime defined in `SELF_REFERENTIAL_TRITON_RUNTIME.md`.
+It extends, rather than replaces, the self-referential PyTorch/Inductor runtime defined in `SELF_REFERENTIAL_TRITON_RUNTIME.md` and reuses the backend-neutral transaction protocol in `src/jarvisx/kinetic_runtime.py`.
 
 ## 1. Separation of authorities
 
@@ -57,7 +60,7 @@ The execution configuration is
 C_t=(\text{chunk size},\text{compile mode},\ldots).
 \]
 
-It is updated only from measured benchmark evidence after semantic and resource checks.
+It is updated only from measured benchmark evidence and only after a canonical Jarvis-X transaction commits the candidate.
 
 Therefore
 
@@ -87,8 +90,7 @@ and samples
 
 \[
 x=\rho\cos\theta,
-\qquad
-y=\rho\sin\theta,
+\qquad y=\rho\sin\theta,
 \qquad z=a\sin\phi.
 \]
 
@@ -237,13 +239,12 @@ The field receives normalized execution telemetry as context, but its weights ar
 \[
 \Theta_{t+1}
 =
-\Theta_t-\eta\nabla_\Theta
-L_{geometry}.
+\Theta_t-\eta\nabla_\Theta L_{geometry}.
 \]
 
 Measured wall-clock latency and throughput remain outside autograd.
 
-## 7. Runtime autotuning and promotion
+## 7. Measured runtime candidate search
 
 For the current phase coordinates and one frozen telemetry snapshot, the runtime evaluates a bounded neighborhood of execution configurations.
 
@@ -253,42 +254,108 @@ Each candidate is:
 2. warmed up outside the timed interval;
 3. measured using synchronized execution;
 4. compared against the eager semantic reference;
-5. rejected if semantic error exceeds tolerance;
-6. rejected if peak allocated memory exceeds the configured budget;
-7. promoted only when throughput exceeds the incumbent by the configured minimum relative improvement.
+5. returned as benchmark evidence without changing the authoritative runtime configuration.
 
-Thus the device-side promotion rule is approximately
+Search and authority are separate. A fast candidate is not yet a committed candidate.
+
+## 8. Canonical kinetic transaction gate
+
+Every scheduled runtime tuning attempt is passed to `KineticTransactionEngine` using the repository's canonical sequence:
+
+```text
+snapshot
+-> observe
+-> encode
+-> propose
+-> shadow
+-> verify
+-> commit | rollback
+-> journal
+-> reenter
+```
+
+The authoritative state supplied to the transaction is the current `RuntimeConfig`.
+
+The proposal contains the measured incumbent, the best bounded candidate, and the number of evaluated configurations.
+
+Three validators are mandatory:
+
+### Semantic validator
 
 \[
-C_{t+1}=C^{best}
+V_{semantic}
+=
+(E_{semantic}\le\epsilon_s).
 \]
 
-only if
+### Memory validator
 
 \[
-E_{semantic}\le\epsilon_s,
+V_{memory}
+=
+(M_{peak}\le M_{budget}).
 \]
+
+### Performance validator
+
+For a valid incumbent,
 
 \[
-M_{peak}\le M_{budget},
+V_{performance}
+=
+q(C^{best})
+\ge
+(1+\rho)q(C_t),
 \]
 
-and
+and the best configuration must differ from the incumbent.
+
+If the incumbent itself is unavailable, a valid replacement may be committed as a recovery transition.
+
+The transaction commits only when
 
 \[
-q(C^{best})\ge
-(1+\rho)q(C_t).
+\boxed{
+V_{semantic}\land V_{memory}\land V_{performance}
+}
 \]
 
-Otherwise
+is true.
+
+Otherwise the original runtime snapshot is restored.
+
+## 9. Hash-chained runtime receipts
+
+Every tuning attempt emits a `KineticReceipt` containing:
+
+```text
+transaction_id
+parent_state_hash
+candidate_hash
+resulting_state_hash
+decision
+stages
+validator results
+shadow telemetry
+previous_receipt_hash
+receipt_hash
+```
+
+Thus runtime self-optimization is auditable as a state-transition chain:
 
 \[
-C_{t+1}=C_t.
+R_{t-1}
+\rightarrow
+R_t
+\rightarrow
+R_{t+1}.
 \]
 
-## 8. Measurement contract
+A rejected candidate still receives a receipt; it simply records a rollback rather than a commit.
 
-The runtime reports two independent measured throughput classes:
+## 10. Measurement contract
+
+The runtime reports two independent measured throughput classes.
 
 ### Phase throughput
 
@@ -312,11 +379,10 @@ in implicit-field queries per second.
 
 No artificial `10^12` or other symbolic multiplier is applied to either measurement.
 
-The console also reports:
+The console reports:
 
 ```text
 phase node updates/s
-phase latency
 mean radius
 shell RMSE
 maximum velocity
@@ -326,12 +392,13 @@ geometry RMSE
 implicit-field queries/s
 implicit-field latency
 peak allocated memory
-compiler/runtime mode
+effective compiler/runtime mode
 chunk size
-runtime promotion decision
+transaction decision
+receipt hash prefix
 ```
 
-## 9. Full recurrence
+## 11. Full recurrence
 
 One complete cycle is
 
@@ -346,7 +413,7 @@ Z_t &= E_{\Theta_t}(X_{t+1},\mathcal T_t),\\
 \Theta_{t+1} &= \Theta_t-\eta\nabla_\Theta L_t,\\
 \mathcal T_{t+1} &= \operatorname{PROFILE}(\Theta_{t+1},C_t),\\
 C^{trial}_{t+1} &= \operatorname{SEARCH}(C_t,\mathcal T_{t+1}),\\
-C_{t+1} &= \operatorname{VERIFY/PROMOTE}(C_t,C^{trial}_{t+1}).
+(C_{t+1},R_{t+1}) &= \operatorname{KINETIC\_TRANSACTION}(C_t,C^{trial}_{t+1}).
 \end{aligned}
 }
 \]
@@ -354,7 +421,7 @@ C_{t+1} &= \operatorname{VERIFY/PROMOTE}(C_t,C^{trial}_{t+1}).
 The combined runtime state is
 
 \[
-\mathcal S_t=(K_t,\Theta_t,C_t,\mathcal T_t)
+\mathcal S_t=(K_t,\Theta_t,C_t,\mathcal T_t,R_t)
 \]
 
 with recurrence
@@ -363,7 +430,24 @@ with recurrence
 \boxed{\mathcal S_{t+1}=\mathcal M(\mathcal S_t)}.
 \]
 
-## 10. Execution
+## 12. Validation workflow
+
+`.github/workflows/phase3d-runtime.yml` installs the optional PyTorch dependency and validates:
+
+1. source compilation;
+2. equilibrium-radius arithmetic;
+3. `N x 3` phase tensor shapes;
+4. finite position and momentum evolution;
+5. subluminal velocity;
+6. finite energy telemetry;
+7. canonical rollback receipt when no improvement exists;
+8. canonical commit receipt for deterministic valid speedup evidence;
+9. conservative end-to-end CPU execution;
+10. damped end-to-end CPU execution.
+
+This is a runtime smoke/contract suite. It is not a GPU performance benchmark.
+
+## 13. Execution
 
 Install optional PyTorch support:
 
@@ -402,7 +486,7 @@ python examples/dr_moagi_phase3d_runtime.py \
   --damping 50
 ```
 
-## 11. Claim boundary
+## 14. Claim boundary
 
 This runtime is an executable research architecture, not evidence of new physical law, quantum mechanics, or state-of-the-art hardware performance.
 

--- a/docs/SELF_REFERENTIAL_TRITON_RUNTIME.md
+++ b/docs/SELF_REFERENTIAL_TRITON_RUNTIME.md
@@ -1,0 +1,302 @@
+# Self-Referential 3D Implicit Field Runtime
+
+## Status
+
+This document defines the PyTorch/Inductor integration path for a self-referential 3D implicit field inside Jarvis-X.
+
+It is intentionally compatible with the existing bounded meta-optimization architecture in `src/jarvisx/dr_moagi_meta_optimizer.py` and the kinetic commit/rollback adapter in `src/jarvisx/dr_moagi_kinetic_system.py`.
+
+The key design rule is that **neural optimization and runtime optimization are different optimization spaces**.
+
+Measured wall-clock throughput is not differentiable with respect to model weights. It must therefore be optimized by an outer measurement-driven controller rather than inserted into a PyTorch loss as if autograd could differentiate through `time.perf_counter()`.
+
+---
+
+## 1. Canonical state
+
+At cycle `t`, define
+
+\[
+S_t = (X_t, Z_t, \theta_t, C_t, M_t),
+\]
+
+where:
+
+- `X_t` is the 3D query field;
+- `Z_t` is the learned meta-latent representation;
+- `theta_t` is the neural parameter state;
+- `C_t` is the runtime configuration;
+- `M_t` is measured execution telemetry.
+
+The operational recurrence is
+
+\[
+S_{t+1}=\mathcal M(S_t).
+\]
+
+The fixed-point target is
+
+\[
+S^*=\mathcal M(S^*)
+\]
+
+subject to explicit quality and resource constraints.
+
+---
+
+## 2. Inner differentiable loop
+
+The implicit field receives 3D coordinates and normalized execution telemetry.
+
+Spatial projection:
+
+\[
+h_s = \operatorname{SiLU}(W_s x+b_s).
+\]
+
+Execution-state conditioning:
+
+\[
+\widetilde M_t =
+\begin{bmatrix}
+\log(1+q_t/q_{target})\\
+\log(1+\tau_t)
+\end{bmatrix}.
+\]
+
+Meta encoding:
+
+\[
+Z_t=E_\phi([h_s,\widetilde M_t]).
+\]
+
+Implicit field evaluation:
+
+\[
+\widehat d_t=F_\theta([Z_t,h_s]).
+\]
+
+The reference example supervises a non-trivial sphere signed-distance field:
+
+\[
+d^*(x)=\|x\|_2-r.
+\]
+
+Neural parameters are updated only through a differentiable geometry objective:
+
+\[
+\theta_{t+1}=\theta_t-\eta\nabla_\theta L_{geometry}.
+\]
+
+This avoids the collapse induced by training every point toward zero SDF.
+
+---
+
+## 3. Outer runtime loop
+
+Let the bounded runtime configuration be
+
+\[
+C_t=(\text{chunk size},\text{compile mode},\ldots).
+\]
+
+A candidate runtime is measured using the same coordinates and model state as the incumbent.
+
+For each candidate:
+
+1. compile or select the runner;
+2. execute warm-up passes outside the benchmark;
+3. synchronize CUDA before timing;
+4. measure one or more steady-state passes;
+5. synchronize CUDA after timing;
+6. compute query throughput, latency, and peak allocated memory;
+7. compare candidate output against the eager semantic reference;
+8. reject candidates outside the declared numerical tolerance.
+
+The outer objective is empirical:
+
+\[
+C_{t+1}
+=
+\arg\max_{C\in\mathcal N(C_t)}q(C)
+\]
+
+subject to
+
+\[
+\|F_{\theta,C}(X)-F_{\theta,ref}(X)\|_\infty\le\epsilon.
+\]
+
+The reference implementation uses bounded neighboring chunk sizes and PyTorch compile modes.
+
+No wall-clock value is added to the differentiable loss.
+
+---
+
+## 4. Why the original throughput penalty was not operational
+
+A construction such as
+
+```python
+current_lps = processed_operations / elapsed_time
+throughput_penalty = torch.exp(
+    torch.tensor((target_lps - current_lps) / target_lps)
+)
+total_loss = sdf_loss + 0.01 * throughput_penalty
+```
+
+does not optimize throughput by gradient descent.
+
+`current_lps` was produced by a host timer outside the autograd graph. Therefore
+
+\[
+\frac{\partial L_{throughput}}{\partial\theta}=0.
+\]
+
+The scalar can change the printed loss value, but it cannot tell AdamW how to modify model parameters to make the kernel faster.
+
+The corrected architecture makes throughput a **measured control signal and runtime-selection criterion**, not a fake differentiable term.
+
+---
+
+## 5. Measurement contract
+
+Every reported performance number must carry its provenance.
+
+For CUDA benchmarking:
+
+```text
+warmup
+cuda synchronize
+start timer
+execute fixed workload
+cuda synchronize
+stop timer
+```
+
+The first compiled execution is not a steady-state benchmark because graph capture, code generation, compilation, and autotuning may occur.
+
+The performance unit in this runtime is **queries per second** because each `(x,y,z)` point is one implicit-field query. It must not be labeled lines per second unless a higher-level line-processing contract explicitly maps lines to queries.
+
+---
+
+## 6. PyTorch, Inductor, and Triton boundary
+
+`torch.compile` can route eligible PyTorch graphs through TorchDynamo and Inductor. On supported CUDA configurations, Inductor can generate Triton kernels.
+
+Accordingly:
+
+- the reference runtime is accurately described as a **PyTorch/Inductor implicit-field accelerator**;
+- Triton may be present in the generated backend path;
+- it is **not** a hand-written Triton kernel unless explicit `triton.jit` kernels are added and versioned in the repository.
+
+This distinction must remain explicit in benchmark and architecture claims.
+
+---
+
+## 7. Integration with the existing Jarvis-X inward optimizer
+
+Jarvis-X already has a bounded three-axis runtime meta-optimizer:
+
+```text
+X: compression geometry
+Y: adaptive dynamics
+Z: spatial dynamics
+```
+
+The PyTorch implicit-field runtime adds a hardware execution subspace rather than replacing that optimizer.
+
+The combined system can be represented as
+
+\[
+C_t=(C_t^{system},C_t^{device}),
+\]
+
+where:
+
+- `C_system` contains the existing Dr Moagi OS mechanics;
+- `C_device` contains execution configuration such as chunking and compile strategy.
+
+A future production integration should pass device candidates through the same kinetic transaction law already used by `CanonicalKineticDrMoagiSystem`:
+
+```text
+observe
+-> encode
+-> propose candidate
+-> shadow benchmark
+-> semantic/resource validators
+-> commit or rollback
+-> append receipt
+```
+
+The model weights and production runtime configuration therefore remain independently recoverable.
+
+---
+
+## 8. Reference implementation
+
+The executable reference is:
+
+```text
+examples/self_referential_triton_engine.py
+```
+
+Install the optional dependency:
+
+```bash
+pip install -e '.[torch]'
+```
+
+Run on CPU:
+
+```bash
+python examples/self_referential_triton_engine.py --device cpu --compile-mode eager
+```
+
+Run on a CUDA host:
+
+```bash
+python examples/self_referential_triton_engine.py --device cuda --compile-mode default
+```
+
+The example deliberately uses a bounded autotuning search. It does not rewrite source code, mutate arbitrary host configuration, or claim external state-of-the-art performance without matched benchmark evidence.
+
+---
+
+## 9. Fixed-point acceptance criterion
+
+A runtime can be treated as operationally converged only when both neural and runtime constraints are simultaneously satisfied:
+
+\[
+L_{geometry}<\epsilon_g,
+\qquad
+q\ge q_{target},
+\qquad
+\tau\le\tau_{target},
+\qquad
+M_{peak}\le M_{budget},
+\qquad
+E_{semantic}\le\epsilon_s.
+\]
+
+This produces the complete inward loop:
+
+\[
+(X_t,M_t,C_t,\theta_t)
+\rightarrow
+\widehat d_t
+\rightarrow
+L_{geometry}
+\rightarrow
+\theta_{t+1}
+\rightarrow
+\operatorname{BENCHMARK}
+\rightarrow
+M_{t+1}
+\rightarrow
+C_{t+1}
+\rightarrow
+(X_{t+1},M_{t+1},C_{t+1},\theta_{t+1}).
+\]
+
+That is the operational boundary between **self-referential conditioning** and **actual self-optimization**.

--- a/examples/dr_moagi_phase3d_runtime.py
+++ b/examples/dr_moagi_phase3d_runtime.py
@@ -9,13 +9,13 @@ physical phase evolution, neural learning, and runtime optimization:
       -> differentiable geometry update
       -> measured execution benchmark
       -> bounded runtime candidate search
-      -> semantic/resource promotion gate
+      -> canonical kinetic transaction gate
+      -> commit/rollback receipt
       -> next cycle
 
 The phase state is authoritative. Neural error never directly changes the phase
 integrator. Wall-clock measurements never enter autograd. Runtime candidates are
-promoted only when they preserve eager semantics, respect the memory budget, and
-beat the incumbent by the configured margin.
+promoted only through Jarvis-X's canonical candidate-first transaction law.
 
 Install and run:
 
@@ -36,6 +36,7 @@ from dataclasses import dataclass
 import torch
 import torch.nn.functional as F
 
+from jarvisx.kinetic_runtime import KineticReceipt, KineticTransactionEngine, ValidatorResult
 from self_referential_triton_engine import (
     BenchmarkResult,
     ExecutionMetrics,
@@ -48,6 +49,10 @@ from self_referential_triton_engine import (
 
 
 C_LIGHT = 299_792_458.0
+
+
+def _finite_or_none(value: float) -> float | None:
+    return float(value) if math.isfinite(float(value)) else None
 
 
 @dataclass(frozen=True)
@@ -104,6 +109,13 @@ class PhaseTelemetry:
 
 
 @dataclass(frozen=True)
+class RuntimeSearchCandidate:
+    incumbent: BenchmarkResult
+    best: BenchmarkResult
+    evaluated_candidates: int
+
+
+@dataclass(frozen=True)
 class CycleReport:
     cycle: int
     phase: PhaseTelemetry
@@ -111,6 +123,8 @@ class CycleReport:
     geometry_rmse: float
     runtime: BenchmarkResult
     runtime_promoted: bool
+    runtime_decision: str
+    runtime_receipt_hash: str
 
 
 class RelativisticPhaseField3D:
@@ -241,7 +255,7 @@ class RelativisticPhaseField3D:
 
 
 class Phase3DSelfOptimizingRuntime:
-    """Close phase dynamics, neural learning, profiling, and runtime promotion."""
+    """Close phase dynamics, neural learning, profiling, and canonical promotion."""
 
     def __init__(
         self,
@@ -283,6 +297,35 @@ class Phase3DSelfOptimizingRuntime:
             repeats=3,
         )
 
+        self._transaction_coords: torch.Tensor | None = None
+        self._transaction_metrics: torch.Tensor | None = None
+        self._transaction_reference: torch.Tensor | None = None
+        self.last_runtime_receipt: KineticReceipt | None = None
+        self.runtime_transaction = KineticTransactionEngine[
+            RuntimeConfig,
+            BenchmarkResult,
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+            RuntimeSearchCandidate,
+        ](
+            snapshot=lambda config: RuntimeConfig(config.chunk_size, config.compile_mode),
+            observe=self._runtime_observe,
+            encode=self._runtime_encode,
+            propose=self._runtime_propose,
+            shadow=self._runtime_shadow,
+            validators=(
+                self._runtime_semantic_validator,
+                self._runtime_memory_validator,
+                self._runtime_performance_validator,
+            ),
+            commit=lambda _config, candidate: candidate.best.config,
+            rollback=lambda config: config,
+            state_identity=lambda config: {
+                "chunk_size": config.chunk_size,
+                "compile_mode": config.compile_mode,
+            },
+            candidate_identity=self._runtime_candidate_identity,
+        )
+
     def _target_sdf(self, coords: torch.Tensor) -> torch.Tensor:
         radius = self.phase.config.equilibrium_radius_m
         return torch.linalg.vector_norm(coords, dim=-1, keepdim=True) - radius
@@ -316,6 +359,16 @@ class Phase3DSelfOptimizingRuntime:
         return float(torch.sqrt(torch.mean((prediction - target).square())).item())
 
     @torch.inference_mode()
+    def _benchmark(
+        self,
+        config: RuntimeConfig,
+        coords: torch.Tensor,
+        metrics: torch.Tensor,
+        reference: torch.Tensor,
+    ) -> BenchmarkResult:
+        return self.autotuner.benchmark(config, coords, metrics, reference)
+
+    @torch.inference_mode()
     def _benchmark_incumbent(self, coords: torch.Tensor) -> BenchmarkResult:
         normalized = self.exec_state.normalized(
             self.target_qps,
@@ -328,16 +381,170 @@ class Phase3DSelfOptimizingRuntime:
             normalized,
             self.runtime_config.chunk_size,
         )
-        return self.autotuner.benchmark(
-            self.runtime_config,
-            coords,
-            normalized,
-            reference,
+        return self._benchmark(self.runtime_config, coords, normalized, reference)
+
+    def _transaction_payload(self) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if (
+            self._transaction_coords is None
+            or self._transaction_metrics is None
+            or self._transaction_reference is None
+        ):
+            raise RuntimeError("runtime transaction payload is not initialized")
+        return (
+            self._transaction_coords,
+            self._transaction_metrics,
+            self._transaction_reference,
         )
 
     @torch.inference_mode()
-    def _tune_runtime(self, coords: torch.Tensor) -> tuple[BenchmarkResult, bool]:
-        """Search bounded candidates under one telemetry snapshot and resource gate."""
+    def _runtime_observe(self, config: RuntimeConfig) -> BenchmarkResult:
+        coords, metrics, reference = self._transaction_payload()
+        return self._benchmark(config, coords, metrics, reference)
+
+    def _runtime_encode(
+        self,
+        config: RuntimeConfig,
+        observation: BenchmarkResult,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        del config, observation
+        return self._transaction_payload()
+
+    @torch.inference_mode()
+    def _runtime_propose(
+        self,
+        config: RuntimeConfig,
+        observation: BenchmarkResult,
+        encoded: tuple[torch.Tensor, torch.Tensor, torch.Tensor],
+    ) -> RuntimeSearchCandidate:
+        coords, metrics, reference = encoded
+        results = [
+            self._benchmark(candidate, coords, metrics, reference)
+            for candidate in self.autotuner.candidates(config)
+        ]
+        admissible = [result for result in results if result.accepted]
+        best = (
+            max(admissible, key=lambda item: item.metrics.throughput_qps)
+            if admissible
+            else observation
+        )
+        return RuntimeSearchCandidate(
+            incumbent=observation,
+            best=best,
+            evaluated_candidates=len(results),
+        )
+
+    def _runtime_shadow(
+        self,
+        config: RuntimeConfig,
+        candidate: RuntimeSearchCandidate,
+    ) -> dict[str, object]:
+        del config
+        return {
+            "evaluated_candidates": candidate.evaluated_candidates,
+            "incumbent_qps": _finite_or_none(candidate.incumbent.metrics.throughput_qps),
+            "candidate_qps": _finite_or_none(candidate.best.metrics.throughput_qps),
+            "candidate_latency_ms": _finite_or_none(candidate.best.metrics.latency_ms),
+            "candidate_peak_memory_mb": _finite_or_none(
+                candidate.best.metrics.peak_memory_mb
+            ),
+            "candidate_semantic_error": _finite_or_none(candidate.best.max_abs_error),
+            "candidate_compile_mode": candidate.best.config.compile_mode,
+            "candidate_effective_mode": candidate.best.effective_mode,
+            "candidate_chunk_size": candidate.best.config.chunk_size,
+        }
+
+    def _runtime_semantic_validator(
+        self,
+        config: RuntimeConfig,
+        candidate: RuntimeSearchCandidate,
+    ) -> ValidatorResult:
+        del config
+        passed = candidate.best.accepted and math.isfinite(candidate.best.max_abs_error)
+        return ValidatorResult(
+            name="phase3d_semantic_equivalence",
+            passed=passed,
+            metrics={"max_abs_error": _finite_or_none(candidate.best.max_abs_error)},
+            reason="semantic tolerance satisfied" if passed else "candidate semantic check failed",
+        )
+
+    def _runtime_memory_validator(
+        self,
+        config: RuntimeConfig,
+        candidate: RuntimeSearchCandidate,
+    ) -> ValidatorResult:
+        del config
+        peak = candidate.best.metrics.peak_memory_mb
+        passed = math.isfinite(peak) and peak <= self.peak_memory_budget_mb
+        return ValidatorResult(
+            name="phase3d_memory_budget",
+            passed=passed,
+            metrics={
+                "peak_memory_mb": _finite_or_none(peak),
+                "budget_mb": _finite_or_none(self.peak_memory_budget_mb),
+            },
+            reason="within memory budget" if passed else "memory budget exceeded",
+        )
+
+    def _runtime_performance_validator(
+        self,
+        config: RuntimeConfig,
+        candidate: RuntimeSearchCandidate,
+    ) -> ValidatorResult:
+        incumbent = candidate.incumbent
+        best = candidate.best
+        incumbent_qps = incumbent.metrics.throughput_qps
+        best_qps = best.metrics.throughput_qps
+
+        if not incumbent.accepted or not math.isfinite(incumbent_qps):
+            passed = best.accepted and best.config != config and math.isfinite(best_qps)
+            required = None
+            reason = "recover unavailable incumbent" if passed else "no valid replacement"
+        else:
+            required_value = incumbent_qps * (1.0 + self.min_runtime_improvement)
+            required = required_value
+            passed = (
+                best.config != config
+                and math.isfinite(best_qps)
+                and best_qps >= required_value
+            )
+            reason = "minimum throughput improvement satisfied" if passed else "retain incumbent"
+
+        return ValidatorResult(
+            name="phase3d_runtime_improvement",
+            passed=passed,
+            metrics={
+                "incumbent_qps": _finite_or_none(incumbent_qps),
+                "candidate_qps": _finite_or_none(best_qps),
+                "required_qps": _finite_or_none(required) if required is not None else None,
+                "min_relative_improvement": self.min_runtime_improvement,
+            },
+            reason=reason,
+        )
+
+    def _runtime_candidate_identity(self, candidate: RuntimeSearchCandidate) -> dict[str, object]:
+        return {
+            "evaluated_candidates": candidate.evaluated_candidates,
+            "incumbent": {
+                "chunk_size": candidate.incumbent.config.chunk_size,
+                "compile_mode": candidate.incumbent.config.compile_mode,
+                "accepted": candidate.incumbent.accepted,
+                "qps": _finite_or_none(candidate.incumbent.metrics.throughput_qps),
+            },
+            "best": {
+                "chunk_size": candidate.best.config.chunk_size,
+                "compile_mode": candidate.best.config.compile_mode,
+                "effective_mode": candidate.best.effective_mode,
+                "accepted": candidate.best.accepted,
+                "qps": _finite_or_none(candidate.best.metrics.throughput_qps),
+                "latency_ms": _finite_or_none(candidate.best.metrics.latency_ms),
+                "peak_memory_mb": _finite_or_none(candidate.best.metrics.peak_memory_mb),
+                "max_abs_error": _finite_or_none(candidate.best.max_abs_error),
+            },
+        }
+
+    @torch.inference_mode()
+    def _tune_runtime(self, coords: torch.Tensor) -> tuple[BenchmarkResult, bool, KineticReceipt]:
+        """Run runtime selection through the canonical Jarvis-X transaction law."""
 
         normalized = self.exec_state.normalized(
             self.target_qps,
@@ -350,37 +557,15 @@ class Phase3DSelfOptimizingRuntime:
             normalized,
             self.runtime_config.chunk_size,
         )
+        self._transaction_coords = coords
+        self._transaction_metrics = normalized
+        self._transaction_reference = reference
 
-        results = [
-            self.autotuner.benchmark(candidate, coords, normalized, reference)
-            for candidate in self.autotuner.candidates(self.runtime_config)
-        ]
-        admissible = [
-            result
-            for result in results
-            if result.accepted
-            and result.metrics.peak_memory_mb <= self.peak_memory_budget_mb
-        ]
-        if not admissible:
-            return self._benchmark_incumbent(coords), False
-
-        incumbent = next(
-            (result for result in admissible if result.config == self.runtime_config),
-            None,
-        )
-        if incumbent is None:
-            incumbent = self._benchmark_incumbent(coords)
-        best = max(admissible, key=lambda item: item.metrics.throughput_qps)
-
-        required = incumbent.metrics.throughput_qps * (1.0 + self.min_runtime_improvement)
-        promoted = (
-            best.config != self.runtime_config
-            and best.metrics.throughput_qps >= required
-        )
-        if promoted:
-            self.runtime_config = best.config
-            return best, True
-        return incumbent, False
+        result = self.runtime_transaction.step(self.runtime_config)
+        self.runtime_config = result.state
+        self.last_runtime_receipt = result.receipt
+        reported = result.candidate.best if result.committed else result.candidate.incumbent
+        return reported, result.committed, result.receipt
 
     def cycle(self, cycle_index: int, *, train_steps: int, tune: bool) -> CycleReport:
         phase_report = self.phase.step()
@@ -392,8 +577,12 @@ class Phase3DSelfOptimizingRuntime:
             self.exec_state = measured.metrics
 
         promoted = False
+        decision = "not_scheduled"
+        receipt_hash = self.runtime_transaction.previous_receipt_hash
         if tune:
-            measured, promoted = self._tune_runtime(coords)
+            measured, promoted, receipt = self._tune_runtime(coords)
+            decision = receipt.decision
+            receipt_hash = receipt.receipt_hash
             if measured.accepted:
                 self.exec_state = measured.metrics
 
@@ -405,6 +594,8 @@ class Phase3DSelfOptimizingRuntime:
             geometry_rmse=rmse,
             runtime=measured,
             runtime_promoted=promoted,
+            runtime_decision=decision,
+            runtime_receipt_hash=receipt_hash,
         )
 
     def run(self, cycles: int, *, train_steps: int = 1, tune_every: int = 2) -> None:
@@ -416,7 +607,7 @@ class Phase3DSelfOptimizingRuntime:
         )
         print(
             "measurement contract: node_updates/s and q/s are measured; "
-            "no symbolic throughput multiplier is reported"
+            "runtime changes require canonical kinetic receipts"
         )
 
         for cycle_index in range(1, cycles + 1):
@@ -441,7 +632,8 @@ class Phase3DSelfOptimizingRuntime:
                 f"mem={runtime.metrics.peak_memory_mb:.1f} MiB "
                 f"mode={runtime.effective_mode} "
                 f"chunk={self.runtime_config.chunk_size} "
-                f"promoted={report.runtime_promoted}"
+                f"decision={report.runtime_decision} "
+                f"receipt={report.runtime_receipt_hash[:12]}"
             )
 
 

--- a/examples/dr_moagi_phase3d_runtime.py
+++ b/examples/dr_moagi_phase3d_runtime.py
@@ -1,0 +1,495 @@
+"""End-to-end Dr Moagi 3D phase-space + implicit-field + runtime optimizer.
+
+This executable closes the current Jarvis-X research loop without conflating
+physical phase evolution, neural learning, and runtime optimization:
+
+    relativistic 3D phase state
+      -> measured phase update
+      -> implicit shell representation
+      -> differentiable geometry update
+      -> measured execution benchmark
+      -> bounded runtime candidate search
+      -> semantic/resource promotion gate
+      -> next cycle
+
+The phase state is authoritative. Neural error never directly changes the phase
+integrator. Wall-clock measurements never enter autograd. Runtime candidates are
+promoted only when they preserve eager semantics, respect the memory budget, and
+beat the incumbent by the configured margin.
+
+Install and run:
+
+    pip install -e '.[torch]'
+    python examples/dr_moagi_phase3d_runtime.py --device cpu
+
+On supported CUDA systems, PyTorch/Inductor may lower compiled candidates to
+Triton-generated kernels. This module does not contain hand-written Triton kernels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from self_referential_triton_engine import (
+    BenchmarkResult,
+    ExecutionMetrics,
+    RuntimeAutotuner,
+    RuntimeConfig,
+    SelfReferentialTritonEngine,
+    _run_chunked,
+    _sync,
+)
+
+
+C_LIGHT = 299_792_458.0
+
+
+@dataclass(frozen=True)
+class PhaseFieldConfig:
+    """Dimensionally explicit central field and deterministic torus initializer."""
+
+    node_count: int = 16_384
+    major_radius_m: float = 2.0
+    minor_radius_m: float = 0.5
+    inverse_square_strength_n_m2: float = 15.0e6
+    spring_constant_n_per_m: float = 5.0e6
+    base_mass_kg: float = 1.0
+    mass_step_kg: float = 0.1
+    mass_period: int = 7
+    damping_per_second: float = 0.0
+    dt_seconds: float = 1.0e-5
+
+    def __post_init__(self) -> None:
+        if self.node_count <= 0:
+            raise ValueError("node_count must be positive")
+        if self.major_radius_m <= 0.0 or self.minor_radius_m <= 0.0:
+            raise ValueError("torus radii must be positive")
+        if self.inverse_square_strength_n_m2 <= 0.0:
+            raise ValueError("inverse_square_strength_n_m2 must be positive")
+        if self.spring_constant_n_per_m <= 0.0:
+            raise ValueError("spring_constant_n_per_m must be positive")
+        if self.base_mass_kg <= 0.0 or self.mass_step_kg < 0.0:
+            raise ValueError("masses must be positive with non-negative step")
+        if self.mass_period <= 0:
+            raise ValueError("mass_period must be positive")
+        if self.damping_per_second < 0.0:
+            raise ValueError("damping_per_second must be non-negative")
+        if self.dt_seconds <= 0.0:
+            raise ValueError("dt_seconds must be positive")
+
+    @property
+    def equilibrium_radius_m(self) -> float:
+        return (
+            self.inverse_square_strength_n_m2 / self.spring_constant_n_per_m
+        ) ** (1.0 / 3.0)
+
+
+@dataclass(frozen=True)
+class PhaseTelemetry:
+    node_updates_per_second: float
+    latency_ms: float
+    max_velocity_m_s: float
+    mean_radius_m: float
+    shell_rmse_m: float
+    kinetic_energy_j: float
+    potential_energy_j: float
+    mechanical_energy_j: float
+    relative_energy_drift: float
+
+
+@dataclass(frozen=True)
+class CycleReport:
+    cycle: int
+    phase: PhaseTelemetry
+    geometry_loss: float
+    geometry_rmse: float
+    runtime: BenchmarkResult
+    runtime_promoted: bool
+
+
+class RelativisticPhaseField3D:
+    """Vectorized N x 3 relativistic momentum integrator.
+
+    The conservative radial field is
+
+        F_r = A / r^2 - k r
+
+    with A in N*m^2 and k in N/m. Optional linear momentum damping adds
+    ``-zeta * p`` to dp/dt. With damping disabled the integrator is a
+    semi-implicit Hamiltonian reference; with damping enabled the shell becomes
+    an attracting dissipative equilibrium.
+    """
+
+    def __init__(
+        self,
+        config: PhaseFieldConfig,
+        device: torch.device,
+        *,
+        dtype: torch.dtype = torch.float64,
+    ) -> None:
+        self.config = config
+        self.device = device
+        self.dtype = dtype
+        self.position = self._torus_surface(config.node_count)
+        self.momentum = torch.zeros_like(self.position)
+        indices = torch.arange(config.node_count, device=device, dtype=torch.int64)
+        masses = config.base_mass_kg + config.mass_step_kg * (
+            indices.remainder(config.mass_period).to(dtype)
+        )
+        self.mass = masses[:, None]
+        self.initial_mechanical_energy = float(self.mechanical_energy().item())
+
+    def _torus_surface(self, count: int) -> torch.Tensor:
+        """Sample a true two-parameter torus surface deterministically."""
+
+        n_theta = int(math.ceil(math.sqrt(count)))
+        n_phi = int(math.ceil(count / n_theta))
+        theta = torch.arange(n_theta, device=self.device, dtype=self.dtype)
+        phi = torch.arange(n_phi, device=self.device, dtype=self.dtype)
+        theta = theta * (2.0 * math.pi / n_theta)
+        phi = phi * (2.0 * math.pi / n_phi)
+        theta_grid, phi_grid = torch.meshgrid(theta, phi, indexing="ij")
+
+        rho = self.config.major_radius_m + self.config.minor_radius_m * torch.cos(phi_grid)
+        x = rho * torch.cos(theta_grid)
+        y = rho * torch.sin(theta_grid)
+        z = self.config.minor_radius_m * torch.sin(phi_grid)
+        return torch.stack((x, y, z), dim=-1).reshape(-1, 3)[:count].contiguous()
+
+    def radial_force(self) -> torch.Tensor:
+        radius = torch.linalg.vector_norm(self.position, dim=-1, keepdim=True).clamp_min(
+            1.0e-12
+        )
+        direction = self.position / radius
+        magnitude = (
+            self.config.inverse_square_strength_n_m2 / radius.square()
+            - self.config.spring_constant_n_per_m * radius
+        )
+        force = magnitude * direction
+        if self.config.damping_per_second > 0.0:
+            force = force - self.config.damping_per_second * self.momentum
+        return force
+
+    def gamma(self) -> torch.Tensor:
+        p2 = self.momentum.square().sum(dim=-1, keepdim=True)
+        denominator = self.mass.square() * (C_LIGHT**2)
+        return torch.sqrt(1.0 + p2 / denominator)
+
+    def velocity(self) -> torch.Tensor:
+        return self.momentum / (self.gamma() * self.mass)
+
+    def kinetic_energy(self) -> torch.Tensor:
+        """Stable relativistic kinetic energy sum, p^2 / (m * (gamma + 1))."""
+
+        p2 = self.momentum.square().sum(dim=-1, keepdim=True)
+        return (p2 / (self.mass * (self.gamma() + 1.0))).sum()
+
+    def potential_energy(self) -> torch.Tensor:
+        radius = torch.linalg.vector_norm(self.position, dim=-1).clamp_min(1.0e-12)
+        potential = (
+            self.config.inverse_square_strength_n_m2 / radius
+            + 0.5 * self.config.spring_constant_n_per_m * radius.square()
+        )
+        return potential.sum()
+
+    def mechanical_energy(self) -> torch.Tensor:
+        return self.kinetic_energy() + self.potential_energy()
+
+    @torch.inference_mode()
+    def step(self) -> PhaseTelemetry:
+        _sync(self.device)
+        started = time.perf_counter()
+
+        force = self.radial_force()
+        self.momentum.add_(force, alpha=self.config.dt_seconds)
+        velocity = self.velocity()
+        self.position.add_(velocity, alpha=self.config.dt_seconds)
+
+        _sync(self.device)
+        elapsed = time.perf_counter() - started
+
+        radius = torch.linalg.vector_norm(self.position, dim=-1)
+        kinetic = float(self.kinetic_energy().item())
+        potential = float(self.potential_energy().item())
+        mechanical = kinetic + potential
+        reference = max(abs(self.initial_mechanical_energy), 1.0e-12)
+        drift = (mechanical - self.initial_mechanical_energy) / reference
+        shell_error = radius - self.config.equilibrium_radius_m
+
+        return PhaseTelemetry(
+            node_updates_per_second=self.config.node_count / max(elapsed, 1.0e-12),
+            latency_ms=elapsed * 1_000.0,
+            max_velocity_m_s=float(torch.linalg.vector_norm(velocity, dim=-1).max().item()),
+            mean_radius_m=float(radius.mean().item()),
+            shell_rmse_m=float(torch.sqrt(torch.mean(shell_error.square())).item()),
+            kinetic_energy_j=kinetic,
+            potential_energy_j=potential,
+            mechanical_energy_j=mechanical,
+            relative_energy_drift=drift,
+        )
+
+    def neural_coordinates(self) -> torch.Tensor:
+        """Return one B x N x 3 float32 view for the neural field."""
+
+        return self.position.to(dtype=torch.float32).unsqueeze(0)
+
+
+class Phase3DSelfOptimizingRuntime:
+    """Close phase dynamics, neural learning, profiling, and runtime promotion."""
+
+    def __init__(
+        self,
+        phase_config: PhaseFieldConfig,
+        *,
+        device: str = "cuda",
+        target_qps: float = 1_000_000.0,
+        runtime_config: RuntimeConfig | None = None,
+        peak_memory_budget_mb: float = math.inf,
+        min_runtime_improvement: float = 0.01,
+        latent_dim: int = 128,
+        hidden_dim: int = 256,
+    ) -> None:
+        self.device = torch.device(
+            device if device == "cpu" or torch.cuda.is_available() else "cpu"
+        )
+        self.phase = RelativisticPhaseField3D(phase_config, self.device)
+        self.engine = SelfReferentialTritonEngine(
+            latent_dim=latent_dim,
+            hidden_dim=hidden_dim,
+        ).to(self.device)
+        self.neural_optimizer = torch.optim.AdamW(
+            self.engine.parameters(),
+            lr=1.0e-3,
+            weight_decay=1.0e-5,
+        )
+        self.target_qps = float(target_qps)
+        self.runtime_config = runtime_config or RuntimeConfig()
+        self.peak_memory_budget_mb = float(peak_memory_budget_mb)
+        self.min_runtime_improvement = float(min_runtime_improvement)
+        self.exec_state = ExecutionMetrics(
+            throughput_qps=0.5 * self.target_qps,
+            latency_ms=2.0,
+        )
+        self.autotuner = RuntimeAutotuner(
+            self.engine,
+            self.device,
+            warmup=1,
+            repeats=3,
+        )
+
+    def _target_sdf(self, coords: torch.Tensor) -> torch.Tensor:
+        radius = self.phase.config.equilibrium_radius_m
+        return torch.linalg.vector_norm(coords, dim=-1, keepdim=True) - radius
+
+    def train_geometry(self, coords: torch.Tensor, steps: int) -> float:
+        loss_value = math.inf
+        for _ in range(steps):
+            normalized = self.exec_state.normalized(
+                self.target_qps,
+                self.device,
+                coords.shape[0],
+            )
+            target = self._target_sdf(coords)
+            prediction = self.engine(coords, normalized)
+            loss = F.smooth_l1_loss(prediction, target)
+            self.neural_optimizer.zero_grad(set_to_none=True)
+            loss.backward()
+            self.neural_optimizer.step()
+            loss_value = float(loss.detach().item())
+        return loss_value
+
+    @torch.inference_mode()
+    def geometry_rmse(self, coords: torch.Tensor) -> float:
+        normalized = self.exec_state.normalized(
+            self.target_qps,
+            self.device,
+            coords.shape[0],
+        )
+        prediction = self.engine(coords, normalized)
+        target = self._target_sdf(coords)
+        return float(torch.sqrt(torch.mean((prediction - target).square())).item())
+
+    @torch.inference_mode()
+    def _benchmark_incumbent(self, coords: torch.Tensor) -> BenchmarkResult:
+        normalized = self.exec_state.normalized(
+            self.target_qps,
+            self.device,
+            coords.shape[0],
+        )
+        reference = _run_chunked(
+            self.engine,
+            coords,
+            normalized,
+            self.runtime_config.chunk_size,
+        )
+        return self.autotuner.benchmark(
+            self.runtime_config,
+            coords,
+            normalized,
+            reference,
+        )
+
+    @torch.inference_mode()
+    def _tune_runtime(self, coords: torch.Tensor) -> tuple[BenchmarkResult, bool]:
+        """Search bounded candidates under one telemetry snapshot and resource gate."""
+
+        normalized = self.exec_state.normalized(
+            self.target_qps,
+            self.device,
+            coords.shape[0],
+        )
+        reference = _run_chunked(
+            self.engine,
+            coords,
+            normalized,
+            self.runtime_config.chunk_size,
+        )
+
+        results = [
+            self.autotuner.benchmark(candidate, coords, normalized, reference)
+            for candidate in self.autotuner.candidates(self.runtime_config)
+        ]
+        admissible = [
+            result
+            for result in results
+            if result.accepted
+            and result.metrics.peak_memory_mb <= self.peak_memory_budget_mb
+        ]
+        if not admissible:
+            return self._benchmark_incumbent(coords), False
+
+        incumbent = next(
+            (result for result in admissible if result.config == self.runtime_config),
+            None,
+        )
+        if incumbent is None:
+            incumbent = self._benchmark_incumbent(coords)
+        best = max(admissible, key=lambda item: item.metrics.throughput_qps)
+
+        required = incumbent.metrics.throughput_qps * (1.0 + self.min_runtime_improvement)
+        promoted = (
+            best.config != self.runtime_config
+            and best.metrics.throughput_qps >= required
+        )
+        if promoted:
+            self.runtime_config = best.config
+            return best, True
+        return incumbent, False
+
+    def cycle(self, cycle_index: int, *, train_steps: int, tune: bool) -> CycleReport:
+        phase_report = self.phase.step()
+        coords = self.phase.neural_coordinates()
+        geometry_loss = self.train_geometry(coords, train_steps)
+
+        measured = self._benchmark_incumbent(coords)
+        if measured.accepted:
+            self.exec_state = measured.metrics
+
+        promoted = False
+        if tune:
+            measured, promoted = self._tune_runtime(coords)
+            if measured.accepted:
+                self.exec_state = measured.metrics
+
+        rmse = self.geometry_rmse(coords)
+        return CycleReport(
+            cycle=cycle_index,
+            phase=phase_report,
+            geometry_loss=geometry_loss,
+            geometry_rmse=rmse,
+            runtime=measured,
+            runtime_promoted=promoted,
+        )
+
+    def run(self, cycles: int, *, train_steps: int = 1, tune_every: int = 2) -> None:
+        print(
+            "DM-vOmegaXi+ Phase3D runtime | "
+            f"device={self.device.type.upper()} "
+            f"nodes={self.phase.config.node_count:,} "
+            f"r*={self.phase.config.equilibrium_radius_m:.6f} m"
+        )
+        print(
+            "measurement contract: node_updates/s and q/s are measured; "
+            "no symbolic throughput multiplier is reported"
+        )
+
+        for cycle_index in range(1, cycles + 1):
+            report = self.cycle(
+                cycle_index,
+                train_steps=train_steps,
+                tune=(tune_every > 0 and cycle_index % tune_every == 0),
+            )
+            phase = report.phase
+            runtime = report.runtime
+            print(
+                f"cycle={cycle_index:03d} "
+                f"phase={phase.node_updates_per_second:,.0f} nodes/s "
+                f"r_mean={phase.mean_radius_m:.6f} m "
+                f"shell_rmse={phase.shell_rmse_m:.6f} m "
+                f"v_max={phase.max_velocity_m_s:,.2f} m/s "
+                f"dE/E0={phase.relative_energy_drift:+.3e} "
+                f"field_loss={report.geometry_loss:.6f} "
+                f"field_rmse={report.geometry_rmse:.6f} "
+                f"runtime={runtime.metrics.throughput_qps:,.0f} q/s "
+                f"latency={runtime.metrics.latency_ms:.3f} ms "
+                f"mem={runtime.metrics.peak_memory_mb:.1f} MiB "
+                f"mode={runtime.effective_mode} "
+                f"chunk={self.runtime_config.chunk_size} "
+                f"promoted={report.runtime_promoted}"
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cycles", type=int, default=5)
+    parser.add_argument("--nodes", type=int, default=16_384)
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
+    parser.add_argument("--dt", type=float, default=1.0e-5)
+    parser.add_argument("--damping", type=float, default=0.0)
+    parser.add_argument("--train-steps", type=int, default=1)
+    parser.add_argument("--tune-every", type=int, default=2)
+    parser.add_argument("--target-qps", type=float, default=1_000_000.0)
+    parser.add_argument("--chunk-size", type=int, default=65_536)
+    parser.add_argument(
+        "--compile-mode",
+        choices=("eager", "default", "reduce-overhead", "max-autotune"),
+        default="default",
+    )
+    parser.add_argument("--peak-memory-mb", type=float, default=math.inf)
+    parser.add_argument("--min-runtime-improvement", type=float, default=0.01)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    phase_config = PhaseFieldConfig(
+        node_count=args.nodes,
+        dt_seconds=args.dt,
+        damping_per_second=args.damping,
+    )
+    runtime = Phase3DSelfOptimizingRuntime(
+        phase_config,
+        device=args.device,
+        target_qps=args.target_qps,
+        runtime_config=RuntimeConfig(
+            chunk_size=args.chunk_size,
+            compile_mode=args.compile_mode,
+        ),
+        peak_memory_budget_mb=args.peak_memory_mb,
+        min_runtime_improvement=args.min_runtime_improvement,
+    )
+    runtime.run(
+        args.cycles,
+        train_steps=args.train_steps,
+        tune_every=args.tune_every,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/self_referential_triton_engine.py
+++ b/examples/self_referential_triton_engine.py
@@ -1,0 +1,363 @@
+"""Self-referential 3D implicit field with a separate runtime autotuning loop.
+
+This example keeps two optimization spaces deliberately distinct:
+
+1. ``theta`` -- neural parameters updated by differentiable geometry loss.
+2. ``c``     -- runtime configuration selected by measured benchmark evidence.
+
+Measured wall-clock throughput is not differentiable, so it is never inserted into
+``total_loss`` as if autograd could optimize it. Instead, measured telemetry is
+normalized and fed back into the next neural evaluation, while an outer controller
+benchmarks bounded runtime candidates and promotes only semantically equivalent
+variants.
+
+Install the optional PyTorch dependency before running:
+
+    pip install -e '.[torch]'
+    python examples/self_referential_triton_engine.py
+
+On CUDA, ``torch.compile``/Inductor may lower eligible graph regions to Triton
+kernels. This file does not claim to be a hand-written Triton kernel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+from dataclasses import dataclass, replace
+from typing import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+torch.set_float32_matmul_precision("high")
+
+
+@dataclass(frozen=True)
+class ExecutionMetrics:
+    throughput_qps: float
+    latency_ms: float
+    peak_memory_mb: float = 0.0
+
+    def normalized(self, target_qps: float, device: torch.device, batch_size: int) -> torch.Tensor:
+        """Return numerically bounded execution-state features for the meta encoder."""
+
+        target = max(float(target_qps), 1.0)
+        throughput = math.log1p(max(self.throughput_qps, 0.0) / target)
+        latency = math.log1p(max(self.latency_ms, 0.0))
+        return torch.tensor(
+            [[throughput, latency]],
+            dtype=torch.float32,
+            device=device,
+        ).expand(batch_size, -1)
+
+
+@dataclass(frozen=True, order=True)
+class RuntimeConfig:
+    chunk_size: int = 65_536
+    compile_mode: str = "default"
+
+    def __post_init__(self) -> None:
+        if self.chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        if self.compile_mode not in {"eager", "default", "reduce-overhead", "max-autotune"}:
+            raise ValueError("unsupported compile_mode")
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    config: RuntimeConfig
+    metrics: ExecutionMetrics
+    max_abs_error: float
+    accepted: bool
+
+
+class SelfReferentialTritonEngine(nn.Module):
+    """3D implicit field conditioned on normalized execution telemetry."""
+
+    def __init__(self, latent_dim: int = 256, hidden_dim: int = 512) -> None:
+        super().__init__()
+        self.latent_dim = latent_dim
+        self.spatial_proj = nn.Linear(3, 64)
+        self.meta_encoder = nn.Sequential(
+            nn.Linear(66, 128),
+            nn.SiLU(),
+            nn.Linear(128, latent_dim),
+        )
+        self.core_pipeline = nn.Sequential(
+            nn.Linear(latent_dim + 64, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, hidden_dim),
+            nn.SiLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, coords: torch.Tensor, exec_metrics: torch.Tensor) -> torch.Tensor:
+        if coords.ndim != 3 or coords.shape[-1] != 3:
+            raise ValueError("coords must have shape (B, N, 3)")
+        if exec_metrics.ndim != 2 or exec_metrics.shape != (coords.shape[0], 2):
+            raise ValueError("exec_metrics must have shape (B, 2)")
+
+        spatial_feats = F.silu(self.spatial_proj(coords))
+        metrics_expanded = exec_metrics[:, None, :].expand(-1, coords.shape[1], -1)
+        z_meta = self.meta_encoder(torch.cat((spatial_feats, metrics_expanded), dim=-1))
+        return self.core_pipeline(torch.cat((z_meta, spatial_feats), dim=-1))
+
+
+def sphere_sdf(coords: torch.Tensor, radius: float = 0.65) -> torch.Tensor:
+    """Analytic non-trivial SDF target used by the reference training loop."""
+
+    return torch.linalg.vector_norm(coords, dim=-1, keepdim=True) - radius
+
+
+def _sync(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def _compile(engine: nn.Module, config: RuntimeConfig) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
+    if config.compile_mode == "eager" or not hasattr(torch, "compile"):
+        return engine
+    try:
+        return torch.compile(engine, mode=config.compile_mode)
+    except Exception as exc:  # pragma: no cover - backend availability is platform specific
+        print(f"[compile] {config.compile_mode!r} unavailable ({exc}); falling back to eager")
+        return engine
+
+
+def _run_chunked(
+    runner: Callable[[torch.Tensor, torch.Tensor], torch.Tensor],
+    coords: torch.Tensor,
+    metrics: torch.Tensor,
+    chunk_size: int,
+) -> torch.Tensor:
+    outputs: list[torch.Tensor] = []
+    for start in range(0, coords.shape[1], chunk_size):
+        end = min(coords.shape[1], start + chunk_size)
+        outputs.append(runner(coords[:, start:end, :], metrics))
+    return torch.cat(outputs, dim=1)
+
+
+class RuntimeAutotuner:
+    """Bounded, measurement-driven optimizer over runtime configuration only."""
+
+    def __init__(
+        self,
+        engine: SelfReferentialTritonEngine,
+        device: torch.device,
+        *,
+        semantic_tolerance: float = 5.0e-4,
+        warmup: int = 2,
+        repeats: int = 3,
+    ) -> None:
+        self.engine = engine
+        self.device = device
+        self.semantic_tolerance = semantic_tolerance
+        self.warmup = warmup
+        self.repeats = repeats
+        self._cache: dict[RuntimeConfig, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {}
+
+    def runner(self, config: RuntimeConfig):
+        if config not in self._cache:
+            self._cache[config] = _compile(self.engine, config)
+        return self._cache[config]
+
+    def candidates(self, incumbent: RuntimeConfig) -> tuple[RuntimeConfig, ...]:
+        chunks = sorted(
+            {
+                max(1_024, incumbent.chunk_size // 2),
+                incumbent.chunk_size,
+                min(262_144, incumbent.chunk_size * 2),
+            }
+        )
+        modes = (incumbent.compile_mode, "default", "reduce-overhead", "max-autotune")
+        unique: dict[RuntimeConfig, None] = {}
+        for chunk in chunks:
+            for mode in modes:
+                unique[RuntimeConfig(chunk, mode)] = None
+        return tuple(unique)
+
+    @torch.inference_mode()
+    def benchmark(
+        self,
+        config: RuntimeConfig,
+        coords: torch.Tensor,
+        metrics: torch.Tensor,
+        reference: torch.Tensor,
+    ) -> BenchmarkResult:
+        runner = self.runner(config)
+
+        for _ in range(self.warmup):
+            _run_chunked(runner, coords, metrics, config.chunk_size)
+            _sync(self.device)
+
+        if self.device.type == "cuda":
+            torch.cuda.reset_peak_memory_stats(self.device)
+
+        durations: list[float] = []
+        output = reference
+        for _ in range(self.repeats):
+            _sync(self.device)
+            started = time.perf_counter()
+            output = _run_chunked(runner, coords, metrics, config.chunk_size)
+            _sync(self.device)
+            durations.append(time.perf_counter() - started)
+
+        duration = min(durations)
+        queries = coords.shape[0] * coords.shape[1]
+        throughput = queries / max(duration, 1.0e-9)
+        peak_mb = 0.0
+        if self.device.type == "cuda":
+            peak_mb = torch.cuda.max_memory_allocated(self.device) / (1024.0 * 1024.0)
+
+        max_abs_error = float((output - reference).abs().max().item())
+        accepted = math.isfinite(throughput) and max_abs_error <= self.semantic_tolerance
+        return BenchmarkResult(
+            config=config,
+            metrics=ExecutionMetrics(
+                throughput_qps=throughput,
+                latency_ms=duration * 1_000.0,
+                peak_memory_mb=peak_mb,
+            ),
+            max_abs_error=max_abs_error,
+            accepted=accepted,
+        )
+
+    @torch.inference_mode()
+    def tune(
+        self,
+        incumbent: RuntimeConfig,
+        coords: torch.Tensor,
+        metrics: torch.Tensor,
+    ) -> BenchmarkResult:
+        reference = _run_chunked(self.engine, coords, metrics, incumbent.chunk_size)
+        results = [
+            self.benchmark(candidate, coords, metrics, reference)
+            for candidate in self.candidates(incumbent)
+        ]
+        admissible = [result for result in results if result.accepted]
+        if not admissible:
+            return self.benchmark(incumbent, coords, metrics, reference)
+        return max(admissible, key=lambda item: item.metrics.throughput_qps)
+
+
+class SelfRefiningOptimizer:
+    """Closed loop: gradient geometry learning + measured runtime configuration search."""
+
+    def __init__(
+        self,
+        engine: SelfReferentialTritonEngine,
+        *,
+        target_qps: float = 1_000_000.0,
+        device: str = "cuda",
+        runtime_config: RuntimeConfig | None = None,
+    ) -> None:
+        self.device = torch.device(device if device == "cpu" or torch.cuda.is_available() else "cpu")
+        self.engine = engine.to(self.device)
+        self.optimizer = torch.optim.AdamW(self.engine.parameters(), lr=1.0e-3, weight_decay=1.0e-5)
+        self.target_qps = float(target_qps)
+        self.runtime_config = runtime_config or RuntimeConfig()
+        self.autotuner = RuntimeAutotuner(self.engine, self.device)
+        self.exec_state = ExecutionMetrics(throughput_qps=0.5 * self.target_qps, latency_ms=2.0)
+
+    def _train_step(self, coords: torch.Tensor) -> float:
+        normalized = self.exec_state.normalized(self.target_qps, self.device, coords.shape[0])
+        target = sphere_sdf(coords)
+        prediction = self.engine(coords, normalized)
+        geometry_loss = F.smooth_l1_loss(prediction, target)
+
+        self.optimizer.zero_grad(set_to_none=True)
+        geometry_loss.backward()
+        self.optimizer.step()
+        return float(geometry_loss.detach().item())
+
+    @torch.inference_mode()
+    def _measure_incumbent(self, coords: torch.Tensor) -> BenchmarkResult:
+        normalized = self.exec_state.normalized(self.target_qps, self.device, coords.shape[0])
+        reference = _run_chunked(self.engine, coords, normalized, self.runtime_config.chunk_size)
+        return self.autotuner.benchmark(
+            self.runtime_config,
+            coords,
+            normalized,
+            reference,
+        )
+
+    def run_self_optimization_cycle(
+        self,
+        cycles: int = 5,
+        *,
+        batch_size: int = 4,
+        train_queries: int = 8_192,
+        benchmark_queries: int = 32_768,
+        tune_every: int = 2,
+    ) -> None:
+        print(
+            f"Starting dual-loop optimization on {self.device.type.upper()} | "
+            f"target={self.target_qps:,.0f} queries/s"
+        )
+
+        benchmark_coords = torch.randn(batch_size, benchmark_queries, 3, device=self.device)
+
+        for cycle in range(1, cycles + 1):
+            train_coords = torch.randn(batch_size, train_queries, 3, device=self.device)
+            geometry_loss = self._train_step(train_coords)
+
+            measured = self._measure_incumbent(benchmark_coords)
+            self.exec_state = measured.metrics
+
+            if tune_every > 0 and cycle % tune_every == 0:
+                normalized = self.exec_state.normalized(
+                    self.target_qps,
+                    self.device,
+                    benchmark_coords.shape[0],
+                )
+                tuned = self.autotuner.tune(self.runtime_config, benchmark_coords, normalized)
+                if tuned.accepted and tuned.metrics.throughput_qps > measured.metrics.throughput_qps:
+                    self.runtime_config = tuned.config
+                    self.exec_state = tuned.metrics
+                    measured = tuned
+
+            print(
+                f"cycle={cycle:02d} "
+                f"geometry_loss={geometry_loss:.6f} "
+                f"throughput={measured.metrics.throughput_qps:,.0f} q/s "
+                f"latency={measured.metrics.latency_ms:.3f} ms "
+                f"peak_mem={measured.metrics.peak_memory_mb:.1f} MiB "
+                f"chunk={self.runtime_config.chunk_size} "
+                f"mode={self.runtime_config.compile_mode} "
+                f"semantic_error={measured.max_abs_error:.2e}"
+            )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cycles", type=int, default=5)
+    parser.add_argument("--target-qps", type=float, default=1_000_000.0)
+    parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
+    parser.add_argument("--compile-mode", default="default", choices=("eager", "default", "reduce-overhead", "max-autotune"))
+    parser.add_argument("--chunk-size", type=int, default=65_536)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    engine = SelfReferentialTritonEngine()
+    loop = SelfRefiningOptimizer(
+        engine,
+        target_qps=args.target_qps,
+        device=args.device,
+        runtime_config=RuntimeConfig(
+            chunk_size=args.chunk_size,
+            compile_mode=args.compile_mode,
+        ),
+    )
+    loop.run_self_optimization_cycle(cycles=args.cycles)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/self_referential_triton_engine.py
+++ b/examples/self_referential_triton_engine.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import argparse
 import math
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Callable
 
 import torch
@@ -42,7 +42,12 @@ class ExecutionMetrics:
     latency_ms: float
     peak_memory_mb: float = 0.0
 
-    def normalized(self, target_qps: float, device: torch.device, batch_size: int) -> torch.Tensor:
+    def normalized(
+        self,
+        target_qps: float,
+        device: torch.device,
+        batch_size: int,
+    ) -> torch.Tensor:
         """Return numerically bounded execution-state features for the meta encoder."""
 
         target = max(float(target_qps), 1.0)
@@ -73,6 +78,14 @@ class BenchmarkResult:
     metrics: ExecutionMetrics
     max_abs_error: float
     accepted: bool
+    effective_mode: str
+
+
+@dataclass(frozen=True)
+class CompiledRunner:
+    run: Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
+    effective_mode: str
+    available: bool = True
 
 
 class SelfReferentialTritonEngine(nn.Module):
@@ -120,14 +133,17 @@ def _sync(device: torch.device) -> None:
         torch.cuda.synchronize(device)
 
 
-def _compile(engine: nn.Module, config: RuntimeConfig) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
-    if config.compile_mode == "eager" or not hasattr(torch, "compile"):
-        return engine
+def _compile(engine: nn.Module, config: RuntimeConfig) -> CompiledRunner:
+    if config.compile_mode == "eager":
+        return CompiledRunner(engine, "eager")
+    if not hasattr(torch, "compile"):
+        return CompiledRunner(engine, "eager", available=False)
     try:
-        return torch.compile(engine, mode=config.compile_mode)
+        compiled = torch.compile(engine, mode=config.compile_mode)
     except Exception as exc:  # pragma: no cover - backend availability is platform specific
-        print(f"[compile] {config.compile_mode!r} unavailable ({exc}); falling back to eager")
-        return engine
+        print(f"[compile] {config.compile_mode!r} unavailable ({exc})")
+        return CompiledRunner(engine, "eager", available=False)
+    return CompiledRunner(compiled, config.compile_mode)
 
 
 def _run_chunked(
@@ -160,9 +176,9 @@ class RuntimeAutotuner:
         self.semantic_tolerance = semantic_tolerance
         self.warmup = warmup
         self.repeats = repeats
-        self._cache: dict[RuntimeConfig, Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = {}
+        self._cache: dict[RuntimeConfig, CompiledRunner] = {}
 
-    def runner(self, config: RuntimeConfig):
+    def runner(self, config: RuntimeConfig) -> CompiledRunner:
         if config not in self._cache:
             self._cache[config] = _compile(self.engine, config)
         return self._cache[config]
@@ -175,7 +191,7 @@ class RuntimeAutotuner:
                 min(262_144, incumbent.chunk_size * 2),
             }
         )
-        modes = (incumbent.compile_mode, "default", "reduce-overhead", "max-autotune")
+        modes = (incumbent.compile_mode, "eager", "default", "reduce-overhead")
         unique: dict[RuntimeConfig, None] = {}
         for chunk in chunks:
             for mode in modes:
@@ -190,23 +206,51 @@ class RuntimeAutotuner:
         metrics: torch.Tensor,
         reference: torch.Tensor,
     ) -> BenchmarkResult:
-        runner = self.runner(config)
+        variant = self.runner(config)
+        if not variant.available:
+            return BenchmarkResult(
+                config=config,
+                metrics=ExecutionMetrics(0.0, math.inf, 0.0),
+                max_abs_error=math.inf,
+                accepted=False,
+                effective_mode=variant.effective_mode,
+            )
 
-        for _ in range(self.warmup):
-            _run_chunked(runner, coords, metrics, config.chunk_size)
-            _sync(self.device)
+        try:
+            for _ in range(self.warmup):
+                _run_chunked(variant.run, coords, metrics, config.chunk_size)
+                _sync(self.device)
+        except Exception as exc:  # pragma: no cover - backend failures are platform specific
+            print(f"[benchmark] {config} failed during warm-up ({exc})")
+            return BenchmarkResult(
+                config=config,
+                metrics=ExecutionMetrics(0.0, math.inf, 0.0),
+                max_abs_error=math.inf,
+                accepted=False,
+                effective_mode=variant.effective_mode,
+            )
 
         if self.device.type == "cuda":
             torch.cuda.reset_peak_memory_stats(self.device)
 
         durations: list[float] = []
         output = reference
-        for _ in range(self.repeats):
-            _sync(self.device)
-            started = time.perf_counter()
-            output = _run_chunked(runner, coords, metrics, config.chunk_size)
-            _sync(self.device)
-            durations.append(time.perf_counter() - started)
+        try:
+            for _ in range(self.repeats):
+                _sync(self.device)
+                started = time.perf_counter()
+                output = _run_chunked(variant.run, coords, metrics, config.chunk_size)
+                _sync(self.device)
+                durations.append(time.perf_counter() - started)
+        except Exception as exc:  # pragma: no cover - backend failures are platform specific
+            print(f"[benchmark] {config} failed during measurement ({exc})")
+            return BenchmarkResult(
+                config=config,
+                metrics=ExecutionMetrics(0.0, math.inf, 0.0),
+                max_abs_error=math.inf,
+                accepted=False,
+                effective_mode=variant.effective_mode,
+            )
 
         duration = min(durations)
         queries = coords.shape[0] * coords.shape[1]
@@ -226,6 +270,7 @@ class RuntimeAutotuner:
             ),
             max_abs_error=max_abs_error,
             accepted=accepted,
+            effective_mode=variant.effective_mode,
         )
 
     @torch.inference_mode()
@@ -235,6 +280,8 @@ class RuntimeAutotuner:
         coords: torch.Tensor,
         metrics: torch.Tensor,
     ) -> BenchmarkResult:
+        """Benchmark incumbent and candidates under one identical telemetry snapshot."""
+
         reference = _run_chunked(self.engine, coords, metrics, incumbent.chunk_size)
         results = [
             self.benchmark(candidate, coords, metrics, reference)
@@ -242,8 +289,24 @@ class RuntimeAutotuner:
         ]
         admissible = [result for result in results if result.accepted]
         if not admissible:
-            return self.benchmark(incumbent, coords, metrics, reference)
-        return max(admissible, key=lambda item: item.metrics.throughput_qps)
+            return BenchmarkResult(
+                config=incumbent,
+                metrics=ExecutionMetrics(0.0, math.inf, 0.0),
+                max_abs_error=math.inf,
+                accepted=False,
+                effective_mode="unavailable",
+            )
+
+        incumbent_result = next(
+            (result for result in admissible if result.config == incumbent),
+            None,
+        )
+        best = max(admissible, key=lambda item: item.metrics.throughput_qps)
+        if incumbent_result is not None and (
+            best.metrics.throughput_qps <= incumbent_result.metrics.throughput_qps
+        ):
+            return incumbent_result
+        return best
 
 
 class SelfRefiningOptimizer:
@@ -259,11 +322,18 @@ class SelfRefiningOptimizer:
     ) -> None:
         self.device = torch.device(device if device == "cpu" or torch.cuda.is_available() else "cpu")
         self.engine = engine.to(self.device)
-        self.optimizer = torch.optim.AdamW(self.engine.parameters(), lr=1.0e-3, weight_decay=1.0e-5)
+        self.optimizer = torch.optim.AdamW(
+            self.engine.parameters(),
+            lr=1.0e-3,
+            weight_decay=1.0e-5,
+        )
         self.target_qps = float(target_qps)
         self.runtime_config = runtime_config or RuntimeConfig()
         self.autotuner = RuntimeAutotuner(self.engine, self.device)
-        self.exec_state = ExecutionMetrics(throughput_qps=0.5 * self.target_qps, latency_ms=2.0)
+        self.exec_state = ExecutionMetrics(
+            throughput_qps=0.5 * self.target_qps,
+            latency_ms=2.0,
+        )
 
     def _train_step(self, coords: torch.Tensor) -> float:
         normalized = self.exec_state.normalized(self.target_qps, self.device, coords.shape[0])
@@ -308,7 +378,8 @@ class SelfRefiningOptimizer:
             geometry_loss = self._train_step(train_coords)
 
             measured = self._measure_incumbent(benchmark_coords)
-            self.exec_state = measured.metrics
+            if measured.accepted:
+                self.exec_state = measured.metrics
 
             if tune_every > 0 and cycle % tune_every == 0:
                 normalized = self.exec_state.normalized(
@@ -316,8 +387,12 @@ class SelfRefiningOptimizer:
                     self.device,
                     benchmark_coords.shape[0],
                 )
-                tuned = self.autotuner.tune(self.runtime_config, benchmark_coords, normalized)
-                if tuned.accepted and tuned.metrics.throughput_qps > measured.metrics.throughput_qps:
+                tuned = self.autotuner.tune(
+                    self.runtime_config,
+                    benchmark_coords,
+                    normalized,
+                )
+                if tuned.accepted:
                     self.runtime_config = tuned.config
                     self.exec_state = tuned.metrics
                     measured = tuned
@@ -329,7 +404,8 @@ class SelfRefiningOptimizer:
                 f"latency={measured.metrics.latency_ms:.3f} ms "
                 f"peak_mem={measured.metrics.peak_memory_mb:.1f} MiB "
                 f"chunk={self.runtime_config.chunk_size} "
-                f"mode={self.runtime_config.compile_mode} "
+                f"requested={self.runtime_config.compile_mode} "
+                f"effective={measured.effective_mode} "
                 f"semantic_error={measured.max_abs_error:.2e}"
             )
 
@@ -339,7 +415,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--cycles", type=int, default=5)
     parser.add_argument("--target-qps", type=float, default=1_000_000.0)
     parser.add_argument("--device", choices=("cpu", "cuda"), default="cuda")
-    parser.add_argument("--compile-mode", default="default", choices=("eager", "default", "reduce-overhead", "max-autotune"))
+    parser.add_argument(
+        "--compile-mode",
+        default="default",
+        choices=("eager", "default", "reduce-overhead", "max-autotune"),
+    )
     parser.add_argument("--chunk-size", type=int, default=65_536)
     return parser.parse_args()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ test = [
     "pytest-cov>=5.0",
     "z3-solver>=4.13.0",
 ]
+torch = [
+    "torch>=2.4",
+]
 
 [project.urls]
 Homepage = "https://github.com/Lord-Xido/Jarvis-X"


### PR DESCRIPTION
## Summary

Permeates the self-referential 3D implicit-field design into the existing Jarvis-X inward-optimization architecture and closes it with an executable Phase3D dynamical substrate.

The implementation deliberately separates three authorities:

```text
3D phase dynamics
  -> relativistic momentum evolution

neural field theta
  -> differentiable geometry learning

runtime configuration C
  -> measured benchmark
  -> canonical kinetic transaction
  -> semantic/resource/performance validators
  -> commit or rollback + hash-chained receipt
```

Measured wall-clock throughput is never treated as differentiable, and neural error is not allowed to directly overwrite the authoritative phase state.

## What changed

### Self-referential implicit-field/runtime layer

- adds `examples/self_referential_triton_engine.py` as an executable PyTorch/Inductor reference;
- replaces the non-differentiable throughput-loss pattern with a separate bounded runtime autotuner;
- normalizes measured throughput/latency before reinjecting telemetry into the meta encoder;
- trains against a non-trivial analytic SDF instead of collapsing all points toward zero;
- uses CUDA synchronization, warm-up passes, repeated steady-state measurements, semantic-equivalence checks, and peak-memory telemetry;
- compares incumbent and candidate runtime configurations under the same telemetry snapshot before promotion;
- records requested versus effective compile mode and rejects unavailable/failed compiled variants;
- keeps PyTorch optional via `pip install -e '.[torch]'`.

### Phase3D end-to-end layer

- adds `examples/dr_moagi_phase3d_runtime.py`;
- replaces the object-per-node loop with vectorized `N x 3` PyTorch phase tensors;
- initializes a genuine two-parameter torus surface instead of a one-parameter toroidal curve;
- replaces Newtonian velocity stepping + light-speed clipping with relativistic momentum integration;
- uses the dimensionally explicit field `F_r = A/r^2 - k r`, with equilibrium shell `r* = (A/k)^(1/3)`;
- supports optional momentum damping without mislabeling the conservative shell as an attractor;
- reports stable relativistic kinetic energy, potential energy, mechanical-energy drift, shell RMSE, maximum velocity, and measured node updates/s;
- trains the neural field against the analytic equilibrium-shell SDF while keeping phase dynamics authoritative;
- feeds measured runtime telemetry back into the next neural cycle;
- routes every scheduled device search through `KineticTransactionEngine`;
- validates semantic equivalence, peak-memory budget, and minimum throughput improvement before commit;
- rolls rejected candidates back to the runtime snapshot;
- emits a hash-chained `KineticReceipt` for every runtime tuning attempt;
- reports measured phase throughput and implicit-field query throughput separately with no symbolic throughput multiplier.

### Documentation and validation

- adds `docs/SELF_REFERENTIAL_TRITON_RUNTIME.md`;
- adds `docs/PHASE3D_END_TO_END_RUNTIME.md`;
- documents the integration boundary with `DrMoagi3DMetaOptimizer` and `CanonicalKineticDrMoagiSystem`;
- adds the `torch` optional dependency extra;
- adds a general CI syntax check for the optional self-referential runtime;
- adds `.github/workflows/phase3d-runtime.yml`, which installs the optional PyTorch runtime, asserts Phase3D invariants, verifies the canonical rollback/receipt path, and executes conservative and damped end-to-end CPU cycles;
- records the capabilities in the Unreleased changelog.

## Canonical recurrence

```text
K_t = (X_t, P_t, M)
Theta_t = neural field
C_t = runtime configuration
T_t = measured telemetry

K_t
-> phase force / relativistic momentum update
-> K_{t+1}
-> implicit shell evaluation
-> differentiable Theta update
-> measured benchmark
-> T_{t+1}
-> bounded runtime search
-> KineticTransactionEngine
-> VERIFY
-> COMMIT | ROLLBACK
-> receipt
-> C_{t+1}
```

Equivalently:

```text
S_t = (K_t, Theta_t, C_t, T_t)
S_{t+1} = M(S_t)
```

## Measurement contract

The runtime reports real wall-clock-derived quantities separately:

- node updates/second for Phase3D integration;
- implicit-field queries/second;
- phase and field latency;
- peak allocated device memory;
- semantic error;
- mechanical-energy drift;
- runtime transaction decision and receipt hash.

No `10^12` or other symbolic multiplier is presented as measured hardware throughput.

## Claim boundary

This is an executable research architecture, not evidence of a new physical law, quantum dynamics, or external state-of-the-art hardware performance.

`torch.compile`/Inductor may generate Triton-backed CUDA kernels on supported systems. The repository still does not claim the example is a hand-written Triton kernel.

External performance claims require matched hardware, workloads, baselines, statistics, and reproducible benchmark provenance.