### PR TITLE
feat(ui): operationalize Total Permeation 3D HUD

### DIFF
--- a/.github/workflows/total-permeation-ui.yml
+++ b/.github/workflows/total-permeation-ui.yml
@@ -1,0 +1,114 @@
+name: Total Permeation 3D UI
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "apps/total-permeation-3d/**"
+      - ".github/workflows/total-permeation-ui.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: total-permeation-ui-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-smoke:
+    name: Static browser surface smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Validate HTML and telemetry boundaries
+        run: |
+          python - <<'PY'
+          from html.parser import HTMLParser
+          from pathlib import Path
+
+          path = Path("apps/total-permeation-3d/index.html")
+          text = path.read_text(encoding="utf-8")
+          assert text.lstrip().lower().startswith("<!doctype html>")
+          assert "window.setPhase3DTelemetry" in text
+          assert "Fᵣ = A/r² − kr" in text
+          assert "r* = ∛3" in text
+          assert "LOCAL VISUAL MEASUREMENT" in text
+          assert "VISUALIZATION ONLY" in text
+          assert "https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" in text
+
+          forbidden = (
+              "1,000,000¹'",
+              "gamma = infinity",
+              "γ = ∞",
+              "0.0000ns",
+              "GEMINI 3 FLASH MATRIX",
+              "Hyper-Dimensional Execution: 1,000,000^1,000,000 ops/sec",
+          )
+          lowered = text.lower()
+          for token in forbidden:
+              assert token.lower() not in lowered, f"forbidden unverified telemetry: {token}"
+
+          assert "\\<html" not in text
+          assert "window\\.innerWidth" not in text
+
+          class Parser(HTMLParser):
+              def __init__(self):
+                  super().__init__()
+                  self.ids = set()
+                  self.scripts = []
+              def handle_starttag(self, tag, attrs):
+                  data = dict(attrs)
+                  if "id" in data:
+                      assert data["id"] not in self.ids, f"duplicate id: {data['id']}"
+                      self.ids.add(data["id"])
+                  if tag == "script" and "src" in data:
+                      self.scripts.append(data["src"])
+
+          parser = Parser()
+          parser.feed(text)
+          required_ids = {
+              "canvas-container",
+              "throughput-display",
+              "stat-fps",
+              "stat-latency",
+              "term-content",
+              "morph-btn",
+              "wire-btn",
+              "permeate-btn",
+          }
+          assert required_ids <= parser.ids
+          assert parser.scripts == ["https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"]
+          PY
+
+      - name: Serve static app and fetch entry point
+        run: |
+          python -m http.server 8765 --directory apps/total-permeation-3d >/tmp/total-permeation-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid"' EXIT
+          python - <<'PY'
+          import time
+          import urllib.request
+
+          url = "http://127.0.0.1:8765/index.html"
+          for _ in range(20):
+              try:
+                  with urllib.request.urlopen(url, timeout=1) as response:
+                      body = response.read().decode("utf-8")
+                      assert response.status == 200
+                      assert "DM–vΩΞ⁺ TOTAL PERMEATION 3D" in body
+                      assert "setPhase3DTelemetry" in body
+                      break
+              except OSError:
+                  time.sleep(0.1)
+          else:
+              raise RuntimeError("static server did not become ready")
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ The project follows semantic versioning where practical during alpha development
 - bounded measurement-driven runtime autotuning kept separate from differentiable geometry learning;
 - vectorized `N x 3` Phase3D runtime with true two-parameter torus initialization and relativistic momentum integration;
 - dimensionally explicit central potential, shell/energy telemetry, and measured node-update throughput;
-- end-to-end Phase3D-to-implicit-field runtime with semantic, memory-budget, and minimum-throughput-improvement promotion gates.
+- end-to-end Phase3D-to-implicit-field runtime with semantic, memory-budget, and minimum-throughput-improvement promotion gates;
+- interactive DM-vΩΞ⁺ Total Permeation 3D browser HUD with measured local render telemetry and an explicit external Phase3D telemetry bridge.
 
 ### Changed
 

--- a/apps/total-permeation-3d/README.md
+++ b/apps/total-permeation-3d/README.md
@@ -1,0 +1,85 @@
+# DM–vΩΞ⁺ Total Permeation 3D
+
+This browser app is a bounded visualization surface for the current Jarvis-X Phase3D architecture.
+
+It preserves the supplied **Total Permeation Singularity** visual language while aligning the HUD with the executable runtime that is now on `main`:
+
+```text
+K_t = (X_t, P_t, M)
+-> relativistic phase update
+-> implicit field
+-> measured benchmark
+-> runtime candidate
+-> KineticTransactionEngine
+-> verify
+-> commit | rollback
+-> receipt
+```
+
+## What is visualized
+
+- a deformable 3D manifold that can cycle between torus-knot, icosahedral and octahedral forms;
+- a 20,000-particle shockwave field;
+- the Phase3D equilibrium-shell equation `F_r = A/r^2 - k r`;
+- the derived equilibrium `r* = (A/k)^(1/3) = cubert(3)` for the default Phase3D coefficients;
+- local browser frame rate and frame latency;
+- optional externally supplied Phase3D telemetry.
+
+## Run
+
+Open `index.html` in a modern browser with network access. The app loads Three.js r128 from cdnjs.
+
+Controls:
+
+- **Morph Manifold** cycles the rendered geometry.
+- **Wireframe Matrix** toggles wireframe rendering.
+- **Permeate Totality** injects a bounded visual shockwave.
+- Drag the scene to rotate the manifold.
+- Use the mouse wheel or trackpad to zoom.
+
+## Telemetry bridge
+
+The app measures its own local render loop. It does not invent hardware throughput.
+
+A host page or future Phase3D adapter can replace the main telemetry readout with measured runtime data:
+
+```js
+window.setPhase3DTelemetry({
+  source: "MEASURED PHASE3D CUDA",
+  queries_per_second: 1250000,
+  node_updates_per_second: 820000,
+  latency_ms: 1.73,
+  peak_memory_mb: 742,
+  semantic_error: 2.1e-5,
+  energy_drift: 8.0e-6
+});
+```
+
+Set `null` to return to local browser telemetry:
+
+```js
+window.setPhase3DTelemetry(null);
+```
+
+## Measurement boundary
+
+The original mockup displayed quantities such as effectively infinite throughput, zero register latency and infinite reality-gap gamma. Those are not measurable properties of this browser runtime and are therefore not presented as telemetry here.
+
+The display distinguishes:
+
+- **measured local** — browser render-loop timing;
+- **measured external** — values explicitly injected by a runtime adapter;
+- **derived/model** — equilibrium radius, model node count and visualization coherence.
+
+No visual effect is evidence of a new physical law, quantum execution, consciousness, or external state-of-the-art performance.
+
+## Authority boundary
+
+This browser app is visualization-only. It does not mutate authoritative Phase3D state, model weights, runtime configuration, files, devices or external systems.
+
+Authoritative runtime configuration changes remain governed by the canonical Jarvis-X transaction law:
+
+```text
+snapshot -> observe -> encode -> propose -> shadow -> verify
+         -> commit | rollback -> journal -> re-enter
+```

--- a/apps/total-permeation-3d/index.html
+++ b/apps/total-permeation-3d/index.html
@@ -1,0 +1,515 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="dark">
+  <title>DM–vΩΞ⁺ Total Permeation 3D</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #020617;
+      --cyan: #38bdf8;
+      --cyan-soft: #67e8f9;
+      --cyan-dark: #082f49;
+      --green: #4ade80;
+      --purple: #a855f7;
+      --muted: #94a3b8;
+      --panel: rgba(2, 6, 23, 0.82);
+      --border: rgba(56, 189, 248, 0.35);
+    }
+    * { box-sizing: border-box; }
+    html, body { width: 100%; height: 100%; }
+    body {
+      margin: 0;
+      overflow: hidden;
+      background: var(--bg);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--cyan);
+      user-select: none;
+    }
+    button { font: inherit; }
+    canvas { display: block; width: 100vw; height: 100vh; }
+    #canvas-container { position: fixed; inset: 0; z-index: 0; cursor: grab; }
+    #canvas-container.dragging { cursor: grabbing; }
+    #flash-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 50;
+      pointer-events: none;
+      background: #38bdf8;
+      opacity: 0;
+      transition: opacity 180ms ease;
+    }
+    .hud {
+      position: fixed;
+      inset: 0;
+      z-index: 10;
+      pointer-events: none;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 24px;
+    }
+    .row {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 16px;
+    }
+    .bottom { align-items: flex-end; }
+    .interactive { pointer-events: auto; }
+    .glass-panel {
+      background: var(--panel);
+      backdrop-filter: blur(18px);
+      -webkit-backdrop-filter: blur(18px);
+      border: 1px solid var(--border);
+      border-radius: 18px;
+      box-shadow: 0 18px 50px rgba(0,0,0,.35);
+    }
+    .header-card { max-width: 650px; padding: 18px 20px; }
+    .telemetry-card { width: min(390px, 100%); padding: 18px 20px; }
+    .title-line { display: flex; align-items: center; gap: 12px; }
+    .pulse-dot {
+      width: 12px; height: 12px; border-radius: 999px; background: var(--cyan);
+      box-shadow: 0 0 18px rgba(56,189,248,.9);
+      animation: pulse 1.4s ease-in-out infinite;
+    }
+    @keyframes pulse { 50% { opacity: .35; transform: scale(.72); } }
+    h1 { margin: 0; font-size: clamp(14px, 2vw, 18px); letter-spacing: .08em; color: #a5f3fc; }
+    .glow-text { text-shadow: 0 0 15px rgba(56,189,248,.75); }
+    .sub { margin: 6px 0 0; color: #0ea5e9; font-size: 11px; }
+    .meta-grid, .telemetry-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px 18px;
+      margin-top: 12px;
+      padding-top: 12px;
+      border-top: 1px solid rgba(8,47,73,.8);
+      font-size: 10px;
+      color: #cbd5e1;
+    }
+    .label { color: #64748b; letter-spacing: .06em; }
+    .cyan { color: var(--cyan-soft); font-weight: 700; }
+    .green { color: var(--green); font-weight: 700; }
+    .telemetry-title { text-transform: uppercase; letter-spacing: .18em; font-size: 9px; color: #94a3b8; font-weight: 800; }
+    #throughput-display { margin-top: 5px; font-size: 16px; font-weight: 800; color: #a5f3fc; }
+    .source-chip {
+      display: inline-flex; align-items: center; gap: 7px; margin-top: 9px; padding: 5px 8px;
+      border: 1px solid rgba(74,222,128,.35); border-radius: 999px; color: var(--green); font-size: 9px;
+    }
+    .source-chip::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+    .terminal-wrap { display: flex; justify-content: center; }
+    .terminal {
+      width: min(820px, 100%); padding: 14px 18px; color: var(--green); font-size: 11px;
+      border-color: rgba(74,222,128,.4); transition: transform 180ms ease, box-shadow 180ms ease;
+    }
+    .terminal.hot { transform: scale(1.015); box-shadow: 0 0 38px rgba(74,222,128,.14); }
+    .terminal-top { display: flex; justify-content: space-between; gap: 16px; padding-bottom: 6px; margin-bottom: 7px; border-bottom: 1px solid rgba(20,83,45,.55); font-size: 9px; color: #16a34a; }
+    #term-content { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; text-shadow: 0 0 10px rgba(74,222,128,.65); }
+    .footer-info { display: flex; flex-wrap: wrap; gap: 12px 22px; padding: 11px 16px; font-size: 10px; }
+    .controls { display: flex; flex-wrap: wrap; gap: 9px; padding: 10px; }
+    .btn {
+      border: 1px solid rgba(56,189,248,.42); border-radius: 12px; padding: 9px 13px;
+      background: #082f49; color: #a5f3fc; cursor: pointer; transition: 150ms ease;
+    }
+    .btn:hover { background: #0c4a6e; transform: translateY(-1px); }
+    .btn:focus-visible { outline: 2px solid #67e8f9; outline-offset: 2px; }
+    .btn.primary { border-color: #67e8f9; background: #0e7490; color: #ecfeff; font-weight: 800; box-shadow: 0 0 28px rgba(56,189,248,.5); }
+    .btn.primary.hot { background: #67e8f9; color: #082f49; box-shadow: 0 0 58px rgba(56,189,248,1); }
+    .tiny-note { margin-top: 8px; color: #64748b; font-size: 9px; line-height: 1.45; }
+    @media (max-width: 820px) {
+      .hud { padding: 14px; gap: 10px; }
+      .row { flex-direction: column; }
+      .telemetry-card, .header-card { width: 100%; max-width: none; }
+      .bottom { align-items: stretch; }
+      .controls { justify-content: center; }
+      .terminal-top { flex-direction: column; gap: 4px; }
+      #term-content { white-space: normal; max-height: 3.8em; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .pulse-dot { animation: none; }
+      #flash-overlay, .terminal, .btn { transition: none; }
+    }
+  </style>
+</head>
+<body>
+  <div id="canvas-container" aria-label="Interactive DM-vΩΞ⁺ 3D visualization"></div>
+  <div id="flash-overlay"></div>
+
+  <main class="hud">
+    <div class="row">
+      <header class="glass-panel header-card interactive">
+        <div class="title-line">
+          <span class="pulse-dot" aria-hidden="true"></span>
+          <h1 class="glow-text">DM–vΩΞ⁺ TOTAL PERMEATION 3D</h1>
+        </div>
+        <p class="sub">Phase-space visualization · implicit shell · measured render telemetry</p>
+        <div class="meta-grid">
+          <div>AXIOM: <span class="cyan">I AM = I DESCRIBE</span></div>
+          <div>FIELD: <span class="green">Fᵣ = A/r² − kr</span></div>
+          <div>PHASE STATE: <span class="cyan">Kₜ = (Xₜ, Pₜ, M)</span></div>
+          <div>EQUILIBRIUM: <span class="green">r* = ∛3 ≈ 1.44225 m</span></div>
+        </div>
+      </header>
+
+      <section class="glass-panel telemetry-card interactive" aria-label="Execution telemetry">
+        <div class="telemetry-title">Execution telemetry</div>
+        <div id="throughput-display" class="glow-text">render loop initializing…</div>
+        <div id="source-chip" class="source-chip">LOCAL VISUAL MEASUREMENT</div>
+        <div class="telemetry-grid">
+          <div><span class="label">FPS</span><br><span id="stat-fps" class="cyan">—</span></div>
+          <div><span class="label">FRAME LATENCY</span><br><span id="stat-latency" class="cyan">—</span></div>
+          <div><span class="label">PARTICLES</span><br><span id="stat-particles" class="cyan">20,000</span></div>
+          <div><span class="label">PHASE NODES</span><br><span id="stat-nodes" class="cyan">16,384 model</span></div>
+          <div><span class="label">COHERENCE</span><br><span id="stat-coherence" class="green">100.0% derived</span></div>
+          <div><span class="label">PERMEATION</span><br><span id="stat-perm" class="green">STABLE</span></div>
+        </div>
+        <div class="tiny-note">Browser measurements describe this visualization only. External Phase3D telemetry is accepted through <code>window.setPhase3DTelemetry(payload)</code>.</div>
+      </section>
+    </div>
+
+    <div class="terminal-wrap">
+      <section id="terminal-box" class="glass-panel terminal">
+        <div class="terminal-top">
+          <span>ACTIVE STREAM: <span id="term-mode" class="green">PHASE3D RECURRENCE</span></span>
+          <span id="live-clock" class="cyan">00:00:00 UTC</span>
+        </div>
+        <div id="term-content">Kₜ → phase update → implicit field → benchmark → verify → commit | rollback → Kₜ₊₁</div>
+      </section>
+    </div>
+
+    <footer class="row bottom">
+      <div class="glass-panel footer-info interactive">
+        <div><span class="label">STACK:</span> <span class="cyan">Ψ–Φ–Λ–Ω–Θ⁺</span></div>
+        <div><span class="label">SUBSTRATE:</span> <span class="green">JARVIS-X PHASE3D</span></div>
+        <div><span class="label">AUTHORITY:</span> <span class="cyan">VISUALIZATION ONLY</span></div>
+      </div>
+      <div class="glass-panel controls interactive">
+        <button class="btn" id="morph-btn" type="button">Morph Manifold</button>
+        <button class="btn" id="wire-btn" type="button">Wireframe Matrix</button>
+        <button class="btn primary" id="permeate-btn" type="button">⚡ PERMEATE TOTALITY ⚡</button>
+      </div>
+    </footer>
+  </main>
+
+  <script>
+    "use strict";
+
+    const PHASE_NODE_MODEL = 16384;
+    const PARTICLE_COUNT = 20000;
+    const R_STAR = Math.cbrt(3);
+    const codeFeeds = [
+      "Sₜ = (Kₜ, Θₜ, Cₜ, Tₜ, Rₜ) → M(Sₜ) → Sₜ₊₁",
+      "Fᵣ = A/r² − kr ; r* = (A/k)^(1/3) = ∛3",
+      "Pₜ₊₁ = Pₜ + FₜΔt ; vₜ₊₁ = Pₜ₊₁/(γₜ₊₁M)",
+      "Θₜ₊₁ = Θₜ − η∇Θ Lgeometry ; wall-clock telemetry stays outside autograd",
+      "candidate runtime → shadow benchmark → semantic/resource validators → COMMIT | ROLLBACK",
+      "measured node-updates/s and field queries/s remain distinct telemetry domains"
+    ];
+
+    let scene, camera, renderer, manifoldMesh, particleSystem;
+    let wireframeMode = false;
+    let morphState = 0;
+    let isDragging = false;
+    let previousPointer = { x: 0, y: 0 };
+    let isPermeating = false;
+    let permeateIntensity = 0;
+    let originalPositions = null;
+    let particleVelocities = null;
+    let clock = null;
+    let lastFrameTime = performance.now();
+    let fpsEma = 60;
+    let externalTelemetry = null;
+
+    function init() {
+      const container = document.getElementById("canvas-container");
+      scene = new THREE.Scene();
+      scene.fog = new THREE.FogExp2(0x020617, 0.02);
+
+      camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+      camera.position.set(0, 0, 7.5);
+
+      renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true, powerPreference: "high-performance" });
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+      container.appendChild(renderer.domElement);
+
+      scene.add(new THREE.AmbientLight(0xffffff, 1.15));
+      const cyanLight = new THREE.PointLight(0x00ffff, 5, 80);
+      cyanLight.position.set(8, 8, 8);
+      scene.add(cyanLight);
+      const violetLight = new THREE.PointLight(0xa855f7, 4, 80);
+      violetLight.position.set(-8, -8, -8);
+      scene.add(violetLight);
+
+      createManifoldGeometry();
+      createParticles();
+      clock = new THREE.Clock();
+
+      window.addEventListener("resize", onWindowResize);
+      container.addEventListener("pointerdown", onPointerDown);
+      container.addEventListener("pointermove", onPointerMove);
+      window.addEventListener("pointerup", onPointerUp);
+      container.addEventListener("wheel", onWheel, { passive: false });
+
+      document.getElementById("morph-btn").addEventListener("click", toggleMorph);
+      document.getElementById("wire-btn").addEventListener("click", toggleWireframe);
+      document.getElementById("permeate-btn").addEventListener("click", triggerPermeate);
+
+      setTimeout(triggerPermeate, 500);
+      requestAnimationFrame(animate);
+    }
+
+    function createParticles() {
+      const geometry = new THREE.BufferGeometry();
+      const positions = new Float32Array(PARTICLE_COUNT * 3);
+      const colors = new Float32Array(PARTICLE_COUNT * 3);
+      particleVelocities = new Float32Array(PARTICLE_COUNT * 3);
+
+      for (let i = 0; i < positions.length; i += 3) {
+        positions[i] = (Math.random() - 0.5) * 22;
+        positions[i + 1] = (Math.random() - 0.5) * 22;
+        positions[i + 2] = (Math.random() - 0.5) * 22;
+        particleVelocities[i] = (Math.random() - 0.5) * 0.03;
+        particleVelocities[i + 1] = -0.05 - Math.random() * 0.06;
+        particleVelocities[i + 2] = (Math.random() - 0.5) * 0.03;
+        colors[i] = 0.05;
+        colors[i + 1] = 0.75 + Math.random() * 0.25;
+        colors[i + 2] = 0.95;
+      }
+
+      geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+      geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+      const material = new THREE.PointsMaterial({
+        size: 0.045,
+        vertexColors: true,
+        transparent: true,
+        opacity: 0.9,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+      });
+      particleSystem = new THREE.Points(geometry, material);
+      scene.add(particleSystem);
+    }
+
+    function createManifoldGeometry() {
+      let geometry;
+      if (morphState === 0) geometry = new THREE.TorusKnotGeometry(1.6, 0.45, 180, 48);
+      else if (morphState === 1) geometry = new THREE.IcosahedronGeometry(2.0, 4);
+      else geometry = new THREE.OctahedronGeometry(2.2, 5);
+
+      const material = new THREE.MeshPhysicalMaterial({
+        color: 0x00f0ff,
+        emissive: 0x003949,
+        emissiveIntensity: 0.6,
+        roughness: 0.05,
+        metalness: 0.88,
+        transmission: 0.45,
+        thickness: 1.4,
+        wireframe: wireframeMode,
+        transparent: true,
+        opacity: 0.92
+      });
+
+      if (manifoldMesh) {
+        scene.remove(manifoldMesh);
+        manifoldMesh.geometry.dispose();
+        manifoldMesh.material.dispose();
+      }
+      manifoldMesh = new THREE.Mesh(geometry, material);
+      scene.add(manifoldMesh);
+      originalPositions = new Float32Array(geometry.attributes.position.array);
+    }
+
+    function toggleWireframe() {
+      wireframeMode = !wireframeMode;
+      if (manifoldMesh) manifoldMesh.material.wireframe = wireframeMode;
+    }
+
+    function toggleMorph() {
+      morphState = (morphState + 1) % 3;
+      createManifoldGeometry();
+    }
+
+    function triggerPermeate() {
+      isPermeating = true;
+      permeateIntensity = 3.5;
+      document.getElementById("stat-perm").textContent = "SHOCKWAVE";
+      document.getElementById("terminal-box").classList.add("hot");
+
+      const flash = document.getElementById("flash-overlay");
+      flash.style.opacity = "0.42";
+      setTimeout(() => { flash.style.opacity = "0"; }, 170);
+
+      const positions = particleSystem.geometry.attributes.position.array;
+      for (let i = 0; i < positions.length; i += 3) {
+        const len = Math.hypot(positions[i], positions[i + 1], positions[i + 2]) + 0.1;
+        const gain = 0.4 + Math.random();
+        particleVelocities[i] = positions[i] / len * gain;
+        particleVelocities[i + 1] = positions[i + 1] / len * gain;
+        particleVelocities[i + 2] = positions[i + 2] / len * gain;
+      }
+
+      const button = document.getElementById("permeate-btn");
+      button.classList.add("hot");
+      setTimeout(() => {
+        button.classList.remove("hot");
+        document.getElementById("terminal-box").classList.remove("hot");
+      }, 700);
+    }
+
+    function onPointerDown(event) {
+      isDragging = true;
+      document.getElementById("canvas-container").classList.add("dragging");
+      previousPointer = { x: event.clientX, y: event.clientY };
+    }
+
+    function onPointerMove(event) {
+      if (!isDragging || !manifoldMesh) return;
+      const dx = event.clientX - previousPointer.x;
+      const dy = event.clientY - previousPointer.y;
+      manifoldMesh.rotation.y += dx * 0.005;
+      manifoldMesh.rotation.x += dy * 0.005;
+      previousPointer = { x: event.clientX, y: event.clientY };
+    }
+
+    function onPointerUp() {
+      isDragging = false;
+      document.getElementById("canvas-container").classList.remove("dragging");
+    }
+
+    function onWheel(event) {
+      event.preventDefault();
+      camera.position.z = THREE.MathUtils.clamp(camera.position.z + event.deltaY * 0.006, 4.0, 14.0);
+    }
+
+    function onWindowResize() {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    }
+
+    function updateManifold(elapsedTime) {
+      manifoldMesh.rotation.y += 0.005 + permeateIntensity * 0.045;
+      manifoldMesh.rotation.z += 0.0025 + permeateIntensity * 0.025;
+
+      if (isPermeating) {
+        permeateIntensity *= 0.93;
+        if (permeateIntensity < 0.01) {
+          permeateIntensity = 0;
+          isPermeating = false;
+          document.getElementById("stat-perm").textContent = "STABLE";
+        }
+      }
+
+      const posAttr = manifoldMesh.geometry.attributes.position;
+      for (let i = 0; i < posAttr.count; i++) {
+        const ox = originalPositions[i * 3];
+        const oy = originalPositions[i * 3 + 1];
+        const oz = originalPositions[i * 3 + 2];
+        if (permeateIntensity > 0.01) {
+          const wave = Math.sin(elapsedTime * 40 + i * 0.3) * 0.18 * permeateIntensity;
+          const noise = (Math.random() - 0.5) * 0.06 * permeateIntensity;
+          posAttr.setXYZ(i, ox + ox * wave + noise, oy + oy * wave + noise, oz + oz * wave + noise);
+        } else {
+          posAttr.setXYZ(
+            i,
+            posAttr.getX(i) + (ox - posAttr.getX(i)) * 0.1,
+            posAttr.getY(i) + (oy - posAttr.getY(i)) * 0.1,
+            posAttr.getZ(i) + (oz - posAttr.getZ(i)) * 0.1
+          );
+        }
+      }
+      posAttr.needsUpdate = true;
+      manifoldMesh.material.emissiveIntensity = 0.5 + Math.sin(elapsedTime * 10) * 0.25 + permeateIntensity * 1.2;
+    }
+
+    function updateParticles() {
+      const positions = particleSystem.geometry.attributes.position.array;
+      for (let i = 0; i < positions.length; i += 3) {
+        positions[i] += particleVelocities[i];
+        positions[i + 1] += particleVelocities[i + 1];
+        positions[i + 2] += particleVelocities[i + 2];
+        particleVelocities[i] *= 0.96;
+        particleVelocities[i + 1] = particleVelocities[i + 1] * 0.96 - 0.012;
+        particleVelocities[i + 2] *= 0.96;
+        for (let axis = 0; axis < 3; axis++) {
+          const p = i + axis;
+          if (positions[p] > 14) positions[p] = -14;
+          if (positions[p] < -14) positions[p] = 14;
+        }
+      }
+      particleSystem.geometry.attributes.position.needsUpdate = true;
+      particleSystem.rotation.y -= 0.0025 * (1 + permeateIntensity);
+    }
+
+    function updateTelemetry(now, elapsedTime) {
+      const frameMs = Math.max(now - lastFrameTime, 0.01);
+      lastFrameTime = now;
+      const instantFps = 1000 / frameMs;
+      fpsEma = fpsEma * 0.9 + instantFps * 0.1;
+
+      const coherence = Math.max(0, 100 - Math.min(permeateIntensity * 12, 35));
+      document.getElementById("stat-coherence").textContent = coherence.toFixed(1) + "% derived";
+
+      if (externalTelemetry) {
+        const t = externalTelemetry;
+        document.getElementById("source-chip").textContent = t.source || "MEASURED EXTERNAL";
+        document.getElementById("throughput-display").textContent = Number.isFinite(t.queries_per_second)
+          ? Math.round(t.queries_per_second).toLocaleString() + " field queries/s"
+          : "external telemetry connected";
+        document.getElementById("stat-fps").textContent = fpsEma.toFixed(1) + " local";
+        document.getElementById("stat-latency").textContent = Number.isFinite(t.latency_ms)
+          ? t.latency_ms.toFixed(3) + " ms field"
+          : frameMs.toFixed(2) + " ms local";
+        if (Number.isFinite(t.node_updates_per_second)) {
+          document.getElementById("stat-nodes").textContent = Math.round(t.node_updates_per_second).toLocaleString() + " updates/s";
+        }
+      } else {
+        document.getElementById("source-chip").textContent = "LOCAL VISUAL MEASUREMENT";
+        document.getElementById("throughput-display").textContent = fpsEma.toFixed(1) + " rendered frames/s";
+        document.getElementById("stat-fps").textContent = fpsEma.toFixed(1) + " measured";
+        document.getElementById("stat-latency").textContent = frameMs.toFixed(2) + " ms measured";
+        document.getElementById("stat-nodes").textContent = PHASE_NODE_MODEL.toLocaleString() + " model";
+      }
+
+      const codeIndex = Math.floor(elapsedTime / 5) % codeFeeds.length;
+      document.getElementById("term-content").textContent = codeFeeds[codeIndex];
+      document.getElementById("live-clock").textContent = new Date().toISOString().slice(11, 19) + " UTC";
+    }
+
+    window.setPhase3DTelemetry = function setPhase3DTelemetry(payload) {
+      if (payload === null) {
+        externalTelemetry = null;
+        return;
+      }
+      if (typeof payload !== "object") throw new TypeError("telemetry payload must be an object or null");
+      const numericKeys = ["queries_per_second", "node_updates_per_second", "latency_ms", "peak_memory_mb", "semantic_error", "energy_drift"];
+      for (const key of numericKeys) {
+        if (payload[key] !== undefined && !Number.isFinite(Number(payload[key]))) {
+          throw new TypeError(key + " must be finite when supplied");
+        }
+      }
+      externalTelemetry = { ...payload };
+      for (const key of numericKeys) {
+        if (externalTelemetry[key] !== undefined) externalTelemetry[key] = Number(externalTelemetry[key]);
+      }
+    };
+
+    function animate(now) {
+      requestAnimationFrame(animate);
+      const elapsedTime = clock.getElapsedTime();
+      updateManifold(elapsedTime);
+      updateParticles();
+      updateTelemetry(now, elapsedTime);
+      renderer.render(scene, camera);
+    }
+
+    window.addEventListener("load", init, { once: true });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Operationalizes the supplied DM–vΩΞ⁺ Total Permeation Singularity mockup as a bounded Jarvis-X Phase3D browser visualization.

### What changed

- adds `apps/total-permeation-3d/index.html` with the supplied Three.js manifold, particle shockwave, morph, wireframe and permeation interactions;
- cleans the escaped HTML/JavaScript syntax and invalid markdown-wrapped CDN URLs from the supplied source;
- removes unverified infinite-throughput, zero-latency and infinite-gamma telemetry claims;
- reports measured local browser FPS/frame latency separately from derived/model quantities;
- adds `window.setPhase3DTelemetry(payload)` so measured Phase3D runtime telemetry can be injected without rewriting the visualization;
- aligns the HUD with the merged Phase3D recurrence, equilibrium-shell equation and Jarvis-X commit/rollback authority boundary;
- documents the visualization/measurement trust boundary;
- adds a dependency-free static CI smoke workflow that parses the HTML, rejects the original impossible telemetry strings, verifies required controls and serves/fetches the entry point;
- records the new visualization surface in the changelog.

## Authority boundary

This is a browser visualization surface only. It does not mutate authoritative Phase3D state, model weights, runtime configuration, files, devices or external systems.

Measured external runtime values must be explicitly injected by an adapter; otherwise the HUD shows only its own local render-loop timing and clearly labeled model/derived quantities.

## Runtime dependency

The page loads Three.js r128 from cdnjs. No Tailwind runtime dependency remains.