### PR TITLE
Evolve 3D autoencoder into multimodal multimedia generator

### DIFF
--- a/cpp_runtime/CMakeLists.txt
+++ b/cpp_runtime/CMakeLists.txt
@@ -275,3 +275,4 @@ add_test(NAME pixels-to-bits-regressions COMMAND jarvisx-pixels-to-bits-tests)
 set_tests_properties(pixels-to-bits-regressions PROPERTIES TIMEOUT 120)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/world_engine.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/multimodal_generator3d.cmake)

--- a/cpp_runtime/include/jarvisx/multimodal_generator3d.hpp
+++ b/cpp_runtime/include/jarvisx/multimodal_generator3d.hpp
@@ -1,0 +1,503 @@
+#pragma once
+
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace jarvisx::mm3d {
+
+enum class Modality : std::uint8_t {
+    Text = 0U,
+    Image = 1U,
+    Audio = 2U,
+    Video = 3U,
+    Volume3D = 4U,
+    Generic = 5U,
+};
+
+inline const char* modality_name(Modality modality) noexcept {
+    switch (modality) {
+    case Modality::Text: return "text";
+    case Modality::Image: return "image";
+    case Modality::Audio: return "audio";
+    case Modality::Video: return "video";
+    case Modality::Volume3D: return "volume3d";
+    case Modality::Generic: return "generic";
+    }
+    return "unknown";
+}
+
+inline Modality parse_modality(const std::string& value) {
+    if (value == "text") return Modality::Text;
+    if (value == "image" || value == "visual") return Modality::Image;
+    if (value == "audio") return Modality::Audio;
+    if (value == "video" || value == "animation") return Modality::Video;
+    if (value == "volume" || value == "volume3d" || value == "3d") {
+        return Modality::Volume3D;
+    }
+    if (value == "generic" || value == "binary") return Modality::Generic;
+    throw std::invalid_argument("unsupported modality: " + value);
+}
+
+struct MediaPacket {
+    Modality modality{Modality::Generic};
+    std::vector<float> samples;
+    std::string text;
+    std::size_t width{0U};
+    std::size_t height{0U};
+    std::size_t depth{0U};
+    std::size_t channels{1U};
+    std::size_t frames{1U};
+    std::uint32_t sample_rate{44100U};
+};
+
+struct GeneratedMedia {
+    Modality modality{Modality::Generic};
+    std::vector<float> samples;
+    std::string text;
+    std::size_t width{0U};
+    std::size_t height{0U};
+    std::size_t depth{0U};
+    std::size_t channels{1U};
+    std::size_t frames{1U};
+    std::uint32_t sample_rate{44100U};
+};
+
+struct GeneratorConfig {
+    Autoencoder3DConfig autoencoder{};
+    std::size_t default_text_length{192U};
+    std::size_t default_image_edge{64U};
+    std::size_t default_audio_samples{4096U};
+    std::size_t default_video_frames{8U};
+    std::size_t default_video_edge{32U};
+    float prompt_strength{0.18F};
+
+    void validate() const {
+        autoencoder.validate();
+        if (default_text_length == 0U || default_text_length > 65536U) {
+            throw std::invalid_argument("default text length must be in [1, 65536]");
+        }
+        if (default_image_edge == 0U || default_image_edge > 4096U) {
+            throw std::invalid_argument("default image edge must be in [1, 4096]");
+        }
+        if (default_audio_samples == 0U || default_audio_samples > 16777216U) {
+            throw std::invalid_argument("default audio samples out of range");
+        }
+        if (default_video_frames == 0U || default_video_frames > 1024U ||
+            default_video_edge == 0U || default_video_edge > 1024U) {
+            throw std::invalid_argument("default video geometry out of range");
+        }
+        if (!std::isfinite(prompt_strength) || prompt_strength < 0.0F ||
+            prompt_strength > 1.0F) {
+            throw std::invalid_argument("prompt strength must be in [0,1]");
+        }
+    }
+};
+
+struct GenerationMetrics {
+    Modality source{Modality::Generic};
+    Modality target{Modality::Generic};
+    float latent_energy{};
+    float output_energy{};
+    float conditioning_mix{};
+    std::size_t latent_elements{};
+    std::size_t output_elements{};
+};
+
+class MultimodalGenerator3D {
+public:
+    explicit MultimodalGenerator3D(GeneratorConfig config)
+        : config_(std::move(config)) {
+        config_.validate();
+        models_.reserve(kModalityCount);
+        for (std::size_t i = 0U; i < kModalityCount; ++i) {
+            Autoencoder3DConfig model_config = config_.autoencoder;
+            model_config.seed ^= mix64(static_cast<std::uint64_t>(i) + 1ULL);
+            models_.emplace_back(model_config);
+        }
+    }
+
+    const GeneratorConfig& config() const noexcept { return config_; }
+
+    Tensor4D tensorize(const MediaPacket& packet) const {
+        const std::size_t edge = config_.autoencoder.input_edge;
+        Tensor4D tensor({1U, edge, edge, edge});
+        if (packet.modality == Modality::Text) {
+            tensorize_text(packet, tensor);
+        } else if (packet.modality == Modality::Image) {
+            tensorize_image(packet, tensor);
+        } else if (packet.modality == Modality::Audio) {
+            tensorize_audio(packet, tensor);
+        } else if (packet.modality == Modality::Video) {
+            tensorize_video(packet, tensor);
+        } else if (packet.modality == Modality::Volume3D) {
+            tensorize_volume(packet, tensor);
+        } else {
+            tensorize_generic(packet, tensor);
+        }
+        return tensor;
+    }
+
+    Tensor4D encode(const MediaPacket& packet, bool quantized = false) const {
+        return model(packet.modality).encode(tensorize(packet), quantized);
+    }
+
+    GeneratedMedia reconstruct(const MediaPacket& packet,
+                               bool quantized = false) const {
+        const Tensor4D decoded = model(packet.modality).reconstruct(
+            tensorize(packet), quantized);
+        return materialize(packet.modality, decoded, &packet);
+    }
+
+    Autoencoder3DMetrics train_step(const MediaPacket& packet) {
+        return mutable_model(packet.modality).train_step(tensorize(packet));
+    }
+
+    GeneratedMedia generate(Modality target, const std::string& prompt,
+                            std::uint64_t seed = 0ULL) const {
+        Tensor4D latent = prompt_latent(prompt, seed);
+        const Tensor4D decoded = model(target).decode(latent);
+        return materialize(target, decoded, nullptr);
+    }
+
+    GeneratedMedia translate(const MediaPacket& source, Modality target,
+                             const std::string& prompt = std::string(),
+                             float conditioning_mix = 0.85F,
+                             bool quantized = false,
+                             std::uint64_t seed = 0ULL,
+                             GenerationMetrics* metrics = nullptr) const {
+        if (!std::isfinite(conditioning_mix) || conditioning_mix < 0.0F ||
+            conditioning_mix > 1.0F) {
+            throw std::invalid_argument("conditioning mix must be in [0,1]");
+        }
+        Tensor4D conditioned = encode(source, quantized);
+        Tensor4D prompted = prompt_latent(prompt, seed);
+        if (conditioned.shape().elements() != prompted.shape().elements()) {
+            throw std::logic_error("latent geometry mismatch between modality models");
+        }
+        for (std::size_t i = 0U; i < conditioned.size(); ++i) {
+            const float mixed = conditioning_mix * conditioned.values()[i] +
+                (1.0F - conditioning_mix) * prompted.values()[i];
+            conditioned.values()[i] = std::clamp(mixed, -1.0F, 1.0F);
+        }
+        const Tensor4D decoded = model(target).decode(conditioned);
+        GeneratedMedia output = materialize(target, decoded, nullptr);
+        if (metrics != nullptr) {
+            metrics->source = source.modality;
+            metrics->target = target;
+            metrics->latent_energy = rms(conditioned.values());
+            metrics->output_energy = rms(output.samples);
+            metrics->conditioning_mix = conditioning_mix;
+            metrics->latent_elements = conditioned.size();
+            metrics->output_elements = output.samples.size();
+        }
+        return output;
+    }
+
+    Tensor4D prompt_latent(const std::string& prompt,
+                           std::uint64_t seed = 0ULL) const {
+        const std::size_t latent_edge = config_.autoencoder.input_edge / 2U;
+        Tensor4D latent({config_.autoencoder.latent_channels,
+                         latent_edge, latent_edge, latent_edge});
+        std::uint64_t state = seed ^ hash_text(prompt) ^ config_.autoencoder.seed;
+        if (state == 0ULL) state = 0x9E3779B97F4A7C15ULL;
+        const float semantic = prompt.empty() ? 0.0F :
+            static_cast<float>((hash_text(prompt) >> 11U) & 0xFFFFULL) / 32767.5F - 1.0F;
+        for (std::size_t i = 0U; i < latent.size(); ++i) {
+            state = xorshift64(state);
+            const std::uint32_t low = static_cast<std::uint32_t>(state & 0xFFFFFFULL);
+            const float noise = static_cast<float>(low) / 8388607.5F - 1.0F;
+            const float phase = std::sin(static_cast<float>(i + 1U) * 0.17320508F +
+                                         semantic * 1.6180339F);
+            const float value = 0.70F * noise + config_.prompt_strength * phase +
+                                0.12F * semantic;
+            latent.values()[i] = std::clamp(value, -1.0F, 1.0F);
+        }
+        return latent;
+    }
+
+private:
+    static constexpr std::size_t kModalityCount = 6U;
+    GeneratorConfig config_;
+    std::vector<Autoencoder3D> models_;
+
+    static std::size_t modality_index(Modality modality) noexcept {
+        return static_cast<std::size_t>(modality);
+    }
+
+    const Autoencoder3D& model(Modality modality) const {
+        return models_.at(modality_index(modality));
+    }
+
+    Autoencoder3D& mutable_model(Modality modality) {
+        return models_.at(modality_index(modality));
+    }
+
+    static float clamp_sample(float value) noexcept {
+        if (!std::isfinite(value)) return 0.0F;
+        return std::clamp(value, -1.0F, 1.0F);
+    }
+
+    static std::uint64_t mix64(std::uint64_t value) noexcept {
+        value += 0x9E3779B97F4A7C15ULL;
+        value = (value ^ (value >> 30U)) * 0xBF58476D1CE4E5B9ULL;
+        value = (value ^ (value >> 27U)) * 0x94D049BB133111EBULL;
+        return value ^ (value >> 31U);
+    }
+
+    static std::uint64_t xorshift64(std::uint64_t value) noexcept {
+        value ^= value << 13U;
+        value ^= value >> 7U;
+        value ^= value << 17U;
+        return value;
+    }
+
+    static std::uint64_t hash_text(const std::string& text) noexcept {
+        std::uint64_t hash = 1469598103934665603ULL;
+        for (unsigned char byte : text) {
+            hash ^= static_cast<std::uint64_t>(byte);
+            hash *= 1099511628211ULL;
+        }
+        return hash;
+    }
+
+    static float rms(const std::vector<float>& values) noexcept {
+        if (values.empty()) return 0.0F;
+        double sum = 0.0;
+        for (float value : values) sum += static_cast<double>(value) * value;
+        return static_cast<float>(std::sqrt(sum / static_cast<double>(values.size())));
+    }
+
+    static std::size_t nearest(std::size_t coordinate, std::size_t dst_extent,
+                               std::size_t src_extent) noexcept {
+        if (src_extent <= 1U || dst_extent <= 1U) return 0U;
+        const double scaled = static_cast<double>(coordinate) *
+            static_cast<double>(src_extent - 1U) /
+            static_cast<double>(dst_extent - 1U);
+        return static_cast<std::size_t>(std::llround(scaled));
+    }
+
+    static float sample_channel_mean(const MediaPacket& packet,
+                                     std::size_t base_index) noexcept {
+        if (packet.samples.empty()) return 0.0F;
+        const std::size_t channels = std::max<std::size_t>(1U, packet.channels);
+        double sum = 0.0;
+        std::size_t count = 0U;
+        for (std::size_t channel = 0U; channel < channels; ++channel) {
+            const std::size_t index = base_index + channel;
+            if (index >= packet.samples.size()) break;
+            sum += static_cast<double>(clamp_sample(packet.samples[index]));
+            ++count;
+        }
+        return count == 0U ? 0.0F :
+            static_cast<float>(sum / static_cast<double>(count));
+    }
+
+    void tensorize_text(const MediaPacket& packet, Tensor4D& tensor) const {
+        const std::string& text = packet.text;
+        if (text.empty()) return;
+        const std::size_t edge = config_.autoencoder.input_edge;
+        for (std::size_t i = 0U; i < tensor.size(); ++i) {
+            const unsigned char byte = static_cast<unsigned char>(text[i % text.size()]);
+            const float lexical = static_cast<float>(byte) / 127.5F - 1.0F;
+            const std::size_t z = i / (edge * edge);
+            const float depth_phase = std::sin(static_cast<float>(z + 1U) * 0.6180339F);
+            tensor.values()[i] = std::clamp(0.88F * lexical + 0.12F * depth_phase,
+                                            -1.0F, 1.0F);
+        }
+    }
+
+    void tensorize_image(const MediaPacket& packet, Tensor4D& tensor) const {
+        if (packet.samples.empty() || packet.width == 0U || packet.height == 0U) return;
+        const std::size_t edge = config_.autoencoder.input_edge;
+        const std::size_t channels = std::max<std::size_t>(1U, packet.channels);
+        for (std::size_t z = 0U; z < edge; ++z) {
+            for (std::size_t y = 0U; y < edge; ++y) {
+                for (std::size_t x = 0U; x < edge; ++x) {
+                    const std::size_t sx = nearest(x, edge, packet.width);
+                    const std::size_t sy = nearest(y, edge, packet.height);
+                    const std::size_t base = (sy * packet.width + sx) * channels;
+                    const float value = sample_channel_mean(packet, base);
+                    tensor(0U, z, y, x) = value;
+                }
+            }
+        }
+    }
+
+    void tensorize_audio(const MediaPacket& packet, Tensor4D& tensor) const {
+        if (packet.samples.empty()) return;
+        for (std::size_t i = 0U; i < tensor.size(); ++i) {
+            const std::size_t source = nearest(i, tensor.size(), packet.samples.size());
+            tensor.values()[i] = clamp_sample(packet.samples[source]);
+        }
+    }
+
+    void tensorize_video(const MediaPacket& packet, Tensor4D& tensor) const {
+        if (packet.samples.empty() || packet.width == 0U || packet.height == 0U ||
+            packet.frames == 0U) return;
+        const std::size_t edge = config_.autoencoder.input_edge;
+        const std::size_t channels = std::max<std::size_t>(1U, packet.channels);
+        const std::size_t frame_stride = packet.width * packet.height * channels;
+        for (std::size_t z = 0U; z < edge; ++z) {
+            const std::size_t frame = nearest(z, edge, packet.frames);
+            for (std::size_t y = 0U; y < edge; ++y) {
+                for (std::size_t x = 0U; x < edge; ++x) {
+                    const std::size_t sx = nearest(x, edge, packet.width);
+                    const std::size_t sy = nearest(y, edge, packet.height);
+                    const std::size_t base = frame * frame_stride +
+                                             (sy * packet.width + sx) * channels;
+                    tensor(0U, z, y, x) = sample_channel_mean(packet, base);
+                }
+            }
+        }
+    }
+
+    void tensorize_volume(const MediaPacket& packet, Tensor4D& tensor) const {
+        if (packet.samples.empty() || packet.width == 0U || packet.height == 0U ||
+            packet.depth == 0U) return;
+        const std::size_t edge = config_.autoencoder.input_edge;
+        const std::size_t channels = std::max<std::size_t>(1U, packet.channels);
+        for (std::size_t z = 0U; z < edge; ++z) {
+            const std::size_t sz = nearest(z, edge, packet.depth);
+            for (std::size_t y = 0U; y < edge; ++y) {
+                const std::size_t sy = nearest(y, edge, packet.height);
+                for (std::size_t x = 0U; x < edge; ++x) {
+                    const std::size_t sx = nearest(x, edge, packet.width);
+                    const std::size_t base =
+                        ((sz * packet.height + sy) * packet.width + sx) * channels;
+                    tensor(0U, z, y, x) = sample_channel_mean(packet, base);
+                }
+            }
+        }
+    }
+
+    void tensorize_generic(const MediaPacket& packet, Tensor4D& tensor) const {
+        if (packet.samples.empty()) return;
+        for (std::size_t i = 0U; i < tensor.size(); ++i) {
+            tensor.values()[i] = clamp_sample(packet.samples[i % packet.samples.size()]);
+        }
+    }
+
+    float decoded_sample(const Tensor4D& decoded,
+                         std::size_t linear_index,
+                         std::size_t output_count) const noexcept {
+        if (output_count <= 1U) return clamp_sample(decoded.values().front());
+        const std::size_t index = nearest(linear_index, output_count, decoded.size());
+        return clamp_sample(decoded.values()[index]);
+    }
+
+    GeneratedMedia materialize(Modality target, const Tensor4D& decoded,
+                               const MediaPacket* shape_hint) const {
+        GeneratedMedia output;
+        output.modality = target;
+        if (target == Modality::Text) {
+            const std::size_t count = shape_hint != nullptr && !shape_hint->text.empty()
+                ? shape_hint->text.size() : config_.default_text_length;
+            output.text.reserve(count);
+            output.samples.reserve(count);
+            for (std::size_t i = 0U; i < count; ++i) {
+                const float value = decoded_sample(decoded, i, count);
+                output.samples.push_back(value);
+                const int code = 32 + static_cast<int>(std::lround((value + 1.0F) * 47.0F));
+                output.text.push_back(static_cast<char>(std::clamp(code, 32, 126)));
+            }
+            return output;
+        }
+        if (target == Modality::Image) {
+            output.width = shape_hint != nullptr && shape_hint->width != 0U
+                ? shape_hint->width : config_.default_image_edge;
+            output.height = shape_hint != nullptr && shape_hint->height != 0U
+                ? shape_hint->height : config_.default_image_edge;
+            output.channels = 1U;
+            const std::size_t count = output.width * output.height;
+            output.samples.resize(count);
+            const std::size_t edge = config_.autoencoder.input_edge;
+            const std::size_t z = edge / 2U;
+            for (std::size_t y = 0U; y < output.height; ++y) {
+                for (std::size_t x = 0U; x < output.width; ++x) {
+                    const std::size_t sx = nearest(x, output.width, edge);
+                    const std::size_t sy = nearest(y, output.height, edge);
+                    output.samples[y * output.width + x] = decoded(0U, z, sy, sx);
+                }
+            }
+            return output;
+        }
+        if (target == Modality::Audio) {
+            output.sample_rate = shape_hint != nullptr ? shape_hint->sample_rate : 44100U;
+            const std::size_t count = shape_hint != nullptr && !shape_hint->samples.empty()
+                ? shape_hint->samples.size() : config_.default_audio_samples;
+            output.samples.resize(count);
+            for (std::size_t i = 0U; i < count; ++i) {
+                output.samples[i] = decoded_sample(decoded, i, count);
+            }
+            return output;
+        }
+        if (target == Modality::Video) {
+            output.width = shape_hint != nullptr && shape_hint->width != 0U
+                ? shape_hint->width : config_.default_video_edge;
+            output.height = shape_hint != nullptr && shape_hint->height != 0U
+                ? shape_hint->height : config_.default_video_edge;
+            output.frames = shape_hint != nullptr && shape_hint->frames != 0U
+                ? shape_hint->frames : config_.default_video_frames;
+            output.channels = 1U;
+            const std::size_t count = output.width * output.height * output.frames;
+            output.samples.resize(count);
+            const std::size_t edge = config_.autoencoder.input_edge;
+            for (std::size_t frame = 0U; frame < output.frames; ++frame) {
+                const std::size_t z = nearest(frame, output.frames, edge);
+                for (std::size_t y = 0U; y < output.height; ++y) {
+                    const std::size_t sy = nearest(y, output.height, edge);
+                    for (std::size_t x = 0U; x < output.width; ++x) {
+                        const std::size_t sx = nearest(x, output.width, edge);
+                        const std::size_t index =
+                            (frame * output.height + y) * output.width + x;
+                        output.samples[index] = decoded(0U, z, sy, sx);
+                    }
+                }
+            }
+            return output;
+        }
+        if (target == Modality::Volume3D) {
+            const std::size_t edge = shape_hint != nullptr && shape_hint->width != 0U
+                ? shape_hint->width : config_.autoencoder.input_edge;
+            output.width = edge;
+            output.height = shape_hint != nullptr && shape_hint->height != 0U
+                ? shape_hint->height : edge;
+            output.depth = shape_hint != nullptr && shape_hint->depth != 0U
+                ? shape_hint->depth : edge;
+            output.channels = 1U;
+            const std::size_t count = output.width * output.height * output.depth;
+            output.samples.resize(count);
+            const std::size_t model_edge = config_.autoencoder.input_edge;
+            for (std::size_t z = 0U; z < output.depth; ++z) {
+                const std::size_t sz = nearest(z, output.depth, model_edge);
+                for (std::size_t y = 0U; y < output.height; ++y) {
+                    const std::size_t sy = nearest(y, output.height, model_edge);
+                    for (std::size_t x = 0U; x < output.width; ++x) {
+                        const std::size_t sx = nearest(x, output.width, model_edge);
+                        output.samples[(z * output.height + y) * output.width + x] =
+                            decoded(0U, sz, sy, sx);
+                    }
+                }
+            }
+            return output;
+        }
+        output.samples = decoded.values();
+        output.width = decoded.shape().width;
+        output.height = decoded.shape().height;
+        output.depth = decoded.shape().depth;
+        output.channels = decoded.shape().channels;
+        return output;
+    }
+};
+
+} // namespace jarvisx::mm3d

--- a/cpp_runtime/multimodal_generator3d.cmake
+++ b/cpp_runtime/multimodal_generator3d.cmake
@@ -1,0 +1,34 @@
+add_executable(jarvisx-multimodal-generator3d
+    src/multimodal_generator3d_main.cpp
+)
+set_target_properties(jarvisx-multimodal-generator3d PROPERTIES
+    OUTPUT_NAME "DrMoagi-Multimodal-3D"
+)
+jarvisx_include_runtime(jarvisx-multimodal-generator3d)
+jarvisx_harden(jarvisx-multimodal-generator3d)
+
+add_test(
+    NAME multimodal-generator3d-runtime-smoke
+    COMMAND jarvisx-multimodal-generator3d
+        --source text
+        --target image
+        --text "Jarvis X MM3D smoke test"
+        --prompt "bounded deterministic generated geometry"
+        --edge 8
+        --channels 3
+        --output-dir ${CMAKE_CURRENT_BINARY_DIR}/multimodal-generator3d-smoke
+        --quiet
+)
+set_tests_properties(multimodal-generator3d-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-multimodal-generator3d-tests
+    tests/multimodal_generator3d_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-multimodal-generator3d-tests)
+jarvisx_harden(jarvisx-multimodal-generator3d-tests)
+
+add_test(
+    NAME multimodal-generator3d-regressions
+    COMMAND jarvisx-multimodal-generator3d-tests
+)
+set_tests_properties(multimodal-generator3d-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/src/multimodal_generator3d_main.cpp
+++ b/cpp_runtime/src/multimodal_generator3d_main.cpp
@@ -1,0 +1,358 @@
+#include "jarvisx/multimodal_generator3d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Options {
+    jarvisx::mm3d::Modality source{jarvisx::mm3d::Modality::Text};
+    jarvisx::mm3d::Modality target{jarvisx::mm3d::Modality::Image};
+    std::string text{"Jarvis X 3D multimodal generation"};
+    std::string prompt{"translate through a shared three-dimensional latent field"};
+    std::filesystem::path input_path;
+    std::filesystem::path output_dir{".jarvisx-mm3d"};
+    std::size_t edge{8U};
+    std::size_t channels{4U};
+    std::size_t width{0U};
+    std::size_t height{0U};
+    std::size_t frames{1U};
+    std::size_t train_steps{0U};
+    std::uint32_t sample_rate{44100U};
+    std::uint64_t seed{0x4D4F4147493344ULL};
+    float conditioning_mix{0.85F};
+    bool quantized{false};
+    bool unconditional{false};
+    bool quiet{false};
+};
+
+std::size_t parse_size(const std::string& value, const char* name) {
+    std::size_t consumed = 0U;
+    const unsigned long long parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) throw std::invalid_argument(std::string(name) + " must be an integer");
+    return static_cast<std::size_t>(parsed);
+}
+
+float parse_float(const std::string& value, const char* name) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument(std::string(name) + " must be finite");
+    }
+    return parsed;
+}
+
+Options parse_args(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const char* name) -> std::string {
+            if (i + 1 >= argc) throw std::invalid_argument(std::string("missing value for ") + name);
+            ++i;
+            return argv[i];
+        };
+        if (arg == "--source") options.source = jarvisx::mm3d::parse_modality(require_value("--source"));
+        else if (arg == "--target") options.target = jarvisx::mm3d::parse_modality(require_value("--target"));
+        else if (arg == "--text") options.text = require_value("--text");
+        else if (arg == "--prompt") options.prompt = require_value("--prompt");
+        else if (arg == "--input") options.input_path = require_value("--input");
+        else if (arg == "--output-dir") options.output_dir = require_value("--output-dir");
+        else if (arg == "--edge") options.edge = parse_size(require_value("--edge"), "--edge");
+        else if (arg == "--channels") options.channels = parse_size(require_value("--channels"), "--channels");
+        else if (arg == "--width") options.width = parse_size(require_value("--width"), "--width");
+        else if (arg == "--height") options.height = parse_size(require_value("--height"), "--height");
+        else if (arg == "--frames") options.frames = parse_size(require_value("--frames"), "--frames");
+        else if (arg == "--train-steps") options.train_steps = parse_size(require_value("--train-steps"), "--train-steps");
+        else if (arg == "--sample-rate") options.sample_rate = static_cast<std::uint32_t>(parse_size(require_value("--sample-rate"), "--sample-rate"));
+        else if (arg == "--seed") options.seed = static_cast<std::uint64_t>(parse_size(require_value("--seed"), "--seed"));
+        else if (arg == "--mix") options.conditioning_mix = parse_float(require_value("--mix"), "--mix");
+        else if (arg == "--quantized") options.quantized = true;
+        else if (arg == "--unconditional") options.unconditional = true;
+        else if (arg == "--quiet") options.quiet = true;
+        else if (arg == "--help" || arg == "-h") {
+            std::cout
+                << "Jarvis-X 3D multimodal generator\n"
+                << "  --source text|image|audio|video|volume3d|generic\n"
+                << "  --target text|image|audio|video|volume3d|generic\n"
+                << "  --text TEXT | --input FILE\n"
+                << "  --prompt TEXT --mix 0..1 --seed N\n"
+                << "  --edge N --channels N --train-steps N --quantized\n"
+                << "  --width N --height N --frames N --sample-rate N\n"
+                << "  --unconditional --output-dir PATH --quiet\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown argument: " + arg);
+        }
+    }
+    return options;
+}
+
+std::vector<std::uint8_t> read_bytes(const std::filesystem::path& path) {
+    std::ifstream stream(path, std::ios::binary);
+    if (!stream) throw std::runtime_error("unable to open input: " + path.string());
+    stream.seekg(0, std::ios::end);
+    const std::streamoff length = stream.tellg();
+    stream.seekg(0, std::ios::beg);
+    if (length < 0) throw std::runtime_error("unable to measure input file");
+    std::vector<std::uint8_t> bytes(static_cast<std::size_t>(length));
+    if (!bytes.empty()) {
+        stream.read(reinterpret_cast<char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+        if (!stream) throw std::runtime_error("failed while reading input file");
+    }
+    return bytes;
+}
+
+jarvisx::mm3d::MediaPacket build_packet(const Options& options) {
+    jarvisx::mm3d::MediaPacket packet;
+    packet.modality = options.source;
+    packet.width = options.width;
+    packet.height = options.height;
+    packet.frames = options.frames;
+    packet.sample_rate = options.sample_rate;
+
+    if (options.source == jarvisx::mm3d::Modality::Text) {
+        if (!options.input_path.empty()) {
+            const auto bytes = read_bytes(options.input_path);
+            packet.text.assign(bytes.begin(), bytes.end());
+        } else {
+            packet.text = options.text;
+        }
+        return packet;
+    }
+
+    std::vector<std::uint8_t> bytes;
+    if (!options.input_path.empty()) {
+        bytes = read_bytes(options.input_path);
+    } else {
+        const std::size_t demo_count = 4096U;
+        bytes.resize(demo_count);
+        std::uint64_t state = options.seed == 0ULL ? 1ULL : options.seed;
+        for (std::size_t i = 0U; i < demo_count; ++i) {
+            state ^= state << 13U;
+            state ^= state >> 7U;
+            state ^= state << 17U;
+            const double phase = static_cast<double>(i) * 0.03125;
+            const int wave = static_cast<int>(std::lround(127.5 + 86.0 * std::sin(phase)));
+            const int noise = static_cast<int>(state & 0x1FULL) - 16;
+            bytes[i] = static_cast<std::uint8_t>(std::clamp(wave + noise, 0, 255));
+        }
+    }
+    packet.samples.reserve(bytes.size());
+    for (std::uint8_t byte : bytes) {
+        packet.samples.push_back(static_cast<float>(byte) / 127.5F - 1.0F);
+    }
+
+    if (options.source == jarvisx::mm3d::Modality::Image) {
+        if (packet.width == 0U || packet.height == 0U) {
+            const std::size_t side = static_cast<std::size_t>(std::sqrt(static_cast<double>(packet.samples.size())));
+            packet.width = std::max<std::size_t>(1U, side);
+            packet.height = std::max<std::size_t>(1U, side);
+            packet.samples.resize(packet.width * packet.height);
+        }
+    } else if (options.source == jarvisx::mm3d::Modality::Video) {
+        if (packet.width == 0U) packet.width = 32U;
+        if (packet.height == 0U) packet.height = 32U;
+        if (packet.frames == 0U) packet.frames = 1U;
+        const std::size_t needed = packet.width * packet.height * packet.frames;
+        if (packet.samples.size() < needed) {
+            const std::vector<float> original = packet.samples;
+            packet.samples.resize(needed);
+            for (std::size_t i = 0U; i < needed; ++i) {
+                packet.samples[i] = original.empty() ? 0.0F : original[i % original.size()];
+            }
+        } else {
+            packet.samples.resize(needed);
+        }
+    } else if (options.source == jarvisx::mm3d::Modality::Volume3D) {
+        std::size_t side = options.width;
+        if (side == 0U) {
+            side = static_cast<std::size_t>(std::cbrt(static_cast<double>(packet.samples.size())));
+            side = std::max<std::size_t>(1U, side);
+        }
+        packet.width = side;
+        packet.height = options.height == 0U ? side : options.height;
+        packet.depth = side;
+        const std::size_t needed = packet.width * packet.height * packet.depth;
+        packet.samples.resize(needed, 0.0F);
+    }
+    return packet;
+}
+
+std::uint8_t to_u8(float value) noexcept {
+    const float normalized = std::clamp((value + 1.0F) * 127.5F, 0.0F, 255.0F);
+    return static_cast<std::uint8_t>(std::lround(normalized));
+}
+
+void write_pgm(const std::filesystem::path& path, const std::vector<float>& samples,
+               std::size_t width, std::size_t height, std::size_t offset = 0U) {
+    std::ofstream stream(path, std::ios::binary);
+    if (!stream) throw std::runtime_error("unable to create " + path.string());
+    stream << "P5\n" << width << ' ' << height << "\n255\n";
+    const std::size_t count = width * height;
+    for (std::size_t i = 0U; i < count; ++i) {
+        const std::size_t index = offset + i;
+        const std::uint8_t byte = index < samples.size() ? to_u8(samples[index]) : 0U;
+        stream.write(reinterpret_cast<const char*>(&byte), 1);
+    }
+}
+
+void write_u16_le(std::ofstream& stream, std::uint16_t value) {
+    const std::array<std::uint8_t, 2U> bytes{
+        static_cast<std::uint8_t>(value & 0xFFU),
+        static_cast<std::uint8_t>((value >> 8U) & 0xFFU)};
+    stream.write(reinterpret_cast<const char*>(bytes.data()), 2);
+}
+
+void write_u32_le(std::ofstream& stream, std::uint32_t value) {
+    const std::array<std::uint8_t, 4U> bytes{
+        static_cast<std::uint8_t>(value & 0xFFU),
+        static_cast<std::uint8_t>((value >> 8U) & 0xFFU),
+        static_cast<std::uint8_t>((value >> 16U) & 0xFFU),
+        static_cast<std::uint8_t>((value >> 24U) & 0xFFU)};
+    stream.write(reinterpret_cast<const char*>(bytes.data()), 4);
+}
+
+void write_wav(const std::filesystem::path& path, const std::vector<float>& samples,
+               std::uint32_t sample_rate) {
+    if (samples.size() > static_cast<std::size_t>(std::numeric_limits<std::uint32_t>::max() / 2U)) {
+        throw std::runtime_error("audio output exceeds WAV32 size limit");
+    }
+    const std::uint32_t data_bytes = static_cast<std::uint32_t>(samples.size() * 2U);
+    std::ofstream stream(path, std::ios::binary);
+    if (!stream) throw std::runtime_error("unable to create " + path.string());
+    stream.write("RIFF", 4);
+    write_u32_le(stream, 36U + data_bytes);
+    stream.write("WAVEfmt ", 8);
+    write_u32_le(stream, 16U);
+    write_u16_le(stream, 1U);
+    write_u16_le(stream, 1U);
+    write_u32_le(stream, sample_rate);
+    write_u32_le(stream, sample_rate * 2U);
+    write_u16_le(stream, 2U);
+    write_u16_le(stream, 16U);
+    stream.write("data", 4);
+    write_u32_le(stream, data_bytes);
+    for (float value : samples) {
+        const float clipped = std::clamp(value, -1.0F, 1.0F);
+        const std::int16_t pcm = static_cast<std::int16_t>(std::lround(clipped * 32767.0F));
+        write_u16_le(stream, static_cast<std::uint16_t>(pcm));
+    }
+}
+
+void write_volume_obj(const std::filesystem::path& path,
+                      const jarvisx::mm3d::GeneratedMedia& media) {
+    std::ofstream stream(path);
+    if (!stream) throw std::runtime_error("unable to create " + path.string());
+    stream << "# Jarvis-X MM3D generated volume point cloud\n";
+    for (std::size_t z = 0U; z < media.depth; ++z) {
+        for (std::size_t y = 0U; y < media.height; ++y) {
+            for (std::size_t x = 0U; x < media.width; ++x) {
+                const std::size_t index = (z * media.height + y) * media.width + x;
+                if (index >= media.samples.size() || media.samples[index] <= 0.0F) continue;
+                stream << "v " << x << ' ' << y << ' ' << z << '\n';
+            }
+        }
+    }
+}
+
+void write_output(const std::filesystem::path& directory,
+                  const jarvisx::mm3d::GeneratedMedia& media) {
+    std::filesystem::create_directories(directory);
+    using jarvisx::mm3d::Modality;
+    if (media.modality == Modality::Text) {
+        std::ofstream stream(directory / "generated.txt");
+        stream << media.text << '\n';
+    } else if (media.modality == Modality::Image) {
+        write_pgm(directory / "generated.pgm", media.samples, media.width, media.height);
+    } else if (media.modality == Modality::Audio) {
+        write_wav(directory / "generated.wav", media.samples, media.sample_rate);
+    } else if (media.modality == Modality::Video) {
+        const std::filesystem::path frames_dir = directory / "frames";
+        std::filesystem::create_directories(frames_dir);
+        const std::size_t stride = media.width * media.height;
+        for (std::size_t frame = 0U; frame < media.frames; ++frame) {
+            std::ostringstream name;
+            name << "frame-" << std::setw(4) << std::setfill('0') << frame << ".pgm";
+            write_pgm(frames_dir / name.str(), media.samples, media.width, media.height,
+                      frame * stride);
+        }
+        std::ofstream manifest(directory / "generated-video.txt");
+        manifest << "format=pgm-sequence\nframes=" << media.frames
+                 << "\nwidth=" << media.width << "\nheight=" << media.height << '\n';
+    } else if (media.modality == Modality::Volume3D) {
+        write_volume_obj(directory / "generated.obj", media);
+    } else {
+        std::ofstream stream(directory / "generated.f32", std::ios::binary);
+        stream.write(reinterpret_cast<const char*>(media.samples.data()),
+                     static_cast<std::streamsize>(media.samples.size() * sizeof(float)));
+    }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_args(argc, argv);
+        jarvisx::mm3d::GeneratorConfig config;
+        config.autoencoder.input_edge = options.edge;
+        config.autoencoder.latent_channels = options.channels;
+        config.autoencoder.seed = options.seed;
+        config.validate();
+
+        jarvisx::mm3d::MultimodalGenerator3D engine(config);
+        const jarvisx::mm3d::MediaPacket source = build_packet(options);
+
+        jarvisx::Autoencoder3DMetrics last_train{};
+        for (std::size_t step = 0U; step < options.train_steps; ++step) {
+            last_train = engine.train_step(source);
+        }
+
+        jarvisx::mm3d::GenerationMetrics metrics;
+        jarvisx::mm3d::GeneratedMedia output;
+        if (options.unconditional) {
+            output = engine.generate(options.target, options.prompt, options.seed);
+            metrics.source = source.modality;
+            metrics.target = options.target;
+            metrics.output_elements = output.samples.size();
+        } else {
+            output = engine.translate(source, options.target, options.prompt,
+                                      options.conditioning_mix, options.quantized,
+                                      options.seed, &metrics);
+        }
+        write_output(options.output_dir, output);
+
+        std::ofstream telemetry(options.output_dir / "generation.csv");
+        telemetry << "source,target,latent_elements,output_elements,latent_energy,output_energy,mix,train_steps,last_train_mse\n"
+                  << jarvisx::mm3d::modality_name(metrics.source) << ','
+                  << jarvisx::mm3d::modality_name(metrics.target) << ','
+                  << metrics.latent_elements << ',' << metrics.output_elements << ','
+                  << metrics.latent_energy << ',' << metrics.output_energy << ','
+                  << metrics.conditioning_mix << ',' << options.train_steps << ','
+                  << last_train.mse << '\n';
+
+        if (!options.quiet) {
+            std::cout << "Jarvis-X MM3D generated "
+                      << jarvisx::mm3d::modality_name(options.target)
+                      << " from " << jarvisx::mm3d::modality_name(options.source)
+                      << " through a " << options.channels << "x"
+                      << options.edge / 2U << "^3 latent field\n"
+                      << "output: " << options.output_dir << '\n'
+                      << "latent energy: " << metrics.latent_energy
+                      << " output energy: " << metrics.output_energy << '\n';
+        }
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "jarvisx-mm3d: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/src/multimodal_generator3d_main.cpp
+++ b/cpp_runtime/src/multimodal_generator3d_main.cpp
@@ -1,13 +1,16 @@
 #include "jarvisx/multimodal_generator3d.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <limits>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/cpp_runtime/tests/multimodal_generator3d_tests.cpp
+++ b/cpp_runtime/tests/multimodal_generator3d_tests.cpp
@@ -1,0 +1,123 @@
+#include "jarvisx/multimodal_generator3d.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <string>
+
+namespace {
+
+jarvisx::mm3d::GeneratorConfig test_config() {
+    jarvisx::mm3d::GeneratorConfig config;
+    config.autoencoder.input_edge = 8U;
+    config.autoencoder.latent_channels = 3U;
+    config.autoencoder.seed = 0x12345678ULL;
+    config.default_text_length = 64U;
+    config.default_image_edge = 16U;
+    config.default_audio_samples = 128U;
+    config.default_video_frames = 4U;
+    config.default_video_edge = 8U;
+    return config;
+}
+
+void assert_bounded(const std::vector<float>& values) {
+    for (float value : values) {
+        assert(std::isfinite(value));
+        assert(value >= -1.000001F);
+        assert(value <= 1.000001F);
+    }
+}
+
+void test_text_tensorization_and_latent_shape() {
+    jarvisx::mm3d::MultimodalGenerator3D engine(test_config());
+    jarvisx::mm3d::MediaPacket packet;
+    packet.modality = jarvisx::mm3d::Modality::Text;
+    packet.text = "identity preserving multimodal latent geometry";
+
+    const jarvisx::Tensor4D tensor = engine.tensorize(packet);
+    assert(tensor.shape().channels == 1U);
+    assert(tensor.shape().depth == 8U);
+    assert(tensor.size() == 512U);
+
+    const jarvisx::Tensor4D latent = engine.encode(packet);
+    assert(latent.shape().channels == 3U);
+    assert(latent.shape().depth == 4U);
+    assert(latent.shape().height == 4U);
+    assert(latent.shape().width == 4U);
+    assert(latent.size() == 192U);
+}
+
+void test_prompt_generation_is_deterministic() {
+    jarvisx::mm3d::MultimodalGenerator3D first(test_config());
+    jarvisx::mm3d::MultimodalGenerator3D second(test_config());
+
+    const auto a = first.generate(jarvisx::mm3d::Modality::Audio,
+                                  "same prompt same latent", 99ULL);
+    const auto b = second.generate(jarvisx::mm3d::Modality::Audio,
+                                   "same prompt same latent", 99ULL);
+    assert(a.samples == b.samples);
+    assert(a.samples.size() == 128U);
+    assert_bounded(a.samples);
+}
+
+void test_cross_modal_outputs() {
+    jarvisx::mm3d::MultimodalGenerator3D engine(test_config());
+    jarvisx::mm3d::MediaPacket source;
+    source.modality = jarvisx::mm3d::Modality::Text;
+    source.text = "cross modal conditioning fixture";
+
+    jarvisx::mm3d::GenerationMetrics metrics;
+    const auto image = engine.translate(source, jarvisx::mm3d::Modality::Image,
+                                        "render geometry", 0.75F, false, 7ULL,
+                                        &metrics);
+    assert(image.width == 16U);
+    assert(image.height == 16U);
+    assert(image.samples.size() == 256U);
+    assert(metrics.latent_elements == 192U);
+    assert(metrics.output_elements == image.samples.size());
+    assert_bounded(image.samples);
+
+    const auto video = engine.translate(source, jarvisx::mm3d::Modality::Video,
+                                        "animate geometry", 0.65F);
+    assert(video.frames == 4U);
+    assert(video.width == 8U);
+    assert(video.height == 8U);
+    assert(video.samples.size() == 256U);
+    assert_bounded(video.samples);
+
+    const auto volume = engine.translate(source, jarvisx::mm3d::Modality::Volume3D,
+                                         "volumetric geometry", 0.9F);
+    assert(volume.width == 8U);
+    assert(volume.height == 8U);
+    assert(volume.depth == 8U);
+    assert(volume.samples.size() == 512U);
+    assert_bounded(volume.samples);
+}
+
+void test_training_path_remains_available() {
+    jarvisx::mm3d::MultimodalGenerator3D engine(test_config());
+    jarvisx::mm3d::MediaPacket packet;
+    packet.modality = jarvisx::mm3d::Modality::Audio;
+    packet.samples.resize(256U);
+    for (std::size_t i = 0U; i < packet.samples.size(); ++i) {
+        packet.samples[i] = std::sin(static_cast<float>(i) * 0.07F);
+    }
+    const auto before = engine.reconstruct(packet);
+    const auto metrics = engine.train_step(packet);
+    const auto after = engine.reconstruct(packet);
+    assert(std::isfinite(metrics.mse));
+    assert(before.samples.size() == after.samples.size());
+    assert_bounded(after.samples);
+}
+
+} // namespace
+
+int main() {
+    test_text_tensorization_and_latent_shape();
+    test_prompt_generation_is_deterministic();
+    test_cross_modal_outputs();
+    test_training_path_remains_available();
+    std::cout << "multimodal generator 3D regressions passed\n";
+    return 0;
+}

--- a/docs/3D_MULTIMODAL_GENERATOR.md
+++ b/docs/3D_MULTIMODAL_GENERATOR.md
@@ -1,0 +1,167 @@
+# Dr. Moagi 3D Multimodal Generator
+
+## Scope
+
+`DrMoagi-Multimodal-3D` evolves the bounded Jarvis-X 3D autoencoder into a dependency-free reference composition layer for text, image, audio, video, volumetric and generic numeric media. It reuses the existing `Autoencoder3D` numerical kernel rather than replacing it.
+
+The runtime is intentionally explicit about its capability boundary: it is a deterministic research generator and cross-modal latent transport engine. The default weights are not a pretrained foundation model, so prompt-conditioned outputs are procedural until modality models are trained on aligned data. It does not claim semantic text-to-image/video quality without such training.
+
+## Architecture
+
+Every supported modality is mapped into a bounded scalar 3D field
+
+```text
+X_m in [-1,1]^(1 x N x N x N)
+```
+
+and encoded by a modality-specific 3D autoencoder
+
+```text
+Z_m = E_m(X_m)
+```
+
+with common latent geometry
+
+```text
+Z_m in [-1,1]^(C x N/2 x N/2 x N/2).
+```
+
+Because every model shares the same latent tensor shape, a source latent can be decoded through another modality head:
+
+```text
+Y_n = D_n(Z_m).
+```
+
+This is the engine's cross-modal transport primitive. It is shape-compatible by construction; semantic alignment must be learned from paired or otherwise aligned training data.
+
+## Prompt-conditioned generation
+
+A deterministic prompt field `P(prompt, seed)` is generated in the same latent geometry. Conditional translation mixes encoded source state and prompt state:
+
+```text
+Z* = alpha E_m(X_m) + (1-alpha) P(prompt, seed)
+Y_n = D_n(Z*)
+```
+
+where `alpha` is `--mix` in `[0,1]`.
+
+Unconditional generation bypasses source encoding:
+
+```text
+Y_n = D_n(P(prompt, seed)).
+```
+
+Prompt seeding uses a stable FNV-style text hash, xorshift state evolution and bounded sinusoidal phase injection. This gives deterministic replay for the same configuration, seed, prompt and platform.
+
+## Modality adapters
+
+- **text**: UTF-8 bytes are folded through the 3D lattice with a depth positional phase; generated values map to printable ASCII in this reference backend.
+- **image**: scalar/RGB-like sample packets are channel-averaged, nearest-resampled in `x/y`, and replicated through the input volume; output is a grayscale PGM slice.
+- **audio**: waveform samples are resampled over the 3D lattice; output is mono PCM16 WAV.
+- **video**: frame index maps to the `z` axis and spatial coordinates map to `x/y`; output is a deterministic PGM frame sequence plus manifest.
+- **volume3d**: 3D samples are nearest-resampled directly into the model field; positive generated voxels can be exported as an OBJ point cloud.
+- **generic**: arbitrary normalized samples are folded through the lattice and emitted as raw `float32`.
+
+The current CLI treats non-text input files as raw bytes normalized to `[-1,1]`. PNG/JPEG/MP4/MP3 container decoding is deliberately outside the dependency-free core; production deployments should attach codec adapters before constructing `MediaPacket` values.
+
+## Build
+
+```bash
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --parallel
+ctest --test-dir build/cpp-runtime --output-on-failure
+```
+
+The new executable is emitted as:
+
+```text
+DrMoagi-Multimodal-3D
+```
+
+## Examples
+
+Text to image-volume projection:
+
+```bash
+./build/cpp-runtime/DrMoagi-Multimodal-3D \
+  --source text \
+  --target image \
+  --text "recursive geometric intelligence" \
+  --prompt "high spatial coherence" \
+  --mix 0.8 \
+  --edge 8 \
+  --channels 4 \
+  --output-dir .jarvisx-mm3d
+```
+
+Text to waveform:
+
+```bash
+./build/cpp-runtime/DrMoagi-Multimodal-3D \
+  --source text \
+  --target audio \
+  --text "Jarvis X" \
+  --prompt "smooth harmonic pulse" \
+  --output-dir .jarvisx-audio
+```
+
+Prompt-only volumetric generation:
+
+```bash
+./build/cpp-runtime/DrMoagi-Multimodal-3D \
+  --source text \
+  --target volume3d \
+  --prompt "symmetric shell" \
+  --unconditional \
+  --output-dir .jarvisx-volume
+```
+
+Source-adaptation steps remain available through the inherited autoencoder training path:
+
+```bash
+./build/cpp-runtime/DrMoagi-Multimodal-3D \
+  --source audio \
+  --target video \
+  --input waveform.raw \
+  --train-steps 16 \
+  --prompt "temporal field" \
+  --output-dir .jarvisx-video
+```
+
+## Output contract
+
+Each run writes `generation.csv` plus one target-specific artifact:
+
+- text: `generated.txt`
+- image: `generated.pgm`
+- audio: `generated.wav`
+- video: `frames/frame-NNNN.pgm` and `generated-video.txt`
+- volume3d: `generated.obj`
+- generic: `generated.f32`
+
+Telemetry records source/target modality, latent/output element counts, RMS energy, conditioning mix and final adaptation MSE.
+
+## Identity and attractor semantics
+
+The module preserves the architectural distinction established by the 3D locked formulation:
+
+```text
+representation: D_m(E_m(X)) approximates X after training
+control/physical convergence: separate subsystem
+```
+
+The generator is a representation and synthesis layer. It does not infer that a reconstructed physical state is repaired, nor does it directly command safety-critical actuators.
+
+## Evolution path
+
+This reference layer is designed so production capability can be added without changing the core contract:
+
+1. attach real codec adapters (PNG/JPEG, WAV/FLAC, MP4/WebM, tokenizers);
+2. replace independent modality training with aligned contrastive/cycle objectives;
+3. add temporal latent prediction for video/audio continuation;
+4. add diffusion/flow or autoregressive latent priors behind `prompt_latent`;
+5. add GPU tensor backends while retaining the bounded CPU reference implementation;
+6. checkpoint modality models plus shared latent alignment state;
+7. benchmark reconstruction, cross-modal retrieval/alignment and generation quality separately.
+
+This keeps the execution order: working -> robust -> portable -> elegant -> advanced.


### PR DESCRIPTION
## Summary

Evolves the existing bounded `Autoencoder3D` runtime into a multi-purpose 3D multimodal generation layer without replacing the tested ANN core.

### Adds

- `MultimodalGenerator3D` composition layer with six modalities:
  - text
  - image
  - audio
  - video / animation
  - 3D volume
  - generic numeric media
- common 3D latent geometry across modality-specific autoencoder heads
- source-conditioned cross-modal latent transfer
- deterministic prompt-seeded latent generation
- optional Q3 latent inference through the existing autoencoder path
- inherited source-modality training via `Autoencoder3D::train_step`
- dependency-free target exporters:
  - text -> TXT
  - image -> grayscale PGM
  - audio -> mono PCM16 WAV
  - video -> PGM frame sequence + manifest
  - volume -> OBJ point cloud
  - generic -> raw float32
- `generation.csv` telemetry
- CMake/CTest integration and deterministic regression coverage
- architecture/capability documentation

## Mathematical contract

For modality `m`:

```text
X_m -> E_m -> Z_m
Z_m in [-1,1]^(C x N/2 x N/2 x N/2)
```

Cross-modal generation into target `n`:

```text
Z* = alpha E_m(X_m) + (1-alpha) P(prompt, seed)
Y_n = D_n(Z*)
```

Unconditional generation:

```text
Y_n = D_n(P(prompt, seed))
```

All modality models share the same latent tensor shape, so transfer is geometrically well-defined. Semantic alignment is intentionally not overstated: the default weights are not pretrained, and useful semantic cross-modal generation requires aligned training or a stronger learned latent prior.

## Identity / control boundary

This keeps the locked architecture mathematically clean:

- representation/generation stays inside the autoencoding layer;
- no claim that reconstruction repairs a physical system;
- no direct safety-critical actuation path is introduced.

## Validation

The change adds:

- `multimodal-generator3d-runtime-smoke`
- `multimodal-generator3d-regressions`

Coverage includes latent shape, deterministic prompt replay, text -> image/video/volume transfer, bounded generated samples and inherited training-path execution.

The repository's existing C++ workflow will run the full CMake/CTest matrix on GCC, sanitizer-enabled Clang, and MSVC.

## Capability boundary

The CLI currently treats non-text input files as raw normalized bytes. It emits portable dependency-free reference formats. Real PNG/JPEG/MP4/MP3/FLAC decoding should be attached as codec adapters around `MediaPacket`; this PR intentionally keeps codec/container dependencies outside the numerical core.