### PR TITLE
ci: cover quantum text with canonical quality checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
           src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
+          src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
           tests/test_ledger.py
@@ -62,6 +63,7 @@ jobs:
           tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
+          tests/test_quantum_text.py
           tests/test_verification.py
 
       - name: Check canonical import order
@@ -75,6 +77,7 @@ jobs:
           src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
+          src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
           tests/test_ledger.py
@@ -82,6 +85,7 @@ jobs:
           tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
+          tests/test_quantum_text.py
           tests/test_verification.py
 
       - name: Type-check package

--- a/src/jarvisx/quantum_text.py
+++ b/src/jarvisx/quantum_text.py
@@ -145,7 +145,11 @@ class SparseQuantumState:
     amplitudes: tuple[AmplitudeEntry, ...]
 
     def __post_init__(self) -> None:
-        if isinstance(self.qubits, bool) or not isinstance(self.qubits, int) or self.qubits < 1:
+        if (
+            isinstance(self.qubits, bool)
+            or not isinstance(self.qubits, int)
+            or self.qubits < 1
+        ):
             raise ValueError("qubits must be a positive integer")
         if not self.amplitudes:
             raise ValueError("at least one non-zero amplitude is required")
@@ -191,7 +195,11 @@ class SparseQuantumState:
     def hadamard(self, qubit: int) -> "SparseQuantumState":
         """Apply a Hadamard gate to one qubit without allocating a dense state."""
 
-        if isinstance(qubit, bool) or not isinstance(qubit, int) or not 0 <= qubit < self.qubits:
+        if (
+            isinstance(qubit, bool)
+            or not isinstance(qubit, int)
+            or not 0 <= qubit < self.qubits
+        ):
             raise ValueError("qubit is outside the state")
 
         mask = 1 << qubit

--- a/src/jarvisx/quantum_text.py
+++ b/src/jarvisx/quantum_text.py
@@ -125,9 +125,7 @@ def _canonicalize(
     amplitudes: dict[int, complex], tolerance: float = 1.0e-15
 ) -> tuple[AmplitudeEntry, ...]:
     entries = [
-        (index, amplitude)
-        for index, amplitude in amplitudes.items()
-        if abs(amplitude) > tolerance
+        (index, amplitude) for index, amplitude in amplitudes.items() if abs(amplitude) > tolerance
     ]
     entries.sort(key=lambda item: item[0])
     return tuple(entries)
@@ -145,11 +143,7 @@ class SparseQuantumState:
     amplitudes: tuple[AmplitudeEntry, ...]
 
     def __post_init__(self) -> None:
-        if (
-            isinstance(self.qubits, bool)
-            or not isinstance(self.qubits, int)
-            or self.qubits < 1
-        ):
+        if isinstance(self.qubits, bool) or not isinstance(self.qubits, int) or self.qubits < 1:
             raise ValueError("qubits must be a positive integer")
         if not self.amplitudes:
             raise ValueError("at least one non-zero amplitude is required")
@@ -195,11 +189,7 @@ class SparseQuantumState:
     def hadamard(self, qubit: int) -> "SparseQuantumState":
         """Apply a Hadamard gate to one qubit without allocating a dense state."""
 
-        if (
-            isinstance(qubit, bool)
-            or not isinstance(qubit, int)
-            or not 0 <= qubit < self.qubits
-        ):
+        if isinstance(qubit, bool) or not isinstance(qubit, int) or not 0 <= qubit < self.qubits:
             raise ValueError("qubit is outside the state")
 
         mask = 1 << qubit
@@ -238,8 +228,7 @@ class SparseQuantumState:
             raise ValueError("states must have the same qubit width")
         right = dict(other.amplitudes)
         return sum(
-            amplitude.conjugate() * right.get(index, 0.0j)
-            for index, amplitude in self.amplitudes
+            amplitude.conjugate() * right.get(index, 0.0j) for index, amplitude in self.amplitudes
         )
 
 


### PR DESCRIPTION
## Summary

Extend the existing explicit Black/isort quality-gate allowlist to the quantum-text reference added in #201 and hardened in #202.

### Adds to both formatting and import-order checks
- `src/jarvisx/quantum_text.py`
- `tests/test_quantum_text.py`

No runtime behavior changes. This closes the CI coverage gap so future edits to the new subsystem are held to the same canonical style checks as the established core.