### PR TITLE
feat: add verified PDF-carried DM3D bytecode and 3D animation loop runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
           src/jarvisx/dr_moagi_kinetic_system.py
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          src/jarvisx/dr_moagi_animation_loop.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -66,6 +67,7 @@ jobs:
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
           tests/test_dr_moagi_pdf_bytecode.py
+          tests/test_dr_moagi_animation_loop.py
           tests/test_quantum_text.py
           tests/test_verification.py
 
@@ -82,6 +84,7 @@ jobs:
           src/jarvisx/dr_moagi_kinetic_system.py
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          src/jarvisx/dr_moagi_animation_loop.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -91,6 +94,7 @@ jobs:
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
           tests/test_dr_moagi_pdf_bytecode.py
+          tests/test_dr_moagi_animation_loop.py
           tests/test_quantum_text.py
           tests/test_verification.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/dr_moagi_animation_loop.py
+          src/jarvisx/dr_moagi_animation_pdf.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -68,6 +69,7 @@ jobs:
           tests/test_dr_moagi_kinetic_system.py
           tests/test_dr_moagi_pdf_bytecode.py
           tests/test_dr_moagi_animation_loop.py
+          tests/test_dr_moagi_animation_pdf.py
           tests/test_quantum_text.py
           tests/test_verification.py
 
@@ -85,6 +87,7 @@ jobs:
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/dr_moagi_animation_loop.py
+          src/jarvisx/dr_moagi_animation_pdf.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -95,6 +98,7 @@ jobs:
           tests/test_dr_moagi_kinetic_system.py
           tests/test_dr_moagi_pdf_bytecode.py
           tests/test_dr_moagi_animation_loop.py
+          tests/test_dr_moagi_animation_pdf.py
           tests/test_quantum_text.py
           tests/test_verification.py
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
           src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
+          src/jarvisx/dr_moagi_pdf_bytecode.py
+          src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -63,6 +65,7 @@ jobs:
           tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
+          tests/test_dr_moagi_pdf_bytecode.py
           tests/test_quantum_text.py
           tests/test_verification.py
 
@@ -77,6 +80,8 @@ jobs:
           src/jarvisx/inward4d_ann.py
           src/jarvisx/kinetic_runtime.py
           src/jarvisx/dr_moagi_kinetic_system.py
+          src/jarvisx/dr_moagi_pdf_bytecode.py
+          src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/quantum_text.py
           src/jarvisx/verification.py
           tests/test_vm.py
@@ -85,6 +90,7 @@ jobs:
           tests/test_inward4d_ann.py
           tests/test_kinetic_runtime.py
           tests/test_dr_moagi_kinetic_system.py
+          tests/test_dr_moagi_pdf_bytecode.py
           tests/test_quantum_text.py
           tests/test_verification.py
 

--- a/.github/workflows/dr-moagi-pdf-bytecode.yml
+++ b/.github/workflows/dr-moagi-pdf-bytecode.yml
@@ -1,0 +1,60 @@
+name: Dr Moagi PDF Bytecode Runtime
+
+on:
+  push:
+    paths:
+      - "src/jarvisx/dr_moagi_pdf_bytecode.py"
+      - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
+      - "tests/test_dr_moagi_pdf_bytecode.py"
+      - "examples/dr_moagi_pdf_bytecode_runtime.py"
+      - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-pdf-bytecode.yml"
+  pull_request:
+    paths:
+      - "src/jarvisx/dr_moagi_pdf_bytecode.py"
+      - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
+      - "tests/test_dr_moagi_pdf_bytecode.py"
+      - "examples/dr_moagi_pdf_bytecode_runtime.py"
+      - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-pdf-bytecode.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install runtime and PDF test dependencies
+        run: python -m pip install -e ".[dev,pdf]"
+      - name: Static syntax check
+        run: >-
+          python -m py_compile
+          src/jarvisx/dr_moagi_pdf_bytecode.py
+          src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          examples/dr_moagi_pdf_bytecode_runtime.py
+      - name: Format check
+        run: >-
+          black --check --diff
+          src/jarvisx/dr_moagi_pdf_bytecode.py
+          src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          tests/test_dr_moagi_pdf_bytecode.py
+          examples/dr_moagi_pdf_bytecode_runtime.py
+      - name: Import-order check
+        run: >-
+          isort --check-only --diff
+          src/jarvisx/dr_moagi_pdf_bytecode.py
+          src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          tests/test_dr_moagi_pdf_bytecode.py
+          examples/dr_moagi_pdf_bytecode_runtime.py
+      - name: Focused runtime tests
+        run: pytest -q -o addopts='' tests/test_dr_moagi_pdf_bytecode.py
+      - name: PDF package smoke test
+        run: python examples/dr_moagi_pdf_bytecode_runtime.py

--- a/.github/workflows/dr-moagi-pdf-bytecode.yml
+++ b/.github/workflows/dr-moagi-pdf-bytecode.yml
@@ -6,8 +6,10 @@ on:
       - "src/jarvisx/dr_moagi_pdf_bytecode.py"
       - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
       - "src/jarvisx/dr_moagi_animation_loop.py"
+      - "src/jarvisx/dr_moagi_animation_pdf.py"
       - "tests/test_dr_moagi_pdf_bytecode.py"
       - "tests/test_dr_moagi_animation_loop.py"
+      - "tests/test_dr_moagi_animation_pdf.py"
       - "examples/dr_moagi_pdf_bytecode_runtime.py"
       - "examples/dr_moagi_animation_loop.py"
       - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
@@ -19,8 +21,10 @@ on:
       - "src/jarvisx/dr_moagi_pdf_bytecode.py"
       - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
       - "src/jarvisx/dr_moagi_animation_loop.py"
+      - "src/jarvisx/dr_moagi_animation_pdf.py"
       - "tests/test_dr_moagi_pdf_bytecode.py"
       - "tests/test_dr_moagi_animation_loop.py"
+      - "tests/test_dr_moagi_animation_pdf.py"
       - "examples/dr_moagi_pdf_bytecode_runtime.py"
       - "examples/dr_moagi_animation_loop.py"
       - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
@@ -48,6 +52,7 @@ jobs:
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/dr_moagi_animation_loop.py
+          src/jarvisx/dr_moagi_animation_pdf.py
           examples/dr_moagi_pdf_bytecode_runtime.py
           examples/dr_moagi_animation_loop.py
       - name: Format check
@@ -56,8 +61,10 @@ jobs:
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/dr_moagi_animation_loop.py
+          src/jarvisx/dr_moagi_animation_pdf.py
           tests/test_dr_moagi_pdf_bytecode.py
           tests/test_dr_moagi_animation_loop.py
+          tests/test_dr_moagi_animation_pdf.py
           examples/dr_moagi_pdf_bytecode_runtime.py
           examples/dr_moagi_animation_loop.py
       - name: Import-order check
@@ -66,8 +73,10 @@ jobs:
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
           src/jarvisx/dr_moagi_animation_loop.py
+          src/jarvisx/dr_moagi_animation_pdf.py
           tests/test_dr_moagi_pdf_bytecode.py
           tests/test_dr_moagi_animation_loop.py
+          tests/test_dr_moagi_animation_pdf.py
           examples/dr_moagi_pdf_bytecode_runtime.py
           examples/dr_moagi_animation_loop.py
       - name: Focused runtime tests
@@ -75,6 +84,7 @@ jobs:
           pytest -q -o addopts=''
           tests/test_dr_moagi_pdf_bytecode.py
           tests/test_dr_moagi_animation_loop.py
+          tests/test_dr_moagi_animation_pdf.py
       - name: PDF package smoke test
         run: python examples/dr_moagi_pdf_bytecode_runtime.py
       - name: Animation auto-loop smoke test

--- a/.github/workflows/dr-moagi-pdf-bytecode.yml
+++ b/.github/workflows/dr-moagi-pdf-bytecode.yml
@@ -5,18 +5,26 @@ on:
     paths:
       - "src/jarvisx/dr_moagi_pdf_bytecode.py"
       - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
+      - "src/jarvisx/dr_moagi_animation_loop.py"
       - "tests/test_dr_moagi_pdf_bytecode.py"
+      - "tests/test_dr_moagi_animation_loop.py"
       - "examples/dr_moagi_pdf_bytecode_runtime.py"
+      - "examples/dr_moagi_animation_loop.py"
       - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
+      - "docs/DR_MOAGI_3D_ANIMATION_AUTO_LOOP.md"
       - "pyproject.toml"
       - ".github/workflows/dr-moagi-pdf-bytecode.yml"
   pull_request:
     paths:
       - "src/jarvisx/dr_moagi_pdf_bytecode.py"
       - "src/jarvisx/dr_moagi_pdf_bytecode_cli.py"
+      - "src/jarvisx/dr_moagi_animation_loop.py"
       - "tests/test_dr_moagi_pdf_bytecode.py"
+      - "tests/test_dr_moagi_animation_loop.py"
       - "examples/dr_moagi_pdf_bytecode_runtime.py"
+      - "examples/dr_moagi_animation_loop.py"
       - "docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md"
+      - "docs/DR_MOAGI_3D_ANIMATION_AUTO_LOOP.md"
       - "pyproject.toml"
       - ".github/workflows/dr-moagi-pdf-bytecode.yml"
 
@@ -39,22 +47,35 @@ jobs:
           python -m py_compile
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          src/jarvisx/dr_moagi_animation_loop.py
           examples/dr_moagi_pdf_bytecode_runtime.py
+          examples/dr_moagi_animation_loop.py
       - name: Format check
         run: >-
           black --check --diff
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          src/jarvisx/dr_moagi_animation_loop.py
           tests/test_dr_moagi_pdf_bytecode.py
+          tests/test_dr_moagi_animation_loop.py
           examples/dr_moagi_pdf_bytecode_runtime.py
+          examples/dr_moagi_animation_loop.py
       - name: Import-order check
         run: >-
           isort --check-only --diff
           src/jarvisx/dr_moagi_pdf_bytecode.py
           src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+          src/jarvisx/dr_moagi_animation_loop.py
           tests/test_dr_moagi_pdf_bytecode.py
+          tests/test_dr_moagi_animation_loop.py
           examples/dr_moagi_pdf_bytecode_runtime.py
+          examples/dr_moagi_animation_loop.py
       - name: Focused runtime tests
-        run: pytest -q -o addopts='' tests/test_dr_moagi_pdf_bytecode.py
+        run: >-
+          pytest -q -o addopts=''
+          tests/test_dr_moagi_pdf_bytecode.py
+          tests/test_dr_moagi_animation_loop.py
       - name: PDF package smoke test
         run: python examples/dr_moagi_pdf_bytecode_runtime.py
+      - name: Animation auto-loop smoke test
+        run: python examples/dr_moagi_animation_loop.py

--- a/docs/DR_MOAGI_3D_ANIMATION_AUTO_LOOP.md
+++ b/docs/DR_MOAGI_3D_ANIMATION_AUTO_LOOP.md
@@ -1,0 +1,107 @@
+# Dr Moagi 3D Animation Auto-Execution Loop
+
+This layer turns the verified DM3D auto-encoding/decoding program into a finite cyclic
+3D state machine suitable for animation generation and downstream rendering.
+
+## Execution model
+
+The outer bytecode contains a verified inner DM3D program and bounded loop metadata:
+
+```text
+DM3D-LOOP
+  cycles
+  feedback register
+  convergence scalar register
+  frame-register mask
+  inner DM3D bytecode
+  SHA-256 digest
+```
+
+The inner canonical program remains:
+
+```text
+X_t
+  -> ENCODE_3D       -> Z_t^0
+  -> REFINE_3D^K     -> Z_t^*
+  -> DECODE_3D       -> X_hat_t
+  -> REENCODE_3D     -> Z_tilde_t
+  -> ERROR_3D
+  -> CYCLE_ERROR
+  -> ERROR_MEMORY
+  -> CHECK_FIXED
+  -> HALT
+```
+
+The outer executor then applies the explicit feedback edge:
+
+```text
+X_(t+1) <- X_hat_t
+```
+
+and repeats only up to the encoded cycle bound.
+
+Mathematically:
+
+```text
+Z_t^0       = E(X_t)
+Z_t^*       = R^K(Z_t^0)
+X_hat_t     = D(Z_t^*)
+Z_tilde_t   = E(X_hat_t)
+Omega_(t+1) = rho Omega_t + (1-rho)(lambda_x e_x + lambda_z e_z)
+X_(t+1)     = X_hat_t
+```
+
+where the current deterministic block-average / replication codec satisfies the latent
+cycle identity to floating-point precision:
+
+```text
+E(D(Z_t^*)) ~= Z_t^*
+```
+
+## Animation frames
+
+The canonical loop captures registers `r0..r4` on each cycle:
+
+| Register | Stage |
+| --- | --- |
+| `r0` | input field |
+| `r1` | encoded latent |
+| `r2` | inward-refined latent |
+| `r3` | decoded reconstruction |
+| `r4` | re-encoded latent |
+
+Each frame carries the complete `Volume3D` state for a downstream renderer and reports
+shape, minimum, maximum, mean, and a SHA-256 state digest. Rendering is deliberately
+kept outside the VM so the bytecode remains deterministic and graphics-backend neutral.
+
+## Safety and bounded execution
+
+The auto-loop format does not provide general jumps, shell access, dynamic imports, or
+host-code execution. It can only repeat a previously verified finite DM3D program.
+Execution is constrained by three independent bounds:
+
+1. per-cycle `ProgramLimits`, including instruction, voxel, refinement and physical-step
+   caps;
+2. `AutoLoopLimits.max_cycles`;
+3. `AutoLoopLimits.max_total_physical_steps` and `max_frames` across all cycles.
+
+A PDF remains a transport container only. Opening the PDF does not trigger this loop.
+The Jarvis-X runtime must explicitly extract and verify the bytecode before execution.
+
+## Reference use
+
+```python
+from jarvisx.dr_moagi_animation_loop import (
+    canonical_animation_loop_program,
+    execute_auto_loop,
+)
+from jarvisx.dr_moagi_pdf_bytecode import make_seed_volume
+
+program = canonical_animation_loop_program(cycles=4, refinement_passes=6)
+result = execute_auto_loop(program, make_seed_volume(16))
+print(result.report())
+```
+
+For interactive or video output, a renderer can consume `result.frames` in order and
+map each volumetric state to points, voxels, meshes, SDF surfaces, or GPU textures.
+Measured physical VM work and rendered-frame throughput should be reported separately.

--- a/docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md
+++ b/docs/DR_MOAGI_PDF_BYTECODE_RUNTIME.md
@@ -1,0 +1,197 @@
+# Dr Moagi PDF-Carried DM3D Bytecode Runtime
+
+## Status
+
+This layer turns the PDF experiment into a bounded repository runtime:
+
+```text
+PDF transport container
+-> embedded manifest
+-> embedded DM3D bytecode
+-> SHA-256 verification
+-> structural bytecode validation
+-> bounded 3D VM
+-> encode/refine/decode/re-encode
+-> reconstruction + cycle error
+-> measured physical-work telemetry
+```
+
+Opening the PDF never executes it. Execution occurs only when the explicit Jarvis-X runtime is invoked.
+
+## Why bytecode instead of embedded Python
+
+The earlier proof demonstrated that a PDF can carry source, be parsed, verified, extracted, and handed to CPython. That proves packaging but leaves arbitrary Python authority outside the document model.
+
+DM3D narrows authority to a finite instruction set:
+
+| Opcode | Operation |
+| --- | --- |
+| `ENCODE_3D` | Block-average 3D contraction |
+| `REFINE_3D` | Bounded six-neighbour inward latent refinement |
+| `DECODE_3D` | Deterministic nearest-cell 3D expansion |
+| `REENCODE_3D` | Encode reconstructed output back to latent space |
+| `ERROR_3D` | Reconstruction MSE |
+| `CYCLE_ERROR` | Latent cycle MSE |
+| `ERROR_MEMORY` | Persistent error-memory update |
+| `CHECK_FIXED` | Fixed-point tolerance check |
+| `HALT` | Final instruction |
+
+The bytecode therefore describes computation without granting general-purpose source-code execution.
+
+## Binary format
+
+A DM3D program is:
+
+```text
+16-byte header
+N x 16-byte fixed-width instructions
+32-byte SHA-256 digest
+```
+
+Header fields:
+
+```text
+magic   = DM3DVM1\0
+version = 1
+count   = uint16 instruction count
+reserved = 0
+```
+
+The parser rejects malformed sizes, unknown opcodes, misplaced `HALT`, digest failures, excessive instruction counts, and excessive refinement passes before execution.
+
+## Canonical recurrence
+
+The reference program is:
+
+\[
+X_t
+\xrightarrow{E}
+Z_t^{(0)}
+\xrightarrow{\mathcal R^K}
+Z_t^*
+\xrightarrow{D}
+\widehat X_t
+\xrightarrow{E}
+\widetilde Z_t.
+\]
+
+The six-neighbour inward refinement is
+
+\[
+Z_{ijk}^{(k+1)}
+=0.88Z_{ijk}^{(k)}
++0.10\,\overline{Z}_{\mathcal N(i,j,k)}^{(k)}
++0.02\,\mu_k.
+\]
+
+Reconstruction and cycle errors are
+
+\[
+e_x=\operatorname{MSE}(X_t,\widehat X_t),
+\qquad
+e_z=\operatorname{MSE}(Z_t^*,\widetilde Z_t).
+\]
+
+Error memory is
+
+\[
+\Omega_{t+1}
+=\rho\Omega_t+(1-\rho)(\lambda_xe_x+\lambda_ze_z).
+\]
+
+The canonical program uses
+
+\[
+\rho=0.9,
+\qquad\lambda_x=0.7,
+\qquad\lambda_z=0.3.
+\]
+
+## Kinetic accounting
+
+DM3D reports measured physical work rather than claiming a symbolic source-line rate:
+
+```text
+instructions executed
+physical steps charged
+voxel reads
+voxel writes
+valid neighbour reads
+latent refinement updates
+wall-clock runtime
+physical steps / second
+```
+
+For the `16^3 -> 8^3 -> 16^3` four-pass reference, the recurrent core performs exactly
+
+\[
+4\times8^3=2048
+\]
+
+latent updates and
+
+\[
+10752
+\]
+
+valid directed six-neighbour reads.
+
+A compressed super-instruction may represent large logical work, but represented work is not reported as physical hardware throughput.
+
+## Resource bounds
+
+`ProgramLimits` gates:
+
+- maximum instruction count;
+- maximum active voxels;
+- maximum refinement passes;
+- maximum charged physical steps.
+
+A program that exceeds any bound aborts instead of partially continuing.
+
+## PDF package integrity
+
+The PDF embeds exactly two required attachments:
+
+```text
+manifest.json
+engine.dm3d
+```
+
+The manifest records the bytecode SHA-256, byte length, instruction count, engine format, and the policy:
+
+```text
+explicit-runtime-only
+```
+
+The runtime verifies all manifest claims before parsing the bytecode.
+
+## CLI
+
+Install PDF support:
+
+```bash
+pip install -e '.[pdf]'
+```
+
+Build a package:
+
+```bash
+jarvisx-dr-moagi-pdfvm build dr-moagi.pdf --pool 2 --passes 4
+```
+
+Verify without executing:
+
+```bash
+jarvisx-dr-moagi-pdfvm inspect dr-moagi.pdf
+```
+
+Explicitly execute:
+
+```bash
+jarvisx-dr-moagi-pdfvm run dr-moagi.pdf --size 16
+```
+
+## Claim boundary
+
+This is a deterministic executable research runtime and document-packaging format. It does not make a PDF reader itself a Python runtime, does not silently execute on document open, and does not interpret astronomical logical iteration counts as measured hardware throughput.

--- a/examples/dr_moagi_animation_loop.py
+++ b/examples/dr_moagi_animation_loop.py
@@ -1,0 +1,21 @@
+"""Run the bounded Dr Moagi 3D animation auto-execution loop."""
+
+from __future__ import annotations
+
+import json
+
+from jarvisx.dr_moagi_animation_loop import (
+    canonical_animation_loop_program,
+    execute_auto_loop,
+)
+from jarvisx.dr_moagi_pdf_bytecode import make_seed_volume
+
+
+def main() -> None:
+    program = canonical_animation_loop_program(cycles=4, refinement_passes=6)
+    result = execute_auto_loop(program, make_seed_volume(16))
+    print(json.dumps(result.report(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/dr_moagi_pdf_bytecode_runtime.py
+++ b/examples/dr_moagi_pdf_bytecode_runtime.py
@@ -1,0 +1,36 @@
+"""Build, verify, and execute a bounded PDF-carried DM3D bytecode package."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from jarvisx.dr_moagi_pdf_bytecode import (
+    build_pdf_package,
+    canonical_autoencoder_program,
+    make_seed_volume,
+    run_pdf_package,
+)
+
+
+def main() -> None:
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    with tempfile.TemporaryDirectory(prefix="jarvisx-dm3d-") as directory:
+        package = Path(directory) / "dr-moagi-bytecode.pdf"
+        manifest = build_pdf_package(package, program)
+        result = run_pdf_package(package, make_seed_volume(16))
+        print(
+            json.dumps(
+                {
+                    "manifest": manifest.__dict__,
+                    "result": result.report(),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ test = [
 torch = [
     "torch>=2.4",
 ]
+pdf = [
+    "pymupdf>=1.24",
+]
 
 [project.urls]
 Homepage = "https://github.com/Lord-Xido/Jarvis-X"
@@ -75,6 +78,7 @@ jarvisx-dr-moagi-firmware = "jarvisx.dr_moagi_firmware_cli:main"
 jarvisx-dr-moagi-frontier = "jarvisx.dr_moagi_frontier_cli:main"
 jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
 jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
+jarvisx-dr-moagi-pdfvm = "jarvisx.dr_moagi_pdf_bytecode_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/dr_moagi_animation_loop.py
+++ b/src/jarvisx/dr_moagi_animation_loop.py
@@ -67,7 +67,9 @@ class AutoLoopProgram:
 
     @property
     def frame_registers(self) -> tuple[int, ...]:
-        return tuple(register for register in range(32) if self.frame_register_mask & (1 << register))
+        return tuple(
+            register for register in range(32) if self.frame_register_mask & (1 << register)
+        )
 
 
 @dataclass(frozen=True)

--- a/src/jarvisx/dr_moagi_animation_loop.py
+++ b/src/jarvisx/dr_moagi_animation_loop.py
@@ -265,7 +265,11 @@ def execute_auto_loop(
     program = parse_auto_loop_program(payload, loop_limits=loop_limits, vm_limits=vm_limits)
     inner_instructions = parse_program(program.inner_program, vm_limits)
     error_memory = next(
-        (instruction for instruction in inner_instructions if instruction.opcode is Opcode.ERROR_MEMORY),
+        (
+            instruction
+            for instruction in inner_instructions
+            if instruction.opcode is Opcode.ERROR_MEMORY
+        ),
         None,
     )
     current = initial_volume.copy()

--- a/src/jarvisx/dr_moagi_animation_loop.py
+++ b/src/jarvisx/dr_moagi_animation_loop.py
@@ -1,0 +1,366 @@
+"""Bounded cyclic execution for the Dr Moagi 3D auto-encoding bytecode runtime.
+
+The outer DM3D loop format contains a verified inner DM3D program plus finite loop
+metadata. It does not add arbitrary jumps or host-code execution. Each cycle runs the
+existing finite VM, captures selected 3D volume states, feeds a designated output
+volume back as the next input, and stops at an explicit cycle or work budget.
+"""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import asdict, dataclass, field
+from hashlib import sha256
+
+from .dr_moagi_pdf_bytecode import (
+    ProgramLimits,
+    VmMetrics,
+    Volume3D,
+    canonical_autoencoder_program,
+    execute_program,
+    parse_program,
+)
+
+AUTO_PROGRAM_MAGIC = b"DM3DLP1\0"
+AUTO_PROGRAM_VERSION = 1
+AUTO_PROGRAM_HEADER = struct.Struct("<8sHHIIIII")
+AUTO_PROGRAM_DIGEST_BYTES = 32
+AUTO_FLAG_STOP_ON_FIXED = 0x0001
+AUTO_KNOWN_FLAGS = AUTO_FLAG_STOP_ON_FIXED
+DEFAULT_FRAME_REGISTERS = (0, 1, 2, 3, 4)
+STAGE_NAMES = {
+    0: "input",
+    1: "encoded",
+    2: "refined",
+    3: "decoded",
+    4: "reencoded",
+}
+
+
+@dataclass(frozen=True)
+class AutoLoopLimits:
+    """Resource bounds applied across every VM cycle."""
+
+    max_cycles: int = 256
+    max_total_physical_steps: int = 200_000_000
+    max_frames: int = 4096
+
+    def validate(self) -> None:
+        if self.max_cycles <= 0:
+            raise ValueError("max_cycles must be positive")
+        if self.max_total_physical_steps <= 0:
+            raise ValueError("max_total_physical_steps must be positive")
+        if self.max_frames <= 0:
+            raise ValueError("max_frames must be positive")
+
+
+@dataclass(frozen=True)
+class AutoLoopProgram:
+    """Decoded outer loop bytecode and its verified inner DM3D program."""
+
+    cycles: int
+    feedback_register: int
+    convergence_scalar_register: int
+    frame_register_mask: int
+    stop_on_fixed_point: bool
+    inner_program: bytes
+
+    @property
+    def frame_registers(self) -> tuple[int, ...]:
+        return tuple(register for register in range(32) if self.frame_register_mask & (1 << register))
+
+
+@dataclass(frozen=True)
+class VolumeFrame:
+    """One captured volumetric stage suitable for a downstream renderer."""
+
+    cycle: int
+    register: int
+    stage: str
+    volume: Volume3D
+
+    def report(self) -> dict[str, object]:
+        values = self.volume.values
+        digest = sha256()
+        digest.update(struct.pack("<III", self.volume.nx, self.volume.ny, self.volume.nz))
+        for value in values:
+            digest.update(struct.pack("<d", value))
+        return {
+            "cycle": self.cycle,
+            "register": self.register,
+            "stage": self.stage,
+            "shape": [self.volume.nx, self.volume.ny, self.volume.nz],
+            "minimum": min(values),
+            "maximum": max(values),
+            "mean": sum(values) / len(values),
+            "sha256": digest.hexdigest(),
+        }
+
+
+@dataclass(frozen=True)
+class CycleTelemetry:
+    cycle: int
+    reconstruction_mse: float | None
+    cycle_mse: float | None
+    omega: float | None
+    fixed_point_pass: bool
+    physical_steps: int
+
+
+@dataclass
+class AutoLoopResult:
+    cycles_executed: int
+    stopped_on_fixed_point: bool
+    final_volume: Volume3D
+    metrics: VmMetrics
+    cycles: list[CycleTelemetry] = field(default_factory=list)
+    frames: list[VolumeFrame] = field(default_factory=list)
+
+    def report(self) -> dict[str, object]:
+        metrics = {
+            **asdict(self.metrics),
+            "physical_steps_per_second": self.metrics.physical_steps_per_second,
+        }
+        return {
+            "cycles_executed": self.cycles_executed,
+            "stopped_on_fixed_point": self.stopped_on_fixed_point,
+            "final_shape": [
+                self.final_volume.nx,
+                self.final_volume.ny,
+                self.final_volume.nz,
+            ],
+            "metrics": metrics,
+            "cycles": [asdict(item) for item in self.cycles],
+            "frames": [frame.report() for frame in self.frames],
+        }
+
+
+def serialize_auto_loop_program(
+    inner_program: bytes,
+    *,
+    cycles: int,
+    feedback_register: int = 3,
+    convergence_scalar_register: int = 13,
+    frame_registers: tuple[int, ...] = DEFAULT_FRAME_REGISTERS,
+    stop_on_fixed_point: bool = False,
+) -> bytes:
+    """Wrap a verified DM3D program in finite cyclic execution metadata."""
+
+    parse_program(inner_program)
+    if cycles <= 0:
+        raise ValueError("cycles must be positive")
+    _validate_register(feedback_register)
+    _validate_register(convergence_scalar_register)
+    frame_mask = _frame_mask(frame_registers)
+    flags = AUTO_FLAG_STOP_ON_FIXED if stop_on_fixed_point else 0
+    header = AUTO_PROGRAM_HEADER.pack(
+        AUTO_PROGRAM_MAGIC,
+        AUTO_PROGRAM_VERSION,
+        flags,
+        cycles,
+        feedback_register,
+        convergence_scalar_register,
+        frame_mask,
+        len(inner_program),
+    )
+    body = header + inner_program
+    return body + sha256(body).digest()
+
+
+def parse_auto_loop_program(
+    payload: bytes,
+    *,
+    loop_limits: AutoLoopLimits | None = None,
+    vm_limits: ProgramLimits | None = None,
+) -> AutoLoopProgram:
+    """Validate and decode DM3D cyclic bytecode."""
+
+    loop_limits = loop_limits or AutoLoopLimits()
+    vm_limits = vm_limits or ProgramLimits()
+    loop_limits.validate()
+    vm_limits.validate()
+    minimum = AUTO_PROGRAM_HEADER.size + AUTO_PROGRAM_DIGEST_BYTES
+    if len(payload) <= minimum:
+        raise ValueError("DM3D auto-loop program is truncated")
+
+    body = payload[:-AUTO_PROGRAM_DIGEST_BYTES]
+    digest = payload[-AUTO_PROGRAM_DIGEST_BYTES:]
+    if sha256(body).digest() != digest:
+        raise ValueError("DM3D auto-loop SHA-256 mismatch")
+
+    (
+        magic,
+        version,
+        flags,
+        cycles,
+        feedback_register,
+        convergence_scalar_register,
+        frame_mask,
+        inner_length,
+    ) = AUTO_PROGRAM_HEADER.unpack_from(body, 0)
+    if magic != AUTO_PROGRAM_MAGIC:
+        raise ValueError("invalid DM3D auto-loop magic")
+    if version != AUTO_PROGRAM_VERSION:
+        raise ValueError("unsupported DM3D auto-loop version")
+    if flags & ~AUTO_KNOWN_FLAGS:
+        raise ValueError("unknown DM3D auto-loop flags")
+    if cycles == 0 or cycles > loop_limits.max_cycles:
+        raise ValueError("DM3D auto-loop cycle count exceeds configured limit")
+    _validate_register(feedback_register)
+    _validate_register(convergence_scalar_register)
+
+    inner = body[AUTO_PROGRAM_HEADER.size :]
+    if len(inner) != inner_length:
+        raise ValueError("DM3D auto-loop inner program length mismatch")
+    parse_program(inner, vm_limits)
+
+    frame_registers = tuple(register for register in range(32) if frame_mask & (1 << register))
+    if cycles * len(frame_registers) > loop_limits.max_frames:
+        raise ValueError("DM3D auto-loop frame count exceeds configured limit")
+
+    return AutoLoopProgram(
+        cycles=cycles,
+        feedback_register=feedback_register,
+        convergence_scalar_register=convergence_scalar_register,
+        frame_register_mask=frame_mask,
+        stop_on_fixed_point=bool(flags & AUTO_FLAG_STOP_ON_FIXED),
+        inner_program=inner,
+    )
+
+
+def canonical_animation_loop_program(
+    *,
+    cycles: int = 8,
+    pool: int = 2,
+    refinement_passes: int = 6,
+    stop_on_fixed_point: bool = False,
+) -> bytes:
+    """Build the canonical X -> E -> R^K -> D -> E -> feedback animation loop."""
+
+    inner = canonical_autoencoder_program(pool=pool, refinement_passes=refinement_passes)
+    return serialize_auto_loop_program(
+        inner,
+        cycles=cycles,
+        feedback_register=3,
+        convergence_scalar_register=13,
+        frame_registers=DEFAULT_FRAME_REGISTERS,
+        stop_on_fixed_point=stop_on_fixed_point,
+    )
+
+
+def execute_auto_loop(
+    payload: bytes,
+    initial_volume: Volume3D,
+    *,
+    loop_limits: AutoLoopLimits | None = None,
+    vm_limits: ProgramLimits | None = None,
+) -> AutoLoopResult:
+    """Execute a finite auto-encoding/decoding feedback loop end to end."""
+
+    loop_limits = loop_limits or AutoLoopLimits()
+    vm_limits = vm_limits or ProgramLimits()
+    program = parse_auto_loop_program(payload, loop_limits=loop_limits, vm_limits=vm_limits)
+    current = initial_volume.copy()
+    cumulative = VmMetrics()
+    frames: list[VolumeFrame] = []
+    telemetry: list[CycleTelemetry] = []
+    stopped = False
+
+    for cycle in range(program.cycles):
+        remaining = loop_limits.max_total_physical_steps - cumulative.physical_steps
+        if remaining <= 0:
+            raise RuntimeError("DM3D auto-loop physical-step budget exceeded")
+        cycle_limits = ProgramLimits(
+            max_instructions=vm_limits.max_instructions,
+            max_voxels=vm_limits.max_voxels,
+            max_refinement_passes=vm_limits.max_refinement_passes,
+            max_physical_steps=min(vm_limits.max_physical_steps, remaining),
+        )
+        result = execute_program(program.inner_program, current, cycle_limits)
+        _accumulate_metrics(cumulative, result.metrics)
+        if cumulative.physical_steps > loop_limits.max_total_physical_steps:
+            raise RuntimeError("DM3D auto-loop physical-step budget exceeded")
+
+        for register in program.frame_registers:
+            volume = result.volumes.get(register)
+            if volume is not None:
+                frames.append(
+                    VolumeFrame(
+                        cycle=cycle,
+                        register=register,
+                        stage=STAGE_NAMES.get(register, f"volume-r{register}"),
+                        volume=volume.copy(),
+                    )
+                )
+                if len(frames) > loop_limits.max_frames:
+                    raise RuntimeError("DM3D auto-loop frame budget exceeded")
+
+        fixed = result.scalars.get(program.convergence_scalar_register, 0.0) >= 1.0
+        telemetry.append(
+            CycleTelemetry(
+                cycle=cycle,
+                reconstruction_mse=result.scalars.get(10),
+                cycle_mse=result.scalars.get(11),
+                omega=result.scalars.get(12),
+                fixed_point_pass=fixed,
+                physical_steps=result.metrics.physical_steps,
+            )
+        )
+
+        try:
+            current = result.volumes[program.feedback_register].copy()
+        except KeyError as exc:
+            raise RuntimeError(
+                f"DM3D feedback volume r{program.feedback_register} is unavailable"
+            ) from exc
+
+        if program.stop_on_fixed_point and fixed:
+            stopped = True
+            break
+
+    return AutoLoopResult(
+        cycles_executed=len(telemetry),
+        stopped_on_fixed_point=stopped,
+        final_volume=current,
+        metrics=cumulative,
+        cycles=telemetry,
+        frames=frames,
+    )
+
+
+def _frame_mask(registers: tuple[int, ...]) -> int:
+    if len(set(registers)) != len(registers):
+        raise ValueError("frame registers must be unique")
+    mask = 0
+    for register in registers:
+        _validate_register(register)
+        mask |= 1 << register
+    return mask
+
+
+def _validate_register(register: int) -> None:
+    if not 0 <= register < 32:
+        raise ValueError("DM3D auto-loop register must lie in [0, 31]")
+
+
+def _accumulate_metrics(total: VmMetrics, current: VmMetrics) -> None:
+    total.instructions_executed += current.instructions_executed
+    total.physical_steps += current.physical_steps
+    total.voxel_reads += current.voxel_reads
+    total.voxel_writes += current.voxel_writes
+    total.neighbor_reads += current.neighbor_reads
+    total.refinement_updates += current.refinement_updates
+    total.elapsed_seconds += current.elapsed_seconds
+
+
+__all__ = [
+    "AutoLoopLimits",
+    "AutoLoopProgram",
+    "AutoLoopResult",
+    "CycleTelemetry",
+    "VolumeFrame",
+    "canonical_animation_loop_program",
+    "execute_auto_loop",
+    "parse_auto_loop_program",
+    "serialize_auto_loop_program",
+]

--- a/src/jarvisx/dr_moagi_animation_loop.py
+++ b/src/jarvisx/dr_moagi_animation_loop.py
@@ -13,6 +13,7 @@ from dataclasses import asdict, dataclass, field
 from hashlib import sha256
 
 from .dr_moagi_pdf_bytecode import (
+    Opcode,
     ProgramLimits,
     VmMetrics,
     Volume3D,
@@ -262,10 +263,16 @@ def execute_auto_loop(
     loop_limits = loop_limits or AutoLoopLimits()
     vm_limits = vm_limits or ProgramLimits()
     program = parse_auto_loop_program(payload, loop_limits=loop_limits, vm_limits=vm_limits)
+    inner_instructions = parse_program(program.inner_program, vm_limits)
+    error_memory = next(
+        (instruction for instruction in inner_instructions if instruction.opcode is Opcode.ERROR_MEMORY),
+        None,
+    )
     current = initial_volume.copy()
     cumulative = VmMetrics()
     frames: list[VolumeFrame] = []
     telemetry: list[CycleTelemetry] = []
+    omega_state = 0.0
     stopped = False
 
     for cycle in range(program.cycles):
@@ -297,13 +304,28 @@ def execute_auto_loop(
                 if len(frames) > loop_limits.max_frames:
                     raise RuntimeError("DM3D auto-loop frame budget exceeded")
 
+        reconstruction_mse = result.scalars.get(10)
+        cycle_mse = result.scalars.get(11)
+        omega_value = result.scalars.get(12)
+        if error_memory is not None:
+            error_x = result.scalars.get(error_memory.src)
+            error_z = result.scalars.get(error_memory.aux)
+            if error_x is not None and error_z is not None:
+                rho = error_memory.arg0 / 1_000_000.0
+                lambda_x = error_memory.arg1 / 1_000_000.0
+                lambda_z = error_memory.arg2 / 1_000_000.0
+                omega_state = rho * omega_state + (1.0 - rho) * (
+                    lambda_x * error_x + lambda_z * error_z
+                )
+                omega_value = omega_state
+
         fixed = result.scalars.get(program.convergence_scalar_register, 0.0) >= 1.0
         telemetry.append(
             CycleTelemetry(
                 cycle=cycle,
-                reconstruction_mse=result.scalars.get(10),
-                cycle_mse=result.scalars.get(11),
-                omega=result.scalars.get(12),
+                reconstruction_mse=reconstruction_mse,
+                cycle_mse=cycle_mse,
+                omega=omega_value,
                 fixed_point_pass=fixed,
                 physical_steps=result.metrics.physical_steps,
             )

--- a/src/jarvisx/dr_moagi_animation_pdf.py
+++ b/src/jarvisx/dr_moagi_animation_pdf.py
@@ -118,9 +118,7 @@ def load_animation_pdf_package(path: str | Path) -> tuple[AnimationPdfManifest, 
         names = set(document.embfile_names())
         if ANIMATION_MANIFEST_NAME not in names or ANIMATION_PAYLOAD_NAME not in names:
             raise ValueError("animation PDF package is missing required attachments")
-        manifest = AnimationPdfManifest.from_bytes(
-            document.embfile_get(ANIMATION_MANIFEST_NAME)
-        )
+        manifest = AnimationPdfManifest.from_bytes(document.embfile_get(ANIMATION_MANIFEST_NAME))
         payload = bytes(document.embfile_get(ANIMATION_PAYLOAD_NAME))
     finally:
         document.close()

--- a/src/jarvisx/dr_moagi_animation_pdf.py
+++ b/src/jarvisx/dr_moagi_animation_pdf.py
@@ -1,0 +1,173 @@
+"""PDF transport for the bounded DM3D 3D-animation auto-execution loop."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from hashlib import sha256
+from pathlib import Path
+
+from .dr_moagi_animation_loop import (
+    AutoLoopLimits,
+    AutoLoopResult,
+    execute_auto_loop,
+    parse_auto_loop_program,
+)
+from .dr_moagi_pdf_bytecode import ProgramLimits, Volume3D, parse_program
+
+ANIMATION_MANIFEST_NAME = "manifest.json"
+ANIMATION_PAYLOAD_NAME = "animation.dm3dloop"
+ANIMATION_ENGINE_FORMAT = "dm3d-animation-loop-v1"
+
+
+@dataclass(frozen=True)
+class AnimationPdfManifest:
+    manifest_version: int
+    engine_format: str
+    payload_name: str
+    payload_sha256: str
+    payload_bytes: int
+    cycles: int
+    inner_instruction_count: int
+    execution_policy: str = "explicit-runtime-only"
+
+    def to_bytes(self) -> bytes:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> "AnimationPdfManifest":
+        manifest = cls(**json.loads(payload.decode("utf-8")))
+        if manifest.manifest_version != 1:
+            raise ValueError("unsupported animation PDF manifest version")
+        if manifest.engine_format != ANIMATION_ENGINE_FORMAT:
+            raise ValueError("unsupported animation PDF engine format")
+        if manifest.payload_name != ANIMATION_PAYLOAD_NAME:
+            raise ValueError("unexpected animation PDF payload name")
+        if manifest.execution_policy != "explicit-runtime-only":
+            raise ValueError("unsafe or unsupported animation execution policy")
+        if manifest.payload_bytes <= 0 or manifest.cycles <= 0:
+            raise ValueError("invalid animation PDF size or cycle metadata")
+        if manifest.inner_instruction_count <= 0:
+            raise ValueError("invalid animation PDF instruction metadata")
+        if len(manifest.payload_sha256) != 64:
+            raise ValueError("invalid animation PDF SHA-256 digest")
+        return manifest
+
+
+def build_animation_pdf_package(
+    path: str | Path,
+    payload: bytes,
+    *,
+    title: str = "Dr Moagi 3D Animation Auto-Execution Loop",
+) -> AnimationPdfManifest:
+    """Write verified DM3D-LOOP bytecode as an inert PDF attachment package."""
+
+    loop = parse_auto_loop_program(payload)
+    inner_instructions = parse_program(loop.inner_program)
+    manifest = AnimationPdfManifest(
+        manifest_version=1,
+        engine_format=ANIMATION_ENGINE_FORMAT,
+        payload_name=ANIMATION_PAYLOAD_NAME,
+        payload_sha256=sha256(payload).hexdigest(),
+        payload_bytes=len(payload),
+        cycles=loop.cycles,
+        inner_instruction_count=len(inner_instructions),
+    )
+    fitz = _require_pymupdf()
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    document = fitz.open()
+    page = document.new_page(width=842, height=595)
+    text = (
+        f"{title}\n\n"
+        "Execution policy: explicit runtime only\n"
+        f"Payload: {ANIMATION_PAYLOAD_NAME}\n"
+        f"Cycles: {manifest.cycles}\n"
+        f"Inner instructions: {manifest.inner_instruction_count}\n"
+        f"SHA-256: {manifest.payload_sha256}\n\n"
+        "Pipeline:\n"
+        "PDF -> verify loop -> verify DM3D -> bounded cycles -> volumetric frames\n"
+    )
+    page.insert_textbox(fitz.Rect(48, 48, 794, 540), text, fontsize=12)
+    document.embfile_add(
+        ANIMATION_MANIFEST_NAME,
+        manifest.to_bytes(),
+        filename=ANIMATION_MANIFEST_NAME,
+        ufilename=ANIMATION_MANIFEST_NAME,
+        desc="Dr Moagi animation auto-loop manifest",
+    )
+    document.embfile_add(
+        ANIMATION_PAYLOAD_NAME,
+        payload,
+        filename=ANIMATION_PAYLOAD_NAME,
+        ufilename=ANIMATION_PAYLOAD_NAME,
+        desc="Verified DM3D animation loop payload",
+    )
+    document.save(str(output), deflate=True, garbage=4)
+    document.close()
+    return manifest
+
+
+def load_animation_pdf_package(path: str | Path) -> tuple[AnimationPdfManifest, bytes]:
+    """Extract and verify the inert animation loop payload from a PDF package."""
+
+    fitz = _require_pymupdf()
+    document = fitz.open(str(path))
+    try:
+        names = set(document.embfile_names())
+        if ANIMATION_MANIFEST_NAME not in names or ANIMATION_PAYLOAD_NAME not in names:
+            raise ValueError("animation PDF package is missing required attachments")
+        manifest = AnimationPdfManifest.from_bytes(
+            document.embfile_get(ANIMATION_MANIFEST_NAME)
+        )
+        payload = bytes(document.embfile_get(ANIMATION_PAYLOAD_NAME))
+    finally:
+        document.close()
+
+    if len(payload) != manifest.payload_bytes:
+        raise ValueError("animation PDF payload length does not match manifest")
+    if sha256(payload).hexdigest() != manifest.payload_sha256:
+        raise ValueError("animation PDF payload SHA-256 does not match manifest")
+    loop = parse_auto_loop_program(payload)
+    if loop.cycles != manifest.cycles:
+        raise ValueError("animation PDF cycle count does not match manifest")
+    if len(parse_program(loop.inner_program)) != manifest.inner_instruction_count:
+        raise ValueError("animation PDF instruction count does not match manifest")
+    return manifest, payload
+
+
+def run_animation_pdf_package(
+    path: str | Path,
+    initial_volume: Volume3D,
+    *,
+    loop_limits: AutoLoopLimits | None = None,
+    vm_limits: ProgramLimits | None = None,
+) -> AutoLoopResult:
+    """Explicitly verify and execute a PDF-carried DM3D animation loop."""
+
+    _, payload = load_animation_pdf_package(path)
+    return execute_auto_loop(
+        payload,
+        initial_volume,
+        loop_limits=loop_limits,
+        vm_limits=vm_limits,
+    )
+
+
+def _require_pymupdf():
+    try:
+        import fitz
+    except ImportError as exc:  # pragma: no cover - depends on optional package
+        raise RuntimeError(
+            "animation PDF packaging requires PyMuPDF; install jarvisx[pdf] or pymupdf>=1.24"
+        ) from exc
+    return fitz
+
+
+__all__ = [
+    "AnimationPdfManifest",
+    "build_animation_pdf_package",
+    "load_animation_pdf_package",
+    "run_animation_pdf_package",
+]

--- a/src/jarvisx/dr_moagi_pdf_bytecode.py
+++ b/src/jarvisx/dr_moagi_pdf_bytecode.py
@@ -1,0 +1,611 @@
+"""Bounded PDF-carried bytecode runtime for the Dr Moagi 3D codec loop.
+
+A PDF package is a transport container only. Opening a document never executes it.
+Execution requires this runtime to explicitly extract a manifest and DM3D bytecode,
+verify integrity, parse a finite instruction set, and run under resource limits.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+import time
+from dataclasses import asdict, dataclass, field
+from enum import IntEnum
+from hashlib import sha256
+from pathlib import Path
+from typing import Sequence
+
+PROGRAM_MAGIC = b"DM3DVM1\0"
+PROGRAM_VERSION = 1
+PROGRAM_HEADER = struct.Struct("<8sHHI")
+INSTRUCTION_STRUCT = struct.Struct("<BBBBIII")
+PROGRAM_DIGEST_BYTES = 32
+MANIFEST_NAME = "manifest.json"
+PAYLOAD_NAME = "engine.dm3d"
+
+
+class Opcode(IntEnum):
+    """Finite DM3D instruction set."""
+
+    ENCODE_3D = 0x10
+    REFINE_3D = 0x11
+    DECODE_3D = 0x20
+    REENCODE_3D = 0x21
+    ERROR_3D = 0x30
+    CYCLE_ERROR = 0x31
+    ERROR_MEMORY = 0x32
+    CHECK_FIXED = 0x40
+    HALT = 0xFF
+
+
+@dataclass(frozen=True)
+class Instruction:
+    opcode: Opcode
+    dst: int = 0
+    src: int = 0
+    aux: int = 0
+    arg0: int = 0
+    arg1: int = 0
+    arg2: int = 0
+
+
+@dataclass(frozen=True)
+class ProgramLimits:
+    max_instructions: int = 128
+    max_voxels: int = 1 << 20
+    max_refinement_passes: int = 64
+    max_physical_steps: int = 50_000_000
+
+    def validate(self) -> None:
+        if self.max_instructions <= 0:
+            raise ValueError("max_instructions must be positive")
+        if self.max_voxels <= 0:
+            raise ValueError("max_voxels must be positive")
+        if self.max_refinement_passes <= 0:
+            raise ValueError("max_refinement_passes must be positive")
+        if self.max_physical_steps <= 0:
+            raise ValueError("max_physical_steps must be positive")
+
+
+@dataclass
+class Volume3D:
+    nx: int
+    ny: int
+    nz: int
+    values: list[float]
+
+    def __post_init__(self) -> None:
+        if min(self.nx, self.ny, self.nz) <= 0:
+            raise ValueError("volume dimensions must be positive")
+        if len(self.values) != self.voxel_count:
+            raise ValueError("volume value count does not match dimensions")
+        if not all(math.isfinite(value) for value in self.values):
+            raise ValueError("volume values must be finite")
+
+    @property
+    def voxel_count(self) -> int:
+        return self.nx * self.ny * self.nz
+
+    def index(self, x: int, y: int, z: int) -> int:
+        return x + self.nx * (y + self.ny * z)
+
+    def copy(self) -> "Volume3D":
+        return Volume3D(self.nx, self.ny, self.nz, list(self.values))
+
+
+@dataclass
+class VmMetrics:
+    instructions_executed: int = 0
+    physical_steps: int = 0
+    voxel_reads: int = 0
+    voxel_writes: int = 0
+    neighbor_reads: int = 0
+    refinement_updates: int = 0
+    elapsed_seconds: float = 0.0
+
+    @property
+    def physical_steps_per_second(self) -> float:
+        if self.elapsed_seconds <= 0.0:
+            return 0.0
+        return self.physical_steps / self.elapsed_seconds
+
+
+@dataclass
+class VmResult:
+    volumes: dict[int, Volume3D]
+    scalars: dict[int, float]
+    metrics: VmMetrics
+
+    def report(self) -> dict[str, object]:
+        return {
+            "scalars": {str(key): value for key, value in sorted(self.scalars.items())},
+            "volumes": {
+                str(key): [value.nx, value.ny, value.nz]
+                for key, value in sorted(self.volumes.items())
+            },
+            "metrics": {
+                **asdict(self.metrics),
+                "physical_steps_per_second": self.metrics.physical_steps_per_second,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class PdfPackageManifest:
+    manifest_version: int
+    engine_format: str
+    payload_name: str
+    payload_sha256: str
+    payload_bytes: int
+    instruction_count: int
+    execution_policy: str = "explicit-runtime-only"
+
+    def to_bytes(self) -> bytes:
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @classmethod
+    def from_bytes(cls, payload: bytes) -> "PdfPackageManifest":
+        raw = json.loads(payload.decode("utf-8"))
+        manifest = cls(**raw)
+        if manifest.manifest_version != 1:
+            raise ValueError("unsupported PDF package manifest version")
+        if manifest.engine_format != "dm3d-bytecode-v1":
+            raise ValueError("unsupported PDF package engine format")
+        if manifest.execution_policy != "explicit-runtime-only":
+            raise ValueError("unsafe or unsupported execution policy")
+        if manifest.payload_name != PAYLOAD_NAME:
+            raise ValueError("unexpected bytecode payload name")
+        if manifest.payload_bytes <= 0 or manifest.instruction_count <= 0:
+            raise ValueError("invalid manifest size metadata")
+        if len(manifest.payload_sha256) != 64:
+            raise ValueError("invalid SHA-256 digest in manifest")
+        return manifest
+
+
+@dataclass
+class _Budget:
+    limits: ProgramLimits
+    metrics: VmMetrics = field(default_factory=VmMetrics)
+
+    def charge(
+        self,
+        steps: int,
+        *,
+        reads: int = 0,
+        writes: int = 0,
+        neighbor_reads: int = 0,
+        refinement_updates: int = 0,
+    ) -> None:
+        if min(steps, reads, writes, neighbor_reads, refinement_updates) < 0:
+            raise ValueError("budget charges cannot be negative")
+        next_steps = self.metrics.physical_steps + steps
+        if next_steps > self.limits.max_physical_steps:
+            raise RuntimeError("DM3D physical-step budget exceeded")
+        self.metrics.physical_steps = next_steps
+        self.metrics.voxel_reads += reads
+        self.metrics.voxel_writes += writes
+        self.metrics.neighbor_reads += neighbor_reads
+        self.metrics.refinement_updates += refinement_updates
+
+
+def serialize_program(instructions: Sequence[Instruction]) -> bytes:
+    if not instructions:
+        raise ValueError("DM3D program cannot be empty")
+    if len(instructions) > 0xFFFF:
+        raise ValueError("DM3D instruction count exceeds uint16")
+    if instructions[-1].opcode is not Opcode.HALT:
+        raise ValueError("DM3D program must end with HALT")
+    if any(instruction.opcode is Opcode.HALT for instruction in instructions[:-1]):
+        raise ValueError("DM3D HALT must be the final instruction")
+
+    body = bytearray(PROGRAM_HEADER.pack(PROGRAM_MAGIC, PROGRAM_VERSION, len(instructions), 0))
+    for instruction in instructions:
+        body.extend(
+            INSTRUCTION_STRUCT.pack(
+                int(instruction.opcode),
+                instruction.dst,
+                instruction.src,
+                instruction.aux,
+                instruction.arg0,
+                instruction.arg1,
+                instruction.arg2,
+            )
+        )
+    return bytes(body) + sha256(body).digest()
+
+
+def parse_program(payload: bytes, limits: ProgramLimits | None = None) -> list[Instruction]:
+    limits = limits or ProgramLimits()
+    limits.validate()
+    minimum = PROGRAM_HEADER.size + INSTRUCTION_STRUCT.size + PROGRAM_DIGEST_BYTES
+    if len(payload) < minimum:
+        raise ValueError("DM3D program is truncated")
+
+    body = payload[:-PROGRAM_DIGEST_BYTES]
+    digest = payload[-PROGRAM_DIGEST_BYTES:]
+    if sha256(body).digest() != digest:
+        raise ValueError("DM3D program SHA-256 mismatch")
+
+    magic, version, count, reserved = PROGRAM_HEADER.unpack_from(body, 0)
+    if magic != PROGRAM_MAGIC:
+        raise ValueError("invalid DM3D program magic")
+    if version != PROGRAM_VERSION:
+        raise ValueError("unsupported DM3D program version")
+    if reserved != 0:
+        raise ValueError("DM3D reserved header field must be zero")
+    if count == 0 or count > limits.max_instructions:
+        raise ValueError("DM3D instruction count exceeds configured limit")
+
+    expected = PROGRAM_HEADER.size + count * INSTRUCTION_STRUCT.size
+    if len(body) != expected:
+        raise ValueError("DM3D program size does not match instruction count")
+
+    instructions: list[Instruction] = []
+    offset = PROGRAM_HEADER.size
+    for index in range(count):
+        opcode_raw, dst, src, aux, arg0, arg1, arg2 = INSTRUCTION_STRUCT.unpack_from(body, offset)
+        offset += INSTRUCTION_STRUCT.size
+        try:
+            opcode = Opcode(opcode_raw)
+        except ValueError as exc:
+            raise ValueError(f"unknown DM3D opcode 0x{opcode_raw:02x}") from exc
+        if opcode is Opcode.HALT and index != count - 1:
+            raise ValueError("DM3D HALT must be final")
+        if opcode is Opcode.REFINE_3D and (arg0 == 0 or arg0 > limits.max_refinement_passes):
+            raise ValueError("DM3D refinement pass count exceeds configured limit")
+        instructions.append(Instruction(opcode, dst, src, aux, arg0, arg1, arg2))
+
+    if instructions[-1].opcode is not Opcode.HALT:
+        raise ValueError("DM3D program is missing HALT")
+    return instructions
+
+
+def canonical_autoencoder_program(*, pool: int = 2, refinement_passes: int = 4) -> bytes:
+    if pool <= 0:
+        raise ValueError("pool must be positive")
+    if refinement_passes <= 0:
+        raise ValueError("refinement_passes must be positive")
+    parts_per_million = 1_000_000
+    instructions = [
+        Instruction(Opcode.ENCODE_3D, dst=1, src=0, arg0=pool),
+        Instruction(Opcode.REFINE_3D, dst=2, src=1, arg0=refinement_passes),
+        Instruction(Opcode.DECODE_3D, dst=3, src=2, arg0=pool),
+        Instruction(Opcode.REENCODE_3D, dst=4, src=3, arg0=pool),
+        Instruction(Opcode.ERROR_3D, dst=10, src=0, aux=3),
+        Instruction(Opcode.CYCLE_ERROR, dst=11, src=2, aux=4),
+        Instruction(
+            Opcode.ERROR_MEMORY,
+            dst=12,
+            src=10,
+            aux=11,
+            arg0=int(0.9 * parts_per_million),
+            arg1=int(0.7 * parts_per_million),
+            arg2=int(0.3 * parts_per_million),
+        ),
+        Instruction(Opcode.CHECK_FIXED, dst=13, src=2, aux=4, arg0=1),
+        Instruction(Opcode.HALT),
+    ]
+    return serialize_program(instructions)
+
+
+def execute_program(
+    payload: bytes,
+    initial_volume: Volume3D,
+    limits: ProgramLimits | None = None,
+) -> VmResult:
+    limits = limits or ProgramLimits()
+    instructions = parse_program(payload, limits)
+    if initial_volume.voxel_count > limits.max_voxels:
+        raise RuntimeError("initial volume exceeds configured voxel limit")
+
+    volumes: dict[int, Volume3D] = {0: initial_volume.copy()}
+    scalars: dict[int, float] = {12: 0.0}
+    budget = _Budget(limits)
+    started = time.perf_counter()
+
+    for instruction in instructions:
+        budget.metrics.instructions_executed += 1
+        opcode = instruction.opcode
+        if opcode is Opcode.HALT:
+            break
+        if opcode in (Opcode.ENCODE_3D, Opcode.REENCODE_3D):
+            source = _volume(volumes, instruction.src)
+            result = _encode(source, instruction.arg0, budget, limits)
+            volumes[instruction.dst] = result
+        elif opcode is Opcode.REFINE_3D:
+            source = _volume(volumes, instruction.src)
+            volumes[instruction.dst] = _refine(source, instruction.arg0, budget, limits)
+        elif opcode is Opcode.DECODE_3D:
+            source = _volume(volumes, instruction.src)
+            volumes[instruction.dst] = _decode(source, instruction.arg0, budget, limits)
+        elif opcode in (Opcode.ERROR_3D, Opcode.CYCLE_ERROR):
+            left = _volume(volumes, instruction.src)
+            right = _volume(volumes, instruction.aux)
+            scalars[instruction.dst] = _mse(left, right, budget)
+        elif opcode is Opcode.ERROR_MEMORY:
+            rho = _ppm(instruction.arg0)
+            lambda_x = _ppm(instruction.arg1)
+            lambda_z = _ppm(instruction.arg2)
+            if not 0.0 <= rho <= 1.0:
+                raise RuntimeError("rho must lie in [0, 1]")
+            error_x = _scalar(scalars, instruction.src)
+            error_z = _scalar(scalars, instruction.aux)
+            previous = scalars.get(instruction.dst, 0.0)
+            scalars[instruction.dst] = rho * previous + (1.0 - rho) * (
+                lambda_x * error_x + lambda_z * error_z
+            )
+            budget.charge(8)
+        elif opcode is Opcode.CHECK_FIXED:
+            left = _volume(volumes, instruction.src)
+            right = _volume(volumes, instruction.aux)
+            epsilon = instruction.arg0 * 1e-12
+            error = _mse(left, right, budget)
+            scalars[instruction.dst] = 1.0 if error <= epsilon else 0.0
+        else:  # pragma: no cover - parse_program rejects unknown opcodes
+            raise RuntimeError(f"unhandled DM3D opcode {opcode}")
+
+    budget.metrics.elapsed_seconds = time.perf_counter() - started
+    return VmResult(volumes, scalars, budget.metrics)
+
+
+def make_seed_volume(size: int = 16) -> Volume3D:
+    if size <= 0:
+        raise ValueError("size must be positive")
+    center = (size - 1) / 2.0
+    values: list[float] = []
+    for z in range(size):
+        dz = (z - center) / size
+        for y in range(size):
+            dy = (y - center) / size
+            for x in range(size):
+                dx = (x - center) / size
+                radius = math.sqrt(dx * dx + dy * dy + dz * dz)
+                value = math.sin(12.0 * radius) * math.exp(-2.2 * radius)
+                value += 0.25 * math.cos(5.0 * (dx - dy + dz))
+                values.append(value)
+    return Volume3D(size, size, size, values)
+
+
+def build_pdf_package(
+    path: str | Path,
+    program: bytes,
+    *,
+    title: str = "Dr Moagi 3D Bytecode Runtime",
+) -> PdfPackageManifest:
+    """Create a PDF transport package with verified DM3D bytecode attachments.
+
+    PyMuPDF is imported lazily so the core VM remains dependency-free.
+    """
+
+    fitz = _require_pymupdf()
+    instructions = parse_program(program)
+    manifest = PdfPackageManifest(
+        manifest_version=1,
+        engine_format="dm3d-bytecode-v1",
+        payload_name=PAYLOAD_NAME,
+        payload_sha256=sha256(program).hexdigest(),
+        payload_bytes=len(program),
+        instruction_count=len(instructions),
+    )
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    document = fitz.open()
+    page = document.new_page(width=842, height=595)
+    text = (
+        f"{title}\n\n"
+        "Execution policy: explicit runtime only\n"
+        f"Payload: {PAYLOAD_NAME}\n"
+        f"Instructions: {manifest.instruction_count}\n"
+        f"SHA-256: {manifest.payload_sha256}\n\n"
+        "Pipeline:\n"
+        "PDF -> verify manifest -> parse DM3D bytecode -> bounded 3D VM -> metrics\n"
+    )
+    page.insert_textbox(fitz.Rect(48, 48, 794, 540), text, fontsize=12)
+    document.embfile_add(
+        MANIFEST_NAME,
+        manifest.to_bytes(),
+        filename=MANIFEST_NAME,
+        ufilename=MANIFEST_NAME,
+        desc="Dr Moagi PDF runtime manifest",
+    )
+    document.embfile_add(
+        PAYLOAD_NAME,
+        program,
+        filename=PAYLOAD_NAME,
+        ufilename=PAYLOAD_NAME,
+        desc="Verified DM3D bytecode payload",
+    )
+    document.save(str(output), deflate=True, garbage=4)
+    document.close()
+    return manifest
+
+
+def load_pdf_package(path: str | Path) -> tuple[PdfPackageManifest, bytes]:
+    fitz = _require_pymupdf()
+    document = fitz.open(str(path))
+    try:
+        names = set(document.embfile_names())
+        if MANIFEST_NAME not in names or PAYLOAD_NAME not in names:
+            raise ValueError("PDF package is missing required attachments")
+        manifest = PdfPackageManifest.from_bytes(document.embfile_get(MANIFEST_NAME))
+        payload = bytes(document.embfile_get(PAYLOAD_NAME))
+    finally:
+        document.close()
+
+    if len(payload) != manifest.payload_bytes:
+        raise ValueError("PDF bytecode payload length does not match manifest")
+    if sha256(payload).hexdigest() != manifest.payload_sha256:
+        raise ValueError("PDF bytecode payload SHA-256 does not match manifest")
+    instructions = parse_program(payload)
+    if len(instructions) != manifest.instruction_count:
+        raise ValueError("PDF bytecode instruction count does not match manifest")
+    return manifest, payload
+
+
+def run_pdf_package(
+    path: str | Path,
+    initial_volume: Volume3D,
+    limits: ProgramLimits | None = None,
+) -> VmResult:
+    _, payload = load_pdf_package(path)
+    return execute_program(payload, initial_volume, limits)
+
+
+def _encode(
+    source: Volume3D,
+    pool: int,
+    budget: _Budget,
+    limits: ProgramLimits,
+) -> Volume3D:
+    if pool <= 0:
+        raise RuntimeError("pool factor must be positive")
+    if source.nx % pool or source.ny % pool or source.nz % pool:
+        raise RuntimeError("volume dimensions must be divisible by pool factor")
+    nx, ny, nz = source.nx // pool, source.ny // pool, source.nz // pool
+    output_count = nx * ny * nz
+    if output_count > limits.max_voxels:
+        raise RuntimeError("encoded volume exceeds configured voxel limit")
+    block = pool**3
+    values = [0.0] * output_count
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                total = 0.0
+                for dz in range(pool):
+                    for dy in range(pool):
+                        for dx in range(pool):
+                            total += source.values[
+                                source.index(x * pool + dx, y * pool + dy, z * pool + dz)
+                            ]
+                values[x + nx * (y + ny * z)] = total / block
+    budget.charge(source.voxel_count + output_count, reads=source.voxel_count, writes=output_count)
+    return Volume3D(nx, ny, nz, values)
+
+
+def _decode(
+    source: Volume3D,
+    pool: int,
+    budget: _Budget,
+    limits: ProgramLimits,
+) -> Volume3D:
+    if pool <= 0:
+        raise RuntimeError("pool factor must be positive")
+    nx, ny, nz = source.nx * pool, source.ny * pool, source.nz * pool
+    count = nx * ny * nz
+    if count > limits.max_voxels:
+        raise RuntimeError("decoded volume exceeds configured voxel limit")
+    values = [0.0] * count
+    for z in range(nz):
+        for y in range(ny):
+            for x in range(nx):
+                values[x + nx * (y + ny * z)] = source.values[
+                    source.index(x // pool, y // pool, z // pool)
+                ]
+    budget.charge(count * 2, reads=count, writes=count)
+    return Volume3D(nx, ny, nz, values)
+
+
+def _refine(
+    source: Volume3D,
+    passes: int,
+    budget: _Budget,
+    limits: ProgramLimits,
+) -> Volume3D:
+    if passes <= 0 or passes > limits.max_refinement_passes:
+        raise RuntimeError("refinement passes exceed configured limit")
+    current = list(source.values)
+    nx, ny, nz = source.nx, source.ny, source.nz
+    count = source.voxel_count
+    directions = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+
+    for _ in range(passes):
+        mean = sum(current) / count
+        next_values = [0.0] * count
+        valid_neighbor_reads = 0
+        for z in range(nz):
+            for y in range(ny):
+                for x in range(nx):
+                    index = x + nx * (y + ny * z)
+                    neighbor_total = 0.0
+                    neighbor_count = 0
+                    for dx, dy, dz in directions:
+                        xx, yy, zz = x + dx, y + dy, z + dz
+                        if 0 <= xx < nx and 0 <= yy < ny and 0 <= zz < nz:
+                            neighbor_total += current[xx + nx * (yy + ny * zz)]
+                            neighbor_count += 1
+                    neighbor_mean = (
+                        neighbor_total / neighbor_count if neighbor_count else current[index]
+                    )
+                    next_values[index] = 0.88 * current[index] + 0.10 * neighbor_mean + 0.02 * mean
+                    valid_neighbor_reads += neighbor_count
+        budget.charge(
+            count * 5 + valid_neighbor_reads,
+            reads=count * 2 + valid_neighbor_reads,
+            writes=count,
+            neighbor_reads=valid_neighbor_reads,
+            refinement_updates=count,
+        )
+        current = next_values
+    return Volume3D(nx, ny, nz, current)
+
+
+def _mse(left: Volume3D, right: Volume3D, budget: _Budget) -> float:
+    if (left.nx, left.ny, left.nz) != (right.nx, right.ny, right.nz):
+        raise RuntimeError("MSE operands must have identical dimensions")
+    total = 0.0
+    for a, b in zip(left.values, right.values):
+        delta = a - b
+        total += delta * delta
+    count = left.voxel_count
+    budget.charge(count * 4, reads=count * 2)
+    return total / count
+
+
+def _volume(volumes: dict[int, Volume3D], register: int) -> Volume3D:
+    try:
+        return volumes[register]
+    except KeyError as exc:
+        raise RuntimeError(f"DM3D volume register r{register} is uninitialized") from exc
+
+
+def _scalar(scalars: dict[int, float], register: int) -> float:
+    try:
+        return scalars[register]
+    except KeyError as exc:
+        raise RuntimeError(f"DM3D scalar register s{register} is uninitialized") from exc
+
+
+def _ppm(value: int) -> float:
+    return value / 1_000_000.0
+
+
+def _require_pymupdf():
+    try:
+        import fitz
+    except ImportError as exc:  # pragma: no cover - depends on optional package
+        raise RuntimeError(
+            "PDF packaging requires PyMuPDF; install jarvisx[pdf] or pymupdf>=1.24"
+        ) from exc
+    return fitz
+
+
+__all__ = [
+    "Instruction",
+    "Opcode",
+    "PdfPackageManifest",
+    "ProgramLimits",
+    "VmMetrics",
+    "VmResult",
+    "Volume3D",
+    "build_pdf_package",
+    "canonical_autoencoder_program",
+    "execute_program",
+    "load_pdf_package",
+    "make_seed_volume",
+    "parse_program",
+    "run_pdf_package",
+    "serialize_program",
+]

--- a/src/jarvisx/dr_moagi_pdf_bytecode_cli.py
+++ b/src/jarvisx/dr_moagi_pdf_bytecode_cli.py
@@ -1,0 +1,59 @@
+"""Command-line interface for the bounded Dr Moagi PDF bytecode runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .dr_moagi_pdf_bytecode import (
+    ProgramLimits,
+    build_pdf_package,
+    canonical_autoencoder_program,
+    load_pdf_package,
+    make_seed_volume,
+    run_pdf_package,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Dr Moagi PDF-carried DM3D bytecode runtime")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="build a verified PDF bytecode package")
+    build.add_argument("output", type=Path)
+    build.add_argument("--pool", type=int, default=2)
+    build.add_argument("--passes", type=int, default=4)
+
+    inspect = subparsers.add_parser("inspect", help="verify and inspect a PDF bytecode package")
+    inspect.add_argument("pdf", type=Path)
+
+    run = subparsers.add_parser("run", help="explicitly execute a verified PDF bytecode package")
+    run.add_argument("pdf", type=Path)
+    run.add_argument("--size", type=int, default=16)
+    run.add_argument("--max-physical-steps", type=int, default=50_000_000)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if args.command == "build":
+        program = canonical_autoencoder_program(pool=args.pool, refinement_passes=args.passes)
+        manifest = build_pdf_package(args.output, program)
+        print(json.dumps(manifest.__dict__, indent=2, sort_keys=True))
+        return 0
+    if args.command == "inspect":
+        manifest, payload = load_pdf_package(args.pdf)
+        report = {**manifest.__dict__, "verified_payload_bytes": len(payload)}
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return 0
+    if args.command == "run":
+        limits = ProgramLimits(max_physical_steps=args.max_physical_steps)
+        result = run_pdf_package(args.pdf, make_seed_volume(args.size), limits)
+        print(json.dumps(result.report(), indent=2, sort_keys=True))
+        return 0
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dr_moagi_animation_loop.py
+++ b/tests/test_dr_moagi_animation_loop.py
@@ -1,0 +1,62 @@
+import pytest
+
+from jarvisx.dr_moagi_animation_loop import (
+    AutoLoopLimits,
+    canonical_animation_loop_program,
+    execute_auto_loop,
+    parse_auto_loop_program,
+)
+from jarvisx.dr_moagi_pdf_bytecode import ProgramLimits, make_seed_volume
+
+
+def test_canonical_animation_loop_closes_and_captures_frames() -> None:
+    payload = canonical_animation_loop_program(cycles=3, refinement_passes=2)
+    parsed = parse_auto_loop_program(payload)
+    assert parsed.cycles == 3
+    assert parsed.feedback_register == 3
+    assert parsed.frame_registers == (0, 1, 2, 3, 4)
+
+    result = execute_auto_loop(payload, make_seed_volume(8))
+    assert result.cycles_executed == 3
+    assert result.stopped_on_fixed_point is False
+    assert len(result.frames) == 15
+    assert result.final_volume.voxel_count == 8**3
+    assert result.metrics.refinement_updates == 3 * 2 * 4**3
+    assert all(item.fixed_point_pass for item in result.cycles)
+    assert all(item.cycle_mse == pytest.approx(0.0, abs=1e-24) for item in result.cycles)
+
+
+def test_auto_loop_stops_on_fixed_point_when_requested() -> None:
+    payload = canonical_animation_loop_program(
+        cycles=8,
+        refinement_passes=2,
+        stop_on_fixed_point=True,
+    )
+    result = execute_auto_loop(payload, make_seed_volume(8))
+    assert result.cycles_executed == 1
+    assert result.stopped_on_fixed_point is True
+    assert len(result.frames) == 5
+
+
+def test_auto_loop_rejects_digest_tampering() -> None:
+    payload = bytearray(canonical_animation_loop_program(cycles=2))
+    payload[-40] ^= 0x01
+    with pytest.raises(ValueError, match="SHA-256"):
+        parse_auto_loop_program(bytes(payload))
+
+
+def test_auto_loop_enforces_cycle_limit() -> None:
+    payload = canonical_animation_loop_program(cycles=4)
+    with pytest.raises(ValueError, match="cycle count"):
+        parse_auto_loop_program(payload, loop_limits=AutoLoopLimits(max_cycles=3))
+
+
+def test_auto_loop_enforces_total_physical_work_budget() -> None:
+    payload = canonical_animation_loop_program(cycles=3, refinement_passes=2)
+    with pytest.raises(RuntimeError, match="physical-step budget"):
+        execute_auto_loop(
+            payload,
+            make_seed_volume(8),
+            loop_limits=AutoLoopLimits(max_total_physical_steps=10_000),
+            vm_limits=ProgramLimits(max_physical_steps=100_000),
+        )

--- a/tests/test_dr_moagi_animation_loop.py
+++ b/tests/test_dr_moagi_animation_loop.py
@@ -25,6 +25,16 @@ def test_canonical_animation_loop_closes_and_captures_frames() -> None:
     assert all(item.fixed_point_pass for item in result.cycles)
     assert all(item.cycle_mse == pytest.approx(0.0, abs=1e-24) for item in result.cycles)
 
+    first, second = result.cycles[:2]
+    assert first.omega is not None
+    assert second.omega is not None
+    assert second.reconstruction_mse is not None
+    assert second.cycle_mse is not None
+    expected_omega = 0.9 * first.omega + 0.1 * (
+        0.7 * second.reconstruction_mse + 0.3 * second.cycle_mse
+    )
+    assert second.omega == pytest.approx(expected_omega)
+
 
 def test_auto_loop_stops_on_fixed_point_when_requested() -> None:
     payload = canonical_animation_loop_program(

--- a/tests/test_dr_moagi_animation_pdf.py
+++ b/tests/test_dr_moagi_animation_pdf.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jarvisx.dr_moagi_animation_loop import canonical_animation_loop_program
+from jarvisx.dr_moagi_animation_pdf import (
+    build_animation_pdf_package,
+    load_animation_pdf_package,
+    run_animation_pdf_package,
+)
+from jarvisx.dr_moagi_pdf_bytecode import make_seed_volume
+
+
+def test_animation_pdf_round_trip_and_execution(tmp_path: Path) -> None:
+    pytest.importorskip("fitz")
+    program = canonical_animation_loop_program(cycles=2, refinement_passes=2)
+    path = tmp_path / "dr-moagi-animation.dm3d.pdf"
+
+    written_manifest = build_animation_pdf_package(path, program)
+    read_manifest, recovered = load_animation_pdf_package(path)
+
+    assert recovered == program
+    assert read_manifest == written_manifest
+    assert read_manifest.cycles == 2
+    assert read_manifest.inner_instruction_count == 9
+
+    result = run_animation_pdf_package(path, make_seed_volume(8))
+    assert result.cycles_executed == 2
+    assert len(result.frames) == 10
+    assert all(cycle.fixed_point_pass for cycle in result.cycles)

--- a/tests/test_dr_moagi_pdf_bytecode.py
+++ b/tests/test_dr_moagi_pdf_bytecode.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from jarvisx.dr_moagi_pdf_bytecode import (
+    ProgramLimits,
+    build_pdf_package,
+    canonical_autoencoder_program,
+    execute_program,
+    load_pdf_package,
+    make_seed_volume,
+    parse_program,
+)
+
+
+def test_program_round_trip_and_integrity_gate() -> None:
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    instructions = parse_program(program)
+    assert len(instructions) == 9
+
+    tampered = bytearray(program)
+    tampered[20] ^= 0x01
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        parse_program(bytes(tampered))
+
+
+def test_end_to_end_3d_cycle_is_bounded_and_cycle_consistent() -> None:
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    result = execute_program(program, make_seed_volume(16))
+
+    assert (result.volumes[0].nx, result.volumes[0].ny, result.volumes[0].nz) == (16, 16, 16)
+    assert (result.volumes[2].nx, result.volumes[2].ny, result.volumes[2].nz) == (8, 8, 8)
+    assert (result.volumes[3].nx, result.volumes[3].ny, result.volumes[3].nz) == (16, 16, 16)
+    assert result.scalars[10] > 0.0
+    assert result.scalars[11] < 1e-24
+    assert result.scalars[12] > 0.0
+    assert result.scalars[13] == 1.0
+    assert result.metrics.refinement_updates == 4 * 8**3
+    assert result.metrics.neighbor_reads == 10_752
+    assert result.metrics.physical_steps > 0
+
+
+def test_refinement_pass_limit_is_enforced_before_execution() -> None:
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    with pytest.raises(ValueError, match="refinement pass count"):
+        parse_program(program, ProgramLimits(max_refinement_passes=2))
+
+
+def test_physical_work_budget_is_enforced() -> None:
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    limits = ProgramLimits(max_physical_steps=1_000)
+    with pytest.raises(RuntimeError, match="physical-step budget"):
+        execute_program(program, make_seed_volume(16), limits)
+
+
+def test_pdf_package_round_trip(tmp_path: Path) -> None:
+    pytest.importorskip("fitz")
+    program = canonical_autoencoder_program(pool=2, refinement_passes=4)
+    path = tmp_path / "dr-moagi.dm3d.pdf"
+    written_manifest = build_pdf_package(path, program)
+    read_manifest, recovered = load_pdf_package(path)
+
+    assert recovered == program
+    assert read_manifest == written_manifest
+    result = execute_program(recovered, make_seed_volume(16))
+    assert result.scalars[13] == 1.0


### PR DESCRIPTION
## Summary

Operationalizes the full PDF → verified DM3D bytecode → bounded 3D auto-encoding/decoding → cyclic feedback → renderer-ready volumetric frame path as a repository-native runtime.

## What changed

### Inner DM3D VM
- fixed-width, SHA-256 protected DM3D instruction format
- finite opcodes for encode, inward refine, decode, re-encode, reconstruction/cycle error, error memory, fixed-point check, and halt
- explicit physical-work accounting: voxel reads/writes, neighbour reads, refinement updates, charged steps, wall time
- per-program instruction, voxel, refinement-pass, and physical-step caps

### Bounded 3D animation auto-loop
- adds a second SHA-256 protected `DM3DLP1` envelope around the verified inner DM3D program
- encodes finite cycle count, feedback register, convergence scalar register, and renderer frame-register mask
- canonical feedback edge is `X_(t+1) <- X_hat_t` using decoded volume `r3`
- preserves error-memory state across outer cycles using the encoded `rho`, `lambda_x`, and `lambda_z` recurrence
- captures `r0..r4` on each cycle as deterministic renderer-ready `Volume3D` states: input, encoded, refined, decoded, re-encoded
- each captured state reports shape, min/max/mean, and SHA-256 state digest
- optional fixed-point early stop plus hard global cycle, total-work, and frame budgets
- the cumulative physical-work budget cannot be reset by starting another inner VM cycle

### PDF transport
- original single-cycle package: `manifest.json + engine.dm3d`
- animation package: `manifest.json + animation.dm3dloop`
- animation manifest binds payload SHA-256, byte length, cycle count, and nested inner instruction count
- both formats use `explicit-runtime-only`: opening a PDF never executes it
- the Jarvis-X runtime must explicitly extract, hash-verify, structurally validate, and execute the finite opcode set
- arbitrary embedded Python, shell commands, dynamic imports, and general jump opcodes are not executed

### Tooling and validation
- `jarvisx-dr-moagi-pdfvm` build / inspect / run CLI for the base DM3D package
- animation-loop example and architecture documentation
- focused tests cover digest tampering, fixed-point closure, persistent Omega recurrence, cycle cap, cumulative physical-work abort, frame capture, and animation-PDF round trip
- dedicated PDF/animation workflow installs the optional PDF dependency and runs syntax, Black, isort, focused tests, PDF smoke, and animation-loop smoke checks
- canonical Jarvis-X quality gate includes the new modules and tests

## Runtime topology

```text
PDF
  -> verify manifest
  -> verify DM3D-LOOP SHA-256
  -> verify nested DM3D SHA-256
  -> X_t
  -> ENCODE_3D       -> Z_t^0
  -> REFINE_3D^K     -> Z_t^*
  -> DECODE_3D       -> X_hat_t
  -> REENCODE_3D     -> Z_tilde_t
  -> ERROR_3D / CYCLE_ERROR
  -> persistent ERROR_MEMORY Omega_(t+1)
  -> CHECK_FIXED
  -> capture r0..r4 frame states
  -> X_(t+1) <- X_hat_t
  -> bounded next cycle
```

## Reference bytecode geometry

The canonical inner `16^3 -> 8^3 -> 16^3` program remains:
- 9 DM3D instructions
- 192 bytes including inner header and digest
- 2,048 recurrent latent updates for four refinement passes
- 10,752 valid directed six-neighbour reads
- latent cycle fixed-point check passes for the deterministic block-average / replication codec

The default outer animation envelope adds a 32-byte loop header and a 32-byte outer SHA-256 digest, so the canonical nested program occupies 256 bytes before PDF packaging.

## Claim boundary

Logical or super-instruction work is kept separate from measured physical throughput. The runtime reports finite executed work; it does not convert symbolic iteration counts or astronomical source-line multipliers into hardware-performance claims.
