### PR TITLE
Add DM-vOmegaXi+ monadic latent-flow resonator

### DIFF
--- a/.github/workflows/dr-moagi-monadic-resonator.yml
+++ b/.github/workflows/dr-moagi-monadic-resonator.yml
@@ -1,0 +1,85 @@
+name: Dr Moagi Monadic Resonator
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_monadic_resonator.py"
+      - "tests/test_dr_moagi_monadic_resonator.py"
+      - "docs/DR_MOAGI_MONADIC_RESONATOR.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-monadic-resonator.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_monadic_resonator.py"
+      - "tests/test_dr_moagi_monadic_resonator.py"
+      - "docs/DR_MOAGI_MONADIC_RESONATOR.md"
+      - "pyproject.toml"
+      - ".github/workflows/dr-moagi-monadic-resonator.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: monadic-resonator-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify latent-flow recurrence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Compile runtime and tests
+        run: >-
+          python -m py_compile
+          src/jarvisx/dr_moagi_monadic_resonator.py
+          tests/test_dr_moagi_monadic_resonator.py
+
+      - name: Check formatting
+        run: >-
+          black --check --diff
+          src/jarvisx/dr_moagi_monadic_resonator.py
+          tests/test_dr_moagi_monadic_resonator.py
+
+      - name: Check import order
+        run: >-
+          isort --check-only --diff
+          src/jarvisx/dr_moagi_monadic_resonator.py
+          tests/test_dr_moagi_monadic_resonator.py
+
+      - name: Type-check resonator runtime
+        run: mypy src/jarvisx/dr_moagi_monadic_resonator.py --ignore-missing-imports
+
+      - name: Run focused invariant tests
+        run: pytest -q -o addopts='' tests/test_dr_moagi_monadic_resonator.py
+
+      - name: Exercise installed CLI
+        run: |
+          jarvisx-dr-moagi-resonator \
+            --state 1,0.5,-0.25 \
+            --steps 2 \
+            --method rk4 \
+            --substeps 32 \
+            --rate 0.25 > /tmp/resonator.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          payload = json.loads(Path('/tmp/resonator.json').read_text())
+          assert payload['law_id'] == 'DM-vOmegaXi+-MONADIC-FLOW'
+          assert len(payload['steps']) == 2
+          assert payload['steps'][0]['derivative_evaluations'] == 128
+          PY

--- a/docs/DR_MOAGI_MONADIC_RESONATOR.md
+++ b/docs/DR_MOAGI_MONADIC_RESONATOR.md
@@ -1,0 +1,94 @@
+# Dr Moagi DM-vOmegaXi+ Monadic Resonator
+
+The monadic resonator is the executable reference form of the recurrence
+
+```text
+X[t+1] = D_psi(E_phi(X[t]) + integral_t^{t+1} f_theta(Z(tau), tau) d tau)
+```
+
+with the latent state made explicit:
+
+```text
+Z_t   = E_phi(X_t)
+Z_t+1 = Z_t + integral_t^{t+1} f_theta(Z(tau), tau) d tau
+X_t+1 = D_psi(Z_t+1)
+```
+
+The runtime deliberately keeps the encoder `E_phi`, continuous latent dynamics
+`f_theta`, and decoder `D_psi` as separate callables. This prevents a numerical
+implementation from conflating representation, evolution, and reconstruction.
+
+## Operational pipeline
+
+1. Validate a finite observable state `X_t`.
+2. Encode it to `Z_t = E_phi(X_t)`.
+3. Integrate `dZ/dt = f_theta(Z,t)` over a finite interval.
+4. Form the next latent state by adding the accumulated integral to `Z_t`.
+5. Decode `X_t+1 = D_psi(Z_t+1)`.
+6. Emit an audit report containing the latent start, latent integral, latent end,
+   output state, solver, substep count, derivative-evaluation count, and latent
+   displacement norm.
+7. For a rollout, recursively feed each decoded state into the next transition.
+
+## Numerical boundary
+
+The recurrence is exact as a mathematical definition. A generic nonlinear latent
+ODE normally does not have an analytic closed-form integral, so this reference
+runtime approximates the integral with one of two bounded fixed-step methods:
+
+- `euler`: one derivative evaluation per substep.
+- `rk4`: classical fourth-order Runge-Kutta, four derivative evaluations per
+  substep.
+
+The implementation therefore does **not** claim exact continuous-time evolution
+for arbitrary learned dynamics. Solver method and computational effort remain
+visible in every report.
+
+## Stability and validation
+
+Each observable state, latent state, derivative, and decoded result must be
+non-empty and finite. Latent dimensionality may not change inside one integration
+interval. `max_abs_value` bounds runaway numerical states. The integration
+interval and substep count must both be positive and finite.
+
+These are execution invariants, not claims of semantic correctness. A production
+learned model can add task-specific reconstruction loss, conservation laws,
+spectral constraints, or a Pi_Lambda acceptance gate around the same core law.
+
+## Reference dynamics
+
+For deterministic validation the package includes
+
+```text
+dZ/dt = -rate * Z + forcing
+```
+
+For zero forcing the exact scalar solution is
+
+```text
+Z(t+Delta) = Z(t) * exp(-rate * Delta)
+```
+
+which supplies an independent check of the RK4 implementation.
+
+## CLI
+
+```bash
+jarvisx-dr-moagi-resonator \
+  --state 1,0.5,-0.25 \
+  --steps 4 \
+  --method rk4 \
+  --substeps 32 \
+  --rate 0.25
+```
+
+The command prints deterministic JSON telemetry for every transition.
+
+## Architectural role
+
+The resonator is complementary to the existing Deep Distiller. The Deep Distiller
+implements bounded residual-memory and parameter-update dynamics. The resonator
+implements the continuous latent-flow equation directly. They should remain
+separate primitives until an explicit higher-level controller defines how latent
+ODE evolution, residual memory, parameter learning, and transactional acceptance
+compose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ jarvisx-bitmatrix3d = "jarvisx.bitmatrix3d_cli:main"
 jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
 jarvisx-dr-moagi-3d-animation = "jarvisx.dr_moagi_3d_animation_codec:main"
 jarvisx-dr-moagi-codegen = "jarvisx.dr_moagi_codegen_engine:main"
+jarvisx-dr-moagi-resonator = "jarvisx.dr_moagi_monadic_resonator:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/dr_moagi_monadic_resonator.py
+++ b/src/jarvisx/dr_moagi_monadic_resonator.py
@@ -138,7 +138,9 @@ class MonadicResonator:
             max_abs_value=self.config.max_abs_value,
         )
 
-    def integrate(self, latent_start: Sequence[float], t_start: float) -> tuple[Vector, Vector, int]:
+    def integrate(
+        self, latent_start: Sequence[float], t_start: float
+    ) -> tuple[Vector, Vector, int]:
         """Integrate f_theta over one configured interval.
 
         Returns ``(latent_end, accumulated_integral, derivative_evaluations)``.
@@ -165,12 +167,15 @@ class MonadicResonator:
                 evaluations += 1
             else:
                 k1 = self._dynamics(current, tau)
-                k2 = self._dynamics(_add(current, _scale(k1, 0.5 * step_size)), tau + 0.5 * step_size)
-                k3 = self._dynamics(_add(current, _scale(k2, 0.5 * step_size)), tau + 0.5 * step_size)
+                k2 = self._dynamics(
+                    _add(current, _scale(k1, 0.5 * step_size)), tau + 0.5 * step_size
+                )
+                k3 = self._dynamics(
+                    _add(current, _scale(k2, 0.5 * step_size)), tau + 0.5 * step_size
+                )
                 k4 = self._dynamics(_add(current, _scale(k3, step_size)), tau + step_size)
                 weighted = tuple(
-                    (a + 2.0 * b + 2.0 * c + d) / 6.0
-                    for a, b, c, d in zip(k1, k2, k3, k4)
+                    (a + 2.0 * b + 2.0 * c + d) / 6.0 for a, b, c, d in zip(k1, k2, k3, k4)
                 )
                 current = _add(current, _scale(weighted, step_size))
                 evaluations += 4
@@ -284,7 +289,9 @@ def _parse_state(raw: str) -> Vector:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run the DM-vOmegaXi+ monadic latent-flow recurrence")
+    parser = argparse.ArgumentParser(
+        description="Run the DM-vOmegaXi+ monadic latent-flow recurrence"
+    )
     parser.add_argument("--state", type=_parse_state, default=(1.0, 0.5, -0.25))
     parser.add_argument("--steps", type=int, default=1)
     parser.add_argument("--substeps", type=int, default=16)

--- a/src/jarvisx/dr_moagi_monadic_resonator.py
+++ b/src/jarvisx/dr_moagi_monadic_resonator.py
@@ -1,0 +1,324 @@
+"""Executable DM-vOmegaXi+ monadic latent-flow recurrence.
+
+The runtime implements the operational law::
+
+    Z_t     = E_phi(X_t)
+    Z_t+1   = Z_t + integral[t,t+1] f_theta(Z(tau), tau) d tau
+    X_t+1   = D_psi(Z_t+1)
+
+The integral is evaluated with an explicit bounded numerical solver.  Encoder,
+latent dynamics, and decoder remain separate callables so that state encoding,
+continuous-time evolution, and reconstruction do not collapse into one opaque
+operation.
+
+This is a numerical reference runtime, not a claim that arbitrary learned latent
+dynamics are solved exactly.  The report records the integration method,
+substeps, derivative evaluations, and the accumulated latent increment.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict, dataclass
+from typing import Callable, Literal, Sequence
+
+Vector = tuple[float, ...]
+Encoder = Callable[[Vector], Sequence[float]]
+Decoder = Callable[[Vector], Sequence[float]]
+LatentDynamics = Callable[[Vector, float], Sequence[float]]
+IntegrationMethod = Literal["euler", "rk4"]
+
+
+def _vector(
+    values: Sequence[float],
+    *,
+    label: str,
+    expected_dim: int | None = None,
+    max_abs_value: float | None = None,
+) -> Vector:
+    result = tuple(float(value) for value in values)
+    if not result:
+        raise ValueError(f"{label} cannot be empty")
+    if expected_dim is not None and len(result) != expected_dim:
+        raise ValueError(f"{label} dimension changed from {expected_dim} to {len(result)}")
+    for value in result:
+        if not math.isfinite(value):
+            raise ValueError(f"{label} must contain only finite values")
+        if max_abs_value is not None and abs(value) > max_abs_value:
+            raise ValueError(
+                f"{label} exceeded max_abs_value={max_abs_value}: observed {abs(value)}"
+            )
+    return result
+
+
+def _add(left: Vector, right: Vector) -> Vector:
+    return tuple(a + b for a, b in zip(left, right))
+
+
+def _scale(vector: Vector, scalar: float) -> Vector:
+    return tuple(scalar * value for value in vector)
+
+
+def _difference(left: Vector, right: Vector) -> Vector:
+    return tuple(a - b for a, b in zip(left, right))
+
+
+def _l2(vector: Vector) -> float:
+    return math.sqrt(sum(value * value for value in vector))
+
+
+@dataclass(frozen=True)
+class ResonatorConfig:
+    """Bounded integration policy for one DM-vOmegaXi+ transition."""
+
+    interval: float = 1.0
+    substeps: int = 16
+    method: IntegrationMethod = "rk4"
+    max_abs_value: float = 1.0e12
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.interval) or self.interval <= 0.0:
+            raise ValueError("interval must be finite and positive")
+        if isinstance(self.substeps, bool) or not isinstance(self.substeps, int):
+            raise TypeError("substeps must be an integer")
+        if self.substeps <= 0:
+            raise ValueError("substeps must be positive")
+        if self.method not in ("euler", "rk4"):
+            raise ValueError("method must be 'euler' or 'rk4'")
+        if not math.isfinite(self.max_abs_value) or self.max_abs_value <= 0.0:
+            raise ValueError("max_abs_value must be finite and positive")
+
+
+@dataclass(frozen=True)
+class ResonatorStepReport:
+    """Auditable record of one encode -> integrate -> decode transition."""
+
+    t_start: float
+    t_end: float
+    input_state: Vector
+    latent_start: Vector
+    latent_integral: Vector
+    latent_end: Vector
+    output_state: Vector
+    integration_method: str
+    integration_substeps: int
+    derivative_evaluations: int
+    latent_delta_l2: float
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class MonadicResonator:
+    """Composable implementation of the DM-vOmegaXi+ latent-flow law."""
+
+    LAW_ID = "DM-vOmegaXi+-MONADIC-FLOW"
+    EQUATION = "X[t+1] = D_psi(E_phi(X[t]) + integral_t^{t+1} f_theta(Z(tau),tau) dtau)"
+
+    def __init__(
+        self,
+        encoder: Encoder,
+        dynamics: LatentDynamics,
+        decoder: Decoder,
+        config: ResonatorConfig | None = None,
+    ) -> None:
+        self.encoder = encoder
+        self.dynamics = dynamics
+        self.decoder = decoder
+        self.config = config or ResonatorConfig()
+
+    def _dynamics(self, latent: Vector, time_value: float) -> Vector:
+        derivative = self.dynamics(latent, time_value)
+        return _vector(
+            derivative,
+            label="latent derivative",
+            expected_dim=len(latent),
+            max_abs_value=self.config.max_abs_value,
+        )
+
+    def integrate(self, latent_start: Sequence[float], t_start: float) -> tuple[Vector, Vector, int]:
+        """Integrate f_theta over one configured interval.
+
+        Returns ``(latent_end, accumulated_integral, derivative_evaluations)``.
+        The integral term is represented by ``latent_end - latent_start`` so the
+        returned values preserve the governing recurrence directly.
+        """
+
+        if not math.isfinite(t_start):
+            raise ValueError("t_start must be finite")
+        start = _vector(
+            latent_start,
+            label="latent_start",
+            max_abs_value=self.config.max_abs_value,
+        )
+        current = start
+        step_size = self.config.interval / self.config.substeps
+        evaluations = 0
+
+        for substep in range(self.config.substeps):
+            tau = t_start + substep * step_size
+            if self.config.method == "euler":
+                k1 = self._dynamics(current, tau)
+                current = _add(current, _scale(k1, step_size))
+                evaluations += 1
+            else:
+                k1 = self._dynamics(current, tau)
+                k2 = self._dynamics(_add(current, _scale(k1, 0.5 * step_size)), tau + 0.5 * step_size)
+                k3 = self._dynamics(_add(current, _scale(k2, 0.5 * step_size)), tau + 0.5 * step_size)
+                k4 = self._dynamics(_add(current, _scale(k3, step_size)), tau + step_size)
+                weighted = tuple(
+                    (a + 2.0 * b + 2.0 * c + d) / 6.0
+                    for a, b, c, d in zip(k1, k2, k3, k4)
+                )
+                current = _add(current, _scale(weighted, step_size))
+                evaluations += 4
+
+            current = _vector(
+                current,
+                label="latent state",
+                expected_dim=len(start),
+                max_abs_value=self.config.max_abs_value,
+            )
+
+        return current, _difference(current, start), evaluations
+
+    def step(self, input_state: Sequence[float], t_start: float = 0.0) -> ResonatorStepReport:
+        """Execute one full encode -> latent flow -> decode transition."""
+
+        source = _vector(
+            input_state,
+            label="input_state",
+            max_abs_value=self.config.max_abs_value,
+        )
+        latent_start = _vector(
+            self.encoder(source),
+            label="encoder output",
+            max_abs_value=self.config.max_abs_value,
+        )
+        latent_end, latent_integral, evaluations = self.integrate(latent_start, t_start)
+        output = _vector(
+            self.decoder(latent_end),
+            label="decoder output",
+            max_abs_value=self.config.max_abs_value,
+        )
+        return ResonatorStepReport(
+            t_start=float(t_start),
+            t_end=float(t_start + self.config.interval),
+            input_state=source,
+            latent_start=latent_start,
+            latent_integral=latent_integral,
+            latent_end=latent_end,
+            output_state=output,
+            integration_method=self.config.method,
+            integration_substeps=self.config.substeps,
+            derivative_evaluations=evaluations,
+            latent_delta_l2=_l2(latent_integral),
+        )
+
+    def rollout(
+        self,
+        input_state: Sequence[float],
+        *,
+        steps: int,
+        t_start: float = 0.0,
+    ) -> list[ResonatorStepReport]:
+        """Recursively feed each decoded state into the next transition."""
+
+        if isinstance(steps, bool) or not isinstance(steps, int):
+            raise TypeError("steps must be an integer")
+        if steps <= 0:
+            raise ValueError("steps must be positive")
+
+        state = _vector(
+            input_state,
+            label="input_state",
+            max_abs_value=self.config.max_abs_value,
+        )
+        time_value = float(t_start)
+        reports: list[ResonatorStepReport] = []
+        for _ in range(steps):
+            report = self.step(state, time_value)
+            reports.append(report)
+            state = report.output_state
+            time_value = report.t_end
+        return reports
+
+
+def scaled_identity(scale: float) -> Callable[[Vector], Vector]:
+    """Return a finite element-wise scaling transform for reference experiments."""
+
+    scale_value = float(scale)
+    if not math.isfinite(scale_value):
+        raise ValueError("scale must be finite")
+
+    def transform(vector: Vector) -> Vector:
+        return tuple(scale_value * value for value in vector)
+
+    return transform
+
+
+def linear_relaxation(rate: float, forcing: float = 0.0) -> LatentDynamics:
+    """Return dZ/dt = -rate * Z + forcing as a deterministic reference field."""
+
+    rate_value = float(rate)
+    forcing_value = float(forcing)
+    if not math.isfinite(rate_value) or not math.isfinite(forcing_value):
+        raise ValueError("rate and forcing must be finite")
+
+    def field(latent: Vector, _time_value: float) -> Vector:
+        return tuple(-rate_value * value + forcing_value for value in latent)
+
+    return field
+
+
+def _parse_state(raw: str) -> Vector:
+    try:
+        values = tuple(float(part.strip()) for part in raw.split(",") if part.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("state must be comma-separated numbers") from exc
+    if not values or not all(math.isfinite(value) for value in values):
+        raise argparse.ArgumentTypeError("state must contain finite comma-separated numbers")
+    return values
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the DM-vOmegaXi+ monadic latent-flow recurrence")
+    parser.add_argument("--state", type=_parse_state, default=(1.0, 0.5, -0.25))
+    parser.add_argument("--steps", type=int, default=1)
+    parser.add_argument("--substeps", type=int, default=16)
+    parser.add_argument("--interval", type=float, default=1.0)
+    parser.add_argument("--method", choices=("euler", "rk4"), default="rk4")
+    parser.add_argument("--rate", type=float, default=0.25)
+    parser.add_argument("--forcing", type=float, default=0.0)
+    parser.add_argument("--encoder-scale", type=float, default=1.0)
+    parser.add_argument("--decoder-scale", type=float, default=1.0)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    config = ResonatorConfig(
+        interval=args.interval,
+        substeps=args.substeps,
+        method=args.method,
+    )
+    engine = MonadicResonator(
+        encoder=scaled_identity(args.encoder_scale),
+        dynamics=linear_relaxation(args.rate, args.forcing),
+        decoder=scaled_identity(args.decoder_scale),
+        config=config,
+    )
+    reports = engine.rollout(args.state, steps=args.steps)
+    payload = {
+        "law_id": engine.LAW_ID,
+        "equation": engine.EQUATION,
+        "steps": [report.as_dict() for report in reports],
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dr_moagi_monadic_resonator.py
+++ b/tests/test_dr_moagi_monadic_resonator.py
@@ -1,0 +1,138 @@
+import json
+import math
+
+import pytest
+
+from jarvisx.dr_moagi_monadic_resonator import (
+    MonadicResonator,
+    ResonatorConfig,
+    linear_relaxation,
+    main,
+    scaled_identity,
+)
+
+
+def test_zero_dynamics_reduces_to_decode_encode() -> None:
+    engine = MonadicResonator(
+        encoder=scaled_identity(2.0),
+        dynamics=lambda latent, _time: tuple(0.0 for _ in latent),
+        decoder=scaled_identity(0.5),
+    )
+
+    report = engine.step((1.0, -2.0, 3.0))
+
+    assert report.latent_start == (2.0, -4.0, 6.0)
+    assert report.latent_integral == (0.0, 0.0, 0.0)
+    assert report.output_state == pytest.approx((1.0, -2.0, 3.0))
+
+
+def test_constant_field_matches_integral_law_exactly() -> None:
+    engine = MonadicResonator(
+        encoder=scaled_identity(1.0),
+        dynamics=lambda latent, _time: tuple(2.0 for _ in latent),
+        decoder=scaled_identity(1.0),
+        config=ResonatorConfig(interval=1.0, substeps=4, method="rk4"),
+    )
+
+    report = engine.step((1.0, -1.0))
+
+    assert report.latent_integral == pytest.approx((2.0, 2.0))
+    assert report.latent_end == pytest.approx((3.0, 1.0))
+    assert report.output_state == pytest.approx((3.0, 1.0))
+    assert report.derivative_evaluations == 16
+
+
+def test_rk4_tracks_linear_relaxation_solution() -> None:
+    rate = 0.75
+    engine = MonadicResonator(
+        encoder=scaled_identity(1.0),
+        dynamics=linear_relaxation(rate),
+        decoder=scaled_identity(1.0),
+        config=ResonatorConfig(interval=1.0, substeps=32, method="rk4"),
+    )
+
+    report = engine.step((2.0,))
+
+    expected = 2.0 * math.exp(-rate)
+    assert report.output_state[0] == pytest.approx(expected, rel=1.0e-7)
+    assert report.latent_delta_l2 == pytest.approx(abs(expected - 2.0), rel=1.0e-7)
+
+
+def test_euler_reports_one_derivative_evaluation_per_substep() -> None:
+    engine = MonadicResonator(
+        encoder=scaled_identity(1.0),
+        dynamics=linear_relaxation(0.1),
+        decoder=scaled_identity(1.0),
+        config=ResonatorConfig(substeps=7, method="euler"),
+    )
+
+    report = engine.step((1.0, 2.0))
+
+    assert report.derivative_evaluations == 7
+    assert report.integration_method == "euler"
+
+
+def test_dynamics_dimension_change_is_rejected() -> None:
+    engine = MonadicResonator(
+        encoder=scaled_identity(1.0),
+        dynamics=lambda _latent, _time: (1.0, 2.0),
+        decoder=scaled_identity(1.0),
+    )
+
+    with pytest.raises(ValueError, match="dimension changed"):
+        engine.step((1.0,))
+
+
+def test_non_finite_latent_state_is_rejected() -> None:
+    engine = MonadicResonator(
+        encoder=lambda _state: (float("inf"),),
+        dynamics=linear_relaxation(0.1),
+        decoder=scaled_identity(1.0),
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        engine.step((1.0,))
+
+
+def test_rollout_recursively_feeds_decoder_output_forward() -> None:
+    engine = MonadicResonator(
+        encoder=scaled_identity(1.0),
+        dynamics=lambda latent, _time: tuple(1.0 for _ in latent),
+        decoder=scaled_identity(1.0),
+        config=ResonatorConfig(interval=0.5, substeps=2, method="euler"),
+    )
+
+    reports = engine.rollout((0.0,), steps=3, t_start=2.0)
+
+    assert [report.output_state[0] for report in reports] == pytest.approx([0.5, 1.0, 1.5])
+    assert [report.t_end for report in reports] == pytest.approx([2.5, 3.0, 3.5])
+
+
+def test_cli_emits_auditable_equation_payload(capsys: pytest.CaptureFixture[str]) -> None:
+    exit_code = main(
+        [
+            "--state",
+            "1,2",
+            "--steps",
+            "1",
+            "--rate",
+            "0",
+            "--substeps",
+            "2",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert payload["law_id"] == MonadicResonator.LAW_ID
+    assert payload["equation"] == MonadicResonator.EQUATION
+    assert payload["steps"][0]["output_state"] == [1.0, 2.0]
+
+
+def test_configuration_rejects_unbounded_or_invalid_solver_inputs() -> None:
+    with pytest.raises(ValueError, match="interval"):
+        ResonatorConfig(interval=0.0)
+    with pytest.raises(ValueError, match="substeps"):
+        ResonatorConfig(substeps=0)
+    with pytest.raises(ValueError, match="method"):
+        ResonatorConfig(method="bogus")  # type: ignore[arg-type]


### PR DESCRIPTION
Implements the recurrence `X[t+1] = D_psi(E_phi(X[t]) + integral_t^{t+1} f_theta(Z(tau), tau) d tau)` as a first-class bounded runtime.

Key changes:
- generic `E_phi -> f_theta -> D_psi` composition with explicit latent state
- bounded Euler and classical RK4 integration
- finite-state, dimension, interval, and magnitude guards
- auditable per-step telemetry including latent integral and derivative counts
- recursive rollout semantics
- deterministic linear-relaxation reference dynamics for analytic validation
- `jarvisx-dr-moagi-resonator` CLI
- focused invariant/analytic tests and dedicated CI workflow
- architecture documentation preserving the distinction between exact recurrence semantics and numerical integration approximation

This remains separate from DM-DD: the resonator handles continuous latent-flow evolution, while the Deep Distiller retains residual-memory/parameter-update semantics.