### PR TITLE
feat(world): operationalize bit-wise 500^3 World Engine kernel

### DIFF
--- a/.github/workflows/world-engine-windows.yml
+++ b/.github/workflows/world-engine-windows.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/include/jarvisx/bitwise_world500.hpp"
       - "cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp"
       - "cpp_runtime/src/world_engine_main.cpp"
       - "cpp_runtime/src/recursive_cube_main.cpp"
@@ -12,11 +13,13 @@ on:
       - "cpp_runtime/world_engine.cmake"
       - "cpp_runtime/CMakeLists.txt"
       - "docs/VMAD128_WORLD_ENGINE.md"
+      - "docs/DR_MOAGI_BITWISE_WORLD500.md"
       - "docs/RECURSIVE_CUBE_INTERPRETER.md"
       - ".github/workflows/world-engine-windows.yml"
   pull_request:
     paths:
       - "cpp_runtime/include/jarvisx/world_engine_vmad.hpp"
+      - "cpp_runtime/include/jarvisx/bitwise_world500.hpp"
       - "cpp_runtime/include/jarvisx/recursive_cube_interpreter.hpp"
       - "cpp_runtime/src/world_engine_main.cpp"
       - "cpp_runtime/src/recursive_cube_main.cpp"
@@ -25,6 +28,7 @@ on:
       - "cpp_runtime/world_engine.cmake"
       - "cpp_runtime/CMakeLists.txt"
       - "docs/VMAD128_WORLD_ENGINE.md"
+      - "docs/DR_MOAGI_BITWISE_WORLD500.md"
       - "docs/RECURSIVE_CUBE_INTERPRETER.md"
       - ".github/workflows/world-engine-windows.yml"
   workflow_dispatch:
@@ -89,6 +93,7 @@ jobs:
           Copy-Item "build/world-engine/Release/DrMoagi-World-Engine.exe" "$stage/DrMoagi-World-Engine.exe"
           Copy-Item "build/world-engine/Release/DrMoagi-Recursive-Cube.exe" "$stage/DrMoagi-Recursive-Cube.exe"
           Copy-Item "docs/VMAD128_WORLD_ENGINE.md" "$stage/VMAD128_WORLD_ENGINE.md"
+          Copy-Item "docs/DR_MOAGI_BITWISE_WORLD500.md" "$stage/DR_MOAGI_BITWISE_WORLD500.md"
           Copy-Item "docs/RECURSIVE_CUBE_INTERPRETER.md" "$stage/RECURSIVE_CUBE_INTERPRETER.md"
           $worldHash = (Get-FileHash "$stage/DrMoagi-World-Engine.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
           $cubeHash = (Get-FileHash "$stage/DrMoagi-Recursive-Cube.exe" -Algorithm SHA256).Hash.ToLowerInvariant()
@@ -106,6 +111,7 @@ jobs:
             build/world-engine/package/DrMoagi-World-Engine.exe
             build/world-engine/package/DrMoagi-Recursive-Cube.exe
             build/world-engine/package/VMAD128_WORLD_ENGINE.md
+            build/world-engine/package/DR_MOAGI_BITWISE_WORLD500.md
             build/world-engine/package/RECURSIVE_CUBE_INTERPRETER.md
             build/world-engine/package/SHA256SUMS.txt
             build/world-engine/DrMoagi-World-Engine-Windows-x64.zip

--- a/cpp_runtime/include/jarvisx/bitwise_world500.hpp
+++ b/cpp_runtime/include/jarvisx/bitwise_world500.hpp
@@ -1,0 +1,201 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace jarvisx::world::bitwise500 {
+
+constexpr std::uint32_t kWorldEdge = 500U;
+constexpr std::uint64_t kWorldAgentCount =
+    static_cast<std::uint64_t>(kWorldEdge) * kWorldEdge * kWorldEdge;
+constexpr std::uint32_t kLatentDimensions = 16U;
+constexpr std::uint32_t kBitsPerFp32 = 32U;
+constexpr std::uint32_t kBitsPerAgent = kLatentDimensions * kBitsPerFp32;
+constexpr std::uint64_t kWorldLatentBits = kWorldAgentCount * kBitsPerAgent;
+constexpr std::uint64_t kWorldLatentBytes = kWorldLatentBits / 8ULL;
+constexpr long double kWorldLatentGiB =
+    static_cast<long double>(kWorldLatentBytes) / 1073741824.0L;
+
+struct Coord500 {
+    std::uint16_t x{};
+    std::uint16_t y{};
+    std::uint16_t z{};
+
+    bool operator==(const Coord500& other) const noexcept {
+        return x == other.x && y == other.y && z == other.z;
+    }
+};
+
+inline std::uint64_t linear_address(std::uint32_t x, std::uint32_t y, std::uint32_t z) {
+    if (x >= kWorldEdge || y >= kWorldEdge || z >= kWorldEdge) {
+        throw std::out_of_range("500^3 world coordinate is outside [0,499]");
+    }
+    return static_cast<std::uint64_t>(x) +
+           static_cast<std::uint64_t>(kWorldEdge) * static_cast<std::uint64_t>(y) +
+           static_cast<std::uint64_t>(kWorldEdge) * static_cast<std::uint64_t>(kWorldEdge) *
+               static_cast<std::uint64_t>(z);
+}
+
+inline Coord500 coordinate_from_address(std::uint64_t address) {
+    if (address >= kWorldAgentCount) {
+        throw std::out_of_range("500^3 world address exceeds the agent domain");
+    }
+    const std::uint64_t plane = static_cast<std::uint64_t>(kWorldEdge) * kWorldEdge;
+    const auto z = static_cast<std::uint16_t>(address / plane);
+    const std::uint64_t remainder = address % plane;
+    const auto y = static_cast<std::uint16_t>(remainder / kWorldEdge);
+    const auto x = static_cast<std::uint16_t>(remainder % kWorldEdge);
+    return {x, y, z};
+}
+
+inline std::vector<std::uint8_t> pack_bits_lsb_first(const std::vector<std::uint8_t>& bits) {
+    std::vector<std::uint8_t> bytes((bits.size() + 7U) / 8U, 0U);
+    for (std::size_t i = 0U; i < bits.size(); ++i) {
+        if (bits[i] > 1U) throw std::invalid_argument("bit stream contains a value other than 0 or 1");
+        bytes[i / 8U] |= static_cast<std::uint8_t>(bits[i] << (i % 8U));
+    }
+    return bytes;
+}
+
+inline std::vector<std::uint8_t> unpack_bits_lsb_first(
+    const std::vector<std::uint8_t>& bytes, std::size_t bit_count) {
+    if (bit_count > bytes.size() * 8U) {
+        throw std::invalid_argument("requested bit count exceeds packed byte capacity");
+    }
+    std::vector<std::uint8_t> bits(bit_count, 0U);
+    for (std::size_t i = 0U; i < bit_count; ++i) {
+        bits[i] = static_cast<std::uint8_t>((bytes[i / 8U] >> (i % 8U)) & 1U);
+    }
+    return bits;
+}
+
+inline float normalize_byte(std::uint8_t value) noexcept {
+    return static_cast<float>(value) / 255.0F;
+}
+
+inline std::uint8_t xor_residual(std::uint8_t source, std::uint8_t reconstructed) noexcept {
+    return static_cast<std::uint8_t>(source ^ reconstructed);
+}
+
+inline std::uint32_t popcount32(std::uint32_t value) noexcept {
+    std::uint32_t count = 0U;
+    while (value != 0U) {
+        value &= value - 1U;
+        ++count;
+    }
+    return count;
+}
+
+inline std::uint32_t fp32_bits(float value) noexcept {
+    static_assert(sizeof(float) == sizeof(std::uint32_t), "World500 requires IEEE-like 32-bit float storage");
+    std::uint32_t bits = 0U;
+    std::memcpy(&bits, &value, sizeof(bits));
+    return bits;
+}
+
+inline std::uint32_t fp32_xor_residual(float source, float reconstructed) noexcept {
+    return fp32_bits(source) ^ fp32_bits(reconstructed);
+}
+
+inline float byte_xor_error_rate(std::uint8_t source, std::uint8_t reconstructed) noexcept {
+    return static_cast<float>(popcount32(xor_residual(source, reconstructed))) / 8.0F;
+}
+
+inline float numeric_abs_error(float source, float reconstructed) noexcept {
+    return std::fabs(source - reconstructed);
+}
+
+inline float permeate_channel(float self, float neighbourhood_mean, float self_weight = 0.82F) {
+    if (!std::isfinite(self) || !std::isfinite(neighbourhood_mean) || !std::isfinite(self_weight)) {
+        throw std::invalid_argument("permeation inputs must be finite");
+    }
+    if (self_weight < 0.0F || self_weight > 1.0F) {
+        throw std::invalid_argument("permeation self weight must lie in [0,1]");
+    }
+    const float neighbour_weight = 1.0F - self_weight;
+    return self_weight * self + neighbour_weight * neighbourhood_mean;
+}
+
+inline std::vector<float> softmax(const std::vector<float>& logits) {
+    if (logits.empty()) return {};
+    for (const float value : logits) {
+        if (!std::isfinite(value)) throw std::invalid_argument("attention logits must be finite");
+    }
+    const float maximum = *std::max_element(logits.begin(), logits.end());
+    std::vector<float> weights(logits.size(), 0.0F);
+    double denominator = 0.0;
+    for (std::size_t i = 0U; i < logits.size(); ++i) {
+        weights[i] = static_cast<float>(std::exp(static_cast<double>(logits[i] - maximum)));
+        denominator += static_cast<double>(weights[i]);
+    }
+    if (!(denominator > 0.0) || !std::isfinite(denominator)) {
+        throw std::runtime_error("attention softmax denominator is invalid");
+    }
+    for (float& value : weights) value = static_cast<float>(static_cast<double>(value) / denominator);
+    return weights;
+}
+
+inline float scaled_dot_logit(
+    const std::array<float, kLatentDimensions>& query,
+    const std::array<float, kLatentDimensions>& key) {
+    double dot = 0.0;
+    for (std::size_t i = 0U; i < query.size(); ++i) {
+        if (!std::isfinite(query[i]) || !std::isfinite(key[i])) {
+            throw std::invalid_argument("attention vectors must be finite");
+        }
+        dot += static_cast<double>(query[i]) * static_cast<double>(key[i]);
+    }
+    return static_cast<float>(dot / std::sqrt(static_cast<double>(kLatentDimensions)));
+}
+
+inline float memory_update(float omega, float residual_signal, float rho) {
+    if (!std::isfinite(omega) || !std::isfinite(residual_signal) || !std::isfinite(rho)) {
+        throw std::invalid_argument("memory update inputs must be finite");
+    }
+    if (rho < 0.0F || rho > 1.0F) throw std::invalid_argument("memory rho must lie in [0,1]");
+    return rho * omega + (1.0F - rho) * residual_signal;
+}
+
+inline float latent_velocity(
+    float reconstruction_gradient,
+    float attention_pressure,
+    float memory_pressure,
+    float latent_state,
+    float alpha,
+    float beta,
+    float gamma,
+    float delta) {
+    const std::array<float, 8U> values{
+        reconstruction_gradient, attention_pressure, memory_pressure, latent_state,
+        alpha, beta, gamma, delta,
+    };
+    for (const float value : values) {
+        if (!std::isfinite(value)) throw std::invalid_argument("latent velocity inputs must be finite");
+    }
+    if (alpha < 0.0F || beta < 0.0F || gamma < 0.0F || delta < 0.0F) {
+        throw std::invalid_argument("latent velocity coefficients must be non-negative");
+    }
+    return -alpha * reconstruction_gradient + beta * attention_pressure +
+           gamma * memory_pressure - delta * latent_state;
+}
+
+inline bool should_commit(double current_error, double candidate_error) {
+    if (!std::isfinite(current_error) || !std::isfinite(candidate_error) ||
+        current_error < 0.0 || candidate_error < 0.0) {
+        throw std::invalid_argument("commit errors must be finite and non-negative");
+    }
+    return candidate_error < current_error;
+}
+
+inline bool byte_fixed_point(std::uint8_t input, std::uint8_t output) noexcept {
+    return xor_residual(input, output) == 0U;
+}
+
+} // namespace jarvisx::world::bitwise500

--- a/cpp_runtime/tests/world_engine_vmad_tests.cpp
+++ b/cpp_runtime/tests/world_engine_vmad_tests.cpp
@@ -1,11 +1,14 @@
+#include "jarvisx/bitwise_world500.hpp"
 #include "jarvisx/world_engine_vmad.hpp"
 
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -15,6 +18,89 @@ void require(bool condition, const std::string& message) {
 
 std::filesystem::path test_dir(const char* name) {
     return std::filesystem::temp_directory_path() / (std::string("jarvisx-world-") + name);
+}
+
+void test_world500_footprint_and_address_geometry() {
+    namespace bw = jarvisx::world::bitwise500;
+    require(bw::kWorldEdge == 500U, "World500 edge constant is incorrect");
+    require(bw::kWorldAgentCount == 125000000ULL, "World500 agent count is incorrect");
+    require(bw::kLatentDimensions == 16U, "World500 latent width is incorrect");
+    require(bw::kBitsPerAgent == 512U, "World500 bits-per-agent is incorrect");
+    require(bw::kWorldLatentBits == 64000000000ULL, "World500 latent bit footprint is incorrect");
+    require(bw::kWorldLatentBytes == 8000000000ULL, "World500 latent byte footprint is incorrect");
+    require(bw::kWorldLatentGiB > 7.45L && bw::kWorldLatentGiB < 7.46L,
+            "World500 GiB conversion is incorrect");
+
+    require(bw::linear_address(0U, 0U, 0U) == 0ULL, "World500 origin address is incorrect");
+    const std::uint64_t last = bw::linear_address(499U, 499U, 499U);
+    require(last == bw::kWorldAgentCount - 1ULL, "World500 terminal address is incorrect");
+    require(bw::coordinate_from_address(last) == bw::Coord500{499U, 499U, 499U},
+            "World500 inverse address mapping failed");
+
+    const std::uint64_t interior = bw::linear_address(17U, 231U, 404U);
+    require(bw::coordinate_from_address(interior) == bw::Coord500{17U, 231U, 404U},
+            "World500 address mapping is not bijective");
+
+    bool rejected = false;
+    try {
+        (void)bw::linear_address(500U, 0U, 0U);
+    } catch (const std::out_of_range&) {
+        rejected = true;
+    }
+    require(rejected, "World500 accepted an out-of-range coordinate");
+}
+
+void test_world500_bit_and_residual_semantics() {
+    namespace bw = jarvisx::world::bitwise500;
+    const std::vector<std::uint8_t> bits{1U, 0U, 1U, 1U, 0U, 0U, 1U, 0U};
+    const auto packed = bw::pack_bits_lsb_first(bits);
+    require(packed.size() == 1U && packed[0] == 0x4dU, "World500 LSB-first bit packing failed");
+    require(bw::unpack_bits_lsb_first(packed, bits.size()) == bits,
+            "World500 bit packing roundtrip failed");
+
+    require(std::fabs(bw::normalize_byte(255U) - 1.0F) < 1.0e-6F,
+            "World500 byte normalization failed");
+    require(bw::xor_residual(0xb6U, 0xa6U) == 0x10U,
+            "World500 byte XOR residual failed");
+    require(std::fabs(bw::byte_xor_error_rate(0xb6U, 0xa6U) - 0.125F) < 1.0e-6F,
+            "World500 XOR error density failed");
+    require(bw::fp32_xor_residual(1.0F, 1.0F) == 0U,
+            "World500 identical FP32 values produced a representation residual");
+    require(bw::fp32_xor_residual(1.0F, 1.5F) != 0U,
+            "World500 distinct FP32 values produced no representation residual");
+    require(std::fabs(bw::numeric_abs_error(1.0F, 1.5F) - 0.5F) < 1.0e-6F,
+            "World500 numeric residual failed");
+    require(bw::byte_fixed_point(0x5aU, 0x5aU), "World500 byte fixed point failed");
+    require(!bw::byte_fixed_point(0x5aU, 0x5bU), "World500 false byte fixed point accepted");
+}
+
+void test_world500_permeation_attention_memory_transaction() {
+    namespace bw = jarvisx::world::bitwise500;
+    require(std::fabs(bw::permeate_channel(1.0F, 0.0F) - 0.82F) < 1.0e-6F,
+            "World500 0.82/0.18 permeation rule failed");
+
+    std::array<float, bw::kLatentDimensions> query{};
+    std::array<float, bw::kLatentDimensions> key{};
+    query.fill(1.0F);
+    key.fill(1.0F);
+    require(std::fabs(bw::scaled_dot_logit(query, key) - 4.0F) < 1.0e-6F,
+            "World500 scaled dot-product attention logit failed");
+
+    const auto weights = bw::softmax({0.0F, 1.0F, 2.0F});
+    require(weights.size() == 3U, "World500 softmax output width is incorrect");
+    const float sum = weights[0] + weights[1] + weights[2];
+    require(std::fabs(sum - 1.0F) < 1.0e-6F, "World500 softmax is not normalized");
+    require(weights[2] > weights[1] && weights[1] > weights[0],
+            "World500 softmax ordering is incorrect");
+
+    require(std::fabs(bw::memory_update(0.0F, 1.0F, 0.9F) - 0.1F) < 1.0e-6F,
+            "World500 Omega memory recurrence failed");
+    require(std::fabs(bw::latent_velocity(1.0F, 2.0F, 3.0F, 4.0F,
+                                          0.5F, 0.25F, 0.1F, 0.05F) - 0.1F) < 1.0e-6F,
+            "World500 latent velocity equation failed");
+    require(bw::should_commit(1.0, 0.5), "World500 strict improvement was not committed");
+    require(!bw::should_commit(1.0, 1.0), "World500 accepted a non-improving equal-error candidate");
+    require(!bw::should_commit(1.0, 1.5), "World500 accepted a worse candidate");
 }
 
 void test_vmad_pack_roundtrip() {
@@ -151,15 +237,18 @@ void test_transfer_bound() {
 
 int main() {
     try {
+        test_world500_footprint_and_address_geometry();
+        test_world500_bit_and_residual_semantics();
+        test_world500_permeation_attention_memory_transaction();
         test_vmad_pack_roundtrip();
         test_micro_op_roundtrip();
         test_sparse_ingest_and_pipeline();
         test_candidate_commit_and_rollback();
         test_transfer_bound();
-        std::cout << "world-engine VMAD128 regressions passed\n";
+        std::cout << "world-engine VMAD128 + World500 regressions passed\n";
         return 0;
     } catch (const std::exception& error) {
-        std::cerr << "world-engine VMAD128 regression failure: " << error.what() << '\n';
+        std::cerr << "world-engine regression failure: " << error.what() << '\n';
         return 1;
     }
 }

--- a/docs/DR_MOAGI_BITWISE_WORLD500.md
+++ b/docs/DR_MOAGI_BITWISE_WORLD500.md
@@ -1,0 +1,225 @@
+# Dr Moagi Bit-Wise World500 Kernel
+
+## Status
+
+This document defines the bit-exact companion model for the existing VMAD128 World Engine. It does **not** replace the VMAD128 sparse 3D address fabric. Instead, it specifies how a bounded `500 x 500 x 500` logical world maps bits, bytes, latent channels, residuals, memory, attention, and transactional state updates onto that runtime.
+
+## 1. World footprint
+
+The logical world contains
+
+```text
+500^3 = 125,000,000 agents
+```
+
+For 16 FP32 latent channels per agent:
+
+```text
+16 channels x 32 bits = 512 bits/agent
+125,000,000 x 512 = 64,000,000,000 bits
+                        8,000,000,000 bytes
+                        ~7.451 GiB
+```
+
+The 8 GB figure is the **single-buffer latent payload only**. Candidate buffers, reconstruction buffers, residual/memory fields, indices, and allocator/page metadata increase resident or virtual storage beyond this base figure.
+
+The runtime exposes these quantities as compile-time constants in:
+
+```text
+cpp_runtime/include/jarvisx/bitwise_world500.hpp
+```
+
+## 2. Deterministic address geometry
+
+For coordinates `0 <= x,y,z < 500`, the canonical row-major address is
+
+```text
+A = x + 500*y + 500^2*z
+```
+
+with range
+
+```text
+0 <= A < 125,000,000.
+```
+
+The kernel implements both `linear_address()` and `coordinate_from_address()` and regression-tests their bijection at the domain boundary.
+
+This bounded logical address is distinct from VMAD128. VMAD128 remains the outer sparse address fabric and can map a World500 cell into a larger virtual region, modality, and attribute namespace.
+
+## 3. Bit ingestion and byte packing
+
+Primitive logical input is binary:
+
+```text
+b_i in {0,1}.
+```
+
+Eight LSB-first logical bits are packed as
+
+```text
+Byte = sum(b_k * 2^k), k=0..7.
+```
+
+The companion kernel validates that every logical bit is exactly `0` or `1`; malformed bit streams are rejected rather than silently coerced.
+
+Normalized byte-domain tensor values use
+
+```text
+x = Byte / 255.
+```
+
+## 4. Numeric latent domain versus physical bit representation
+
+A critical distinction is enforced:
+
+1. **Numeric reconstruction residual** measures value-space error, for example `abs(x - x_hat)` or a higher-level MSE/L1 objective.
+2. **Representation XOR residual** compares encoded bit patterns, for example `bits(x) XOR bits(x_hat)`.
+
+These are not interchangeable for FP32. Two nearby floating-point values may have several representation bits different, while a bit flip in a high-order field can have a large numeric effect. Therefore the commit quality objective should be defined in numeric space unless exact representation identity is explicitly required.
+
+The kernel exposes both forms:
+
+```text
+numeric_abs_error(source, reconstructed)
+fp32_xor_residual(source, reconstructed)
+xor_residual(byte_source, byte_reconstructed)
+byte_xor_error_rate(...)
+```
+
+## 5. Encoder and latent formation
+
+At the model layer, an encoder may be represented as
+
+```text
+z_j = sigma(sum_i W_ji*x_i + b_j).
+```
+
+The existing World Engine already provides a bounded latent reduction micro-op (`EncLatVol`). The World500 layer therefore does not duplicate the encoder. It supplies bit/byte semantics around the existing reduction path.
+
+## 6. Spatial permeation
+
+The expression
+
+```text
+z' = 0.82*z + 0.18*mean(neighbours)
+```
+
+is a **real-valued latent-channel operation**, not a binary-bit operation: its output generally lies in a continuum rather than `{0,1}`.
+
+The kernel names this explicitly as `permeate_channel()` and validates finite values and a mixing coefficient in `[0,1]`.
+
+If a strictly binary cellular rule is required later, it should be implemented as a separate quantized transition operator after thresholding or probabilistic sampling, not by calling the real-valued mixture a bit.
+
+## 7. Attention routing
+
+For a 16-dimensional latent channel vector, the canonical scaled dot-product logit is
+
+```text
+logit(q,k) = dot(q,k) / sqrt(16).
+```
+
+Attention across multiple keys is then
+
+```text
+a = softmax(logits).
+```
+
+The kernel provides a numerically stable softmax and a 16-dimensional scaled-dot logit. The existing World Engine's `FuseAttn` micro-op remains the bounded byte-domain execution primitive.
+
+## 8. Decode and reconstruction
+
+The existing World Engine expands latent bytes through `DecPixVol` and stores the reconstructed result through its sparse VMAD-backed volume. World500 treats that output as the candidate reconstruction used by the two residual domains above.
+
+Logical pipeline:
+
+```text
+bits -> bytes -> numeric tensor -> encode -> latent
+     -> permeate -> attention -> decode -> reconstruction
+```
+
+## 9. Residual memory
+
+A residual signal may feed an exponentially weighted memory field:
+
+```text
+Omega_(t+1) = rho*Omega_t + (1-rho)*R_t
+```
+
+where `R_t` must have a declared domain. Typical choices are numeric reconstruction error, signed numeric correction, or normalized XOR error density. Raw XOR masks should not be added directly to floating-point state without an explicit encoding/normalization rule.
+
+The kernel provides `memory_update()` with `rho` constrained to `[0,1]`.
+
+## 10. Latent velocity
+
+A scalar channel form of the kinetic update is
+
+```text
+dZ/dt = -alpha*grad(E)
+        + beta*attention_pressure
+        + gamma*memory_pressure
+        - delta*Z.
+```
+
+The kernel exposes this as `latent_velocity()` with finite-input and non-negative-coefficient guards.
+
+## 11. Transactional commit/reject
+
+The canonical quality gate is strict improvement:
+
+```text
+commit <=> E_candidate < E_current.
+```
+
+Equality is not improvement. Invalid, negative, NaN, or infinite error values are rejected by the companion helper rather than entering the transactional state machine.
+
+This complements the existing World Engine's `Validate` + `CommitIf` candidate/authoritative bias transaction path.
+
+## 12. Fixed-point semantics
+
+Representation-level fixed point:
+
+```text
+B_out == B_in
+B_in XOR B_out == 0.
+```
+
+Numeric fixed point additionally requires the selected state update to stop changing the latent state within its declared tolerance.
+
+For a memory-coupled system, a complete fixed point must also satisfy the memory recurrence. Omitting `Omega` from the fixed-point equation is valid only when the memory contribution is zero, constant, or absorbed into the state/operator definition.
+
+A more explicit coupled form is
+
+```text
+B_(t+1) = Lambda[D(A(P(E(B_t)))) + Omega_t]
+Omega_(t+1) = rho*Omega_t + (1-rho)*R(B_t, B_(t+1)).
+```
+
+At a coupled fixed point `(B*, Omega*)`:
+
+```text
+B* = Lambda[D(A(P(E(B*)))) + Omega*]
+Omega* = rho*Omega* + (1-rho)*R(B*,B*).
+```
+
+When `R(B*,B*) = 0` and `rho != 1`, the residual-driven component of `Omega*` converges to zero unless another memory source is defined.
+
+## 13. End-to-end operational mapping
+
+```text
+Logical bits
+  -> pack bytes
+  -> normalize/tensorize
+  -> EncLatVol
+  -> spatial permeation
+  -> FuseAttn
+  -> DecPixVol
+  -> numeric + XOR residual telemetry
+  -> Omega update
+  -> candidate evaluation
+  -> Validate
+  -> CommitIf / rollback
+  -> next state
+```
+
+This is the operational interpretation of the bit-wise Dr Moagi World500 equation while preserving the repository's established VMAD128 sparse addressing and transactional execution model.


### PR DESCRIPTION
## Summary

Operationalizes the 500×500×500 Dr Moagi bit-wise world formulation as a tested companion layer to the existing VMAD128 World Engine.

### Added
- `cpp_runtime/include/jarvisx/bitwise_world500.hpp`
  - exact 500³/125M-agent footprint constants
  - 16×FP32 = 512-bit per-agent latent accounting
  - deterministic `(x,y,z) <-> linear address` mapping
  - LSB-first bit packing/unpacking
  - byte normalization
  - byte and FP32 representation-XOR residuals
  - numeric residual kept distinct from representation residual
  - 0.82/0.18 real-valued spatial permeation primitive
  - stable softmax + 16D scaled-dot attention logit
  - Ω residual-memory recurrence
  - latent velocity equation
  - strict commit predicate and byte fixed-point test
- regression coverage in the existing `jarvisx-world-engine-tests` target
- `docs/DR_MOAGI_BITWISE_WORLD500.md` with end-to-end operational semantics and fixed-point constraints

## Important semantic hardening

The original formulation mixed several representation levels. This PR makes them explicit:

1. `X - X_hat` is a numeric reconstruction residual.
2. `bits(X) XOR bits(X_hat)` is a representation residual and is not a substitute for FP32 numeric error.
3. `0.82*z + 0.18*mean(neighbours)` is a real-valued latent-channel update, not a binary-bit transition unless followed by an explicit quantizer.
4. The coupled fixed point includes Ω unless memory is zero, constant, or absorbed into the state/operator definition.
5. The 64,000,000,000-bit latent payload is exactly 8,000,000,000 bytes (~7.451 GiB) before candidate/reconstruction/residual/memory buffers and metadata.

## Compatibility

This does not replace or narrow VMAD128. The 500³ model is a bounded logical companion domain; VMAD128 remains the outer sparse address fabric and transactional execution runtime.

## Validation

Adds regression checks for:
- footprint constants
- address bijection and bounds
- bit-pack roundtrip
- XOR residual example `0xB6 ^ 0xA6 == 0x10`
- FP32 representation-vs-numeric residual separation
- permeation coefficients
- attention normalization
- Ω recurrence
- latent velocity equation
- strict commit/reject semantics
- existing VMAD128 pipeline/transaction tests remain in the same executable
