### PR TITLE
Permeate DM-vOmegaXi+ into bounded mechatronic control

### DIFF
--- a/docs/DM_VOMEGAXI_MECHATRONIC_CONTROL.md
+++ b/docs/DM_VOMEGAXI_MECHATRONIC_CONTROL.md
@@ -1,0 +1,79 @@
+# DM-vOmegaXi+ Mechatronic Control Contract
+
+## Master fixed-point loop
+
+The implementable closed-loop interpretation of `I AM = I DESCRIBE` is
+
+```text
+physical state -> sensing -> pulse description -> Boolean compute
+               -> recurrent memory -> admissibility -> power command
+               -> physical state
+```
+
+For tick `t`,
+
+```text
+Psi_t       = normalized sensor vector in [-1, 1]^N
+b_t         = DeltaSigma(Psi_t)
+r_t         = popcount(XNOR(b_t, W_t))
+d_t         = 2 r_t - N
+yhat_t      = 1[d_t >= 0]
+e_t         = y_t XOR yhat_t
+Omega_t+1   = ROTL16(Omega_t, k) XOR pack16(b_t) XOR (e_t << 15)
+u_raw,t     = round(10^6 d_t / N)
+u_t         = Theta(u_raw,t, stop_t, limits)
+Psi_t+1     = Plant(Psi_t, PowerStage(u_t), disturbances_t)
+```
+
+The software reference terminates at `u_t`. `PowerStage` and `Plant` remain
+explicit interfaces until hardware-specific implementations and evidence are
+provided.
+
+## Operator contract
+
+| Symbol | Concrete primitive | Persistent state | Verified property |
+|---|---|---|---|
+| Psi | normalized sensor vector | external plant state | finite bounded input |
+| Phi | first-order delta-sigma bank | one integrator/channel | one-bit output; density fixture |
+| Lambda | XNOR plus popcount | immutable binary weights | exact bipolar dot identity |
+| Omega | 16-bit rotate/XOR register | `uint16` word | deterministic bounded recurrence |
+| Theta | safety governor | prior duty/dead-time counter | clamp, slew, stop, reversal interlock |
+| Actuation | hardware-neutral H-bridge command | none in reference | no same-leg high/low overlap |
+
+## Timing domains
+
+Three clocks must never be collapsed into one headline number:
+
+1. **Computational timing** measures delta-sigma state updates, popcount,
+   recurrence, and constraint evaluation on a named processor.
+2. **Electrical timing** measures PWM resolution, dead time, propagation delay,
+   rise/fall time, and protection response on a named driver/power stage.
+3. **Plant timing** measures sensor sampling, actuator response, settling time,
+   overshoot, and closed-loop stability for a named mechanical load.
+
+Sub-nanosecond device or logic events do not establish a sub-nanosecond
+sensor-to-mechanical-to-sensor control loop. Every latency or throughput claim
+must identify its boundary, clock, hardware, workload, statistic, and sample
+count.
+
+## Gate-command semantics
+
+Duty is a signed integer in parts per million. Positive duty commands the left
+high-side PWM and right low-side switch; negative duty commands the mirrored
+pair. Zero, emergency stop, and direction dead time produce a coast command.
+The reference never commands a high-side and low-side device on the same leg.
+
+These values are logical commands, not GPIO signals. A physical integration
+must add an independent hardware dead-time generator and fail-safe protection;
+software invariants are not a substitute for electrical protection.
+
+## Verification boundary
+
+The included tests establish arithmetic and state-machine invariants only.
+They do not establish functional safety, ethical adequacy, electromagnetic
+compatibility, thermal performance, motor-control stability, or suitability
+for medical, vehicle, industrial, or other safety-critical use.
+
+Acceptance for physical use requires, at minimum, plant identification,
+control-loop stability analysis, fault-tree/FMEA work, watchdog testing,
+hardware-in-the-loop testing, and compliance review for the target domain.

--- a/docs/adr/0012-dm-vomegaxi-mechatronic-control.md
+++ b/docs/adr/0012-dm-vomegaxi-mechatronic-control.md
@@ -1,0 +1,58 @@
+# ADR-012: Bound DM-vOmegaXi+ as a mechatronic control reference
+
+**Status:** Proposed  
+**Date:** 2026-09-02  
+**Extends:** ADR-001, ADR-002, ADR-007
+
+## Context
+
+The DM-vOmegaXi+ stack maps Psi, Phi, Lambda, Omega, and Theta onto sensing,
+one-bit delta-sigma description, XNOR/popcount arithmetic, 16-bit recurrent
+memory, and safety-constrained actuation. That mapping is implementable, but it
+crosses three domains with materially different semantics: computation, power
+electronics, and a mechanical plant.
+
+Without a boundary, a software state transition can be mistaken for electrical
+switching speed, an electrical edge can be mistaken for closed-loop mechanical
+response, and an XOR prediction error can be mistaken for an ethical system.
+
+## Decision
+
+Jarvis-X adopts a deterministic, hardware-neutral reference with these rules:
+
+1. Psi is a normalized sensor vector supplied by a caller or test fixture.
+2. Phi is a first-order one-bit delta-sigma bank with explicit integrator state.
+3. Lambda uses the exact identity `dot = 2 * popcount(XNOR(x,w)) - N`.
+4. Omega is a bounded 16-bit rotate/XOR recurrent register.
+5. Theta is an admissibility governor: clamp, slew limit, emergency stop,
+   direction-reversal dead time, and per-leg shoot-through exclusion.
+6. The software endpoint is a hardware-neutral gate command. A real driver,
+   MOSFET stage, motor, sensor, and watchdog are outside the reference boundary.
+7. XOR is a prediction-error bit only. Ethical or policy claims require an
+   independently specified policy model, authority source, and validation set.
+8. No latency is called zero. Computational, electrical, and plant timings are
+   measured and reported separately when physical hardware exists.
+
+## Consequences
+
+- Every conceptual operator has a testable transition and bounded state.
+- Gate commands fail closed on invalid inputs and emergency stop.
+- Reversal cannot immediately energize the opposite bridge direction.
+- The reference is suitable for simulation, trace generation, and HDL/MCU
+  conformance fixtures, but not direct deployment to power hardware.
+- Physical deployment additionally requires isolated gate drivers, hardware
+  dead time, over-current and thermal cut-offs, watchdogs, safe-state analysis,
+  and plant-specific control validation.
+
+## Acceptance evidence
+
+- exact XNOR/popcount equivalence tests;
+- delta-sigma density test over a bounded sample window;
+- deterministic 16-bit recurrence test;
+- clamp, slew, emergency-stop, reversal, and shoot-through invariants;
+- complete trace coverage from sensor sample through gate command;
+- hardware-in-the-loop evidence before any physical-performance claim.
+
+The reference implementation is
+`src/jarvisx/dm_vomegaxi_mechatronic.py`; its focused tests are
+`tests/test_dm_vomegaxi_mechatronic.py`.

--- a/src/jarvisx/dm_vomegaxi_mechatronic.py
+++ b/src/jarvisx/dm_vomegaxi_mechatronic.py
@@ -1,0 +1,229 @@
+"""Bounded DM-vOmegaXi+ pulse-domain mechatronic control reference.
+
+The module turns the symbolic Psi -> Phi -> Lambda -> Omega -> Theta chain
+into deterministic software primitives.  It emits hardware-neutral H-bridge
+commands; it does not claim transistor, gate-driver, or mechanical timing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+
+def _require_bit(value: int) -> int:
+    if value not in (0, 1):
+        raise ValueError("bit values must be 0 or 1")
+    return value
+
+
+def xnor_popcount(lhs: Sequence[int], rhs: Sequence[int]) -> int:
+    """Count equal bit positions in two non-empty, equal-width vectors."""
+
+    if not lhs or len(lhs) != len(rhs):
+        raise ValueError("vectors must be non-empty and have equal width")
+    return sum(_require_bit(a) == _require_bit(b) for a, b in zip(lhs, rhs))
+
+
+def bipolar_dot(lhs: Sequence[int], rhs: Sequence[int]) -> int:
+    """Exact {-1,+1} dot product represented through XNOR/popcount."""
+
+    return 2 * xnor_popcount(lhs, rhs) - len(lhs)
+
+
+class DeltaSigmaBank:
+    """First-order one-bit delta-sigma description operator."""
+
+    def __init__(self, channels: int) -> None:
+        if isinstance(channels, bool) or not isinstance(channels, int) or channels <= 0:
+            raise ValueError("channels must be a positive integer")
+        self._integrators = [0.0] * channels
+
+    @property
+    def channels(self) -> int:
+        return len(self._integrators)
+
+    def encode(self, values: Sequence[float]) -> tuple[int, ...]:
+        if len(values) != self.channels:
+            raise ValueError("sensor vector width does not match channel count")
+        bits: list[int] = []
+        for index, raw in enumerate(values):
+            value = float(raw)
+            if not -1.0 <= value <= 1.0:
+                raise ValueError("normalized sensor values must be within [-1, 1]")
+            self._integrators[index] += value
+            bit = 1 if self._integrators[index] >= 0.0 else 0
+            self._integrators[index] -= 1.0 if bit else -1.0
+            bits.append(bit)
+        return tuple(bits)
+
+
+def rotate_u16(value: int, places: int) -> int:
+    """Rotate a value inside an explicit 16-bit recurrent register."""
+
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError("value must be an integer")
+    if isinstance(places, bool) or not isinstance(places, int):
+        raise TypeError("places must be an integer")
+    places %= 16
+    value &= 0xFFFF
+    return ((value << places) | (value >> ((16 - places) % 16))) & 0xFFFF
+
+
+@dataclass
+class RecurrentRegister:
+    value: int = 0
+    rotation: int = 1
+
+    def update(self, bits: Sequence[int], error_bit: int) -> int:
+        injection = 0
+        for index, bit in enumerate(bits[:16]):
+            injection |= _require_bit(bit) << index
+        injection ^= _require_bit(error_bit) << 15
+        self.value = rotate_u16(self.value, self.rotation) ^ injection
+        self.value &= 0xFFFF
+        return self.value
+
+
+@dataclass(frozen=True)
+class SafetyLimits:
+    max_duty_ppm: int = 800_000
+    max_slew_ppm: int = 100_000
+    reversal_dead_ticks: int = 1
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.max_duty_ppm <= 1_000_000:
+            raise ValueError("max_duty_ppm must be within [0, 1_000_000]")
+        if not 0 <= self.max_slew_ppm <= 1_000_000:
+            raise ValueError("max_slew_ppm must be within [0, 1_000_000]")
+        if self.reversal_dead_ticks < 0:
+            raise ValueError("reversal_dead_ticks must be non-negative")
+
+
+@dataclass(frozen=True)
+class GateCommand:
+    signed_duty_ppm: int
+    left_high_pwm: int
+    left_low: bool
+    right_high_pwm: int
+    right_low: bool
+    inhibited: bool
+    reason: str
+
+    @property
+    def shoot_through_safe(self) -> bool:
+        return not (
+            (self.left_high_pwm and self.left_low)
+            or (self.right_high_pwm and self.right_low)
+        )
+
+
+class ConstraintGovernor:
+    """Theta admissibility layer with clamp, slew, stop, and reversal dead time."""
+
+    def __init__(self, limits: SafetyLimits | None = None) -> None:
+        self.limits = limits or SafetyLimits()
+        self._last_duty = 0
+        self._dead_ticks = 0
+
+    @staticmethod
+    def _coast(reason: str) -> GateCommand:
+        return GateCommand(0, 0, False, 0, False, True, reason)
+
+    def apply(self, requested_duty_ppm: int, *, emergency_stop: bool = False) -> GateCommand:
+        if isinstance(requested_duty_ppm, bool) or not isinstance(requested_duty_ppm, int):
+            raise TypeError("requested_duty_ppm must be an integer")
+        if emergency_stop:
+            self._last_duty = 0
+            self._dead_ticks = 0
+            return self._coast("emergency-stop")
+
+        limit = self.limits.max_duty_ppm
+        requested = max(-limit, min(limit, requested_duty_ppm))
+        previous = self._last_duty
+        reversing = previous != 0 and requested != 0 and (previous > 0) != (requested > 0)
+        if reversing and self.limits.reversal_dead_ticks:
+            self._last_duty = 0
+            self._dead_ticks = self.limits.reversal_dead_ticks - 1
+            return self._coast("reversal-dead-time")
+        if self._dead_ticks:
+            self._dead_ticks -= 1
+            self._last_duty = 0
+            return self._coast("reversal-dead-time")
+
+        slew = self.limits.max_slew_ppm
+        duty = max(previous - slew, min(previous + slew, requested))
+        self._last_duty = duty
+        magnitude = abs(duty)
+        if duty > 0:
+            command = GateCommand(duty, magnitude, False, 0, True, False, "forward")
+        elif duty < 0:
+            command = GateCommand(duty, 0, True, magnitude, False, False, "reverse")
+        else:
+            command = self._coast("zero-command")
+        if not command.shoot_through_safe:
+            raise AssertionError("unsafe H-bridge command generated")
+        return command
+
+
+@dataclass(frozen=True)
+class ControlTrace:
+    tick: int
+    pulse_bits: tuple[int, ...]
+    popcount: int
+    signed_dot: int
+    prediction_bit: int
+    error_bit: int
+    memory_u16: int
+    requested_duty_ppm: int
+    command: GateCommand
+
+
+class DMVomegaxiMechatronicLoop:
+    """Closed computational path from normalized sensors to a safe gate command."""
+
+    def __init__(
+        self,
+        weights: Sequence[int],
+        *,
+        limits: SafetyLimits | None = None,
+        memory_rotation: int = 1,
+    ) -> None:
+        if not weights:
+            raise ValueError("weights must not be empty")
+        self.weights = tuple(_require_bit(bit) for bit in weights)
+        self.phi = DeltaSigmaBank(len(self.weights))
+        self.omega = RecurrentRegister(rotation=memory_rotation)
+        self.theta = ConstraintGovernor(limits)
+        self.tick = 0
+
+    def step(
+        self,
+        sensor_values: Sequence[float],
+        *,
+        target_bit: int,
+        emergency_stop: bool = False,
+    ) -> ControlTrace:
+        target_bit = _require_bit(target_bit)
+        pulses = self.phi.encode(sensor_values)
+        matches = xnor_popcount(pulses, self.weights)
+        signed = 2 * matches - len(self.weights)
+        prediction = 1 if signed >= 0 else 0
+        error = target_bit ^ prediction
+        memory = self.omega.update(pulses, error)
+
+        # Lambda: normalize exact Boolean dot product to signed parts-per-million.
+        requested = int(round((signed / len(self.weights)) * 1_000_000))
+        command = self.theta.apply(requested, emergency_stop=emergency_stop)
+        self.tick += 1
+        return ControlTrace(
+            tick=self.tick,
+            pulse_bits=pulses,
+            popcount=matches,
+            signed_dot=signed,
+            prediction_bit=prediction,
+            error_bit=error,
+            memory_u16=memory,
+            requested_duty_ppm=requested,
+            command=command,
+        )

--- a/tests/test_dm_vomegaxi_mechatronic.py
+++ b/tests/test_dm_vomegaxi_mechatronic.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dm_vomegaxi_mechatronic import (
+    DMVomegaxiMechatronicLoop,
+    ConstraintGovernor,
+    DeltaSigmaBank,
+    SafetyLimits,
+    bipolar_dot,
+    rotate_u16,
+    xnor_popcount,
+)
+
+
+def test_xnor_popcount_is_exact_bipolar_dot_product():
+    lhs = (1, 0, 1, 1, 0, 0)
+    rhs = (1, 1, 0, 1, 0, 0)
+    assert xnor_popcount(lhs, rhs) == 4
+    assert bipolar_dot(lhs, rhs) == 2
+    explicit = sum((1 if a else -1) * (1 if b else -1) for a, b in zip(lhs, rhs))
+    assert bipolar_dot(lhs, rhs) == explicit
+
+
+def test_delta_sigma_density_tracks_normalized_signal():
+    encoder = DeltaSigmaBank(1)
+    bits = [encoder.encode((0.25,))[0] for _ in range(4096)]
+    reconstructed = 2.0 * (sum(bits) / len(bits)) - 1.0
+    assert reconstructed == pytest.approx(0.25, abs=1 / 4096)
+
+
+def test_memory_rotation_stays_in_u16_domain():
+    assert rotate_u16(0x8001, 1) == 0x0003
+    assert rotate_u16(0x1234, 16) == 0x1234
+
+
+def test_theta_clamps_slew_and_never_commands_shoot_through():
+    governor = ConstraintGovernor(SafetyLimits(max_duty_ppm=500_000, max_slew_ppm=100_000))
+    command = governor.apply(900_000)
+    assert command.signed_duty_ppm == 100_000
+    assert command.reason == "forward"
+    assert command.shoot_through_safe
+
+
+def test_theta_emergency_stop_and_direction_reversal_are_inhibited():
+    governor = ConstraintGovernor(
+        SafetyLimits(max_duty_ppm=800_000, max_slew_ppm=800_000, reversal_dead_ticks=1)
+    )
+    assert governor.apply(400_000).reason == "forward"
+    reversal = governor.apply(-400_000)
+    assert reversal.inhibited
+    assert reversal.reason == "reversal-dead-time"
+    assert reversal.signed_duty_ppm == 0
+    stopped = governor.apply(400_000, emergency_stop=True)
+    assert stopped.inhibited
+    assert stopped.reason == "emergency-stop"
+
+
+def test_complete_loop_is_deterministic_and_exposes_each_stage():
+    limits = SafetyLimits(max_duty_ppm=750_000, max_slew_ppm=250_000)
+    a = DMVomegaxiMechatronicLoop((1, 0, 1, 0), limits=limits)
+    b = DMVomegaxiMechatronicLoop((1, 0, 1, 0), limits=limits)
+    inputs = (0.8, -0.4, 0.2, -0.9)
+    trace_a = a.step(inputs, target_bit=1)
+    trace_b = b.step(inputs, target_bit=1)
+    assert trace_a == trace_b
+    assert trace_a.tick == 1
+    assert len(trace_a.pulse_bits) == 4
+    assert trace_a.signed_dot == 2 * trace_a.popcount - 4
+    assert 0 <= trace_a.memory_u16 <= 0xFFFF
+    assert abs(trace_a.command.signed_duty_ppm) <= limits.max_slew_ppm
+    assert trace_a.command.shoot_through_safe
+
+
+def test_invalid_bit_and_sensor_domains_fail_closed():
+    with pytest.raises(ValueError):
+        bipolar_dot((1, 2), (1, 0))
+    loop = DMVomegaxiMechatronicLoop((1, 0))
+    with pytest.raises(ValueError):
+        loop.step((1.1, 0.0), target_bit=1)


### PR DESCRIPTION
## Summary

Permeates the DM-vOmegaXi+ master axiom into a bounded, executable mechatronic control reference:

```text
Psi sensors -> Phi delta-sigma -> Lambda XNOR/popcount
            -> Omega u16 recurrence -> Theta safety governor
            -> hardware-neutral H-bridge command
```

The change deliberately terminates at a logical gate command. A real gate driver, MOSFET power stage, mechanical plant, watchdog, and domain certification remain explicit integration boundaries.

## Implementation

- first-order, one-bit delta-sigma bank for normalized sensor channels;
- exact bipolar identity `dot = 2 * popcount(XNOR(x,w)) - N`;
- deterministic 16-bit rotate/XOR recurrent memory;
- signed parts-per-million command normalization;
- safety governor with duty clamp, slew limiting, emergency stop, direction-reversal dead time, and shoot-through exclusion;
- immutable end-to-end traces exposing every operator state.

## Architecture

ADR-012 distinguishes computational timing, electrical switching timing, and physical plant response. It rejects unsupported equivalences between XOR error and ethics, or sub-nanosecond device events and a sub-nanosecond mechanical closed loop.

## Validation

Focused tests cover:

- exact XNOR/popcount arithmetic;
- delta-sigma pulse-density reconstruction;
- bounded u16 memory;
- clamp and slew behavior;
- emergency stop;
- reversal interlock;
- H-bridge shoot-through safety;
- deterministic complete-loop traces;
- fail-closed input validation.

Local verification completed with Python bytecode compilation and a direct invariant suite. The local runtime did not include pytest, so the repository CI remains the authoritative full test runner.

## Files

- `src/jarvisx/dm_vomegaxi_mechatronic.py`
- `tests/test_dm_vomegaxi_mechatronic.py`
- `docs/adr/0012-dm-vomegaxi-mechatronic-control.md`
- `docs/DM_VOMEGAXI_MECHATRONIC_CONTROL.md`
