### PR TITLE
Integrate 1,000-line Dr Moagi 3D animation autoencoder/decoder

### DIFF
--- a/.github/workflows/dr-moagi-3d-animation-codec.yml
+++ b/.github/workflows/dr-moagi-3d-animation-codec.yml
@@ -1,0 +1,52 @@
+name: Dr Moagi 3D Animation Codec
+
+on:
+  push:
+    paths:
+      - 'reference/dr-moagi-3d-animation-autoencoder/**'
+      - 'src/jarvisx/dr_moagi_3d_animation_codec.py'
+      - 'tests/test_dr_moagi_3d_animation_codec.py'
+      - 'pyproject.toml'
+      - '.github/workflows/dr-moagi-3d-animation-codec.yml'
+  pull_request:
+    paths:
+      - 'reference/dr-moagi-3d-animation-autoencoder/**'
+      - 'src/jarvisx/dr_moagi_3d_animation_codec.py'
+      - 'tests/test_dr_moagi_3d_animation_codec.py'
+      - 'pyproject.toml'
+      - '.github/workflows/dr-moagi-3d-animation-codec.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  verify-and-smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install runtime and test dependencies
+        run: python -m pip install -e '.[graphics,test]'
+      - name: Verify canonical 1000-line source
+        run: jarvisx-dr-moagi-3d-animation --verify-reference
+      - name: Run focused codec tests
+        run: pytest tests/test_dr_moagi_3d_animation_codec.py -q --no-cov
+      - name: Run CLI smoke encode/decode
+        run: |
+          jarvisx-dr-moagi-3d-animation \
+            --demo cube \
+            --frames 6 \
+            --latent 4 \
+            --hidden 12 \
+            --epochs 6 \
+            --batch 3 \
+            --quant-bits 8 \
+            --keyframe 2 \
+            --quiet \
+            --output /tmp/dr-moagi-3d-codec
+          test -f /tmp/dr-moagi-3d-codec/animation_packet.npz
+          test -f /tmp/dr-moagi-3d-codec/reconstruction_metrics.json
+          test -f /tmp/dr-moagi-3d-codec/reconstructed_frame_00000.obj

--- a/docs/DR_MOAGI_3D_ANIMATION_CODEC.md
+++ b/docs/DR_MOAGI_3D_ANIMATION_CODEC.md
@@ -1,0 +1,85 @@
+# Dr Moagi 3D Graphics Animation Autoencoder / Decoder
+
+This runtime extends the Jarvis-X 3D auto-encoding work from static latent mappings into a temporal mesh-animation codec.
+
+## Operational pipeline
+
+```text
+mesh frames [T,V,3]
+  -> clip-wide spatial normalization
+  -> position + temporal-velocity features
+  -> feature standardization
+  -> dense NumPy encoder
+  -> latent timeline z[t]
+  -> keyframe-aware delta coding
+  -> symmetric integer quantization
+  -> packet (.npz)
+  -> latent dequantization / temporal reconstruction
+  -> neural decoder
+  -> denormalized mesh frames
+  -> OBJ + PGM previews + reconstruction telemetry
+```
+
+The reference implementation is exactly **1,000 physical Python source lines**. To keep that invariant auditable, Git stores it as five ordered 200-line fragments under:
+
+`reference/dr-moagi-3d-animation-autoencoder/fragments/`
+
+The Jarvis-X bridge in `src/jarvisx/dr_moagi_3d_animation_codec.py` reconstructs the fragments byte-for-byte before execution and rejects the runtime if its line count, syntax, or SHA-256 digest changes unexpectedly.
+
+Canonical source integrity:
+
+- physical lines: `1000`
+- SHA-256: `c3d05a11e3fbb91591f538c75bddc15a72dd398e62ae4624a7b1a0828efa620e`
+- language/runtime: Python 3.10+
+- numerical backend: NumPy (`jarvisx[graphics]`)
+
+## Install
+
+```bash
+python -m pip install -e '.[graphics]'
+```
+
+## Verify the canonical source
+
+```bash
+jarvisx-dr-moagi-3d-animation --verify-reference
+```
+
+## Materialize the single 1,000-line file
+
+```bash
+jarvisx-dr-moagi-3d-animation --materialize ./dr_moagi_3d_animation_autoencoder_1000_lines.py
+```
+
+## Run an end-to-end cube animation encode/decode
+
+```bash
+jarvisx-dr-moagi-3d-animation \
+  --demo cube \
+  --frames 90 \
+  --latent 12 \
+  --hidden 48 \
+  --epochs 400 \
+  --quant-bits 12 \
+  --keyframe 12 \
+  --output ./dr_moagi_codec_output
+```
+
+For a deforming surface instead of a rigid/deforming cube, use `--demo wave`.
+
+## Decode a saved packet
+
+```bash
+jarvisx-dr-moagi-3d-animation \
+  --mode decode \
+  --packet ./dr_moagi_codec_output/animation_packet.npz \
+  --output ./decoded_output
+```
+
+## Packet state
+
+The packet carries the constant mesh topology, spatial normalization state, quantization scales, quantized latent codes, keyframe mask, and decoder parameters needed to reconstruct the animation. The encoder parameters are intentionally not required for playback.
+
+## Current scope
+
+This is a deterministic research/reference implementation for explicit inspection of the full transformation path. It is CPU/NumPy based and is not presented as a production GPU animation codec. Natural next layers are batched GPU tensors, meshlet partitioning, entropy coding, learned motion prediction, and direct integration with the existing QSOL graphics codec and C++ 3D runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ test = [
 torch = [
     "torch>=2.4",
 ]
+graphics = [
+    "numpy>=1.24",
+]
 
 [project.urls]
 Homepage = "https://github.com/Lord-Xido/Jarvis-X"
@@ -75,6 +78,7 @@ jarvisx-dr-moagi-firmware = "jarvisx.dr_moagi_firmware_cli:main"
 jarvisx-dr-moagi-frontier = "jarvisx.dr_moagi_frontier_cli:main"
 jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
 jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
+jarvisx-dr-moagi-3d-animation = "jarvisx.dr_moagi_3d_animation_codec:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
@@ -109,13 +113,13 @@ exclude_also = [
 [tool.black]
 line-length = 100
 target-version = ["py310"]
-include = '\\.pyi?$'
+include = '\.pyi?$'
 extend-exclude = '''
 /(
-    \\.git
-  | \\.mypy_cache
-  | \\.pytest_cache
-  | \\.venv
+    \.git
+  | \.mypy_cache
+  | \.pytest_cache
+  | \.venv
   | build
   | dist
   | htmlcov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dev = [
     "flake8>=7.0",
     "isort>=5.13",
     "mypy>=1.10",
+    "numpy>=1.24",
     "pip-audit>=2.7",
     "pytest>=8.0",
     "pytest-cov>=5.0",
@@ -50,6 +51,7 @@ dev = [
     "z3-solver>=4.13.0",
 ]
 test = [
+    "numpy>=1.24",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "z3-solver>=4.13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,9 @@ package-dir = {"" = "src"}
 [tool.setuptools.packages.find]
 where = ["src"]
 
+[tool.setuptools.package-data]
+jarvisx = ["_reference/dr_moagi_3d_animation_autoencoder/*.part"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,13 +113,13 @@ exclude_also = [
 [tool.black]
 line-length = 100
 target-version = ["py310"]
-include = '\.pyi?$'
+include = '\\.pyi?$'
 extend-exclude = '''
 /(
-    \.git
-  | \.mypy_cache
-  | \.pytest_cache
-  | \.venv
+    \\.git
+  | \\.mypy_cache
+  | \\.pytest_cache
+  | \\.venv
   | build
   | dist
   | htmlcov

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/00.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/00.part
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Dr Moagi 3D Graphics Animation Autoencoder / Decoder Reference Engine.
+
+Purpose
+-------
+This single-file Python program demonstrates an end-to-end 3D animation
+processing pipeline:
+
+1. Generate or ingest a mesh animation as vertex frames.
+2. Normalize spatial coordinates into a codec-friendly representation.
+3. Build per-frame position/velocity features.
+4. Train a compact NumPy autoencoder using mini-batch gradient descent.
+5. Encode animation frames into a latent representation.
+6. Delta-code and quantize the latent timeline for compact storage.
+7. Decode, dequantize, and reconstruct the 3D animation.
+8. Measure reconstruction error and compression characteristics.
+9. Render preview frames with a tiny dependency-free software renderer.
+10. Export reconstructed geometry to OBJ and packet data to NPZ/JSON.
+
+The design is educational and operational rather than a replacement for
+production GPU codecs. It makes all transformations explicit and inspectable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import struct
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Sequence
+
+import numpy as np
+
+
+EPS = 1.0e-8
+FORMAT_VERSION = 1
+
+
+@dataclass
+class MeshFrame:
+    """One animation frame containing vertex positions and triangle faces."""
+
+    vertices: np.ndarray
+    faces: np.ndarray
+    timestamp: float = 0.0
+
+    def validate(self) -> None:
+        vertices = np.asarray(self.vertices)
+        faces = np.asarray(self.faces)
+        if vertices.ndim != 2 or vertices.shape[1] != 3:
+            raise ValueError("vertices must have shape [vertex_count, 3]")
+        if faces.ndim != 2 or faces.shape[1] != 3:
+            raise ValueError("faces must have shape [triangle_count, 3]")
+        if vertices.dtype.kind not in "fc":
+            raise TypeError("vertices must be floating point")
+        if faces.dtype.kind not in "iu":
+            raise TypeError("faces must be integer indices")
+        if faces.size and (faces.min() < 0 or faces.max() >= len(vertices)):
+            raise ValueError("face index is outside the vertex array")
+
+    def copy(self) -> "MeshFrame":
+        return MeshFrame(
+            vertices=self.vertices.copy(),
+            faces=self.faces.copy(),
+            timestamp=float(self.timestamp),
+        )
+
+
+@dataclass
+class AnimationClip:
+    """Ordered sequence of mesh frames with constant topology."""
+
+    frames: list[MeshFrame]
+    fps: float = 30.0
+    name: str = "clip"
+
+    def validate(self) -> None:
+        if not self.frames:
+            raise ValueError("animation must contain at least one frame")
+        if self.fps <= 0.0:
+            raise ValueError("fps must be positive")
+        vertex_count = len(self.frames[0].vertices)
+        faces = self.frames[0].faces
+        for frame in self.frames:
+            frame.validate()
+            if len(frame.vertices) != vertex_count:
+                raise ValueError("all frames must have the same vertex count")
+            if frame.faces.shape != faces.shape or not np.array_equal(frame.faces, faces):
+                raise ValueError("all frames must share the same topology")
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.frames)
+
+    @property
+    def vertex_count(self) -> int:
+        return len(self.frames[0].vertices)
+
+    @property
+    def duration(self) -> float:
+        return self.frame_count / self.fps
+
+    def vertex_tensor(self, dtype=np.float32) -> np.ndarray:
+        return np.stack([f.vertices for f in self.frames], axis=0).astype(dtype)
+
+
+@dataclass
+class CodecConfig:
+    """Hyperparameters for the autoencoder and latent stream codec."""
+
+    latent_dim: int = 12
+    hidden_dim: int = 48
+    epochs: int = 400
+    batch_size: int = 16
+    learning_rate: float = 0.01
+    l2_weight: float = 1.0e-5
+    velocity_weight: float = 0.25
+    quant_bits: int = 12
+    keyframe_interval: int = 12
+    seed: int = 1337
+
+    def validate(self) -> None:
+        if self.latent_dim <= 0:
+            raise ValueError("latent_dim must be positive")
+        if self.hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive")
+        if self.epochs <= 0:
+            raise ValueError("epochs must be positive")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if self.learning_rate <= 0.0:
+            raise ValueError("learning_rate must be positive")
+        if not 2 <= self.quant_bits <= 16:
+            raise ValueError("quant_bits must be in [2, 16]")
+        if self.keyframe_interval <= 0:
+            raise ValueError("keyframe_interval must be positive")
+
+
+@dataclass
+class NormalizationState:
+    """Affine normalization parameters shared by an entire clip."""
+
+    center: np.ndarray
+    scale: float
+
+    def normalize(self, vertices: np.ndarray) -> np.ndarray:
+        return (vertices - self.center) / max(self.scale, EPS)
+
+    def denormalize(self, vertices: np.ndarray) -> np.ndarray:
+        return vertices * self.scale + self.center
+
+
+@dataclass
+class QuantizationState:
+    """Per-latent-channel symmetric quantization scale."""
+
+    scales: np.ndarray
+    bits: int
+
+
+@dataclass
+class EncodedPacket:
+    """Serializable output of the animation codec."""
+
+    version: int
+    fps: float
+    frame_count: int
+    vertex_count: int
+    faces: np.ndarray
+    center: np.ndarray
+    scale: float
+    feature_dim: int
+    latent_dim: int
+    keyframe_interval: int
+    quant_bits: int
+    latent_scales: np.ndarray
+    latent_codes: np.ndarray
+    keyframe_mask: np.ndarray
+    decoder_w1: np.ndarray
+    decoder_b1: np.ndarray
+    decoder_w2: np.ndarray
+    decoder_b2: np.ndarray
+
+
+class RunningStats:
+    """Numerically stable scalar telemetry helper."""
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.mean = 0.0
+        self.m2 = 0.0
+
+    def update(self, value: float) -> None:
+        self.count += 1
+        delta = value - self.mean

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/01.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/01.part
@@ -1,0 +1,200 @@
+        self.mean += delta / self.count
+        delta2 = value - self.mean
+        self.m2 += delta * delta2
+
+    @property
+    def variance(self) -> float:
+        if self.count < 2:
+            return 0.0
+        return self.m2 / (self.count - 1)
+
+    @property
+    def std(self) -> float:
+        return math.sqrt(max(self.variance, 0.0))
+
+
+class Timer:
+    """Small context manager used for pipeline timing."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.elapsed = 0.0
+
+    def __enter__(self) -> "Timer":
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.elapsed = time.perf_counter() - self.start
+        print(f"{self.label}: {self.elapsed:.4f} s")
+
+
+def rotation_x(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]],
+        dtype=np.float32,
+    )
+
+
+def rotation_y(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]],
+        dtype=np.float32,
+    )
+
+
+def rotation_z(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+
+def compose_rotation(rx: float, ry: float, rz: float) -> np.ndarray:
+    return rotation_z(rz) @ rotation_y(ry) @ rotation_x(rx)
+
+
+def transform_vertices(
+    vertices: np.ndarray,
+    rotation: Optional[np.ndarray] = None,
+    translation: Optional[np.ndarray] = None,
+    scale: float = 1.0,
+) -> np.ndarray:
+    result = np.asarray(vertices, dtype=np.float32) * float(scale)
+    if rotation is not None:
+        result = result @ np.asarray(rotation, dtype=np.float32).T
+    if translation is not None:
+        result = result + np.asarray(translation, dtype=np.float32)
+    return result
+
+
+def make_cube_mesh(size: float = 2.0) -> tuple[np.ndarray, np.ndarray]:
+    h = size * 0.5
+    vertices = np.array(
+        [
+            [-h, -h, -h],
+            [h, -h, -h],
+            [h, h, -h],
+            [-h, h, -h],
+            [-h, -h, h],
+            [h, -h, h],
+            [h, h, h],
+            [-h, h, h],
+        ],
+        dtype=np.float32,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2], [0, 2, 3],
+            [4, 6, 5], [4, 7, 6],
+            [0, 4, 5], [0, 5, 1],
+            [1, 5, 6], [1, 6, 2],
+            [2, 6, 7], [2, 7, 3],
+            [3, 7, 4], [3, 4, 0],
+        ],
+        dtype=np.int32,
+    )
+    return vertices, faces
+
+
+def make_grid_mesh(nx: int = 12, ny: int = 12, size: float = 3.0) -> tuple[np.ndarray, np.ndarray]:
+    if nx < 2 or ny < 2:
+        raise ValueError("grid dimensions must be at least 2")
+    xs = np.linspace(-size * 0.5, size * 0.5, nx, dtype=np.float32)
+    ys = np.linspace(-size * 0.5, size * 0.5, ny, dtype=np.float32)
+    vertices = []
+    for y in ys:
+        for x in xs:
+            vertices.append([x, y, 0.0])
+    faces = []
+    for j in range(ny - 1):
+        for i in range(nx - 1):
+            a = j * nx + i
+            b = a + 1
+            c = a + nx
+            d = c + 1
+            faces.append([a, b, d])
+            faces.append([a, d, c])
+    return np.asarray(vertices, dtype=np.float32), np.asarray(faces, dtype=np.int32)
+
+
+def generate_cube_animation(frame_count: int = 90, fps: float = 30.0) -> AnimationClip:
+    base_vertices, faces = make_cube_mesh()
+    frames = []
+    for index in range(frame_count):
+        phase = index / max(frame_count - 1, 1)
+        t = 2.0 * math.pi * phase
+        rotation = compose_rotation(0.35 * math.sin(t), t, 0.25 * math.cos(2.0 * t))
+        pulse = 1.0 + 0.12 * math.sin(3.0 * t)
+        translation = np.array(
+            [0.25 * math.cos(t), 0.18 * math.sin(2.0 * t), 0.12 * math.sin(t)],
+            dtype=np.float32,
+        )
+        vertices = transform_vertices(base_vertices, rotation, translation, pulse)
+        bend = 0.10 * np.sin(vertices[:, 0] * 2.3 + t)
+        vertices[:, 2] += bend.astype(np.float32)
+        frames.append(MeshFrame(vertices, faces, index / fps))
+    clip = AnimationClip(frames=frames, fps=fps, name="procedural_cube")
+    clip.validate()
+    return clip
+
+
+def generate_wave_animation(frame_count: int = 90, fps: float = 30.0) -> AnimationClip:
+    base_vertices, faces = make_grid_mesh(14, 14, 4.0)
+    frames = []
+    radius = np.sqrt(base_vertices[:, 0] ** 2 + base_vertices[:, 1] ** 2)
+    for index in range(frame_count):
+        phase = index / max(frame_count - 1, 1)
+        t = 2.0 * math.pi * phase
+        vertices = base_vertices.copy()
+        vertices[:, 2] = (
+            0.35 * np.sin(2.2 * radius - 2.0 * t)
+            + 0.12 * np.cos(vertices[:, 0] * 2.0 + t)
+            + 0.08 * np.sin(vertices[:, 1] * 3.0 - 1.5 * t)
+        )
+        rotation = compose_rotation(0.35, 0.0, 0.15 * math.sin(t))
+        vertices = transform_vertices(vertices, rotation=rotation)
+        frames.append(MeshFrame(vertices.astype(np.float32), faces, index / fps))
+    clip = AnimationClip(frames=frames, fps=fps, name="procedural_wave")
+    clip.validate()
+    return clip
+
+
+def compute_normalization(tensor: np.ndarray) -> NormalizationState:
+    flat = tensor.reshape(-1, 3).astype(np.float64)
+    center = flat.mean(axis=0).astype(np.float32)
+    centered = flat - center
+    radius = np.linalg.norm(centered, axis=1)
+    scale = float(np.percentile(radius, 99.0))
+    if scale < EPS:
+        scale = 1.0
+    return NormalizationState(center=center, scale=scale)
+
+
+def temporal_velocity(tensor: np.ndarray) -> np.ndarray:
+    velocity = np.zeros_like(tensor, dtype=np.float32)
+    if len(tensor) > 1:
+        velocity[1:] = tensor[1:] - tensor[:-1]
+        velocity[0] = velocity[1]
+    return velocity
+
+
+def build_features(tensor: np.ndarray, velocity_weight: float) -> np.ndarray:
+    frame_count = tensor.shape[0]
+    positions = tensor.reshape(frame_count, -1)
+    velocity = temporal_velocity(tensor).reshape(frame_count, -1)
+    if velocity_weight <= 0.0:
+        return positions.astype(np.float32)
+    features = np.concatenate([positions, velocity * velocity_weight], axis=1)
+    return features.astype(np.float32)
+
+
+def features_to_positions(features: np.ndarray, vertex_count: int) -> np.ndarray:
+    position_dim = vertex_count * 3
+    positions = features[:, :position_dim]

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/02.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/02.part
@@ -1,0 +1,199 @@
+    return positions.reshape(len(features), vertex_count, 3).astype(np.float32)
+
+
+def mse(a: np.ndarray, b: np.ndarray) -> float:
+    diff = np.asarray(a, dtype=np.float64) - np.asarray(b, dtype=np.float64)
+    return float(np.mean(diff * diff))
+
+
+def rmse(a: np.ndarray, b: np.ndarray) -> float:
+    return math.sqrt(max(mse(a, b), 0.0))
+
+
+def max_abs_error(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.max(np.abs(np.asarray(a) - np.asarray(b))))
+
+
+def psnr(a: np.ndarray, b: np.ndarray, peak: float = 2.0) -> float:
+    error = mse(a, b)
+    if error <= EPS:
+        return float("inf")
+    return 20.0 * math.log10(peak) - 10.0 * math.log10(error)
+
+
+def stable_tanh(x: np.ndarray) -> np.ndarray:
+    return np.tanh(np.clip(x, -15.0, 15.0))
+
+
+def tanh_derivative_from_output(y: np.ndarray) -> np.ndarray:
+    return 1.0 - y * y
+
+
+def xavier(rng: np.random.Generator, fan_in: int, fan_out: int) -> np.ndarray:
+    limit = math.sqrt(6.0 / max(fan_in + fan_out, 1))
+    return rng.uniform(-limit, limit, size=(fan_in, fan_out)).astype(np.float32)
+
+
+class DenseAutoencoder:
+    """Small two-layer encoder and two-layer decoder implemented in NumPy."""
+
+    def __init__(self, input_dim: int, config: CodecConfig) -> None:
+        self.input_dim = int(input_dim)
+        self.config = config
+        self.rng = np.random.default_rng(config.seed)
+        h = config.hidden_dim
+        z = config.latent_dim
+        self.enc_w1 = xavier(self.rng, input_dim, h)
+        self.enc_b1 = np.zeros(h, dtype=np.float32)
+        self.enc_w2 = xavier(self.rng, h, z)
+        self.enc_b2 = np.zeros(z, dtype=np.float32)
+        self.dec_w1 = xavier(self.rng, z, h)
+        self.dec_b1 = np.zeros(h, dtype=np.float32)
+        self.dec_w2 = xavier(self.rng, h, input_dim)
+        self.dec_b2 = np.zeros(input_dim, dtype=np.float32)
+        self.history: list[float] = []
+
+    def encode(self, x: np.ndarray) -> np.ndarray:
+        h1 = stable_tanh(x @ self.enc_w1 + self.enc_b1)
+        z = stable_tanh(h1 @ self.enc_w2 + self.enc_b2)
+        return z.astype(np.float32)
+
+    def decode(self, z: np.ndarray) -> np.ndarray:
+        h2 = stable_tanh(z @ self.dec_w1 + self.dec_b1)
+        y = h2 @ self.dec_w2 + self.dec_b2
+        return y.astype(np.float32)
+
+    def reconstruct(self, x: np.ndarray) -> np.ndarray:
+        return self.decode(self.encode(x))
+
+    def _forward(self, x: np.ndarray) -> tuple[np.ndarray, ...]:
+        h1 = stable_tanh(x @ self.enc_w1 + self.enc_b1)
+        z = stable_tanh(h1 @ self.enc_w2 + self.enc_b2)
+        h2 = stable_tanh(z @ self.dec_w1 + self.dec_b1)
+        y = h2 @ self.dec_w2 + self.dec_b2
+        return h1, z, h2, y
+
+    def _train_batch(self, x: np.ndarray, learning_rate: float) -> float:
+        h1, z, h2, y = self._forward(x)
+        batch = max(len(x), 1)
+        error = y - x
+        loss = float(np.mean(error * error))
+        dy = (2.0 / (batch * self.input_dim)) * error
+        grad_dec_w2 = h2.T @ dy + self.config.l2_weight * self.dec_w2
+        grad_dec_b2 = dy.sum(axis=0)
+        dh2 = (dy @ self.dec_w2.T) * tanh_derivative_from_output(h2)
+        grad_dec_w1 = z.T @ dh2 + self.config.l2_weight * self.dec_w1
+        grad_dec_b1 = dh2.sum(axis=0)
+        dz = (dh2 @ self.dec_w1.T) * tanh_derivative_from_output(z)
+        grad_enc_w2 = h1.T @ dz + self.config.l2_weight * self.enc_w2
+        grad_enc_b2 = dz.sum(axis=0)
+        dh1 = (dz @ self.enc_w2.T) * tanh_derivative_from_output(h1)
+        grad_enc_w1 = x.T @ dh1 + self.config.l2_weight * self.enc_w1
+        grad_enc_b1 = dh1.sum(axis=0)
+        self.dec_w2 -= learning_rate * grad_dec_w2.astype(np.float32)
+        self.dec_b2 -= learning_rate * grad_dec_b2.astype(np.float32)
+        self.dec_w1 -= learning_rate * grad_dec_w1.astype(np.float32)
+        self.dec_b1 -= learning_rate * grad_dec_b1.astype(np.float32)
+        self.enc_w2 -= learning_rate * grad_enc_w2.astype(np.float32)
+        self.enc_b2 -= learning_rate * grad_enc_b2.astype(np.float32)
+        self.enc_w1 -= learning_rate * grad_enc_w1.astype(np.float32)
+        self.enc_b1 -= learning_rate * grad_enc_b1.astype(np.float32)
+        return loss
+
+    def fit(self, x: np.ndarray, verbose: bool = True) -> list[float]:
+        if x.ndim != 2 or x.shape[1] != self.input_dim:
+            raise ValueError("training matrix has the wrong shape")
+        n = len(x)
+        batch_size = min(self.config.batch_size, n)
+        for epoch in range(self.config.epochs):
+            order = self.rng.permutation(n)
+            epoch_stats = RunningStats()
+            progress = epoch / max(self.config.epochs - 1, 1)
+            lr = self.config.learning_rate * (0.25 + 0.75 * (1.0 - progress))
+            for start in range(0, n, batch_size):
+                indices = order[start:start + batch_size]
+                loss = self._train_batch(x[indices], lr)
+                epoch_stats.update(loss)
+            self.history.append(epoch_stats.mean)
+            report_every = max(self.config.epochs // 10, 1)
+            if verbose and (epoch == 0 or (epoch + 1) % report_every == 0):
+                print(
+                    f"epoch {epoch + 1:4d}/{self.config.epochs} "
+                    f"loss={epoch_stats.mean:.8f} lr={lr:.6f}"
+                )
+        return self.history
+
+
+class FeatureStandardizer:
+    """Per-feature standardization for stable autoencoder optimization."""
+
+    def __init__(self) -> None:
+        self.mean: Optional[np.ndarray] = None
+        self.std: Optional[np.ndarray] = None
+
+    def fit(self, x: np.ndarray) -> "FeatureStandardizer":
+        self.mean = x.mean(axis=0).astype(np.float32)
+        std = x.std(axis=0).astype(np.float32)
+        self.std = np.where(std < 1.0e-5, 1.0, std).astype(np.float32)
+        return self
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.std is None:
+            raise RuntimeError("standardizer has not been fitted")
+        return ((x - self.mean) / self.std).astype(np.float32)
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.std is None:
+            raise RuntimeError("standardizer has not been fitted")
+        return (x * self.std + self.mean).astype(np.float32)
+
+
+class LatentDeltaCodec:
+    """Keyframe-aware temporal delta coding with symmetric integer quantization."""
+
+    def __init__(self, bits: int = 12, keyframe_interval: int = 12) -> None:
+        self.bits = int(bits)
+        self.keyframe_interval = int(keyframe_interval)
+        self.qmax = (1 << (bits - 1)) - 1
+
+    def _make_delta_stream(self, latent: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        delta = np.zeros_like(latent, dtype=np.float32)
+        mask = np.zeros(len(latent), dtype=np.uint8)
+        for index in range(len(latent)):
+            is_key = index == 0 or index % self.keyframe_interval == 0
+            if is_key:
+                delta[index] = latent[index]
+                mask[index] = 1
+            else:
+                delta[index] = latent[index] - latent[index - 1]
+        return delta, mask
+
+    def _restore_delta_stream(self, delta: np.ndarray, mask: np.ndarray) -> np.ndarray:
+        latent = np.zeros_like(delta, dtype=np.float32)
+        for index in range(len(delta)):
+            if index == 0 or mask[index]:
+                latent[index] = delta[index]
+            else:
+                latent[index] = latent[index - 1] + delta[index]
+        return latent
+
+    def quantize(self, latent: np.ndarray) -> tuple[np.ndarray, QuantizationState, np.ndarray]:
+        delta, mask = self._make_delta_stream(latent)
+        peak = np.max(np.abs(delta), axis=0)
+        scales = np.where(peak < EPS, 1.0, peak / self.qmax).astype(np.float32)
+        quantized = np.rint(delta / scales).clip(-self.qmax, self.qmax)
+        dtype = np.int8 if self.bits <= 8 else np.int16
+        return quantized.astype(dtype), QuantizationState(scales, self.bits), mask
+
+    def dequantize(
+        self,
+        codes: np.ndarray,
+        state: QuantizationState,
+        mask: np.ndarray,
+    ) -> np.ndarray:
+        delta = codes.astype(np.float32) * state.scales.astype(np.float32)
+        return self._restore_delta_stream(delta, mask)
+
+
+class AnimationAutoCodec:
+    """Orchestrates normalization, neural autoencoding, temporal coding and decode."""

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/02.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/02.part
@@ -197,3 +197,4 @@ class LatentDeltaCodec:
 
 class AnimationAutoCodec:
     """Orchestrates normalization, neural autoencoding, temporal coding and decode."""
+

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/03.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/03.part
@@ -1,0 +1,200 @@
+    def __init__(self, config: CodecConfig) -> None:
+        config.validate()
+        self.config = config
+        self.normalization: Optional[NormalizationState] = None
+        self.standardizer = FeatureStandardizer()
+        self.autoencoder: Optional[DenseAutoencoder] = None
+
+    def fit(self, clip: AnimationClip, verbose: bool = True) -> dict[str, float]:
+        clip.validate()
+        tensor = clip.vertex_tensor()
+        self.normalization = compute_normalization(tensor)
+        normalized = self.normalization.normalize(tensor).astype(np.float32)
+        features = build_features(normalized, self.config.velocity_weight)
+        standardized = self.standardizer.fit(features).transform(features)
+        self.autoencoder = DenseAutoencoder(standardized.shape[1], self.config)
+        with Timer("autoencoder training"):
+            self.autoencoder.fit(standardized, verbose=verbose)
+        reconstructed_std = self.autoencoder.reconstruct(standardized)
+        reconstructed_features = self.standardizer.inverse_transform(reconstructed_std)
+        reconstructed_norm = features_to_positions(reconstructed_features, clip.vertex_count)
+        reconstructed = self.normalization.denormalize(reconstructed_norm)
+        metrics = evaluate_reconstruction(tensor, reconstructed)
+        metrics["training_final_loss"] = float(self.autoencoder.history[-1])
+        return metrics
+
+    def encode(self, clip: AnimationClip) -> EncodedPacket:
+        if self.normalization is None or self.autoencoder is None:
+            raise RuntimeError("codec must be fitted before encoding")
+        if self.standardizer.mean is None or self.standardizer.std is None:
+            raise RuntimeError("standardizer state is missing")
+        tensor = clip.vertex_tensor()
+        normalized = self.normalization.normalize(tensor).astype(np.float32)
+        features = build_features(normalized, self.config.velocity_weight)
+        standardized = self.standardizer.transform(features)
+        latent = self.autoencoder.encode(standardized)
+        latent_codec = LatentDeltaCodec(self.config.quant_bits, self.config.keyframe_interval)
+        codes, qstate, mask = latent_codec.quantize(latent)
+        decoder_b2 = self.autoencoder.dec_b2.copy()
+        decoder_b2 = np.stack(
+            [decoder_b2, self.standardizer.mean, self.standardizer.std],
+            axis=0,
+        )
+        return EncodedPacket(
+            version=FORMAT_VERSION,
+            fps=clip.fps,
+            frame_count=clip.frame_count,
+            vertex_count=clip.vertex_count,
+            faces=clip.frames[0].faces.copy(),
+            center=self.normalization.center.copy(),
+            scale=float(self.normalization.scale),
+            feature_dim=features.shape[1],
+            latent_dim=self.config.latent_dim,
+            keyframe_interval=self.config.keyframe_interval,
+            quant_bits=self.config.quant_bits,
+            latent_scales=qstate.scales,
+            latent_codes=codes,
+            keyframe_mask=mask,
+            decoder_w1=self.autoencoder.dec_w1.copy(),
+            decoder_b1=self.autoencoder.dec_b1.copy(),
+            decoder_w2=self.autoencoder.dec_w2.copy(),
+            decoder_b2=decoder_b2,
+        )
+
+    @staticmethod
+    def decode(packet: EncodedPacket) -> AnimationClip:
+        if packet.version != FORMAT_VERSION:
+            raise ValueError(f"unsupported packet version: {packet.version}")
+        qstate = QuantizationState(packet.latent_scales, packet.quant_bits)
+        latent_codec = LatentDeltaCodec(packet.quant_bits, packet.keyframe_interval)
+        latent = latent_codec.dequantize(packet.latent_codes, qstate, packet.keyframe_mask)
+        h2 = stable_tanh(latent @ packet.decoder_w1 + packet.decoder_b1)
+        decoded_standard = h2 @ packet.decoder_w2 + packet.decoder_b2[0]
+        feature_mean = packet.decoder_b2[1]
+        feature_std = packet.decoder_b2[2]
+        decoded_features = decoded_standard * feature_std + feature_mean
+        normalized = features_to_positions(decoded_features, packet.vertex_count)
+        vertices = normalized * packet.scale + packet.center
+        frames = []
+        for index in range(packet.frame_count):
+            frames.append(
+                MeshFrame(
+                    vertices=vertices[index].astype(np.float32),
+                    faces=packet.faces.copy(),
+                    timestamp=index / packet.fps,
+                )
+            )
+        clip = AnimationClip(frames=frames, fps=packet.fps, name="decoded")
+        clip.validate()
+        return clip
+
+
+def packet_raw_bytes(packet: EncodedPacket) -> int:
+    arrays = [
+        packet.faces,
+        packet.center,
+        packet.latent_scales,
+        packet.latent_codes,
+        packet.keyframe_mask,
+        packet.decoder_w1,
+        packet.decoder_b1,
+        packet.decoder_w2,
+        packet.decoder_b2,
+    ]
+    return int(sum(array.nbytes for array in arrays))
+
+
+def original_raw_bytes(clip: AnimationClip) -> int:
+    return int(clip.vertex_tensor().nbytes + clip.frames[0].faces.nbytes)
+
+
+def evaluate_reconstruction(reference: np.ndarray, reconstructed: np.ndarray) -> dict[str, float]:
+    return {
+        "mse": mse(reference, reconstructed),
+        "rmse": rmse(reference, reconstructed),
+        "max_abs_error": max_abs_error(reference, reconstructed),
+        "psnr_db": psnr(reference, reconstructed, peak=2.0),
+    }
+
+
+def save_packet(packet: EncodedPacket, path: Path) -> None:
+    path = Path(path)
+    metadata = {
+        "version": packet.version,
+        "fps": packet.fps,
+        "frame_count": packet.frame_count,
+        "vertex_count": packet.vertex_count,
+        "scale": packet.scale,
+        "feature_dim": packet.feature_dim,
+        "latent_dim": packet.latent_dim,
+        "keyframe_interval": packet.keyframe_interval,
+        "quant_bits": packet.quant_bits,
+    }
+    np.savez_compressed(
+        path,
+        metadata=json.dumps(metadata),
+        faces=packet.faces,
+        center=packet.center,
+        latent_scales=packet.latent_scales,
+        latent_codes=packet.latent_codes,
+        keyframe_mask=packet.keyframe_mask,
+        decoder_w1=packet.decoder_w1,
+        decoder_b1=packet.decoder_b1,
+        decoder_w2=packet.decoder_w2,
+        decoder_b2=packet.decoder_b2,
+    )
+
+
+def load_packet(path: Path) -> EncodedPacket:
+    with np.load(Path(path), allow_pickle=False) as data:
+        metadata = json.loads(str(data["metadata"]))
+        return EncodedPacket(
+            version=int(metadata["version"]),
+            fps=float(metadata["fps"]),
+            frame_count=int(metadata["frame_count"]),
+            vertex_count=int(metadata["vertex_count"]),
+            faces=data["faces"].copy(),
+            center=data["center"].copy(),
+            scale=float(metadata["scale"]),
+            feature_dim=int(metadata["feature_dim"]),
+            latent_dim=int(metadata["latent_dim"]),
+            keyframe_interval=int(metadata["keyframe_interval"]),
+            quant_bits=int(metadata["quant_bits"]),
+            latent_scales=data["latent_scales"].copy(),
+            latent_codes=data["latent_codes"].copy(),
+            keyframe_mask=data["keyframe_mask"].copy(),
+            decoder_w1=data["decoder_w1"].copy(),
+            decoder_b1=data["decoder_b1"].copy(),
+            decoder_w2=data["decoder_w2"].copy(),
+            decoder_b2=data["decoder_b2"].copy(),
+        )
+
+
+def unique_edges(faces: np.ndarray) -> np.ndarray:
+    edges: set[tuple[int, int]] = set()
+    for a, b, c in faces.tolist():
+        for u, v in ((a, b), (b, c), (c, a)):
+            if u > v:
+                u, v = v, u
+            edges.add((u, v))
+    return np.asarray(sorted(edges), dtype=np.int32)
+
+
+def camera_project(
+    vertices: np.ndarray,
+    width: int,
+    height: int,
+    camera_z: float = 6.0,
+    focal_length: float = 2.2,
+) -> tuple[np.ndarray, np.ndarray]:
+    points = np.asarray(vertices, dtype=np.float32).copy()
+    depth = camera_z - points[:, 2]
+    safe_depth = np.where(depth < 0.1, 0.1, depth)
+    x = focal_length * points[:, 0] / safe_depth
+    y = focal_length * points[:, 1] / safe_depth
+    px = (width * 0.5 + x * width * 0.42).astype(np.int32)
+    py = (height * 0.5 - y * height * 0.42).astype(np.int32)
+    return np.stack([px, py], axis=1), safe_depth
+def draw_line(
+    image: np.ndarray,
+    x0: int,

--- a/reference/dr-moagi-3d-animation-autoencoder/fragments/04.part
+++ b/reference/dr-moagi-3d-animation-autoencoder/fragments/04.part
@@ -1,0 +1,200 @@
+    y0: int,
+    x1: int,
+    y1: int,
+    value: int = 230,
+) -> None:
+    dx = abs(x1 - x0)
+    sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0)
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+    height, width = image.shape
+    while True:
+        if 0 <= x0 < width and 0 <= y0 < height:
+            image[y0, x0] = max(int(image[y0, x0]), int(value))
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+def draw_disc(image: np.ndarray, cx: int, cy: int, radius: int, value: int = 255) -> None:
+    height, width = image.shape
+    radius2 = radius * radius
+    for y in range(max(0, cy - radius), min(height, cy + radius + 1)):
+        for x in range(max(0, cx - radius), min(width, cx + radius + 1)):
+            if (x - cx) ** 2 + (y - cy) ** 2 <= radius2:
+                image[y, x] = max(int(image[y, x]), int(value))
+def render_wireframe(
+    frame: MeshFrame,
+    width: int = 512,
+    height: int = 512,
+    camera_rotation: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    vertices = frame.vertices
+    if camera_rotation is not None:
+        vertices = vertices @ camera_rotation.T
+    points, depth = camera_project(vertices, width, height)
+    image = np.zeros((height, width), dtype=np.uint8)
+    edges = unique_edges(frame.faces)
+    edge_depth = (depth[edges[:, 0]] + depth[edges[:, 1]]) * 0.5
+    order = np.argsort(edge_depth)[::-1]
+    for edge_index in order:
+        a, b = edges[edge_index]
+        x0, y0 = points[a]
+        x1, y1 = points[b]
+        shade = int(np.clip(260.0 - edge_depth[edge_index] * 12.0, 70.0, 245.0))
+        draw_line(image, int(x0), int(y0), int(x1), int(y1), shade)
+    for index, (x, y) in enumerate(points):
+        shade = int(np.clip(290.0 - depth[index] * 10.0, 100.0, 255.0))
+        draw_disc(image, int(x), int(y), 2, shade)
+    return image
+def save_pgm(image: np.ndarray, path: Path) -> None:
+    image = np.asarray(image, dtype=np.uint8)
+    height, width = image.shape
+    with open(path, "wb") as handle:
+        handle.write(f"P5\n{width} {height}\n255\n".encode("ascii"))
+        handle.write(image.tobytes())
+def export_obj(frame: MeshFrame, path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("# Reconstructed 3D frame\n")
+        for x, y, z in frame.vertices:
+            handle.write(f"v {x:.7f} {y:.7f} {z:.7f}\n")
+        for a, b, c in frame.faces:
+            handle.write(f"f {a + 1} {b + 1} {c + 1}\n")
+def export_animation_objs(clip: AnimationClip, directory: Path, every: int = 1) -> None:
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    for index in range(0, clip.frame_count, max(every, 1)):
+        export_obj(clip.frames[index], directory / f"frame_{index:05d}.obj")
+def render_animation_previews(
+    clip: AnimationClip,
+    directory: Path,
+    every: int = 6,
+    width: int = 512,
+    height: int = 512,
+) -> None:
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    camera = compose_rotation(math.radians(-18.0), math.radians(25.0), 0.0)
+    for index in range(0, clip.frame_count, max(every, 1)):
+        image = render_wireframe(clip.frames[index], width, height, camera)
+        save_pgm(image, directory / f"preview_{index:05d}.pgm")
+def human_bytes(value: int) -> str:
+    units = ["B", "KiB", "MiB", "GiB"]
+    amount = float(value)
+    for unit in units:
+        if amount < 1024.0 or unit == units[-1]:
+            return f"{amount:.2f} {unit}"
+        amount /= 1024.0
+    return f"{amount:.2f} GiB"
+def summarize_packet(packet: EncodedPacket) -> dict[str, object]:
+    return {
+        "version": packet.version,
+        "fps": packet.fps,
+        "frame_count": packet.frame_count,
+        "vertex_count": packet.vertex_count,
+        "latent_dim": packet.latent_dim,
+        "quant_bits": packet.quant_bits,
+        "keyframe_interval": packet.keyframe_interval,
+        "packet_raw_bytes": packet_raw_bytes(packet),
+    }
+def write_json(data: dict[str, object], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+def build_demo_clip(kind: str, frames: int, fps: float) -> AnimationClip:
+    if kind == "cube":
+        return generate_cube_animation(frames, fps)
+    if kind == "wave":
+        return generate_wave_animation(frames, fps)
+    raise ValueError(f"unknown demo kind: {kind}")
+def train_encode_decode(
+    clip: AnimationClip,
+    config: CodecConfig,
+    output_dir: Path,
+    verbose: bool = True,
+) -> tuple[EncodedPacket, AnimationClip, dict[str, float]]:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    codec = AnimationAutoCodec(config)
+    print(f"clip={clip.name} frames={clip.frame_count} vertices={clip.vertex_count}")
+    train_metrics = codec.fit(clip, verbose=verbose)
+    packet = codec.encode(clip)
+    decoded = codec.decode(packet)
+    reference = clip.vertex_tensor()
+    reconstruction = decoded.vertex_tensor()
+    metrics = evaluate_reconstruction(reference, reconstruction)
+    metrics.update({f"fit_{k}": v for k, v in train_metrics.items()})
+    original_bytes = original_raw_bytes(clip)
+    encoded_bytes = packet_raw_bytes(packet)
+    metrics["original_raw_bytes"] = float(original_bytes)
+    metrics["packet_raw_bytes"] = float(encoded_bytes)
+    metrics["raw_compression_ratio"] = float(original_bytes / max(encoded_bytes, 1))
+    save_packet(packet, output_dir / "animation_packet.npz")
+    write_json(summarize_packet(packet), output_dir / "packet_summary.json")
+    write_json(metrics, output_dir / "reconstruction_metrics.json")
+    export_obj(decoded.frames[0], output_dir / "reconstructed_frame_00000.obj")
+    render_animation_previews(decoded, output_dir / "previews", every=max(clip.frame_count // 12, 1))
+    print(f"original raw: {human_bytes(original_bytes)}")
+    print(f"packet raw:   {human_bytes(encoded_bytes)}")
+    print(f"ratio:        {metrics['raw_compression_ratio']:.3f}x")
+    print(f"RMSE:         {metrics['rmse']:.8f}")
+    print(f"PSNR:         {metrics['psnr_db']:.3f} dB")
+    return packet, decoded, metrics
+def decode_existing_packet(packet_path: Path, output_dir: Path) -> AnimationClip:
+    packet = load_packet(packet_path)
+    clip = AnimationAutoCodec.decode(packet)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    export_animation_objs(clip, output_dir / "obj_frames", every=1)
+    render_animation_previews(clip, output_dir / "previews", every=max(clip.frame_count // 12, 1))
+    write_json(summarize_packet(packet), output_dir / "packet_summary.json")
+    return clip
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train and run a NumPy 3D animation autoencoder/decoder codec."
+    )
+    parser.add_argument("--mode", choices=["demo", "decode"], default="demo")
+    parser.add_argument("--demo", choices=["cube", "wave"], default="cube")
+    parser.add_argument("--frames", type=int, default=90)
+    parser.add_argument("--fps", type=float, default=30.0)
+    parser.add_argument("--latent", type=int, default=12)
+    parser.add_argument("--hidden", type=int, default=48)
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--lr", type=float, default=0.01)
+    parser.add_argument("--quant-bits", type=int, default=12)
+    parser.add_argument("--keyframe", type=int, default=12)
+    parser.add_argument("--velocity-weight", type=float, default=0.25)
+    parser.add_argument("--output", type=Path, default=Path("dr_moagi_codec_output"))
+    parser.add_argument("--packet", type=Path, default=None)
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_arguments(argv)
+    if args.mode == "decode":
+        if args.packet is None:
+            raise SystemExit("--packet is required in decode mode")
+        clip = decode_existing_packet(args.packet, args.output)
+        print(f"decoded {clip.frame_count} frames into {args.output}")
+        return 0
+    if args.frames < 2:
+        raise SystemExit("--frames must be at least 2")
+    config = CodecConfig(
+        latent_dim=args.latent,
+        hidden_dim=args.hidden,
+        epochs=args.epochs,
+        batch_size=args.batch,
+        learning_rate=args.lr,
+        velocity_weight=args.velocity_weight,
+        quant_bits=args.quant_bits,
+        keyframe_interval=args.keyframe,
+    )
+    clip = build_demo_clip(args.demo, args.frames, args.fps)
+    train_encode_decode(clip, config, args.output, verbose=not args.quiet)
+    return 0
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/00.part
+++ b/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/00.part
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""
+Dr Moagi 3D Graphics Animation Autoencoder / Decoder Reference Engine.
+
+Purpose
+-------
+This single-file Python program demonstrates an end-to-end 3D animation
+processing pipeline:
+
+1. Generate or ingest a mesh animation as vertex frames.
+2. Normalize spatial coordinates into a codec-friendly representation.
+3. Build per-frame position/velocity features.
+4. Train a compact NumPy autoencoder using mini-batch gradient descent.
+5. Encode animation frames into a latent representation.
+6. Delta-code and quantize the latent timeline for compact storage.
+7. Decode, dequantize, and reconstruct the 3D animation.
+8. Measure reconstruction error and compression characteristics.
+9. Render preview frames with a tiny dependency-free software renderer.
+10. Export reconstructed geometry to OBJ and packet data to NPZ/JSON.
+
+The design is educational and operational rather than a replacement for
+production GPU codecs. It makes all transformations explicit and inspectable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import struct
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Iterator, Optional, Sequence
+
+import numpy as np
+
+
+EPS = 1.0e-8
+FORMAT_VERSION = 1
+
+
+@dataclass
+class MeshFrame:
+    """One animation frame containing vertex positions and triangle faces."""
+
+    vertices: np.ndarray
+    faces: np.ndarray
+    timestamp: float = 0.0
+
+    def validate(self) -> None:
+        vertices = np.asarray(self.vertices)
+        faces = np.asarray(self.faces)
+        if vertices.ndim != 2 or vertices.shape[1] != 3:
+            raise ValueError("vertices must have shape [vertex_count, 3]")
+        if faces.ndim != 2 or faces.shape[1] != 3:
+            raise ValueError("faces must have shape [triangle_count, 3]")
+        if vertices.dtype.kind not in "fc":
+            raise TypeError("vertices must be floating point")
+        if faces.dtype.kind not in "iu":
+            raise TypeError("faces must be integer indices")
+        if faces.size and (faces.min() < 0 or faces.max() >= len(vertices)):
+            raise ValueError("face index is outside the vertex array")
+
+    def copy(self) -> "MeshFrame":
+        return MeshFrame(
+            vertices=self.vertices.copy(),
+            faces=self.faces.copy(),
+            timestamp=float(self.timestamp),
+        )
+
+
+@dataclass
+class AnimationClip:
+    """Ordered sequence of mesh frames with constant topology."""
+
+    frames: list[MeshFrame]
+    fps: float = 30.0
+    name: str = "clip"
+
+    def validate(self) -> None:
+        if not self.frames:
+            raise ValueError("animation must contain at least one frame")
+        if self.fps <= 0.0:
+            raise ValueError("fps must be positive")
+        vertex_count = len(self.frames[0].vertices)
+        faces = self.frames[0].faces
+        for frame in self.frames:
+            frame.validate()
+            if len(frame.vertices) != vertex_count:
+                raise ValueError("all frames must have the same vertex count")
+            if frame.faces.shape != faces.shape or not np.array_equal(frame.faces, faces):
+                raise ValueError("all frames must share the same topology")
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.frames)
+
+    @property
+    def vertex_count(self) -> int:
+        return len(self.frames[0].vertices)
+
+    @property
+    def duration(self) -> float:
+        return self.frame_count / self.fps
+
+    def vertex_tensor(self, dtype=np.float32) -> np.ndarray:
+        return np.stack([f.vertices for f in self.frames], axis=0).astype(dtype)
+
+
+@dataclass
+class CodecConfig:
+    """Hyperparameters for the autoencoder and latent stream codec."""
+
+    latent_dim: int = 12
+    hidden_dim: int = 48
+    epochs: int = 400
+    batch_size: int = 16
+    learning_rate: float = 0.01
+    l2_weight: float = 1.0e-5
+    velocity_weight: float = 0.25
+    quant_bits: int = 12
+    keyframe_interval: int = 12
+    seed: int = 1337
+
+    def validate(self) -> None:
+        if self.latent_dim <= 0:
+            raise ValueError("latent_dim must be positive")
+        if self.hidden_dim <= 0:
+            raise ValueError("hidden_dim must be positive")
+        if self.epochs <= 0:
+            raise ValueError("epochs must be positive")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if self.learning_rate <= 0.0:
+            raise ValueError("learning_rate must be positive")
+        if not 2 <= self.quant_bits <= 16:
+            raise ValueError("quant_bits must be in [2, 16]")
+        if self.keyframe_interval <= 0:
+            raise ValueError("keyframe_interval must be positive")
+
+
+@dataclass
+class NormalizationState:
+    """Affine normalization parameters shared by an entire clip."""
+
+    center: np.ndarray
+    scale: float
+
+    def normalize(self, vertices: np.ndarray) -> np.ndarray:
+        return (vertices - self.center) / max(self.scale, EPS)
+
+    def denormalize(self, vertices: np.ndarray) -> np.ndarray:
+        return vertices * self.scale + self.center
+
+
+@dataclass
+class QuantizationState:
+    """Per-latent-channel symmetric quantization scale."""
+
+    scales: np.ndarray
+    bits: int
+
+
+@dataclass
+class EncodedPacket:
+    """Serializable output of the animation codec."""
+
+    version: int
+    fps: float
+    frame_count: int
+    vertex_count: int
+    faces: np.ndarray
+    center: np.ndarray
+    scale: float
+    feature_dim: int
+    latent_dim: int
+    keyframe_interval: int
+    quant_bits: int
+    latent_scales: np.ndarray
+    latent_codes: np.ndarray
+    keyframe_mask: np.ndarray
+    decoder_w1: np.ndarray
+    decoder_b1: np.ndarray
+    decoder_w2: np.ndarray
+    decoder_b2: np.ndarray
+
+
+class RunningStats:
+    """Numerically stable scalar telemetry helper."""
+
+    def __init__(self) -> None:
+        self.count = 0
+        self.mean = 0.0
+        self.m2 = 0.0
+
+    def update(self, value: float) -> None:
+        self.count += 1
+        delta = value - self.mean

--- a/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/01.part
+++ b/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/01.part
@@ -1,0 +1,200 @@
+        self.mean += delta / self.count
+        delta2 = value - self.mean
+        self.m2 += delta * delta2
+
+    @property
+    def variance(self) -> float:
+        if self.count < 2:
+            return 0.0
+        return self.m2 / (self.count - 1)
+
+    @property
+    def std(self) -> float:
+        return math.sqrt(max(self.variance, 0.0))
+
+
+class Timer:
+    """Small context manager used for pipeline timing."""
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.elapsed = 0.0
+
+    def __enter__(self) -> "Timer":
+        self.start = time.perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.elapsed = time.perf_counter() - self.start
+        print(f"{self.label}: {self.elapsed:.4f} s")
+
+
+def rotation_x(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]],
+        dtype=np.float32,
+    )
+
+
+def rotation_y(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[c, 0.0, s], [0.0, 1.0, 0.0], [-s, 0.0, c]],
+        dtype=np.float32,
+    )
+
+
+def rotation_z(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(
+        [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float32,
+    )
+
+
+def compose_rotation(rx: float, ry: float, rz: float) -> np.ndarray:
+    return rotation_z(rz) @ rotation_y(ry) @ rotation_x(rx)
+
+
+def transform_vertices(
+    vertices: np.ndarray,
+    rotation: Optional[np.ndarray] = None,
+    translation: Optional[np.ndarray] = None,
+    scale: float = 1.0,
+) -> np.ndarray:
+    result = np.asarray(vertices, dtype=np.float32) * float(scale)
+    if rotation is not None:
+        result = result @ np.asarray(rotation, dtype=np.float32).T
+    if translation is not None:
+        result = result + np.asarray(translation, dtype=np.float32)
+    return result
+
+
+def make_cube_mesh(size: float = 2.0) -> tuple[np.ndarray, np.ndarray]:
+    h = size * 0.5
+    vertices = np.array(
+        [
+            [-h, -h, -h],
+            [h, -h, -h],
+            [h, h, -h],
+            [-h, h, -h],
+            [-h, -h, h],
+            [h, -h, h],
+            [h, h, h],
+            [-h, h, h],
+        ],
+        dtype=np.float32,
+    )
+    faces = np.array(
+        [
+            [0, 1, 2], [0, 2, 3],
+            [4, 6, 5], [4, 7, 6],
+            [0, 4, 5], [0, 5, 1],
+            [1, 5, 6], [1, 6, 2],
+            [2, 6, 7], [2, 7, 3],
+            [3, 7, 4], [3, 4, 0],
+        ],
+        dtype=np.int32,
+    )
+    return vertices, faces
+
+
+def make_grid_mesh(nx: int = 12, ny: int = 12, size: float = 3.0) -> tuple[np.ndarray, np.ndarray]:
+    if nx < 2 or ny < 2:
+        raise ValueError("grid dimensions must be at least 2")
+    xs = np.linspace(-size * 0.5, size * 0.5, nx, dtype=np.float32)
+    ys = np.linspace(-size * 0.5, size * 0.5, ny, dtype=np.float32)
+    vertices = []
+    for y in ys:
+        for x in xs:
+            vertices.append([x, y, 0.0])
+    faces = []
+    for j in range(ny - 1):
+        for i in range(nx - 1):
+            a = j * nx + i
+            b = a + 1
+            c = a + nx
+            d = c + 1
+            faces.append([a, b, d])
+            faces.append([a, d, c])
+    return np.asarray(vertices, dtype=np.float32), np.asarray(faces, dtype=np.int32)
+
+
+def generate_cube_animation(frame_count: int = 90, fps: float = 30.0) -> AnimationClip:
+    base_vertices, faces = make_cube_mesh()
+    frames = []
+    for index in range(frame_count):
+        phase = index / max(frame_count - 1, 1)
+        t = 2.0 * math.pi * phase
+        rotation = compose_rotation(0.35 * math.sin(t), t, 0.25 * math.cos(2.0 * t))
+        pulse = 1.0 + 0.12 * math.sin(3.0 * t)
+        translation = np.array(
+            [0.25 * math.cos(t), 0.18 * math.sin(2.0 * t), 0.12 * math.sin(t)],
+            dtype=np.float32,
+        )
+        vertices = transform_vertices(base_vertices, rotation, translation, pulse)
+        bend = 0.10 * np.sin(vertices[:, 0] * 2.3 + t)
+        vertices[:, 2] += bend.astype(np.float32)
+        frames.append(MeshFrame(vertices, faces, index / fps))
+    clip = AnimationClip(frames=frames, fps=fps, name="procedural_cube")
+    clip.validate()
+    return clip
+
+
+def generate_wave_animation(frame_count: int = 90, fps: float = 30.0) -> AnimationClip:
+    base_vertices, faces = make_grid_mesh(14, 14, 4.0)
+    frames = []
+    radius = np.sqrt(base_vertices[:, 0] ** 2 + base_vertices[:, 1] ** 2)
+    for index in range(frame_count):
+        phase = index / max(frame_count - 1, 1)
+        t = 2.0 * math.pi * phase
+        vertices = base_vertices.copy()
+        vertices[:, 2] = (
+            0.35 * np.sin(2.2 * radius - 2.0 * t)
+            + 0.12 * np.cos(vertices[:, 0] * 2.0 + t)
+            + 0.08 * np.sin(vertices[:, 1] * 3.0 - 1.5 * t)
+        )
+        rotation = compose_rotation(0.35, 0.0, 0.15 * math.sin(t))
+        vertices = transform_vertices(vertices, rotation=rotation)
+        frames.append(MeshFrame(vertices.astype(np.float32), faces, index / fps))
+    clip = AnimationClip(frames=frames, fps=fps, name="procedural_wave")
+    clip.validate()
+    return clip
+
+
+def compute_normalization(tensor: np.ndarray) -> NormalizationState:
+    flat = tensor.reshape(-1, 3).astype(np.float64)
+    center = flat.mean(axis=0).astype(np.float32)
+    centered = flat - center
+    radius = np.linalg.norm(centered, axis=1)
+    scale = float(np.percentile(radius, 99.0))
+    if scale < EPS:
+        scale = 1.0
+    return NormalizationState(center=center, scale=scale)
+
+
+def temporal_velocity(tensor: np.ndarray) -> np.ndarray:
+    velocity = np.zeros_like(tensor, dtype=np.float32)
+    if len(tensor) > 1:
+        velocity[1:] = tensor[1:] - tensor[:-1]
+        velocity[0] = velocity[1]
+    return velocity
+
+
+def build_features(tensor: np.ndarray, velocity_weight: float) -> np.ndarray:
+    frame_count = tensor.shape[0]
+    positions = tensor.reshape(frame_count, -1)
+    velocity = temporal_velocity(tensor).reshape(frame_count, -1)
+    if velocity_weight <= 0.0:
+        return positions.astype(np.float32)
+    features = np.concatenate([positions, velocity * velocity_weight], axis=1)
+    return features.astype(np.float32)
+
+
+def features_to_positions(features: np.ndarray, vertex_count: int) -> np.ndarray:
+    position_dim = vertex_count * 3
+    positions = features[:, :position_dim]

--- a/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/02.part
+++ b/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/02.part
@@ -1,0 +1,200 @@
+    return positions.reshape(len(features), vertex_count, 3).astype(np.float32)
+
+
+def mse(a: np.ndarray, b: np.ndarray) -> float:
+    diff = np.asarray(a, dtype=np.float64) - np.asarray(b, dtype=np.float64)
+    return float(np.mean(diff * diff))
+
+
+def rmse(a: np.ndarray, b: np.ndarray) -> float:
+    return math.sqrt(max(mse(a, b), 0.0))
+
+
+def max_abs_error(a: np.ndarray, b: np.ndarray) -> float:
+    return float(np.max(np.abs(np.asarray(a) - np.asarray(b))))
+
+
+def psnr(a: np.ndarray, b: np.ndarray, peak: float = 2.0) -> float:
+    error = mse(a, b)
+    if error <= EPS:
+        return float("inf")
+    return 20.0 * math.log10(peak) - 10.0 * math.log10(error)
+
+
+def stable_tanh(x: np.ndarray) -> np.ndarray:
+    return np.tanh(np.clip(x, -15.0, 15.0))
+
+
+def tanh_derivative_from_output(y: np.ndarray) -> np.ndarray:
+    return 1.0 - y * y
+
+
+def xavier(rng: np.random.Generator, fan_in: int, fan_out: int) -> np.ndarray:
+    limit = math.sqrt(6.0 / max(fan_in + fan_out, 1))
+    return rng.uniform(-limit, limit, size=(fan_in, fan_out)).astype(np.float32)
+
+
+class DenseAutoencoder:
+    """Small two-layer encoder and two-layer decoder implemented in NumPy."""
+
+    def __init__(self, input_dim: int, config: CodecConfig) -> None:
+        self.input_dim = int(input_dim)
+        self.config = config
+        self.rng = np.random.default_rng(config.seed)
+        h = config.hidden_dim
+        z = config.latent_dim
+        self.enc_w1 = xavier(self.rng, input_dim, h)
+        self.enc_b1 = np.zeros(h, dtype=np.float32)
+        self.enc_w2 = xavier(self.rng, h, z)
+        self.enc_b2 = np.zeros(z, dtype=np.float32)
+        self.dec_w1 = xavier(self.rng, z, h)
+        self.dec_b1 = np.zeros(h, dtype=np.float32)
+        self.dec_w2 = xavier(self.rng, h, input_dim)
+        self.dec_b2 = np.zeros(input_dim, dtype=np.float32)
+        self.history: list[float] = []
+
+    def encode(self, x: np.ndarray) -> np.ndarray:
+        h1 = stable_tanh(x @ self.enc_w1 + self.enc_b1)
+        z = stable_tanh(h1 @ self.enc_w2 + self.enc_b2)
+        return z.astype(np.float32)
+
+    def decode(self, z: np.ndarray) -> np.ndarray:
+        h2 = stable_tanh(z @ self.dec_w1 + self.dec_b1)
+        y = h2 @ self.dec_w2 + self.dec_b2
+        return y.astype(np.float32)
+
+    def reconstruct(self, x: np.ndarray) -> np.ndarray:
+        return self.decode(self.encode(x))
+
+    def _forward(self, x: np.ndarray) -> tuple[np.ndarray, ...]:
+        h1 = stable_tanh(x @ self.enc_w1 + self.enc_b1)
+        z = stable_tanh(h1 @ self.enc_w2 + self.enc_b2)
+        h2 = stable_tanh(z @ self.dec_w1 + self.dec_b1)
+        y = h2 @ self.dec_w2 + self.dec_b2
+        return h1, z, h2, y
+
+    def _train_batch(self, x: np.ndarray, learning_rate: float) -> float:
+        h1, z, h2, y = self._forward(x)
+        batch = max(len(x), 1)
+        error = y - x
+        loss = float(np.mean(error * error))
+        dy = (2.0 / (batch * self.input_dim)) * error
+        grad_dec_w2 = h2.T @ dy + self.config.l2_weight * self.dec_w2
+        grad_dec_b2 = dy.sum(axis=0)
+        dh2 = (dy @ self.dec_w2.T) * tanh_derivative_from_output(h2)
+        grad_dec_w1 = z.T @ dh2 + self.config.l2_weight * self.dec_w1
+        grad_dec_b1 = dh2.sum(axis=0)
+        dz = (dh2 @ self.dec_w1.T) * tanh_derivative_from_output(z)
+        grad_enc_w2 = h1.T @ dz + self.config.l2_weight * self.enc_w2
+        grad_enc_b2 = dz.sum(axis=0)
+        dh1 = (dz @ self.enc_w2.T) * tanh_derivative_from_output(h1)
+        grad_enc_w1 = x.T @ dh1 + self.config.l2_weight * self.enc_w1
+        grad_enc_b1 = dh1.sum(axis=0)
+        self.dec_w2 -= learning_rate * grad_dec_w2.astype(np.float32)
+        self.dec_b2 -= learning_rate * grad_dec_b2.astype(np.float32)
+        self.dec_w1 -= learning_rate * grad_dec_w1.astype(np.float32)
+        self.dec_b1 -= learning_rate * grad_dec_b1.astype(np.float32)
+        self.enc_w2 -= learning_rate * grad_enc_w2.astype(np.float32)
+        self.enc_b2 -= learning_rate * grad_enc_b2.astype(np.float32)
+        self.enc_w1 -= learning_rate * grad_enc_w1.astype(np.float32)
+        self.enc_b1 -= learning_rate * grad_enc_b1.astype(np.float32)
+        return loss
+
+    def fit(self, x: np.ndarray, verbose: bool = True) -> list[float]:
+        if x.ndim != 2 or x.shape[1] != self.input_dim:
+            raise ValueError("training matrix has the wrong shape")
+        n = len(x)
+        batch_size = min(self.config.batch_size, n)
+        for epoch in range(self.config.epochs):
+            order = self.rng.permutation(n)
+            epoch_stats = RunningStats()
+            progress = epoch / max(self.config.epochs - 1, 1)
+            lr = self.config.learning_rate * (0.25 + 0.75 * (1.0 - progress))
+            for start in range(0, n, batch_size):
+                indices = order[start:start + batch_size]
+                loss = self._train_batch(x[indices], lr)
+                epoch_stats.update(loss)
+            self.history.append(epoch_stats.mean)
+            report_every = max(self.config.epochs // 10, 1)
+            if verbose and (epoch == 0 or (epoch + 1) % report_every == 0):
+                print(
+                    f"epoch {epoch + 1:4d}/{self.config.epochs} "
+                    f"loss={epoch_stats.mean:.8f} lr={lr:.6f}"
+                )
+        return self.history
+
+
+class FeatureStandardizer:
+    """Per-feature standardization for stable autoencoder optimization."""
+
+    def __init__(self) -> None:
+        self.mean: Optional[np.ndarray] = None
+        self.std: Optional[np.ndarray] = None
+
+    def fit(self, x: np.ndarray) -> "FeatureStandardizer":
+        self.mean = x.mean(axis=0).astype(np.float32)
+        std = x.std(axis=0).astype(np.float32)
+        self.std = np.where(std < 1.0e-5, 1.0, std).astype(np.float32)
+        return self
+
+    def transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.std is None:
+            raise RuntimeError("standardizer has not been fitted")
+        return ((x - self.mean) / self.std).astype(np.float32)
+
+    def inverse_transform(self, x: np.ndarray) -> np.ndarray:
+        if self.mean is None or self.std is None:
+            raise RuntimeError("standardizer has not been fitted")
+        return (x * self.std + self.mean).astype(np.float32)
+
+
+class LatentDeltaCodec:
+    """Keyframe-aware temporal delta coding with symmetric integer quantization."""
+
+    def __init__(self, bits: int = 12, keyframe_interval: int = 12) -> None:
+        self.bits = int(bits)
+        self.keyframe_interval = int(keyframe_interval)
+        self.qmax = (1 << (bits - 1)) - 1
+
+    def _make_delta_stream(self, latent: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        delta = np.zeros_like(latent, dtype=np.float32)
+        mask = np.zeros(len(latent), dtype=np.uint8)
+        for index in range(len(latent)):
+            is_key = index == 0 or index % self.keyframe_interval == 0
+            if is_key:
+                delta[index] = latent[index]
+                mask[index] = 1
+            else:
+                delta[index] = latent[index] - latent[index - 1]
+        return delta, mask
+
+    def _restore_delta_stream(self, delta: np.ndarray, mask: np.ndarray) -> np.ndarray:
+        latent = np.zeros_like(delta, dtype=np.float32)
+        for index in range(len(delta)):
+            if index == 0 or mask[index]:
+                latent[index] = delta[index]
+            else:
+                latent[index] = latent[index - 1] + delta[index]
+        return latent
+
+    def quantize(self, latent: np.ndarray) -> tuple[np.ndarray, QuantizationState, np.ndarray]:
+        delta, mask = self._make_delta_stream(latent)
+        peak = np.max(np.abs(delta), axis=0)
+        scales = np.where(peak < EPS, 1.0, peak / self.qmax).astype(np.float32)
+        quantized = np.rint(delta / scales).clip(-self.qmax, self.qmax)
+        dtype = np.int8 if self.bits <= 8 else np.int16
+        return quantized.astype(dtype), QuantizationState(scales, self.bits), mask
+
+    def dequantize(
+        self,
+        codes: np.ndarray,
+        state: QuantizationState,
+        mask: np.ndarray,
+    ) -> np.ndarray:
+        delta = codes.astype(np.float32) * state.scales.astype(np.float32)
+        return self._restore_delta_stream(delta, mask)
+
+
+class AnimationAutoCodec:
+    """Orchestrates normalization, neural autoencoding, temporal coding and decode."""
+

--- a/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/03.part
+++ b/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/03.part
@@ -1,0 +1,200 @@
+    def __init__(self, config: CodecConfig) -> None:
+        config.validate()
+        self.config = config
+        self.normalization: Optional[NormalizationState] = None
+        self.standardizer = FeatureStandardizer()
+        self.autoencoder: Optional[DenseAutoencoder] = None
+
+    def fit(self, clip: AnimationClip, verbose: bool = True) -> dict[str, float]:
+        clip.validate()
+        tensor = clip.vertex_tensor()
+        self.normalization = compute_normalization(tensor)
+        normalized = self.normalization.normalize(tensor).astype(np.float32)
+        features = build_features(normalized, self.config.velocity_weight)
+        standardized = self.standardizer.fit(features).transform(features)
+        self.autoencoder = DenseAutoencoder(standardized.shape[1], self.config)
+        with Timer("autoencoder training"):
+            self.autoencoder.fit(standardized, verbose=verbose)
+        reconstructed_std = self.autoencoder.reconstruct(standardized)
+        reconstructed_features = self.standardizer.inverse_transform(reconstructed_std)
+        reconstructed_norm = features_to_positions(reconstructed_features, clip.vertex_count)
+        reconstructed = self.normalization.denormalize(reconstructed_norm)
+        metrics = evaluate_reconstruction(tensor, reconstructed)
+        metrics["training_final_loss"] = float(self.autoencoder.history[-1])
+        return metrics
+
+    def encode(self, clip: AnimationClip) -> EncodedPacket:
+        if self.normalization is None or self.autoencoder is None:
+            raise RuntimeError("codec must be fitted before encoding")
+        if self.standardizer.mean is None or self.standardizer.std is None:
+            raise RuntimeError("standardizer state is missing")
+        tensor = clip.vertex_tensor()
+        normalized = self.normalization.normalize(tensor).astype(np.float32)
+        features = build_features(normalized, self.config.velocity_weight)
+        standardized = self.standardizer.transform(features)
+        latent = self.autoencoder.encode(standardized)
+        latent_codec = LatentDeltaCodec(self.config.quant_bits, self.config.keyframe_interval)
+        codes, qstate, mask = latent_codec.quantize(latent)
+        decoder_b2 = self.autoencoder.dec_b2.copy()
+        decoder_b2 = np.stack(
+            [decoder_b2, self.standardizer.mean, self.standardizer.std],
+            axis=0,
+        )
+        return EncodedPacket(
+            version=FORMAT_VERSION,
+            fps=clip.fps,
+            frame_count=clip.frame_count,
+            vertex_count=clip.vertex_count,
+            faces=clip.frames[0].faces.copy(),
+            center=self.normalization.center.copy(),
+            scale=float(self.normalization.scale),
+            feature_dim=features.shape[1],
+            latent_dim=self.config.latent_dim,
+            keyframe_interval=self.config.keyframe_interval,
+            quant_bits=self.config.quant_bits,
+            latent_scales=qstate.scales,
+            latent_codes=codes,
+            keyframe_mask=mask,
+            decoder_w1=self.autoencoder.dec_w1.copy(),
+            decoder_b1=self.autoencoder.dec_b1.copy(),
+            decoder_w2=self.autoencoder.dec_w2.copy(),
+            decoder_b2=decoder_b2,
+        )
+
+    @staticmethod
+    def decode(packet: EncodedPacket) -> AnimationClip:
+        if packet.version != FORMAT_VERSION:
+            raise ValueError(f"unsupported packet version: {packet.version}")
+        qstate = QuantizationState(packet.latent_scales, packet.quant_bits)
+        latent_codec = LatentDeltaCodec(packet.quant_bits, packet.keyframe_interval)
+        latent = latent_codec.dequantize(packet.latent_codes, qstate, packet.keyframe_mask)
+        h2 = stable_tanh(latent @ packet.decoder_w1 + packet.decoder_b1)
+        decoded_standard = h2 @ packet.decoder_w2 + packet.decoder_b2[0]
+        feature_mean = packet.decoder_b2[1]
+        feature_std = packet.decoder_b2[2]
+        decoded_features = decoded_standard * feature_std + feature_mean
+        normalized = features_to_positions(decoded_features, packet.vertex_count)
+        vertices = normalized * packet.scale + packet.center
+        frames = []
+        for index in range(packet.frame_count):
+            frames.append(
+                MeshFrame(
+                    vertices=vertices[index].astype(np.float32),
+                    faces=packet.faces.copy(),
+                    timestamp=index / packet.fps,
+                )
+            )
+        clip = AnimationClip(frames=frames, fps=packet.fps, name="decoded")
+        clip.validate()
+        return clip
+
+
+def packet_raw_bytes(packet: EncodedPacket) -> int:
+    arrays = [
+        packet.faces,
+        packet.center,
+        packet.latent_scales,
+        packet.latent_codes,
+        packet.keyframe_mask,
+        packet.decoder_w1,
+        packet.decoder_b1,
+        packet.decoder_w2,
+        packet.decoder_b2,
+    ]
+    return int(sum(array.nbytes for array in arrays))
+
+
+def original_raw_bytes(clip: AnimationClip) -> int:
+    return int(clip.vertex_tensor().nbytes + clip.frames[0].faces.nbytes)
+
+
+def evaluate_reconstruction(reference: np.ndarray, reconstructed: np.ndarray) -> dict[str, float]:
+    return {
+        "mse": mse(reference, reconstructed),
+        "rmse": rmse(reference, reconstructed),
+        "max_abs_error": max_abs_error(reference, reconstructed),
+        "psnr_db": psnr(reference, reconstructed, peak=2.0),
+    }
+
+
+def save_packet(packet: EncodedPacket, path: Path) -> None:
+    path = Path(path)
+    metadata = {
+        "version": packet.version,
+        "fps": packet.fps,
+        "frame_count": packet.frame_count,
+        "vertex_count": packet.vertex_count,
+        "scale": packet.scale,
+        "feature_dim": packet.feature_dim,
+        "latent_dim": packet.latent_dim,
+        "keyframe_interval": packet.keyframe_interval,
+        "quant_bits": packet.quant_bits,
+    }
+    np.savez_compressed(
+        path,
+        metadata=json.dumps(metadata),
+        faces=packet.faces,
+        center=packet.center,
+        latent_scales=packet.latent_scales,
+        latent_codes=packet.latent_codes,
+        keyframe_mask=packet.keyframe_mask,
+        decoder_w1=packet.decoder_w1,
+        decoder_b1=packet.decoder_b1,
+        decoder_w2=packet.decoder_w2,
+        decoder_b2=packet.decoder_b2,
+    )
+
+
+def load_packet(path: Path) -> EncodedPacket:
+    with np.load(Path(path), allow_pickle=False) as data:
+        metadata = json.loads(str(data["metadata"]))
+        return EncodedPacket(
+            version=int(metadata["version"]),
+            fps=float(metadata["fps"]),
+            frame_count=int(metadata["frame_count"]),
+            vertex_count=int(metadata["vertex_count"]),
+            faces=data["faces"].copy(),
+            center=data["center"].copy(),
+            scale=float(metadata["scale"]),
+            feature_dim=int(metadata["feature_dim"]),
+            latent_dim=int(metadata["latent_dim"]),
+            keyframe_interval=int(metadata["keyframe_interval"]),
+            quant_bits=int(metadata["quant_bits"]),
+            latent_scales=data["latent_scales"].copy(),
+            latent_codes=data["latent_codes"].copy(),
+            keyframe_mask=data["keyframe_mask"].copy(),
+            decoder_w1=data["decoder_w1"].copy(),
+            decoder_b1=data["decoder_b1"].copy(),
+            decoder_w2=data["decoder_w2"].copy(),
+            decoder_b2=data["decoder_b2"].copy(),
+        )
+
+
+def unique_edges(faces: np.ndarray) -> np.ndarray:
+    edges: set[tuple[int, int]] = set()
+    for a, b, c in faces.tolist():
+        for u, v in ((a, b), (b, c), (c, a)):
+            if u > v:
+                u, v = v, u
+            edges.add((u, v))
+    return np.asarray(sorted(edges), dtype=np.int32)
+
+
+def camera_project(
+    vertices: np.ndarray,
+    width: int,
+    height: int,
+    camera_z: float = 6.0,
+    focal_length: float = 2.2,
+) -> tuple[np.ndarray, np.ndarray]:
+    points = np.asarray(vertices, dtype=np.float32).copy()
+    depth = camera_z - points[:, 2]
+    safe_depth = np.where(depth < 0.1, 0.1, depth)
+    x = focal_length * points[:, 0] / safe_depth
+    y = focal_length * points[:, 1] / safe_depth
+    px = (width * 0.5 + x * width * 0.42).astype(np.int32)
+    py = (height * 0.5 - y * height * 0.42).astype(np.int32)
+    return np.stack([px, py], axis=1), safe_depth
+def draw_line(
+    image: np.ndarray,
+    x0: int,

--- a/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/04.part
+++ b/src/jarvisx/_reference/dr_moagi_3d_animation_autoencoder/04.part
@@ -1,0 +1,200 @@
+    y0: int,
+    x1: int,
+    y1: int,
+    value: int = 230,
+) -> None:
+    dx = abs(x1 - x0)
+    sx = 1 if x0 < x1 else -1
+    dy = -abs(y1 - y0)
+    sy = 1 if y0 < y1 else -1
+    err = dx + dy
+    height, width = image.shape
+    while True:
+        if 0 <= x0 < width and 0 <= y0 < height:
+            image[y0, x0] = max(int(image[y0, x0]), int(value))
+        if x0 == x1 and y0 == y1:
+            break
+        e2 = 2 * err
+        if e2 >= dy:
+            err += dy
+            x0 += sx
+        if e2 <= dx:
+            err += dx
+            y0 += sy
+def draw_disc(image: np.ndarray, cx: int, cy: int, radius: int, value: int = 255) -> None:
+    height, width = image.shape
+    radius2 = radius * radius
+    for y in range(max(0, cy - radius), min(height, cy + radius + 1)):
+        for x in range(max(0, cx - radius), min(width, cx + radius + 1)):
+            if (x - cx) ** 2 + (y - cy) ** 2 <= radius2:
+                image[y, x] = max(int(image[y, x]), int(value))
+def render_wireframe(
+    frame: MeshFrame,
+    width: int = 512,
+    height: int = 512,
+    camera_rotation: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    vertices = frame.vertices
+    if camera_rotation is not None:
+        vertices = vertices @ camera_rotation.T
+    points, depth = camera_project(vertices, width, height)
+    image = np.zeros((height, width), dtype=np.uint8)
+    edges = unique_edges(frame.faces)
+    edge_depth = (depth[edges[:, 0]] + depth[edges[:, 1]]) * 0.5
+    order = np.argsort(edge_depth)[::-1]
+    for edge_index in order:
+        a, b = edges[edge_index]
+        x0, y0 = points[a]
+        x1, y1 = points[b]
+        shade = int(np.clip(260.0 - edge_depth[edge_index] * 12.0, 70.0, 245.0))
+        draw_line(image, int(x0), int(y0), int(x1), int(y1), shade)
+    for index, (x, y) in enumerate(points):
+        shade = int(np.clip(290.0 - depth[index] * 10.0, 100.0, 255.0))
+        draw_disc(image, int(x), int(y), 2, shade)
+    return image
+def save_pgm(image: np.ndarray, path: Path) -> None:
+    image = np.asarray(image, dtype=np.uint8)
+    height, width = image.shape
+    with open(path, "wb") as handle:
+        handle.write(f"P5\n{width} {height}\n255\n".encode("ascii"))
+        handle.write(image.tobytes())
+def export_obj(frame: MeshFrame, path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write("# Reconstructed 3D frame\n")
+        for x, y, z in frame.vertices:
+            handle.write(f"v {x:.7f} {y:.7f} {z:.7f}\n")
+        for a, b, c in frame.faces:
+            handle.write(f"f {a + 1} {b + 1} {c + 1}\n")
+def export_animation_objs(clip: AnimationClip, directory: Path, every: int = 1) -> None:
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    for index in range(0, clip.frame_count, max(every, 1)):
+        export_obj(clip.frames[index], directory / f"frame_{index:05d}.obj")
+def render_animation_previews(
+    clip: AnimationClip,
+    directory: Path,
+    every: int = 6,
+    width: int = 512,
+    height: int = 512,
+) -> None:
+    directory = Path(directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    camera = compose_rotation(math.radians(-18.0), math.radians(25.0), 0.0)
+    for index in range(0, clip.frame_count, max(every, 1)):
+        image = render_wireframe(clip.frames[index], width, height, camera)
+        save_pgm(image, directory / f"preview_{index:05d}.pgm")
+def human_bytes(value: int) -> str:
+    units = ["B", "KiB", "MiB", "GiB"]
+    amount = float(value)
+    for unit in units:
+        if amount < 1024.0 or unit == units[-1]:
+            return f"{amount:.2f} {unit}"
+        amount /= 1024.0
+    return f"{amount:.2f} GiB"
+def summarize_packet(packet: EncodedPacket) -> dict[str, object]:
+    return {
+        "version": packet.version,
+        "fps": packet.fps,
+        "frame_count": packet.frame_count,
+        "vertex_count": packet.vertex_count,
+        "latent_dim": packet.latent_dim,
+        "quant_bits": packet.quant_bits,
+        "keyframe_interval": packet.keyframe_interval,
+        "packet_raw_bytes": packet_raw_bytes(packet),
+    }
+def write_json(data: dict[str, object], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(data, handle, indent=2, sort_keys=True)
+def build_demo_clip(kind: str, frames: int, fps: float) -> AnimationClip:
+    if kind == "cube":
+        return generate_cube_animation(frames, fps)
+    if kind == "wave":
+        return generate_wave_animation(frames, fps)
+    raise ValueError(f"unknown demo kind: {kind}")
+def train_encode_decode(
+    clip: AnimationClip,
+    config: CodecConfig,
+    output_dir: Path,
+    verbose: bool = True,
+) -> tuple[EncodedPacket, AnimationClip, dict[str, float]]:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    codec = AnimationAutoCodec(config)
+    print(f"clip={clip.name} frames={clip.frame_count} vertices={clip.vertex_count}")
+    train_metrics = codec.fit(clip, verbose=verbose)
+    packet = codec.encode(clip)
+    decoded = codec.decode(packet)
+    reference = clip.vertex_tensor()
+    reconstruction = decoded.vertex_tensor()
+    metrics = evaluate_reconstruction(reference, reconstruction)
+    metrics.update({f"fit_{k}": v for k, v in train_metrics.items()})
+    original_bytes = original_raw_bytes(clip)
+    encoded_bytes = packet_raw_bytes(packet)
+    metrics["original_raw_bytes"] = float(original_bytes)
+    metrics["packet_raw_bytes"] = float(encoded_bytes)
+    metrics["raw_compression_ratio"] = float(original_bytes / max(encoded_bytes, 1))
+    save_packet(packet, output_dir / "animation_packet.npz")
+    write_json(summarize_packet(packet), output_dir / "packet_summary.json")
+    write_json(metrics, output_dir / "reconstruction_metrics.json")
+    export_obj(decoded.frames[0], output_dir / "reconstructed_frame_00000.obj")
+    render_animation_previews(decoded, output_dir / "previews", every=max(clip.frame_count // 12, 1))
+    print(f"original raw: {human_bytes(original_bytes)}")
+    print(f"packet raw:   {human_bytes(encoded_bytes)}")
+    print(f"ratio:        {metrics['raw_compression_ratio']:.3f}x")
+    print(f"RMSE:         {metrics['rmse']:.8f}")
+    print(f"PSNR:         {metrics['psnr_db']:.3f} dB")
+    return packet, decoded, metrics
+def decode_existing_packet(packet_path: Path, output_dir: Path) -> AnimationClip:
+    packet = load_packet(packet_path)
+    clip = AnimationAutoCodec.decode(packet)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    export_animation_objs(clip, output_dir / "obj_frames", every=1)
+    render_animation_previews(clip, output_dir / "previews", every=max(clip.frame_count // 12, 1))
+    write_json(summarize_packet(packet), output_dir / "packet_summary.json")
+    return clip
+def parse_arguments(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Train and run a NumPy 3D animation autoencoder/decoder codec."
+    )
+    parser.add_argument("--mode", choices=["demo", "decode"], default="demo")
+    parser.add_argument("--demo", choices=["cube", "wave"], default="cube")
+    parser.add_argument("--frames", type=int, default=90)
+    parser.add_argument("--fps", type=float, default=30.0)
+    parser.add_argument("--latent", type=int, default=12)
+    parser.add_argument("--hidden", type=int, default=48)
+    parser.add_argument("--epochs", type=int, default=400)
+    parser.add_argument("--batch", type=int, default=16)
+    parser.add_argument("--lr", type=float, default=0.01)
+    parser.add_argument("--quant-bits", type=int, default=12)
+    parser.add_argument("--keyframe", type=int, default=12)
+    parser.add_argument("--velocity-weight", type=float, default=0.25)
+    parser.add_argument("--output", type=Path, default=Path("dr_moagi_codec_output"))
+    parser.add_argument("--packet", type=Path, default=None)
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_arguments(argv)
+    if args.mode == "decode":
+        if args.packet is None:
+            raise SystemExit("--packet is required in decode mode")
+        clip = decode_existing_packet(args.packet, args.output)
+        print(f"decoded {clip.frame_count} frames into {args.output}")
+        return 0
+    if args.frames < 2:
+        raise SystemExit("--frames must be at least 2")
+    config = CodecConfig(
+        latent_dim=args.latent,
+        hidden_dim=args.hidden,
+        epochs=args.epochs,
+        batch_size=args.batch,
+        learning_rate=args.lr,
+        velocity_weight=args.velocity_weight,
+        quant_bits=args.quant_bits,
+        keyframe_interval=args.keyframe,
+    )
+    clip = build_demo_clip(args.demo, args.frames, args.fps)
+    train_encode_decode(clip, config, args.output, verbose=not args.quiet)
+    return 0
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_3d_animation_codec.py
+++ b/src/jarvisx/dr_moagi_3d_animation_codec.py
@@ -1,0 +1,133 @@
+"""Jarvis-X bridge for the 1,000-line Dr Moagi 3D animation codec reference.
+
+The canonical reference source is intentionally stored as five ordered fragments so
+its exact 1,000-line form is easy to audit in Git. This module verifies, assembles,
+and executes that source without changing its contents.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+import types
+from pathlib import Path
+from typing import Sequence
+
+EXPECTED_LINES = 1000
+EXPECTED_SHA256 = "c3d05a11e3fbb91591f538c75bddc15a72dd398e62ae4624a7b1a0828efa620e"
+_FRAGMENT_DIR = Path("reference/dr-moagi-3d-animation-autoencoder/fragments")
+_RUNTIME_MODULE = "jarvisx._dr_moagi_3d_animation_autoencoder_reference"
+
+
+def repository_root() -> Path:
+    """Return the Jarvis-X source-tree root for a checkout installation."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def fragment_directory(root: Path | None = None) -> Path:
+    """Resolve the canonical reference fragment directory."""
+
+    base = repository_root() if root is None else Path(root)
+    return base / _FRAGMENT_DIR
+
+
+def reference_fragments(root: Path | None = None) -> list[Path]:
+    """Return the five canonical fragments in deterministic order."""
+
+    directory = fragment_directory(root)
+    fragments = sorted(directory.glob("*.part"))
+    if len(fragments) != 5:
+        raise FileNotFoundError(
+            f"expected 5 codec fragments in {directory}, found {len(fragments)}"
+        )
+    return fragments
+
+
+def reference_source(root: Path | None = None) -> str:
+    """Reconstruct the exact canonical 1,000-line Python source."""
+
+    return "".join(path.read_text(encoding="utf-8") for path in reference_fragments(root))
+
+
+def source_line_count(source: str) -> int:
+    """Count physical source lines exactly as stored."""
+
+    return len(source.splitlines())
+
+
+def source_sha256(source: str) -> str:
+    """Return the SHA-256 digest of UTF-8 source bytes."""
+
+    return hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+
+def verify_reference(root: Path | None = None) -> dict[str, object]:
+    """Verify fragment count, physical line count, syntax and source digest."""
+
+    source = reference_source(root)
+    lines = source_line_count(source)
+    digest = source_sha256(source)
+    if lines != EXPECTED_LINES:
+        raise RuntimeError(f"codec line-count mismatch: expected {EXPECTED_LINES}, got {lines}")
+    if digest != EXPECTED_SHA256:
+        raise RuntimeError(f"codec SHA-256 mismatch: expected {EXPECTED_SHA256}, got {digest}")
+    compile(source, "dr_moagi_3d_animation_autoencoder_1000_lines.py", "exec")
+    return {
+        "fragments": len(reference_fragments(root)),
+        "lines": lines,
+        "sha256": digest,
+        "syntax": "ok",
+    }
+
+
+def materialize(path: Path, root: Path | None = None) -> Path:
+    """Write the verified canonical source to a normal .py file."""
+
+    verify_reference(root)
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(reference_source(root), encoding="utf-8", newline="")
+    return target
+
+
+def load_reference_engine(root: Path | None = None) -> types.ModuleType:
+    """Load the verified reference engine as a Python module."""
+
+    verify_reference(root)
+    if _RUNTIME_MODULE in sys.modules:
+        return sys.modules[_RUNTIME_MODULE]
+    module = types.ModuleType(_RUNTIME_MODULE)
+    module.__file__ = str(fragment_directory(root) / "<assembled>")
+    module.__package__ = "jarvisx"
+    sys.modules[_RUNTIME_MODULE] = module
+    source = reference_source(root)
+    try:
+        exec(compile(source, module.__file__, "exec"), module.__dict__)
+    except Exception:
+        sys.modules.pop(_RUNTIME_MODULE, None)
+        raise
+    return module
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify/materialize the reference or delegate to its native CLI."""
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if args and args[0] == "--verify-reference":
+        status = verify_reference()
+        print(
+            f"verified fragments={status['fragments']} lines={status['lines']} "
+            f"sha256={status['sha256']} syntax={status['syntax']}"
+        )
+        return 0
+    if len(args) == 2 and args[0] == "--materialize":
+        target = materialize(Path(args[1]))
+        print(f"materialized verified codec to {target}")
+        return 0
+    engine = load_reference_engine()
+    return int(engine.main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_3d_animation_codec.py
+++ b/src/jarvisx/dr_moagi_3d_animation_codec.py
@@ -1,8 +1,8 @@
 """Jarvis-X bridge for the 1,000-line Dr Moagi 3D animation codec reference.
 
-The canonical reference source is intentionally stored as five ordered fragments so
-its exact 1,000-line form is easy to audit in Git. This module verifies, assembles,
-and executes that source without changing its contents.
+The canonical reference source is stored as five ordered fragments so its exact
+1,000-line form remains auditable. The same byte-identical blobs are packaged with
+Jarvis-X so installed wheels can verify, assemble, and execute the runtime.
 """
 
 from __future__ import annotations
@@ -15,21 +15,26 @@ from typing import Sequence
 
 EXPECTED_LINES = 1000
 EXPECTED_SHA256 = "c3d05a11e3fbb91591f538c75bddc15a72dd398e62ae4624a7b1a0828efa620e"
-_FRAGMENT_DIR = Path("reference/dr-moagi-3d-animation-autoencoder/fragments")
+_REPOSITORY_FRAGMENT_DIR = Path("reference/dr-moagi-3d-animation-autoencoder/fragments")
+_PACKAGED_FRAGMENT_DIR = Path("_reference/dr_moagi_3d_animation_autoencoder")
 _RUNTIME_MODULE = "jarvisx._dr_moagi_3d_animation_autoencoder_reference"
 
 
 def repository_root() -> Path:
-    """Return the Jarvis-X source-tree root for a checkout installation."""
+    """Return the Jarvis-X source-tree root when running from a checkout."""
 
     return Path(__file__).resolve().parents[2]
 
 
 def fragment_directory(root: Path | None = None) -> Path:
-    """Resolve the canonical reference fragment directory."""
+    """Resolve packaged fragments, or an explicitly requested repository copy."""
 
-    base = repository_root() if root is None else Path(root)
-    return base / _FRAGMENT_DIR
+    if root is not None:
+        return Path(root) / _REPOSITORY_FRAGMENT_DIR
+    packaged = Path(__file__).resolve().parent / _PACKAGED_FRAGMENT_DIR
+    if packaged.is_dir():
+        return packaged
+    return repository_root() / _REPOSITORY_FRAGMENT_DIR
 
 
 def reference_fragments(root: Path | None = None) -> list[Path]:

--- a/tests/test_dr_moagi_3d_animation_codec.py
+++ b/tests/test_dr_moagi_3d_animation_codec.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+
+from jarvisx import dr_moagi_3d_animation_codec as bridge
+
+
+def test_reference_source_is_exactly_1000_lines() -> None:
+    status = bridge.verify_reference()
+    assert status["fragments"] == 5
+    assert status["lines"] == 1000
+    assert status["syntax"] == "ok"
+    assert status["sha256"] == bridge.EXPECTED_SHA256
+
+
+def test_materialized_source_matches_reference(tmp_path) -> None:
+    target = bridge.materialize(tmp_path / "dr_moagi_3d_animation_autoencoder.py")
+    payload = target.read_bytes()
+    assert len(target.read_text(encoding="utf-8").splitlines()) == 1000
+    assert hashlib.sha256(payload).hexdigest() == bridge.EXPECTED_SHA256
+
+
+def test_end_to_end_cube_encode_decode(tmp_path) -> None:
+    engine = bridge.load_reference_engine()
+    clip = engine.generate_cube_animation(frame_count=6, fps=30.0)
+    config = engine.CodecConfig(
+        latent_dim=4,
+        hidden_dim=12,
+        epochs=6,
+        batch_size=3,
+        learning_rate=0.01,
+        quant_bits=8,
+        keyframe_interval=2,
+        seed=1337,
+    )
+    codec = engine.AnimationAutoCodec(config)
+    fit_metrics = codec.fit(clip, verbose=False)
+    packet = codec.encode(clip)
+    decoded = codec.decode(packet)
+
+    assert decoded.frame_count == clip.frame_count
+    assert decoded.vertex_count == clip.vertex_count
+    assert decoded.vertex_tensor().shape == clip.vertex_tensor().shape
+    assert np.isfinite(fit_metrics["rmse"])
+    assert packet.latent_codes.shape == (clip.frame_count, config.latent_dim)
+
+    packet_path = tmp_path / "packet.npz"
+    engine.save_packet(packet, packet_path)
+    restored = engine.load_packet(packet_path)
+    decoded_again = codec.decode(restored)
+    assert decoded_again.vertex_tensor().shape == clip.vertex_tensor().shape


### PR DESCRIPTION
## Summary

Integrates the generated Dr Moagi 3D Graphics Animation Autoencoder / Decoder into Jarvis-X as an auditable executable reference runtime.

### Runtime
- Preserves the canonical Python source as five ordered 200-line fragments (exactly 1,000 physical lines total).
- Adds `jarvisx.dr_moagi_3d_animation_codec` as the integrity bridge and runtime loader.
- Verifies source line count, Python syntax, and SHA-256 before execution.
- Adds CLI entry point: `jarvisx-dr-moagi-3d-animation`.
- Adds optional `graphics` dependency set with NumPy.

### Codec path
`mesh frames -> spatial normalization -> position/velocity features -> dense autoencoder -> latent timeline -> keyframe delta coding -> integer quantization -> packet -> dequantization -> decoder -> reconstructed mesh animation`

Outputs include NPZ packet state, JSON metrics, OBJ geometry and PGM previews.

### Integrity
- Canonical lines: `1000`
- Canonical SHA-256: `c3d05a11e3fbb91591f538c75bddc15a72dd398e62ae4624a7b1a0828efa620e`
- All five remote fragment Git blobs were checked against the locally generated reference source before opening this PR.

### Verification
- Adds focused integrity/materialization/end-to-end encode-decode tests.
- Adds path-scoped GitHub Actions workflow for source verification, tests and CLI smoke encoding.
- Adds `docs/DR_MOAGI_3D_ANIMATION_CODEC.md` with operational pipeline and commands.

This PR intentionally leaves `main` untouched until CI verifies the integration.