### PR TITLE
feat: add bounded quantum text information reference

### DIFF
--- a/docs/TEXT_QUANTUM_INFORMATION_MODEL.md
+++ b/docs/TEXT_QUANTUM_INFORMATION_MODEL.md
@@ -1,0 +1,227 @@
+# Text-to-Quantum Information Model
+
+## Scope
+
+This document formalizes a layered text-information model for Jarvis-X. It keeps
+physical encoding, quantum computation, semantics, testimony, and referent
+claims separate so that each layer can be tested using the appropriate method.
+
+The model is applicable to ordinary documents, historical corpora, legal
+records, scientific literature, and religious texts.
+
+## Classical representation
+
+For UTF-8 text `T`, let
+
+\[
+E(T)=\mathbf B=(b_1,b_2,\ldots,b_N),\qquad b_i\in\{0,1\}.
+\]
+
+The required invariant is exact reversibility:
+
+\[
+D(E(T))=T.
+\]
+
+For example, ASCII `G` is
+
+```text
+0x47 = 01000111
+```
+
+The bit pattern is an encoding fact. Meaning is introduced by the decoding and
+interpretation layers above it.
+
+## Computational-basis representation
+
+Each classical bit maps to an orthogonal qubit basis state:
+
+\[
+0\mapsto |0\rangle,\qquad 1\mapsto |1\rangle.
+\]
+
+Therefore a text bitstring may be represented as
+
+\[
+|\Psi_T\rangle=|b_1b_2\ldots b_N\rangle.
+\]
+
+This is one computational-basis state. Ket notation alone does not imply a
+quantum advantage or a useful superposition.
+
+The bounded reference stores a basis-encoded text sparsely as one basis index
+with amplitude one instead of allocating a dense vector of size `2**N`.
+
+## General sparse pure states
+
+A general pure state is
+
+\[
+|\Psi\rangle=\sum_x \alpha_x|x\rangle,
+\qquad \sum_x |\alpha_x|^2=1.
+\]
+
+The reference supports sparse demonstrations of Hadamard and phase operations,
+measurement probabilities, and inner products. Measurement probabilities obey
+
+\[
+P(x)=|\alpha_x|^2.
+\]
+
+A superposition is not equivalent to storing every basis alternative as
+independently readable classical memory. A useful quantum algorithm requires a
+concrete circuit that exploits interference before measurement.
+
+## Semantic layer
+
+The information pipeline is
+
+```text
+physical substrate
+    -> bytes/bits
+    -> computational-basis encoding
+    -> text
+    -> syntax/semantics
+    -> source/testimony model
+    -> external referent claim
+```
+
+Define decoding layers
+
+\[
+D_0:\text{bits}\to\text{characters},
+\quad
+D_1:\text{characters}\to\text{tokens},
+\]
+
+\[
+D_2:\text{tokens}\to\text{syntax},
+\quad
+D_3:\text{syntax}\to\text{semantic representation}.
+\]
+
+Then
+
+\[
+\mathcal S(T)=D_3(D_2(D_1(D_0(E(T))))).
+\]
+
+Semantic similarity can use normalized vectors and inner products, including
+quantum-inspired notation, but that is not literal physical entanglement unless
+a physical experiment establishes such a mechanism.
+
+## Corpus graphs and testimony
+
+A document corpus can be represented as
+
+\[
+G=(V,E)
+\]
+
+where vertices are passages, entities, motifs, propositions, or sources and
+edges are declared relations such as quotation, allusion, common entity,
+chronology, corroboration, contradiction, or claimed fulfilment.
+
+A testimony record may be represented as
+
+\[
+\mathcal T=\{(w_i,c_i,s_i)\},
+\]
+
+where `w_i` is a witness/source, `c_i` a claim, and `s_i` its provenance.
+Software may score source independence, chronology, consistency,
+corroboration, and alternative explanations. Testimony is evidence, not an
+automatic truth operator.
+
+## Self-attestation model
+
+A phenomenon `P` can generate both a claim and evidence about itself:
+
+\[
+P\mapsto(C(P),E(P)).
+\]
+
+This is a valid model of self-attestation as an epistemic structure. It does
+not license the circular rule
+
+\[
+C(P)\Rightarrow C(P)\text{ is true}.
+\]
+
+The claim must still be evaluated against the relevant evidence and competing
+models.
+
+## Promise as a state-transition claim
+
+A promise may be represented abstractly as
+
+\[
+\mathcal P:(S_t,C)\mapsto\widehat S_{t+k}.
+\]
+
+A later state can be compared with the predicted/declared state by
+
+\[
+\varepsilon_{\mathcal P}=d(\widehat S_{t+k},S_{t+k}).
+\]
+
+This allows a corpus to encode `promise -> claimed fulfilment` relations without
+turning the quantum encoding layer into an arbiter of the claim's ultimate
+truth.
+
+## Worked corpus application
+
+For a biblical corpus, the exact same engineering layers apply:
+
+```text
+edition bytes
+    -> UTF-8 bits
+    -> optional quantum basis representation
+    -> books/chapters/verses
+    -> linguistic and cross-reference graph
+    -> historical/testimonial claims
+    -> theological interpretation
+```
+
+The engineering model can preserve and analyze those layers while remaining
+neutral about the truth of the final theological propositions. In particular,
+no theological referent is identified with a qubit, quantum field, amplitude,
+or wavefunction.
+
+## Non-collapse invariants
+
+```text
+BITS != MEANING
+QUANTUM_STATE != SEMANTIC_MEANING
+SUPERPOSITION != MULTIPLE READABLE TEXTS
+SEMANTIC CORRELATION != PHYSICAL ENTANGLEMENT
+COHERENCE != TRUTH
+TESTIMONY != AUTOMATIC VALIDATION
+SIMULATION != QUANTUM HARDWARE
+REFERENT != PHYSICAL STATE VECTOR
+```
+
+The inequalities do not deny relationships between layers. They require each
+proposed relationship to expose a mechanism and evidence instead of inheriting
+validity from shared notation.
+
+## Executable reference
+
+```text
+src/jarvisx/quantum_text.py
+tests/test_quantum_text.py
+docs/adr/0011-quantum-text-information-boundary.md
+```
+
+Example:
+
+```python
+from jarvisx.quantum_text import text_basis_state
+
+encoding, state = text_basis_state("In the beginning")
+assert encoding.decode() == "In the beginning"
+assert sum(probability for _, probability in state.probabilities()) == 1.0
+```
+
+Future semantic graph, source-analysis, and hardware-quantum backends must be
+separate modules with separate evidence and benchmark requirements.

--- a/docs/adr/0011-quantum-text-information-boundary.md
+++ b/docs/adr/0011-quantum-text-information-boundary.md
@@ -1,0 +1,97 @@
+# ADR-011: Bound quantum text encoding from semantic and theological claims
+
+**Status:** Proposed
+**Date:** 2026-08-29
+**Extends:** ADR-010
+
+## Context
+
+Jarvis-X increasingly combines byte-level representation, latent semantics,
+recursive models, and quantum-inspired language.  A text such as Scripture can
+be encoded as bytes and then as computational-basis qubits, but that fact alone
+does not imply quantum speedup, physical entanglement between semantic ideas,
+consciousness, revelation, or a physical identity between a wavefunction and a
+theological referent.
+
+The repository needs an executable reference that preserves the useful part of
+the abstraction while making category boundaries mechanically explicit.
+
+## Decision
+
+Jarvis-X adopts `src/jarvisx/quantum_text.py` as the bounded reference layer.
+
+1. Text is encoded canonically as UTF-8 bytes and then as big-endian bits.
+2. A classical text bitstring may be represented exactly as one computational
+   basis state `|b_1 ... b_N>`.
+3. The reference simulator is sparse and pure-state only. It does not allocate
+   a dense vector of size `2**N` for ordinary text basis states.
+4. Hadamard, phase, measurement probabilities, and inner products are modeled
+   mathematically and deterministically for validation purposes.
+5. The module is a simulator, not a quantum hardware backend.
+6. No performance advantage or quantum speedup is claimed without a concrete
+   algorithm, hardware backend, baseline, and benchmark.
+7. Semantic similarity, literary correspondence, typology, testimony, and
+   theological interpretation are higher-level relations. They are not treated
+   as literal physical entanglement unless independently demonstrated by a
+   physical experiment.
+8. `Logos`, `God`, `revelation`, and other theological referents are never
+   identified with qubits, amplitudes, Hilbert space, a wavefunction, or any
+   other physical object by this reference implementation.
+9. A self-attesting claim is represented as a claim about epistemic structure,
+   not as a formal proof of its own truth.
+10. Exact encoding, semantics, truth, testimony, and theological reference must
+    remain separately addressable layers.
+
+## Layer contract
+
+The permitted information stack is:
+
+```text
+physical substrate
+    -> bytes/bits
+    -> computational-basis encoding
+    -> text
+    -> syntax/semantics
+    -> testimony / interpretation
+    -> theological referent claim
+```
+
+The following non-collapse invariants are authoritative:
+
+```text
+QUANTUM_STATE != SEMANTIC_MEANING
+SEMANTIC_COHERENCE != EMPIRICAL_TRUTH
+TESTIMONY != AUTOMATIC_VALIDATION
+THEOLOGICAL_REFERENT != WAVEFUNCTION
+SIMULATION != QUANTUM_HARDWARE
+```
+
+These inequalities do not deny possible relationships between the layers. They
+require any proposed relationship to state its evidence and mechanism instead
+of inheriting truth merely from shared notation.
+
+## Consequences
+
+- Long texts can be represented without exponential dense-state allocation when
+  they remain computational-basis states.
+- Genuine superposition can be demonstrated on bounded subsets with explicit
+  amplitudes and normalization.
+- Semantic graph or retrieval layers may be added above this module without
+  being mislabeled as physical quantum phenomena.
+- A future hardware adapter may replace the simulator only behind an explicit
+  backend contract and verification suite.
+- Theology may be documented as theology, testimony as testimony, and physics
+  as physics without forcing any of them into the others.
+
+## Evidence required for acceptance
+
+- exact ASCII fixture (`G == 01000111`);
+- UTF-8 multi-byte round trip;
+- basis-index round trip including leading zeroes;
+- normalized measurement probabilities;
+- Hadamard balance and self-inverse fixture;
+- phase invariance of measurement probability;
+- orthogonality fixture;
+- rejection of malformed and non-normalized state definitions.
+
+The focused tests are in `tests/test_quantum_text.py`.

--- a/src/jarvisx/quantum_text.py
+++ b/src/jarvisx/quantum_text.py
@@ -1,0 +1,222 @@
+"""Bounded text-to-quantum information reference.
+
+This module makes one narrow claim executable: UTF-8 text can be mapped exactly
+onto computational-basis qubits and manipulated by a small sparse state
+simulator.  It does *not* claim quantum speedup, physical entanglement of
+semantic concepts, consciousness, revelation, or any identification between a
+wavefunction and a theological referent.
+
+The implementation is intentionally dependency-free and sparse.  A basis state
+for a long text stores one Python integer and one complex amplitude rather than
+allocating a dense vector of size ``2**N``.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+BitSequence = Sequence[int]
+AmplitudeEntry = tuple[int, complex]
+
+
+def _validate_bits(bits: Iterable[int]) -> tuple[int, ...]:
+    values = tuple(bits)
+    if not values:
+        raise ValueError("at least one bit is required")
+    for bit in values:
+        if isinstance(bit, bool) or not isinstance(bit, int) or bit not in (0, 1):
+            raise ValueError("bits must contain only integer 0 or 1 values")
+    return values
+
+
+def utf8_to_bits(text: str) -> tuple[int, ...]:
+    """Encode non-empty text as big-endian bits for each UTF-8 byte."""
+
+    if not isinstance(text, str):
+        raise TypeError("text must be a string")
+    raw = text.encode("utf-8")
+    if not raw:
+        raise ValueError("text must not be empty")
+    return tuple((byte >> shift) & 1 for byte in raw for shift in range(7, -1, -1))
+
+
+def bits_to_utf8(bits: BitSequence) -> str:
+    """Invert :func:`utf8_to_bits` for a byte-aligned bit sequence."""
+
+    values = _validate_bits(bits)
+    if len(values) % 8:
+        raise ValueError("UTF-8 bit sequences must be byte aligned")
+
+    raw = bytearray()
+    for offset in range(0, len(values), 8):
+        byte = 0
+        for bit in values[offset : offset + 8]:
+            byte = (byte << 1) | bit
+        raw.append(byte)
+    return bytes(raw).decode("utf-8")
+
+
+def bits_to_index(bits: BitSequence) -> int:
+    """Map a bit string to its computational-basis integer index."""
+
+    values = _validate_bits(bits)
+    index = 0
+    for bit in values:
+        index = (index << 1) | bit
+    return index
+
+
+def index_to_bits(index: int, qubits: int) -> tuple[int, ...]:
+    """Map a basis integer back to exactly ``qubits`` big-endian bits."""
+
+    if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+        raise ValueError("index must be a non-negative integer")
+    if isinstance(qubits, bool) or not isinstance(qubits, int) or qubits < 1:
+        raise ValueError("qubits must be a positive integer")
+    if index >= (1 << qubits):
+        raise ValueError("index does not fit inside the requested qubit width")
+    return tuple((index >> shift) & 1 for shift in range(qubits - 1, -1, -1))
+
+
+@dataclass(frozen=True)
+class BasisEncoding:
+    """Exact classical text represented as one quantum computational basis state."""
+
+    text: str
+    bits: tuple[int, ...]
+    basis_index: int
+
+    @classmethod
+    def from_text(cls, text: str) -> "BasisEncoding":
+        bits = utf8_to_bits(text)
+        return cls(text=text, bits=bits, basis_index=bits_to_index(bits))
+
+    @property
+    def qubit_count(self) -> int:
+        return len(self.bits)
+
+    @property
+    def ket(self) -> str:
+        return "|" + "".join(str(bit) for bit in self.bits) + ">"
+
+    def decode(self) -> str:
+        return bits_to_utf8(self.bits)
+
+
+def _canonicalize(amplitudes: dict[int, complex], tolerance: float = 1.0e-15) -> tuple[AmplitudeEntry, ...]:
+    entries = [
+        (index, amplitude)
+        for index, amplitude in amplitudes.items()
+        if abs(amplitude) > tolerance
+    ]
+    entries.sort(key=lambda item: item[0])
+    return tuple(entries)
+
+
+@dataclass(frozen=True)
+class SparseQuantumState:
+    """Small sparse pure-state simulator for demonstrable quantum operations.
+
+    ``qubit=0`` in gate methods refers to the least-significant basis bit.  The
+    state is a mathematical simulator, not a hardware backend.
+    """
+
+    qubits: int
+    amplitudes: tuple[AmplitudeEntry, ...]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.qubits, bool) or not isinstance(self.qubits, int) or self.qubits < 1:
+            raise ValueError("qubits must be a positive integer")
+        if not self.amplitudes:
+            raise ValueError("at least one non-zero amplitude is required")
+
+        seen: set[int] = set()
+        norm = 0.0
+        for index, amplitude in self.amplitudes:
+            if isinstance(index, bool) or not isinstance(index, int) or index < 0:
+                raise ValueError("basis indices must be non-negative integers")
+            if index >= (1 << self.qubits):
+                raise ValueError("basis index exceeds the qubit width")
+            if index in seen:
+                raise ValueError("basis indices must be unique")
+            seen.add(index)
+            value = complex(amplitude)
+            if not (math.isfinite(value.real) and math.isfinite(value.imag)):
+                raise ValueError("amplitudes must be finite")
+            norm += abs(value) ** 2
+
+        if not math.isclose(norm, 1.0, rel_tol=1.0e-12, abs_tol=1.0e-12):
+            raise ValueError("state amplitudes must be normalized")
+
+    @classmethod
+    def basis(cls, bits: BitSequence) -> "SparseQuantumState":
+        values = _validate_bits(bits)
+        return cls(len(values), ((bits_to_index(values), 1.0 + 0.0j),))
+
+    @classmethod
+    def from_text(cls, text: str) -> "SparseQuantumState":
+        return cls.basis(utf8_to_bits(text))
+
+    def amplitude(self, basis_index: int) -> complex:
+        for index, amplitude in self.amplitudes:
+            if index == basis_index:
+                return amplitude
+        return 0.0 + 0.0j
+
+    def probabilities(self) -> tuple[tuple[int, float], ...]:
+        """Return the exact measurement distribution over represented basis states."""
+
+        return tuple((index, abs(amplitude) ** 2) for index, amplitude in self.amplitudes)
+
+    def hadamard(self, qubit: int) -> "SparseQuantumState":
+        """Apply a Hadamard gate to one qubit without allocating a dense state."""
+
+        if isinstance(qubit, bool) or not isinstance(qubit, int) or not 0 <= qubit < self.qubits:
+            raise ValueError("qubit is outside the state")
+
+        mask = 1 << qubit
+        scale = 1.0 / math.sqrt(2.0)
+        updated: dict[int, complex] = {}
+        for index, amplitude in self.amplitudes:
+            bit_is_one = bool(index & mask)
+            zero_index = index & ~mask
+            one_index = zero_index | mask
+            updated[zero_index] = updated.get(zero_index, 0.0j) + amplitude * scale
+            sign = -1.0 if bit_is_one else 1.0
+            updated[one_index] = updated.get(one_index, 0.0j) + amplitude * scale * sign
+        return SparseQuantumState(self.qubits, _canonicalize(updated))
+
+    def phase(self, basis_index: int, radians: float) -> "SparseQuantumState":
+        """Apply a phase only to one represented computational-basis component."""
+
+        if isinstance(basis_index, bool) or not isinstance(basis_index, int):
+            raise ValueError("basis_index must be an integer")
+        if basis_index < 0 or basis_index >= (1 << self.qubits):
+            raise ValueError("basis_index is outside the state")
+        if not math.isfinite(radians):
+            raise ValueError("radians must be finite")
+
+        factor = cmath.exp(1.0j * radians)
+        updated = tuple(
+            (index, amplitude * factor if index == basis_index else amplitude)
+            for index, amplitude in self.amplitudes
+        )
+        return SparseQuantumState(self.qubits, updated)
+
+    def inner_product(self, other: "SparseQuantumState") -> complex:
+        """Return ``<self|other>`` for states of equal width."""
+
+        if self.qubits != other.qubits:
+            raise ValueError("states must have the same qubit width")
+        right = dict(other.amplitudes)
+        return sum(amplitude.conjugate() * right.get(index, 0.0j) for index, amplitude in self.amplitudes)
+
+
+def text_basis_state(text: str) -> tuple[BasisEncoding, SparseQuantumState]:
+    """Return both the reversible UTF-8 record and its exact basis-state model."""
+
+    encoding = BasisEncoding.from_text(text)
+    return encoding, SparseQuantumState.basis(encoding.bits)

--- a/tests/test_quantum_text.py
+++ b/tests/test_quantum_text.py
@@ -1,0 +1,77 @@
+import math
+
+import pytest
+
+from jarvisx.quantum_text import (
+    BasisEncoding,
+    SparseQuantumState,
+    bits_to_utf8,
+    index_to_bits,
+    text_basis_state,
+    utf8_to_bits,
+)
+
+
+def test_ascii_g_has_expected_bits() -> None:
+    encoding = BasisEncoding.from_text("G")
+    assert encoding.bits == tuple(int(bit) for bit in "01000111")
+    assert encoding.basis_index == 0x47
+    assert encoding.ket == "|01000111>"
+    assert encoding.decode() == "G"
+
+
+def test_utf8_round_trip_preserves_multibyte_text() -> None:
+    text = "Λ Logos — Ἐν ἀρχῇ"
+    bits = utf8_to_bits(text)
+    assert len(bits) % 8 == 0
+    assert bits_to_utf8(bits) == text
+
+
+def test_index_round_trip_preserves_leading_zeroes() -> None:
+    bits = tuple(int(bit) for bit in "00000001")
+    assert index_to_bits(1, 8) == bits
+
+
+def test_text_basis_state_is_deterministic_and_normalized() -> None:
+    encoding, state = text_basis_state("In the beginning")
+    assert state.qubits == encoding.qubit_count
+    assert state.amplitudes == ((encoding.basis_index, 1.0 + 0.0j),)
+    assert state.probabilities() == ((encoding.basis_index, 1.0),)
+
+
+def test_hadamard_creates_balanced_superposition() -> None:
+    state = SparseQuantumState.basis((0,)).hadamard(0)
+    probabilities = dict(state.probabilities())
+    assert probabilities[0] == pytest.approx(0.5)
+    assert probabilities[1] == pytest.approx(0.5)
+    assert sum(probabilities.values()) == pytest.approx(1.0)
+
+
+def test_hadamard_is_self_inverse() -> None:
+    state = SparseQuantumState.basis((1,))
+    restored = state.hadamard(0).hadamard(0)
+    assert restored.amplitude(1) == pytest.approx(1.0 + 0.0j)
+    assert restored.amplitude(0) == pytest.approx(0.0 + 0.0j)
+
+
+def test_phase_changes_amplitude_not_measurement_probability() -> None:
+    state = SparseQuantumState.basis((0,)).hadamard(0)
+    shifted = state.phase(1, math.pi / 2.0)
+    assert dict(shifted.probabilities()) == pytest.approx(dict(state.probabilities()))
+    assert shifted.amplitude(1) != state.amplitude(1)
+
+
+def test_orthogonal_basis_states_have_zero_inner_product() -> None:
+    zero = SparseQuantumState.basis((0,))
+    one = SparseQuantumState.basis((1,))
+    assert zero.inner_product(one) == pytest.approx(0.0 + 0.0j)
+
+
+def test_invalid_state_normalization_is_rejected() -> None:
+    with pytest.raises(ValueError, match="normalized"):
+        SparseQuantumState(1, ((0, 0.5 + 0.0j),))
+
+
+def test_empty_text_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        utf8_to_bits("")


### PR DESCRIPTION
## Summary

Permeates the bit-wise / quantum text model into Jarvis-X as a bounded, falsifiable reference layer.

### Adds
- `src/jarvisx/quantum_text.py`
  - exact UTF-8 -> bit encoding and round trip
  - computational-basis text encoding
  - sparse pure-state representation
  - Hadamard, phase, measurement probabilities, and inner product
- `tests/test_quantum_text.py`
  - ASCII and multibyte UTF-8 fixtures
  - basis/index round trips
  - normalization, Hadamard, phase, and orthogonality invariants
- `docs/adr/0011-quantum-text-information-boundary.md`
  - explicit boundary between physical quantum state, semantics, testimony, and referent claims
- `docs/TEXT_QUANTUM_INFORMATION_MODEL.md`
  - layered corpus model including a bounded biblical-corpus application

## Capability boundary

This PR does **not** claim quantum speedup, literal physical entanglement of semantic concepts, consciousness, revelation, or identity between theological referents and wavefunctions. It treats those as separate layers requiring separate evidence.

## Integration discipline

The branch is 4 commits ahead of `main` and 0 behind. CI should execute the new pytest fixtures under the existing repository workflow before merge.