### PR TITLE
feat: add 1 KiB inward 3D latent field codec

### DIFF
--- a/docs/ONE_KIB_INWARD_3D_FIELD_CODEC.md
+++ b/docs/ONE_KIB_INWARD_3D_FIELD_CODEC.md
@@ -1,0 +1,343 @@
+# One-KiB Inward 3D Field Codec
+
+## Status
+
+This document defines the executable 1 KiB latent-field primitive used to connect the Jarvis-X
+inward autoencoding architecture to a concrete virtual 3D world.
+
+The implementation is in `src/jarvisx/latent_field_codec.py`.
+
+The capability boundary is strict:
+
+- the latent payload is exactly 1,024 bytes;
+- the virtual address space is 1024 × 1024 × 1024 voxels;
+- the decoder materializes only requested voxels, points, or slices;
+- the codec is generative/lossy for arbitrary fields;
+- it does **not** claim universal lossless compression of an arbitrary 1 GiB voxel volume into 1 KiB.
+
+## 1. State geometry
+
+The virtual world is
+
+\[
+X(x,y,z),\qquad 0\le x,y,z<1024.
+\]
+
+It contains
+
+\[
+1024^3=1,073,741,824
+\]
+
+addressable voxel locations.
+
+The linear address is
+
+\[
+A=x+1024y+1024^2z,
+\]
+
+so the complete address space fits in 30 bits:
+
+\[
+0\le A<2^{30}.
+\]
+
+The persistent latent state is exactly
+
+\[
+z\in\{0,\ldots,255\}^{8\times8\times16}.
+\]
+
+Therefore
+
+\[
+8\times8\times16=1024\text{ bytes}.
+\]
+
+For an explicit unsigned 8-bit scalar world the logical expansion ratio is
+
+\[
+\frac{1024^3}{1024}=1,048,576:1.
+\]
+
+This ratio describes virtual addressability, not universal information-theoretic compression.
+
+## 2. Encoder
+
+The reference encoder samples a bounded scalar field at the 8×8×16 latent knot positions and
+quantizes every sample to one byte:
+
+\[
+z_{ijk}
+=
+Q_8\left(
+X\left(
+\pi_x(i),
+\pi_y(j),
+\pi_z(k)
+\right)
+\right),
+\]
+
+where each \(\pi\) maps a latent coordinate onto the integer 1024-voxel world.
+
+The reference implementation accepts a callable field:
+
+```python
+state = codec.encode_field(field)
+```
+
+and returns an immutable `LatentFieldState` whose payload is exactly 1,024 bytes.
+
+A learned encoder can later replace the sampling transform without changing the packet contract.
+
+## 3. Decoder
+
+A voxel query does not allocate the billion-voxel world.
+
+For a world coordinate \((x,y,z)\), the decoder maps the coordinate into continuous latent
+coordinates:
+
+\[
+u=x\frac{7}{1023},\qquad
+v=y\frac{7}{1023},\qquad
+w=z\frac{15}{1023}.
+\]
+
+The decoded value is the trilinear interpolation of the eight neighboring latent bytes:
+
+\[
+\widehat X(x,y,z)
+=
+\sum_{a,b,c\in\{0,1\}}
+\omega_{abc}(u,v,w)
+\frac{z_{i+a,j+b,k+c}}{255}.
+\]
+
+Operationally:
+
+```text
+1 KiB state
+   ↓
+coordinate (x,y,z)
+   ↓
+find 8 latent neighbors
+   ↓
+compute interpolation weights
+   ↓
+decode one voxel
+```
+
+The virtual field is therefore addressable without being resident.
+
+## 4. Lazy materialization
+
+The API exposes three levels of decoding:
+
+- `decode_voxel` — one coordinate;
+- `decode_points` — a sparse coordinate batch;
+- `materialize_slice` — a bounded 2D diagnostic slice.
+
+A renderer or simulator should query only visible, active, colliding, or otherwise relevant
+regions.
+
+This is the runtime distinction:
+
+\[
+\text{virtual world size}\ne\text{resident decoded state}.
+\]
+
+## 5. Inward residual fold
+
+Given observations
+
+\[
+\mathcal O=
+\{(x_n,y_n,z_n,y_n^*)\}_{n=1}^{N},
+\]
+
+the current decoder predicts
+
+\[
+\widehat y_n=D(z,x_n,y_n,z_n).
+\]
+
+The weighted reconstruction loss is
+
+\[
+L(z)
+=
+\frac{
+\sum_n w_n(\widehat y_n-y_n^*)^2
+}{
+\sum_n w_n
+}.
+\]
+
+Because a trilinear query depends on exactly eight latent cells, its residual can be projected
+directly back into those eight bytes:
+
+\[
+\frac{\partial L}{\partial z_j}
+=
+\sum_n
+2w_n(\widehat y_n-y_n^*)\,
+\omega_{nj}.
+\]
+
+The trial latent update is
+
+\[
+z^{trial}
+=
+Q_8\left[
+\operatorname{clip}_{[0,1]}
+\left(
+\frac{z}{255}-\eta\nabla_zL
+\right)
+\right].
+\]
+
+This is the operational meaning of turning the field inward:
+
+```text
+world observation
+      ↓
+decoded prediction
+      ↓
+residual
+      ↓
+8-neighbor latent pullback
+      ↓
+1 KiB candidate state
+      ↓
+verify loss
+      ↓
+commit or rollback
+```
+
+The implementation performs bounded backtracking. A candidate is committed only when its
+measured observation loss does not exceed the previous committed state.
+
+## 6. Transactional recurrence
+
+One refinement cycle is
+
+\[
+z_t
+\rightarrow
+D(z_t)
+\rightarrow
+R_t
+\rightarrow
+\nabla_zL_t
+\rightarrow
+z_{t+1}^{trial}
+\rightarrow
+\operatorname{VERIFY}
+\rightarrow
+\operatorname{COMMIT/ROLLBACK}.
+\]
+
+If accepted:
+
+\[
+L(z_{t+1})\le L(z_t).
+\]
+
+If every trial fails:
+
+\[
+z_{t+1}=z_t.
+\]
+
+The `revision` field advances only on a committed candidate.
+
+## 7. Images, video, and live 3D animation
+
+The same packet contract can be lifted to different coordinate meanings.
+
+### Image
+
+Treat one axis as a feature/depth axis or use a 2D specialization:
+
+\[
+I(x,y)\rightleftarrows z.
+\]
+
+### Video
+
+Interpret the third coordinate as time:
+
+\[
+V(x,y,t)\rightleftarrows z.
+\]
+
+### Live 3D animation
+
+Use space plus an external time/control parameter:
+
+\[
+S(x,y,z,t)=D(z,x,y,z,t).
+\]
+
+The current reference decoder is a static scalar-field primitive. A future learned decoder can add
+time, vector channels, color, density, motion, material, topology, and neural-field parameters while
+retaining the exact 1 KiB state budget.
+
+## 8. Verification invariants
+
+The executable reference enforces:
+
+1. `len(payload) == 1024`;
+2. coordinates remain inside the declared world;
+3. field values are finite and in `[0,1]`;
+4. the latent shape has exactly 1,024 cells;
+5. refinement learning rates are finite and positive;
+6. candidate bytes remain in `[0,255]`;
+7. refinement is non-regressing on the supplied observation set;
+8. decoding remains lazy unless a bounded slice is explicitly requested.
+
+## 9. Minimal usage
+
+```python
+from jarvisx.latent_field_codec import FieldObservation, LatentFieldCodec
+
+codec = LatentFieldCodec()
+
+state = codec.encode_field(
+    lambda x, y, z: (x + y + z) / (3 * 1023)
+)
+
+value = codec.decode_voxel(state, 512, 512, 512)
+
+report = codec.refine(
+    state,
+    [
+        FieldObservation(512, 512, 512, target=0.9),
+        FieldObservation(128, 256, 384, target=0.2),
+    ],
+)
+
+state = report.state
+```
+
+## 10. Extension path
+
+The safe progression is:
+
+```text
+working scalar field
+→ multi-channel field
+→ sparse/octree query scheduler
+→ learned encoder
+→ learned coordinate-conditioned decoder
+→ temporal latent dynamics
+→ GPU batched decoder
+→ live renderer
+→ shadow verification
+→ bounded promotion
+```
+
+This keeps the Jarvis-X rule intact: working first, then robust, portable, elegant, and advanced.

--- a/src/jarvisx/latent_field_codec.py
+++ b/src/jarvisx/latent_field_codec.py
@@ -1,0 +1,340 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import floor, isfinite
+from typing import Callable, Iterable, Sequence
+
+LATENT_BYTES = 1024
+WORLD_EXTENT = 1024
+ADDRESS_BITS = 30
+DEFAULT_LATENT_SHAPE = (8, 8, 16)
+
+
+@dataclass(frozen=True)
+class LatentFieldConfig:
+    world_extent: int = WORLD_EXTENT
+    latent_shape: tuple[int, int, int] = DEFAULT_LATENT_SHAPE
+    latent_bytes: int = LATENT_BYTES
+    max_backtracks: int = 8
+    minimum_learning_rate: float = 1.0e-6
+
+    def __post_init__(self) -> None:
+        if isinstance(self.world_extent, bool) or not isinstance(self.world_extent, int):
+            raise TypeError("world_extent must be an integer")
+        if self.world_extent < 2:
+            raise ValueError("world_extent must be at least 2")
+        if len(self.latent_shape) != 3:
+            raise ValueError("latent_shape must contain exactly three dimensions")
+        if any(
+            isinstance(value, bool) or not isinstance(value, int) for value in self.latent_shape
+        ):
+            raise TypeError("latent_shape dimensions must be integers")
+        if any(value < 2 for value in self.latent_shape):
+            raise ValueError("latent_shape dimensions must be at least 2")
+        if self.latent_bytes != LATENT_BYTES:
+            raise ValueError("this codec requires exactly 1,024 latent bytes")
+        latent_cells = self.latent_shape[0] * self.latent_shape[1] * self.latent_shape[2]
+        if latent_cells != self.latent_bytes:
+            raise ValueError("latent_shape product must equal latent_bytes")
+        if isinstance(self.max_backtracks, bool) or not isinstance(self.max_backtracks, int):
+            raise TypeError("max_backtracks must be an integer")
+        if self.max_backtracks < 1:
+            raise ValueError("max_backtracks must be positive")
+        if not isfinite(self.minimum_learning_rate) or self.minimum_learning_rate <= 0.0:
+            raise ValueError("minimum_learning_rate must be finite and positive")
+
+
+@dataclass(frozen=True)
+class LatentFieldState:
+    payload: bytes
+    revision: int = 0
+
+    def __post_init__(self) -> None:
+        if len(self.payload) != LATENT_BYTES:
+            raise ValueError("payload must be exactly 1,024 bytes")
+        if isinstance(self.revision, bool) or not isinstance(self.revision, int):
+            raise TypeError("revision must be an integer")
+        if self.revision < 0:
+            raise ValueError("revision cannot be negative")
+
+
+@dataclass(frozen=True)
+class FieldObservation:
+    x: int
+    y: int
+    z: int
+    target: float
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        for name, value in (("x", self.x), ("y", self.y), ("z", self.z)):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+        if not isfinite(self.target) or not 0.0 <= self.target <= 1.0:
+            raise ValueError("target must be finite and within [0, 1]")
+        if not isfinite(self.weight) or self.weight <= 0.0:
+            raise ValueError("weight must be finite and positive")
+
+
+@dataclass(frozen=True)
+class RefinementReport:
+    state: LatentFieldState
+    committed: bool
+    loss_before: float
+    loss_after: float
+    learning_rate_used: float
+    backtracks: int
+
+
+class LatentFieldCodec:
+    """Deterministic 1 KiB latent codec for a lazily queried virtual 3D scalar field."""
+
+    def __init__(self, config: LatentFieldConfig | None = None) -> None:
+        self.config = config or LatentFieldConfig()
+        self._lx, self._ly, self._lz = self.config.latent_shape
+
+    @property
+    def latent_bytes(self) -> int:
+        return self.config.latent_bytes
+
+    @property
+    def virtual_voxels(self) -> int:
+        return self.config.world_extent**3
+
+    @property
+    def raw_u8_storage_bytes(self) -> int:
+        return self.virtual_voxels
+
+    @property
+    def logical_expansion_ratio(self) -> int:
+        return self.raw_u8_storage_bytes // self.latent_bytes
+
+    def linear_address(self, x: int, y: int, z: int) -> int:
+        self._validate_coordinate(x, y, z)
+        extent = self.config.world_extent
+        return x + extent * y + extent * extent * z
+
+    def encode_field(self, field: Callable[[int, int, int], float]) -> LatentFieldState:
+        if not callable(field):
+            raise TypeError("field must be callable")
+        payload = bytearray(self.latent_bytes)
+        for iz in range(self._lz):
+            z = self._latent_to_world(iz, self._lz)
+            for iy in range(self._ly):
+                y = self._latent_to_world(iy, self._ly)
+                for ix in range(self._lx):
+                    x = self._latent_to_world(ix, self._lx)
+                    value = field(x, y, z)
+                    if isinstance(value, bool) or not isinstance(value, (int, float)):
+                        raise TypeError("field samples must be numeric")
+                    value = float(value)
+                    if not isfinite(value) or not 0.0 <= value <= 1.0:
+                        raise ValueError("field samples must be finite and within [0, 1]")
+                    payload[self._latent_index(ix, iy, iz)] = round(value * 255.0)
+        return LatentFieldState(bytes(payload))
+
+    def decode_voxel(self, state: LatentFieldState, x: int, y: int, z: int) -> float:
+        self._validate_state(state)
+        self._validate_coordinate(x, y, z)
+        tx = self._world_to_latent(x, self._lx)
+        ty = self._world_to_latent(y, self._ly)
+        tz = self._world_to_latent(z, self._lz)
+        return self._trilinear(state.payload, tx, ty, tz)
+
+    def decode_points(
+        self,
+        state: LatentFieldState,
+        coordinates: Iterable[tuple[int, int, int]],
+    ) -> tuple[float, ...]:
+        return tuple(self.decode_voxel(state, *coordinate) for coordinate in coordinates)
+
+    def materialize_slice(
+        self,
+        state: LatentFieldState,
+        *,
+        axis: str,
+        index: int,
+        resolution: int = 64,
+    ) -> tuple[tuple[float, ...], ...]:
+        self._validate_state(state)
+        axis = axis.lower()
+        if axis not in {"x", "y", "z"}:
+            raise ValueError("axis must be one of: x, y, z")
+        if isinstance(index, bool) or not isinstance(index, int):
+            raise TypeError("index must be an integer")
+        if not 0 <= index < self.config.world_extent:
+            raise ValueError("index is outside the virtual world")
+        if isinstance(resolution, bool) or not isinstance(resolution, int):
+            raise TypeError("resolution must be an integer")
+        if not 2 <= resolution <= self.config.world_extent:
+            raise ValueError("resolution must be between 2 and world_extent")
+
+        world = tuple(
+            round(i * (self.config.world_extent - 1) / (resolution - 1))
+            for i in range(resolution)
+        )
+        rows: list[tuple[float, ...]] = []
+        for b in world:
+            row: list[float] = []
+            for a in world:
+                coordinate = {
+                    "x": (index, a, b),
+                    "y": (a, index, b),
+                    "z": (a, b, index),
+                }[axis]
+                row.append(self.decode_voxel(state, *coordinate))
+            rows.append(tuple(row))
+        return tuple(rows)
+
+    def self_consistency_error(self, state: LatentFieldState) -> float:
+        self._validate_state(state)
+        squared_error = 0.0
+        count = 0
+        for iz in range(self._lz):
+            z = self._latent_to_world(iz, self._lz)
+            for iy in range(self._ly):
+                y = self._latent_to_world(iy, self._ly)
+                for ix in range(self._lx):
+                    x = self._latent_to_world(ix, self._lx)
+                    expected = state.payload[self._latent_index(ix, iy, iz)] / 255.0
+                    residual = self.decode_voxel(state, x, y, z) - expected
+                    squared_error += residual * residual
+                    count += 1
+        return (squared_error / count) ** 0.5
+
+    def refine(
+        self,
+        state: LatentFieldState,
+        observations: Sequence[FieldObservation],
+        *,
+        learning_rate: float = 0.25,
+    ) -> RefinementReport:
+        self._validate_state(state)
+        if not observations:
+            raise ValueError("observations cannot be empty")
+        if not isfinite(learning_rate) or learning_rate <= 0.0:
+            raise ValueError("learning_rate must be finite and positive")
+        for observation in observations:
+            self._validate_observation_coordinate(observation)
+
+        loss_before = self._observation_loss(state, observations)
+        gradient = [0.0] * self.latent_bytes
+
+        for observation in observations:
+            prediction = self.decode_voxel(state, observation.x, observation.y, observation.z)
+            residual = prediction - observation.target
+            tx = self._world_to_latent(observation.x, self._lx)
+            ty = self._world_to_latent(observation.y, self._ly)
+            tz = self._world_to_latent(observation.z, self._lz)
+            for latent_index, weight in self._neighbor_weights(tx, ty, tz):
+                gradient[latent_index] += 2.0 * observation.weight * residual * weight
+
+        total_weight = sum(observation.weight for observation in observations)
+        gradient = [value / total_weight for value in gradient]
+
+        rate = learning_rate
+        for backtracks in range(self.config.max_backtracks):
+            candidate_payload = bytearray(state.payload)
+            for index, derivative in enumerate(gradient):
+                normalized = state.payload[index] / 255.0 - rate * derivative
+                candidate_payload[index] = round(clamp01(normalized) * 255.0)
+            candidate = LatentFieldState(bytes(candidate_payload), revision=state.revision + 1)
+            loss_after = self._observation_loss(candidate, observations)
+            if loss_after <= loss_before:
+                return RefinementReport(
+                    state=candidate,
+                    committed=True,
+                    loss_before=loss_before,
+                    loss_after=loss_after,
+                    learning_rate_used=rate,
+                    backtracks=backtracks,
+                )
+            rate *= 0.5
+            if rate < self.config.minimum_learning_rate:
+                break
+
+        return RefinementReport(
+            state=state,
+            committed=False,
+            loss_before=loss_before,
+            loss_after=loss_before,
+            learning_rate_used=0.0,
+            backtracks=self.config.max_backtracks,
+        )
+
+    def _observation_loss(
+        self,
+        state: LatentFieldState,
+        observations: Sequence[FieldObservation],
+    ) -> float:
+        weighted_squared_error = 0.0
+        total_weight = 0.0
+        for observation in observations:
+            residual = (
+                self.decode_voxel(state, observation.x, observation.y, observation.z)
+                - observation.target
+            )
+            weighted_squared_error += observation.weight * residual * residual
+            total_weight += observation.weight
+        return weighted_squared_error / total_weight
+
+    def _neighbor_weights(
+        self,
+        tx: float,
+        ty: float,
+        tz: float,
+    ) -> tuple[tuple[int, float], ...]:
+        x0, x1, fx = interpolation_pair(tx, self._lx)
+        y0, y1, fy = interpolation_pair(ty, self._ly)
+        z0, z1, fz = interpolation_pair(tz, self._lz)
+
+        result: list[tuple[int, float]] = []
+        for iz, wz in ((z0, 1.0 - fz), (z1, fz)):
+            for iy, wy in ((y0, 1.0 - fy), (y1, fy)):
+                for ix, wx in ((x0, 1.0 - fx), (x1, fx)):
+                    weight = wx * wy * wz
+                    if weight > 0.0:
+                        result.append((self._latent_index(ix, iy, iz), weight))
+        return tuple(result)
+
+    def _trilinear(self, payload: bytes, tx: float, ty: float, tz: float) -> float:
+        return sum(
+            payload[index] / 255.0 * weight
+            for index, weight in self._neighbor_weights(tx, ty, tz)
+        )
+
+    def _world_to_latent(self, value: int, latent_extent: int) -> float:
+        return value * (latent_extent - 1) / (self.config.world_extent - 1)
+
+    def _latent_to_world(self, value: int, latent_extent: int) -> int:
+        return round(value * (self.config.world_extent - 1) / (latent_extent - 1))
+
+    def _latent_index(self, x: int, y: int, z: int) -> int:
+        return x + self._lx * y + self._lx * self._ly * z
+
+    def _validate_state(self, state: LatentFieldState) -> None:
+        if not isinstance(state, LatentFieldState):
+            raise TypeError("state must be a LatentFieldState")
+
+    def _validate_coordinate(self, x: int, y: int, z: int) -> None:
+        for name, value in (("x", x), ("y", y), ("z", z)):
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+            if not 0 <= value < self.config.world_extent:
+                raise ValueError(f"{name} is outside the virtual world")
+
+    def _validate_observation_coordinate(self, observation: FieldObservation) -> None:
+        if not isinstance(observation, FieldObservation):
+            raise TypeError("observations must contain FieldObservation values")
+        self._validate_coordinate(observation.x, observation.y, observation.z)
+
+
+def interpolation_pair(value: float, extent: int) -> tuple[int, int, float]:
+    lower = floor(value)
+    upper = min(extent - 1, lower + 1)
+    fraction = value - lower
+    return lower, upper, fraction
+
+
+def clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))

--- a/tests/test_latent_field_codec.py
+++ b/tests/test_latent_field_codec.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.latent_field_codec import (
+    ADDRESS_BITS,
+    LATENT_BYTES,
+    WORLD_EXTENT,
+    FieldObservation,
+    LatentFieldCodec,
+    LatentFieldConfig,
+    LatentFieldState,
+)
+
+
+def smooth_field(x: int, y: int, z: int) -> float:
+    extent = WORLD_EXTENT - 1
+    nx, ny, nz = x / extent, y / extent, z / extent
+    return 0.1 + 0.2 * nx + 0.25 * ny + 0.3 * nz
+
+
+def test_default_codec_is_exactly_one_kib_and_addresses_the_full_cube():
+    codec = LatentFieldCodec()
+
+    assert codec.latent_bytes == 1024
+    assert codec.virtual_voxels == 1024**3
+    assert codec.raw_u8_storage_bytes == 1024**3
+    assert codec.logical_expansion_ratio == 1_048_576
+    assert ADDRESS_BITS == 30
+    assert codec.linear_address(1023, 1023, 1023) == 2**30 - 1
+
+
+def test_config_requires_exactly_1024_latent_cells():
+    with pytest.raises(ValueError, match="product"):
+        LatentFieldConfig(latent_shape=(8, 8, 8))
+
+    with pytest.raises(ValueError, match="1,024"):
+        LatentFieldConfig(latent_shape=(8, 8, 16), latent_bytes=2048)
+
+
+def test_constant_field_round_trips_with_only_quantization_error():
+    codec = LatentFieldCodec()
+    state = codec.encode_field(lambda _x, _y, _z: 0.5)
+
+    assert isinstance(state, LatentFieldState)
+    assert len(state.payload) == LATENT_BYTES
+    assert codec.decode_voxel(state, 0, 0, 0) == pytest.approx(128 / 255)
+    assert codec.decode_voxel(state, 512, 512, 512) == pytest.approx(128 / 255)
+    assert codec.self_consistency_error(state) < 1.0e-15
+
+
+def test_smooth_field_is_reconstructed_by_trilinear_latent_decoder():
+    codec = LatentFieldCodec()
+    state = codec.encode_field(smooth_field)
+
+    for coordinate in ((0, 0, 0), (123, 456, 789), (512, 512, 512), (1023, 1023, 1023)):
+        expected = smooth_field(*coordinate)
+        assert codec.decode_voxel(state, *coordinate) == pytest.approx(expected, abs=0.004)
+
+
+def test_materialization_is_lazy_and_bounded_to_requested_slice():
+    codec = LatentFieldCodec()
+    state = codec.encode_field(smooth_field)
+
+    slice_2d = codec.materialize_slice(state, axis="z", index=512, resolution=12)
+
+    assert len(slice_2d) == 12
+    assert all(len(row) == 12 for row in slice_2d)
+    assert all(0.0 <= value <= 1.0 for row in slice_2d for value in row)
+
+
+def test_inward_refinement_reduces_observation_loss_transactionally():
+    codec = LatentFieldCodec()
+    state = LatentFieldState(bytes([64] * LATENT_BYTES))
+    observations = [
+        FieldObservation(128, 128, 128, 0.8),
+        FieldObservation(512, 512, 512, 0.7),
+        FieldObservation(900, 700, 400, 0.2),
+    ]
+
+    report = codec.refine(state, observations, learning_rate=0.5)
+
+    assert report.committed
+    assert report.state.revision == 1
+    assert report.loss_after <= report.loss_before
+    assert report.learning_rate_used > 0.0
+    assert report.state.payload != state.payload
+
+
+def test_decode_points_matches_individual_queries():
+    codec = LatentFieldCodec()
+    state = codec.encode_field(smooth_field)
+    points = ((1, 2, 3), (100, 200, 300), (1023, 1023, 1023))
+
+    batch = codec.decode_points(state, points)
+
+    assert batch == pytest.approx(tuple(codec.decode_voxel(state, *point) for point in points))
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda codec, state: codec.decode_voxel(state, -1, 0, 0),
+        lambda codec, state: codec.decode_voxel(state, 0, 1024, 0),
+        lambda codec, state: codec.materialize_slice(state, axis="q", index=0),
+        lambda codec, state: codec.materialize_slice(state, axis="z", index=1024),
+    ],
+)
+def test_invalid_queries_are_rejected(call):
+    codec = LatentFieldCodec()
+    state = codec.encode_field(smooth_field)
+
+    with pytest.raises((TypeError, ValueError)):
+        call(codec, state)
+
+
+def test_encoder_rejects_non_finite_or_out_of_range_fields():
+    codec = LatentFieldCodec()
+
+    with pytest.raises(ValueError):
+        codec.encode_field(lambda _x, _y, _z: math.inf)
+
+    with pytest.raises(ValueError):
+        codec.encode_field(lambda _x, _y, _z: 1.1)


### PR DESCRIPTION
## Summary

Adds a concrete, auditable 1 KiB latent-field runtime for the Jarvis-X inward 3D architecture.

- exact 1,024-byte latent state (`8×8×16` unsigned-byte lattice)
- `1024³` virtual voxel address space with 30-bit linear addressing
- lazy coordinate-conditioned trilinear decoding (voxel, sparse points, bounded slices)
- deterministic field encoder with explicit quantization
- inward residual pullback into the eight contributing latent nodes
- bounded backtracking and transactional non-regression commit/rollback
- self-consistency diagnostic
- strict capability boundary: no claim of universal lossless 1 GiB → 1 KiB compression
- 12 focused tests covering addressing, exact byte budget, reconstruction, lazy materialization, refinement, batching, and validation

## Operational recurrence

`world observation → encode/decode → residual → latent pullback → 1 KiB trial → verify → commit/rollback`

## Local validation performed

`pytest -q tests/test_latent_field_codec.py`

Result: `12 passed`.

## Files

- `src/jarvisx/latent_field_codec.py`
- `tests/test_latent_field_codec.py`
- `docs/ONE_KIB_INWARD_3D_FIELD_CODEC.md`
