### PR TITLE
feat: inward multiparallel multimodal 3D swarm runtime

### DIFF
--- a/docs/ELECTRONIC_ACTUATION_RUNTIME.md
+++ b/docs/ELECTRONIC_ACTUATION_RUNTIME.md
@@ -1,0 +1,167 @@
+# Jarvis-X Electronic Actuation Runtime
+
+## Scope
+
+This document defines the literal electronic implementation boundary beneath the Jarvis-X inward multimodal runtime.
+
+The mapping is:
+
+```text
+algorithmic state
+-> bounded numerical representation
+-> voltage / bit representation
+-> switching and memory activity
+-> software or I/O command representation
+-> observed result
+-> re-encoding and verification
+```
+
+Jarvis-X does **not** identify semantic state with an electromagnetic field. Semantic variables are algorithmic variables; electrical variables are the physical quantities used to encode and execute them.
+
+## 1. Scalar-to-voltage encoding
+
+For a bounded scalar `x in [x_min, x_max]`, define
+
+```text
+u = (x - x_min) / (x_max - x_min)
+V = V_min + u (V_max - V_min)
+```
+
+and inverse
+
+```text
+x = x_min + (V - V_min)/(V_max - V_min) (x_max - x_min)
+```
+
+This is the explicit bridge from a runtime control scalar to an electrical node representation.
+
+## 2. Bit-level logic
+
+A digital bit is represented by two voltage regions:
+
+```text
+0 <-> V_low
+1 <-> V_high
+```
+
+with decoding threshold
+
+```text
+b = 0, V < V_TH
+b = 1, V >= V_TH
+```
+
+A finite switching event charges or discharges effective capacitance. A representative transition energy is
+
+```text
+E_switch ~= 1/2 C_eff (Delta V)^2
+```
+
+and conventional dynamic power is
+
+```text
+P_dyn ~= alpha_sw C_eff (Delta V)^2 f
+```
+
+where `alpha_sw` is switching activity and `f` is clock rate.
+
+## 3. Runtime execution chain
+
+The practical actuation chain is
+
+```text
+Z_t
+-> candidate action
+-> constraint projection Pi_K
+-> executable instruction / I/O representation
+-> transistor switching and memory transactions
+-> external observation O_(t+1)
+-> E(O_(t+1))
+-> correction
+```
+
+Thus the intelligence layer does not directly move hardware. It emits bounded numerical actions which are lowered through software and hardware layers.
+
+## 4. Relation to the inward RC analogue
+
+The existing inward swarm runtime exposes
+
+```text
+C dV_i/dt =
+    g_phi (V_phi_i - V_i)
+  + g_c sum_j A_ij (V_j - V_i)
+  + I_ext_i
+```
+
+This is a circuit-level dynamical correspondence for the algorithmic recurrence
+
+```text
+dZ/dt = lambda(Phi(Z)-Z) - gamma L Z + F_ext.
+```
+
+The correspondence is structural:
+
+```text
+latent scalar z_i    <-> node voltage V_i
+inward gain lambda   <-> g_phi / C
+coupling A_ij        <-> effective conductance weights
+external forcing     <-> injected current term
+```
+
+It does not imply that semantic distance is literal physical distance or that the runtime is a Maxwell-field solver.
+
+## 5. Practical electronic observability
+
+The hardware boundary should expose measurable quantities wherever available:
+
+- node voltage or digital logic level;
+- switching count or activity estimate;
+- memory transaction count;
+- estimated dynamic energy and power;
+- instruction or kernel provenance;
+- I/O command provenance;
+- observed result after execution.
+
+These become part of the external audit trail rather than relying on hidden model reasoning.
+
+## 6. Safety and authority boundary
+
+The runtime separates intelligence from authority:
+
+```text
+A_intent = G(Z_t, Omega_t)
+A_authorized = Pi_K(A_intent)
+A_executable = Lower(A_authorized)
+```
+
+The research module in this branch performs **representation and estimation only**. It does not perform GPIO writes, device-driver operations, direct peripheral control, or unrestricted hardware actuation.
+
+## 7. Current implementation
+
+`src/jarvisx/electronic_actuation_runtime.py` adds:
+
+- `VoltageCodec` for scalar <-> voltage mapping;
+- `CMOSLogicModel` for logic thresholding and switching-energy/power estimates;
+- `PWMCommand` / `PWMMapper` as a normalized command representation;
+- `ElectronicActuationTrace` for auditable end-to-end mapping of one control scalar;
+- `trace_control_scalar()` and `trace_vector()` helpers.
+
+The module deliberately stops before any hardware API or device driver.
+
+## 8. Engineering interpretation
+
+The complete physical stack is therefore
+
+```text
+semantic/task state
+-> numeric tensors
+-> bits / encoded voltages
+-> logic and memory transitions
+-> electrical switching
+-> I/O representation
+-> environment
+-> observation
+-> re-encoding
+```
+
+This is the literal electronic actuation boundary for Jarvis-X.

--- a/docs/INWARD_MULTIMODAL_MEDIA_ANN.md
+++ b/docs/INWARD_MULTIMODAL_MEDIA_ANN.md
@@ -1,0 +1,150 @@
+# Inward 3D Multimodal Media ANN
+
+**Status:** research runtime  
+**Branch:** `feature/inward-multimodal-swarm3d`
+
+## Purpose
+
+This layer turns the existing inward multimodal 3D runtime into a small trainable
+multimedia ANN. It keeps the logical `8192^3` space virtual and sparse; it does
+not allocate a dense `8192 x 8192 x 8192` tensor.
+
+The operational chain is:
+
+```text
+multimodal bytes/tensors
+    -> modality encoding
+    -> shared state (3D coordination r + high-D feature h)
+    -> trainable autoencoder
+    -> graph/swarm coupling
+    -> inward E(D(z)) correction
+    -> memory coupling
+    -> converged 3D consensus latent
+    -> RGB frame / PCM audio surfaces
+    -> external media container if desired
+```
+
+The 3D coordinate is a control/coordination chart. Rich semantic/media content
+remains in the feature vector; three coordinates are not claimed to preserve
+unrestricted semantics.
+
+## Trainable autoencoder
+
+For input feature matrix `X`, the reference NumPy MLP implements
+
+```text
+h1 = tanh(X W1 + b1)
+z  = tanh(h1 W2 + b2)
+h3 = tanh(z W3 + b3)
+y  = tanh(h3 W4 + b4)
+```
+
+and trains with explicit backpropagation against mean squared reconstruction
+error.
+
+## Inward operator
+
+For each modality particle `p=(r,h,m)`, the autoencoder generates a reconstructed
+feature and latent coordinate. The local inward target is
+
+```text
+Phi_r(p) = q r + (1-q) r_AE
+Phi_h(p) = normalize(q h + (1-q) h_AE)
+```
+
+with `0 < q < 1`.
+
+The runtime measures
+
+```text
+R_phi = mean ||Phi(p_i) - p_i||
+```
+
+as an explicit self-consistency residual.
+
+## 3D graph coordination
+
+Cross-particle graph weights use shared-feature cosine similarity and chart
+distance:
+
+```text
+A_ij = softmax_j(feature_gain * cos(h_i,h_j)
+                 - geometry_gain * ||r_i-r_j||^2)
+```
+
+The recurrent state update blends:
+
+- current state,
+- task anchor,
+- graph consensus,
+- inward autoencoder target,
+- bounded memory state.
+
+The gain sum is constrained below one before the step is accepted.
+
+## Multimedia surfaces
+
+After inward refinement, all modalities share a consensus 3D latent
+
+```text
+r* = mean_i r_i
+```
+
+The research runtime exposes:
+
+- `generate_rgb_frame(r*, phase, size)` -> `uint8[H,W,3]`
+- `generate_pcm_audio(r*, duration, sample_rate)` -> `int16[N]`
+
+Both are conditioned on the same converged 3D state. This establishes a concrete
+cross-media coordination path without coupling the core library to a particular
+video container or operating-system process launcher.
+
+MP4 packaging is intentionally external. A caller may pass the returned RGB
+frames and PCM samples to FFmpeg, PyAV, OpenCV, or another container backend.
+The core remains deterministic and testable without those dependencies.
+
+## Bounded self-optimization
+
+`bounded_optimize()` mutates only declared numerical runtime parameters. Every
+candidate is run in shadow evaluation. Promotion requires:
+
+```text
+candidate_score > incumbent_score * 1.0025
+candidate_fixed_point_residual <= incumbent_fixed_point_residual
+finite(candidate_score)
+```
+
+Source code, permissions, deployment configuration, and hardware control are not
+mutated by this optimizer.
+
+## Local prototype result
+
+The standalone prototype used to design this module produced a real MP4 after
+external FFmpeg packaging. In that run:
+
+```text
+logical cells              549,755,813,888
+initial AE reconstruction  0.0436708
+final AE reconstruction    0.00321634
+initial fixed-point error   0.550212
+final fixed-point error     0.117584
+consensus virtual cell      (4555, 4905, 3929)
+```
+
+These are prototype measurements, not universal performance guarantees.
+Repository CI remains authoritative for the committed implementation.
+
+## Verification
+
+Focused tests cover:
+
+1. autoencoder training reduces reconstruction loss;
+2. inward dynamics reduce fixed-point residual on the deterministic fixture;
+3. RGB and PCM surfaces are generated from the same 3D consensus latent;
+4. bounded optimization cannot promote a fixed-point regression.
+
+## Boundary
+
+This is a classical numerical ANN/runtime. The 3D manifold is virtual. Media
+frames and audio are numerical arrays. No claim is made that the semantic state
+is a literal electromagnetic or physical-spacetime field.

--- a/docs/INWARD_MULTIMODAL_META_OPTIMIZATION.md
+++ b/docs/INWARD_MULTIMODAL_META_OPTIMIZATION.md
@@ -1,0 +1,204 @@
+# Inward Multimodal Meta-Optimization
+
+**Status:** Research-layer companion specification  
+**Runtime:** `src/jarvisx/inward_multimodal_swarm3d.py`  
+**Meta-optimizer:** `src/jarvisx/inward_multimodal_meta_optimizer.py`
+
+## 1. Purpose
+
+This layer turns the multimodal runtime inward onto its own **bounded runtime configuration**.
+It does not rewrite executable source code and it does not autonomously alter the canonical VM.
+Instead, it treats a declared subset of `Swarm3DConfig` as a genotype, evaluates candidate
+configurations in shadow execution, and promotes only candidates that satisfy hard verification gates.
+
+The outer control loop is:
+
+```text
+RUN
+  -> MEASURE
+  -> MUTATE BOUNDED CONFIG
+  -> SHADOW EVALUATE
+  -> VERIFY
+  -> PROMOTE OR REJECT
+  -> RUN AGAIN
+```
+
+The inner multimodal loop remains:
+
+```text
+bytes/media -> encode -> 3D coordination -> inward E(D(z))
+            -> decode -> re-encode -> verify
+```
+
+## 2. Runtime genotype
+
+The current optimizer mutates only bounded numerical controls from `Swarm3DConfig`, including:
+
+- integration step `dt`;
+- Riemannian metric gain `alpha_metric`;
+- task, inward, swarm and memory gains;
+- feature-mixing and feature-similarity gains;
+- geometry-distance gain;
+- maximum inward iteration count.
+
+Resource bounds, particle limits, position bounds and the executable implementation remain outside the
+mutation surface unless a future ADR explicitly promotes them.
+
+Let the tunable configuration be
+
+```text
+theta = (
+    dt,
+    alpha_metric,
+    k_task,
+    k_inward,
+    k_swarm,
+    k_memory,
+    k_feature,
+    k_similarity,
+    k_geometry,
+    N_steps,
+)
+```
+
+and let one shadow run return
+
+```text
+F(theta) = (
+    task_score,
+    semantic_coherence,
+    feature_coherence,
+    fixed_point_error,
+    resource_cost,
+    stable,
+).
+```
+
+The scalar ranking score is intentionally subordinate to hard constraints:
+
+```text
+score(theta) =
+    0.30 task_score
+  + 0.25 semantic_coherence
+  + 0.20 feature_coherence
+  + 0.15 / (1 + fixed_point_error)
+  + 0.10 / (1 + resource_cost)
+```
+
+## 3. Candidate-first promotion law
+
+For incumbent `theta_g`, generate a bounded candidate neighborhood
+
+```text
+N(theta_g) = {theta'_1, ..., theta'_B}.
+```
+
+Each candidate is evaluated without mutating the incumbent runtime.
+A candidate is eligible only if all hard gates pass:
+
+```text
+stable(theta') = true
+fixed_point_error(theta') <= fixed_point_error(theta_g) + epsilon_fp
+resource_cost(theta') <= (1 + epsilon_resource) resource_cost(theta_g)
+score(theta') > (1 + epsilon_gain) score(theta_g)
+```
+
+The default fixed-point regression allowance is zero:
+
+```text
+epsilon_fp = 0.
+```
+
+This encodes an important systems constraint: a candidate may not purchase better task or geometric
+coherence by silently degrading inward fixed-point integrity.
+
+If no candidate passes every gate, the incumbent is retained unchanged.
+
+## 4. Mathematical outer loop
+
+The bounded optimization law is
+
+```text
+theta_(g+1) =
+    argmax score(theta')
+    over theta' in N(theta_g)
+    subject to verification gates,
+```
+
+with rollback-to-incumbent when the admissible candidate set is empty.
+
+This is distinct from gradient training of neural weights. It is closer to deterministic evolutionary
+configuration search under transactional promotion constraints.
+
+## 5. Why this is an inward loop
+
+The first inward loop checks representation self-consistency:
+
+```text
+Phi(z) = E(D(z))
+```
+
+and drives
+
+```text
+Phi(z*) ~= z*.
+```
+
+The second inward loop checks runtime self-consistency:
+
+```text
+runtime(theta)
+  -> telemetry
+  -> candidate theta'
+  -> shadow runtime(theta')
+  -> verification
+  -> theta_(next).
+```
+
+Therefore the architecture has two nested recurrences:
+
+```text
+DATA LOOP:     z -> D(z) -> E(D(z)) -> z'
+RUNTIME LOOP:  theta -> run -> measure -> propose(theta') -> verify -> theta_next
+```
+
+## 6. Verification contract
+
+The meta-optimizer itself does not decide what `task_score`, semantic coherence or resource cost mean.
+The caller must supply an evaluator grounded in the workload being optimized.
+
+A production evaluator should include, where applicable:
+
+- fixed-point residual `||Phi(Z)-Z||`;
+- task loss / answer quality / reconstruction quality;
+- cross-modal semantic disagreement;
+- 3D coordination spread or graph-consensus error;
+- latency and throughput;
+- RAM/VRAM use;
+- thermal or power telemetry when running on real hardware;
+- constraint violations and numerical instability.
+
+Repository CI and workload-specific benchmarks remain authoritative. A locally improved scalar score is
+not by itself evidence of general capability improvement.
+
+## 7. Safety and architectural boundary
+
+This layer is deliberately bounded:
+
+- no arbitrary source-code rewriting;
+- no mutation of repository permissions or deployment policy;
+- no bypass of candidate verification;
+- no direct modification of the canonical VM state during shadow evaluation;
+- no claim that 3D semantic coordinates are literal physical space;
+- no claim that the optimizer provides global or unbounded self-improvement.
+
+Its operational identity is:
+
+```text
+SELF-OBSERVING CONFIGURATION SEARCH
++ SHADOW EXECUTION
++ HARD INTEGRITY GATES
++ TRANSACTIONAL PROMOTION
+```
+
+That is the defensible form of "turn the runtime inward onto itself."

--- a/docs/INWARD_MULTIMODAL_SWARM3D.md
+++ b/docs/INWARD_MULTIMODAL_SWARM3D.md
@@ -1,0 +1,367 @@
+# Inward Multiparallel Multimodal 3D Swarm Runtime
+
+**Status:** Experimental research/runtime layer  
+**Implementation:** `src/jarvisx/inward_multimodal_swarm3d.py`  
+**Tests:** `tests/test_inward_multimodal_swarm3d.py`  
+**Related:** `docs/DR_MOAGI_3D_GEOMETRIC_DIFFUSION_RUNTIME.md`, `docs/INWARD_3D_KINETIC_END_TO_END.md`, `docs/research/DR_MOAGI_3D_ELECTROMAGNETIC_OPERATION.md`
+
+## 1. Purpose
+
+This runtime closes the 3D auto-encoding/decoding loop inward across multiple media modalities while keeping the existing Jarvis-X boundary between the canonical VM and research layers.
+
+The system is intentionally split into three contracts:
+
+1. **Operational:** modality-specific codecs map real media representations into and out of a shared bounded 3D control chart.
+2. **Kinetic:** many modality-tagged particles evolve in parallel under a Riemannian task force, inward decode/re-encode contraction, graph coupling, and bounded memory forcing.
+3. **Electromagnetic analogue:** the inward and graph-relaxation terms are mapped to a bounded RC-network equation. This is an algorithm-to-circuit correspondence, not a Maxwell field solver.
+
+The 3D coordinates are virtual semantic/control coordinates. They are not asserted to be physical spacetime coordinates, and three scalars are not treated as a lossless representation of arbitrary text, image, audio, video, geometry or code. Production codecs may retain high-dimensional state outside the 3D control chart.
+
+---
+
+## 2. Operational state
+
+For modalities
+
+```text
+M = {text, image, audio, video, geometry, code, data}
+```
+
+each registered codec satisfies the narrow interface
+
+```text
+encode_m(X_m) -> z_m in R^3
+decode_m(z_m) -> X_hat_m
+```
+
+All encoded items become one population
+
+```text
+Z = [z_1, z_2, ..., z_N] in R^(N x 3).
+```
+
+Each `Particle3D` additionally carries
+
+```text
+(position, shared_feature, modality, confidence, time_coordinate, source_id).
+```
+
+The shared feature vector is used to compute dynamic cross-modal interaction weights. A caller may supply a `feature_encoder` that projects heterogeneous modalities into one common feature width.
+
+The complete operational loop is
+
+```text
+multimodal inputs
+    -> parallel modality codecs
+    -> N x 3 particle population
+    -> dynamic cross-modal graph
+    -> inward/kinetic relaxation
+    -> consensus control state
+    -> one or more modality decoders
+    -> generated/projected surfaces
+    -> re-encode through the same codecs
+    -> inward correction
+```
+
+The decode/re-encode operator is
+
+```text
+Phi_m(z) = E_m(D_m(z)).
+```
+
+A self-consistent local state satisfies
+
+```text
+Phi_m(z*) ~= z*.
+```
+
+---
+
+## 3. Riemannian task geometry
+
+Let `phi(z)` be a caller-defined local semantic/task potential. The runtime uses the rank-one metric
+
+```text
+G(z) = I + alpha grad(phi) grad(phi)^T.
+```
+
+Its inverse is exact by Sherman-Morrison:
+
+```text
+G^-1 = I - alpha grad(phi) grad(phi)^T
+             / (1 + alpha ||grad(phi)||^2).
+```
+
+A Euclidean task gradient is therefore transformed into the local Riemannian gradient
+
+```text
+grad_g J = G^-1 grad J.
+```
+
+The task force is
+
+```text
+F_task = -k_task grad_g J.
+```
+
+This makes motion along the local potential gradient more resistant as `alpha` and `||grad(phi)||` increase.
+
+The implementation exposes:
+
+- `riemannian_metric_inverse(...)`
+- `local_riemannian_gradient(...)`
+
+No global geodesic solver is claimed. Consensus and inter-particle displacement use the local/tangent-chart approximation.
+
+---
+
+## 4. Dynamic cross-modal swarm
+
+For particles `i` and `j`, the runtime computes
+
+```text
+score_ij = k_f cosine(h_i, h_j) - k_d ||z_i - z_j||^2
+```
+
+and row-normalizes the scores with softmax:
+
+```text
+A_ij = softmax_j(score_ij).
+```
+
+`A` is therefore a dynamic directed adjacency matrix that changes as the particles and shared features evolve.
+
+The local chart form of the graph force is
+
+```text
+F_swarm_i = k_swarm sum_j A_ij (z_j - z_i).
+```
+
+For a symmetric/static graph this has the familiar graph-Laplacian form
+
+```text
+dZ/dt = -gamma L Z,
+L = D - A.
+```
+
+The implementation does not claim that attention weights are a physical force. They are computational interaction coefficients.
+
+---
+
+## 5. Inward contraction
+
+For particle `i`, the runtime computes
+
+```text
+z_phi_i = Phi_mi(z_i) = E_mi(D_mi(z_i))
+```
+
+and applies
+
+```text
+F_inward_i = lambda (z_phi_i - z_i).
+```
+
+The cycle energy is
+
+```text
+E_cycle = mean_i ||Phi_mi(z_i) - z_i||^2.
+```
+
+If the codec cycle is contractive in the region of interest, repeated application drives the state toward a local fixed point. The runtime measures this through `fixed_point_error`; it does not assume Banach contraction unless a codec actually supplies that property.
+
+---
+
+## 6. Memory forcing
+
+A bounded caller-provided memory target may be keyed by `source_id`:
+
+```text
+F_memory_i = k_memory (z_memory_i - z_i).
+```
+
+Memory is optional. The reference runtime neither performs RAG retrieval nor owns a vector database; retrieval systems can inject their selected evidence through encoded particles and/or memory targets.
+
+---
+
+## 7. Complete kinetic equation
+
+The implemented first-order local-chart equation is
+
+```text
+dz_i/dt =
+    - k_task G_i^-1 grad J_i
+    + lambda (Phi_i(z_i) - z_i)
+    + gamma sum_j A_ij (z_j - z_i)
+    + rho (z_memory_i - z_i).
+```
+
+The explicit-Euler implementation is
+
+```text
+z_i[t+1] = clamp(
+    z_i[t] + dt * F_i,
+    -position_bound,
+    +position_bound
+).
+```
+
+Every positional update is additionally capped by `max_position_step`.
+
+Shared features undergo a bounded-rate neighbor mixing step:
+
+```text
+h_i[t+1] = h_i[t]
+           + dt * k_h * (sum_j A_ij h_j[t] - h_i[t]).
+```
+
+The runtime terminates when both movement and enabled inward fixed-point error fall below tolerance, or when `max_steps` is reached.
+
+---
+
+## 8. Measured state
+
+`Swarm3DMetrics` reports:
+
+```text
+step
+particle_count
+energy
+task_energy
+cycle_energy
+coupling_energy
+fixed_point_error
+consensus_error
+max_displacement
+```
+
+The diagnostic energy is
+
+```text
+E = k_task E_task
+    + lambda E_cycle
+    + 1/2 gamma E_coupling.
+```
+
+It is a runtime diagnostic, not a universal physical Hamiltonian.
+
+---
+
+## 9. Multiparallel generation surface
+
+After relaxation, `decode_consensus(...)` computes a confidence-weighted local-chart consensus
+
+```text
+z_bar = sum_i c_i z_i / sum_i c_i
+```
+
+and sends the same control state through any requested modality heads:
+
+```text
+text_hat     = D_text(z_bar)
+image_hat    = D_image(z_bar)
+audio_hat    = D_audio(z_bar)
+video_hat    = D_video(z_bar)
+geometry_hat = D_geometry(z_bar)
+code_hat     = D_code(z_bar).
+```
+
+This is the orchestration contract. The concrete quality and dimensionality of generated media remain the responsibility of the registered codecs/generator heads.
+
+---
+
+## 10. Electromagnetic/circuit analogue
+
+The runtime exposes a separate RC-network analogue with node voltage vector `V_i`, decode/re-encode target voltage `V_phi_i`, adjacency `A_ij`, capacitance `C`, feedback conductance `g_phi`, and coupling conductance `g_c`:
+
+```text
+C dV_i/dt =
+    g_phi (V_phi_i - V_i)
+    + g_c sum_j A_ij (V_j - V_i)
+    + I_ext_i.
+```
+
+This corresponds structurally to
+
+```text
+dz_i/dt =
+    lambda (Phi_i(z_i) - z_i)
+    + gamma sum_j A_ij (z_j - z_i)
+    + F_ext_i.
+```
+
+The mapping is
+
+```text
+algorithmic state z_i        <-> encoded node voltage V_i
+inward gain lambda           <-> g_phi / C
+graph coupling gamma A_ij    <-> g_c A_ij / C
+external/memory force        <-> injected current I_ext / C
+```
+
+`electrical_rhs(...)` evaluates the continuous RC right-hand side and `electrical_step(...)` advances it by one bounded Euler step.
+
+This layer deliberately stops at circuit dynamics. The repository's electromagnetic research specification remains the source for the lower physical boundary: voltages, charges, currents and conductances must ultimately be realized by electromagnetic fields satisfying Maxwell's equations. The software helper itself does not solve those equations.
+
+---
+
+## 11. Safety and numerical bounds
+
+`Swarm3DConfig` makes the research runtime finite by construction:
+
+- finite input validation;
+- bounded position domain;
+- capped per-step displacement;
+- bounded particle count;
+- bounded iteration count;
+- common shared feature width;
+- non-negative gains;
+- explicit convergence tolerance.
+
+`ElectricalAnalogueConfig` similarly bounds capacitance, conductances, integration step and voltage interval.
+
+These constraints are part of the executable contract rather than visualization metadata.
+
+---
+
+## 12. Example adapter
+
+```python
+from jarvisx.inward_multimodal_swarm3d import (
+    InwardMultimodalSwarm3D,
+    Modality,
+)
+
+
+class TextControlCodec:
+    def encode(self, value):
+        # Replace with a trained/text embedding -> 3D control projection.
+        return (0.2, -0.1, 0.4)
+
+    def decode(self, position):
+        # Replace with a conditioned text generator/projection head.
+        return {"latent_control": position}
+
+
+runtime = InwardMultimodalSwarm3D({Modality.TEXT: TextControlCodec()})
+particles = runtime.encode_modalities({Modality.TEXT: ("query",)})
+result = runtime.relax(particles)
+output = runtime.decode_consensus(result.state.particles)
+```
+
+The adapter intentionally makes the system extensible without pulling optional model frameworks into the canonical package dependency set.
+
+---
+
+## 13. Promotion boundary
+
+This feature remains a research layer under ADR-001. Promotion into a canonical execution path requires, at minimum:
+
+1. concrete modality codecs with reproducible fixtures;
+2. benchmarked convergence and stability envelopes;
+3. demonstrated task-quality benefit over simpler baselines;
+4. explicit RAG integration contract if retrieval is enabled;
+5. hardware measurements before electromagnetic acceleration claims;
+6. canonical transaction/provenance integration if the state is allowed to affect authoritative VM behavior.
+
+Until then, the runtime is an executable mathematical reference for the inward multiparallel multimodal swarm architecture.

--- a/docs/adr/0013-inward-multimodal-swarm3d.md
+++ b/docs/adr/0013-inward-multimodal-swarm3d.md
@@ -1,0 +1,101 @@
+# ADR-013: Add an inward multiparallel multimodal 3D swarm research runtime
+
+**Status:** Proposed  
+**Date:** 2026-09-05
+
+## Context
+
+Jarvis-X already contains bounded 3D geometric diffusion, kinetic runtimes, inward auto-encoding research, multimodal media processors, and a separate electromagnetic hardware-mapping specification. The next research step is to connect those ideas through one executable contract without merging experimental semantics into the canonical VM core.
+
+The required architecture has four coupled properties:
+
+- heterogeneous modality adapters encode inputs into a common bounded 3D control chart;
+- many modality-tagged hypotheses evolve concurrently rather than as one 3-vector;
+- generated/projected outputs are decoded and re-encoded to form an inward fixed-point loop;
+- the graph/inward relaxation admits a circuit-level RC analogue while preserving the distinction between virtual semantic geometry and physical electromagnetic fields.
+
+ADR-001 requires spatial and adaptive research layers to remain isolated until their contracts and evidence justify promotion.
+
+## Decision
+
+Add `src/jarvisx/inward_multimodal_swarm3d.py` as a dependency-free research runtime with the following public boundary:
+
+1. `ModalityCodec` adapts one media representation to/from the shared 3D chart.
+2. `Particle3D` carries bounded position, shared feature state, modality identity, confidence, time coordinate and source identity.
+3. `InwardMultimodalSwarm3D` implements dynamic cross-modal adjacency, local Riemannian task preconditioning, decode/re-encode contraction, graph consensus, optional bounded memory forcing and consensus decoding.
+4. `ElectricalAnalogueConfig`, `electrical_rhs` and `electrical_step` expose only the structural RC-network mapping of inward feedback and graph relaxation.
+5. The runtime remains independent of Torch, FAISS, transformer libraries and concrete media generators. Those systems integrate through adapters rather than becoming package-level dependencies.
+
+The local kinetic equation is
+
+```text
+dz_i/dt =
+    - k_task G_i^-1 grad J_i
+    + lambda (Phi_i(z_i) - z_i)
+    + gamma sum_j A_ij (z_j - z_i)
+    + rho (z_memory_i - z_i),
+```
+
+with
+
+```text
+G_i = I + alpha grad(phi_i) grad(phi_i)^T
+Phi_i = E_i o D_i.
+```
+
+The circuit analogue is
+
+```text
+C dV_i/dt =
+    g_phi (V_phi_i - V_i)
+    + g_c sum_j A_ij (V_j - V_i)
+    + I_ext_i.
+```
+
+## Physical boundary
+
+The 3D chart is an algorithmic state space. It is not physical spacetime and is not assumed to have Planck-scale or quantum-gravity structure.
+
+The electrical helper models a bounded circuit-level correspondence. It does not solve Maxwell's equations and cannot establish electromagnetic acceleration, energy efficiency or hardware feasibility without a concrete device/netlist implementation and measurement.
+
+The existing electromagnetic research specification remains the lower-level reference for field, circuit and device semantics.
+
+## Consequences
+
+### Positive
+
+- turns the inward multimodal/swarm equations into executable behavior;
+- creates a narrow adapter boundary for text, image, audio, video, geometry, code and data heads;
+- keeps the 3D control manifold distinct from high-dimensional media payloads;
+- provides deterministic, dependency-free tests for the mathematical contract;
+- gives future analog/mixed-signal work a precise RC equation to target;
+- preserves the canonical-core isolation required by ADR-001.
+
+### Negative
+
+- the local chart uses Euclidean/tangent approximations for consensus and displacement rather than a global geodesic solver;
+- the reference runtime does not itself provide trained modality codecs or high-quality media generation;
+- dynamic all-to-all attention is quadratic in particle count;
+- explicit Euler integration requires conservative bounds for stable parameter regimes;
+- circuit correspondence alone does not prove hardware advantage.
+
+## Validation
+
+The decision is successful when tests demonstrate that:
+
+- the rank-one inverse metric produces the expected Riemannian preconditioning;
+- graph coupling reduces consensus error for a simple symmetric swarm;
+- a contractive decode/re-encode codec converges toward its fixed point;
+- heterogeneous inputs can share a common feature width and decode through multiple heads;
+- the RC analogue relaxes coupled voltage differences while preserving symmetry in the unforced pair case;
+- invalid bounds and incompatible modality/feature inputs are rejected.
+
+## Promotion criteria
+
+Before this layer can influence canonical VM state, require:
+
+- reproducible concrete modality adapters;
+- benchmarked stability and performance against simpler baselines;
+- a provenance/transaction integration design;
+- resource-accounting limits for large swarms;
+- measured hardware evidence for any electromagnetic-compute claim.

--- a/docs/adr/0014-inward-multimodal-meta-optimization.md
+++ b/docs/adr/0014-inward-multimodal-meta-optimization.md
@@ -1,0 +1,103 @@
+# ADR-014: Bounded inward multimodal meta-optimization
+
+**Status:** Proposed  
+**Date:** 2026-09-05
+
+## Context
+
+The inward multimodal 3D research runtime closes media generation through a decode/re-encode fixed-point
+operator. A further requirement is to turn the runtime inward onto its own operating configuration so it
+can refine task, swarm, inward, memory and geometry controls from measured performance.
+
+Unconstrained self-modifying code would conflict with the repository's candidate-first, auditable research
+boundary. A scalar fitness alone is also insufficient: an optimizer can improve global coherence while
+silently degrading fixed-point integrity, stability or resource use.
+
+## Decision
+
+Jarvis-X will represent self-optimization of the inward multimodal runtime as a **bounded outer-loop
+configuration search**.
+
+The optimizer may mutate only an explicit numerical genotype derived from `Swarm3DConfig`. Every candidate
+must execute in a caller-controlled shadow evaluation and return normalized quality metrics plus measured
+fixed-point and resource penalties.
+
+Promotion requires all of the following:
+
+1. the candidate is stable;
+2. fixed-point error does not exceed the incumbent by more than the configured allowance;
+3. resource cost remains within the configured regression allowance;
+4. composite fitness clears the minimum improvement threshold.
+
+The default fixed-point regression allowance is zero.
+
+No candidate may mutate executable source, canonical VM state, repository policy, permissions or deployment
+controls through this subsystem.
+
+## Consequences
+
+### Positive
+
+- adaptation is reproducible under an explicit seed;
+- the incumbent remains unchanged during candidate evaluation;
+- improvements are evidence-driven rather than narrative claims;
+- fixed-point integrity is a hard constraint instead of a weak weighted objective;
+- workload-specific evaluators can incorporate task quality, cross-modal coherence, latency, memory and
+  hardware telemetry without coupling those measurements into the search engine;
+- the design composes with existing Jarvis-X candidate-first transaction patterns.
+
+### Negative
+
+- search explores only the declared parameter surface;
+- local configuration improvement does not imply model-weight improvement or general intelligence gain;
+- workload-specific fitness design remains the caller's responsibility;
+- deterministic evolutionary search can be computationally expensive as branch width and generations grow;
+- hard non-regression gates can reject useful Pareto trade-offs unless explicitly relaxed by policy.
+
+## Mathematical contract
+
+For incumbent configuration `theta_g`, define a bounded neighborhood `N(theta_g)` and measured fitness
+vector `F(theta)`.
+
+The promotion law is
+
+```text
+theta_(g+1) = argmax score(theta')
+              theta' in N(theta_g)
+```
+
+subject to
+
+```text
+stable(theta') = true
+R_fp(theta') <= R_fp(theta_g) + epsilon_fp
+C_resource(theta') <= (1 + epsilon_resource) C_resource(theta_g)
+score(theta') > (1 + epsilon_gain) score(theta_g).
+```
+
+If the admissible set is empty, `theta_(g+1) = theta_g`.
+
+The inner representation recurrence remains
+
+```text
+Phi(Z) = E(D(Z)),
+```
+
+while the outer runtime recurrence is
+
+```text
+theta -> run -> measure -> candidate search -> shadow verify -> theta_next.
+```
+
+These recurrences are intentionally distinct.
+
+## Validation
+
+This decision is successful when:
+
+- candidate generation is deterministic for a fixed seed and generation;
+- unstable incumbents cannot enter optimization;
+- higher scalar fitness cannot bypass fixed-point or resource gates;
+- a genuinely superior admissible candidate can be promoted;
+- the report records every evaluated candidate and promotion reason;
+- ordinary canonical VM tests remain independent of this research layer.

--- a/src/jarvisx/electronic_actuation_runtime.py
+++ b/src/jarvisx/electronic_actuation_runtime.py
@@ -1,0 +1,237 @@
+"""Literal electronic actuation mappings for Jarvis-X research runtimes.
+
+This module bridges bounded algorithmic state to explicit electrical quantities:
+
+    scalar -> voltage -> logic/bit state -> switching estimate -> PWM command
+
+It is intentionally a *model and encoding layer*. It performs no GPIO writes,
+network control, device-driver calls, or physical hardware actuation.
+
+Semantic/latent variables remain algorithmic variables. Voltages, charges,
+currents, switching energies and duty cycles are physical implementation
+quantities used to encode or actuate those variables.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+
+def _finite(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _positive(value: float, *, name: str) -> float:
+    value = _finite(value, name=name)
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+@dataclass(frozen=True)
+class VoltageCodec:
+    """Affine map between a bounded algorithmic scalar and node voltage."""
+
+    scalar_min: float = -1.0
+    scalar_max: float = 1.0
+    voltage_min: float = 0.0
+    voltage_max: float = 1.0
+
+    def __post_init__(self) -> None:
+        s0 = _finite(self.scalar_min, name="scalar_min")
+        s1 = _finite(self.scalar_max, name="scalar_max")
+        v0 = _finite(self.voltage_min, name="voltage_min")
+        v1 = _finite(self.voltage_max, name="voltage_max")
+        if not s0 < s1:
+            raise ValueError("scalar_min must be less than scalar_max")
+        if not v0 < v1:
+            raise ValueError("voltage_min must be less than voltage_max")
+
+    def encode(self, value: float) -> float:
+        value = _finite(value, name="value")
+        if not self.scalar_min <= value <= self.scalar_max:
+            raise ValueError("value lies outside scalar bounds")
+        u = (value - self.scalar_min) / (self.scalar_max - self.scalar_min)
+        return self.voltage_min + u * (self.voltage_max - self.voltage_min)
+
+    def decode(self, voltage: float) -> float:
+        voltage = _finite(voltage, name="voltage")
+        if not self.voltage_min <= voltage <= self.voltage_max:
+            raise ValueError("voltage lies outside voltage bounds")
+        u = (voltage - self.voltage_min) / (self.voltage_max - self.voltage_min)
+        return self.scalar_min + u * (self.scalar_max - self.scalar_min)
+
+
+@dataclass(frozen=True)
+class CMOSLogicModel:
+    """Minimal bounded CMOS logic-level and switching-energy model."""
+
+    v_low: float = 0.0
+    v_high: float = 1.0
+    threshold: float = 0.5
+    effective_capacitance_f: float = 1.0e-15
+    activity_factor: float = 0.10
+    clock_hz: float = 1.0e9
+
+    def __post_init__(self) -> None:
+        v_low = _finite(self.v_low, name="v_low")
+        v_high = _finite(self.v_high, name="v_high")
+        threshold = _finite(self.threshold, name="threshold")
+        if not v_low < threshold < v_high:
+            raise ValueError("threshold must lie strictly between v_low and v_high")
+        _positive(self.effective_capacitance_f, name="effective_capacitance_f")
+        activity = _finite(self.activity_factor, name="activity_factor")
+        if not 0.0 <= activity <= 1.0:
+            raise ValueError("activity_factor must lie within [0, 1]")
+        _positive(self.clock_hz, name="clock_hz")
+
+    @property
+    def delta_v(self) -> float:
+        return self.v_high - self.v_low
+
+    def bit_voltage(self, bit: int) -> float:
+        if bit not in (0, 1):
+            raise ValueError("bit must be 0 or 1")
+        return self.v_high if bit else self.v_low
+
+    def decode_bit(self, voltage: float) -> int:
+        voltage = _finite(voltage, name="voltage")
+        return int(voltage >= self.threshold)
+
+    def switching_energy_j(self) -> float:
+        """Representative 0->1 capacitive energy, 1/2 C (Delta V)^2."""
+
+        return 0.5 * self.effective_capacitance_f * self.delta_v**2
+
+    def dynamic_power_w(self) -> float:
+        """Conventional alpha C V^2 f activity estimate."""
+
+        return (
+            self.activity_factor
+            * self.effective_capacitance_f
+            * self.delta_v**2
+            * self.clock_hz
+        )
+
+
+@dataclass(frozen=True)
+class PWMCommand:
+    """Normalized electronic actuator command before any hardware driver."""
+
+    duty_cycle: float
+    direction: int
+    enable: bool
+
+    def __post_init__(self) -> None:
+        duty = _finite(self.duty_cycle, name="duty_cycle")
+        if not 0.0 <= duty <= 1.0:
+            raise ValueError("duty_cycle must lie within [0, 1]")
+        if self.direction not in (-1, 0, 1):
+            raise ValueError("direction must be -1, 0, or 1")
+        if self.direction == 0 and duty != 0.0:
+            raise ValueError("zero direction requires zero duty cycle")
+
+
+@dataclass(frozen=True)
+class PWMMapper:
+    """Map a bounded signed control scalar to PWM magnitude and direction."""
+
+    deadband: float = 0.02
+    max_duty: float = 1.0
+
+    def __post_init__(self) -> None:
+        deadband = _finite(self.deadband, name="deadband")
+        max_duty = _finite(self.max_duty, name="max_duty")
+        if not 0.0 <= deadband < 1.0:
+            raise ValueError("deadband must lie within [0, 1)")
+        if not 0.0 < max_duty <= 1.0:
+            raise ValueError("max_duty must lie within (0, 1]")
+
+    def map(self, control: float) -> PWMCommand:
+        control = _finite(control, name="control")
+        if not -1.0 <= control <= 1.0:
+            raise ValueError("control must lie within [-1, 1]")
+        magnitude = abs(control)
+        if magnitude <= self.deadband:
+            return PWMCommand(duty_cycle=0.0, direction=0, enable=False)
+        scaled = (magnitude - self.deadband) / (1.0 - self.deadband)
+        duty = min(self.max_duty, self.max_duty * scaled)
+        return PWMCommand(
+            duty_cycle=duty,
+            direction=1 if control > 0.0 else -1,
+            enable=True,
+        )
+
+
+@dataclass(frozen=True)
+class ElectronicActuationTrace:
+    """Auditable algorithmic-to-electronic mapping for one control scalar."""
+
+    control_scalar: float
+    encoded_voltage_v: float
+    quantized_bit: int
+    bit_voltage_v: float
+    switching_energy_j: float
+    dynamic_power_w: float
+    pwm: PWMCommand
+
+
+def trace_control_scalar(
+    control: float,
+    *,
+    voltage_codec: VoltageCodec | None = None,
+    logic: CMOSLogicModel | None = None,
+    pwm_mapper: PWMMapper | None = None,
+) -> ElectronicActuationTrace:
+    """Trace one normalized control value through the electronic mapping stack."""
+
+    codec = voltage_codec or VoltageCodec()
+    model = logic or CMOSLogicModel()
+    mapper = pwm_mapper or PWMMapper()
+    voltage = codec.encode(control)
+    bit = model.decode_bit(voltage)
+    return ElectronicActuationTrace(
+        control_scalar=float(control),
+        encoded_voltage_v=voltage,
+        quantized_bit=bit,
+        bit_voltage_v=model.bit_voltage(bit),
+        switching_energy_j=model.switching_energy_j(),
+        dynamic_power_w=model.dynamic_power_w(),
+        pwm=mapper.map(control),
+    )
+
+
+def trace_vector(
+    controls: Sequence[float],
+    *,
+    voltage_codec: VoltageCodec | None = None,
+    logic: CMOSLogicModel | None = None,
+    pwm_mapper: PWMMapper | None = None,
+) -> tuple[ElectronicActuationTrace, ...]:
+    """Trace a vector of bounded controls independently and deterministically."""
+
+    return tuple(
+        trace_control_scalar(
+            value,
+            voltage_codec=voltage_codec,
+            logic=logic,
+            pwm_mapper=pwm_mapper,
+        )
+        for value in controls
+    )
+
+
+__all__ = [
+    "CMOSLogicModel",
+    "ElectronicActuationTrace",
+    "PWMCommand",
+    "PWMMapper",
+    "VoltageCodec",
+    "trace_control_scalar",
+    "trace_vector",
+]

--- a/src/jarvisx/inward_multimodal_media_ann.py
+++ b/src/jarvisx/inward_multimodal_media_ann.py
@@ -1,0 +1,490 @@
+"""Inward 3D multimodal media ANN research runtime.
+
+This module keeps media generation and host-process packaging separate. It
+implements a trainable NumPy autoencoder, shared 3D coordination, inward
+E(D(z)) refinement, graph coupling, memory, deterministic frame/audio synthesis,
+and bounded configuration search. It does not launch external processes.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import time
+from dataclasses import dataclass, asdict, replace
+from enum import Enum
+from typing import Any, Mapping, Sequence
+
+import numpy as np
+
+VIRTUAL_SIDE = 8192
+VIRTUAL_CELLS = VIRTUAL_SIDE ** 3
+
+
+class Modality(str, Enum):
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    GEOMETRY = "geometry"
+    CODE = "code"
+    DATA = "data"
+
+
+@dataclass
+class Particle:
+    modality: Modality
+    position: np.ndarray
+    feature: np.ndarray
+    source_id: str
+
+
+@dataclass(frozen=True)
+class MediaANNConfig:
+    feature_dim: int = 32
+    latent_dim: int = 16
+    hidden_dim: int = 48
+    dt: float = 0.18
+    task_gain: float = 0.16
+    swarm_gain: float = 0.14
+    inward_gain: float = 0.38
+    memory_gain: float = 0.08
+    memory_retention: float = 0.86
+    q_phi: float = 0.45
+    geometry_gain: float = 0.22
+    feature_gain: float = 1.15
+    inner_steps: int = 18
+    train_epochs: int = 180
+    learning_rate: float = 0.035
+
+    def validate(self) -> None:
+        if min(self.feature_dim, self.latent_dim, self.hidden_dim) <= 0:
+            raise ValueError("network dimensions must be positive")
+        if not 0.0 < self.dt <= 1.0:
+            raise ValueError("dt must lie in (0, 1]")
+        if not 0.0 < self.q_phi < 1.0:
+            raise ValueError("q_phi must lie in (0, 1)")
+        if not 0.0 <= self.memory_retention < 1.0:
+            raise ValueError("memory_retention must lie in [0, 1)")
+        total = self.task_gain + self.swarm_gain + self.inward_gain + self.memory_gain
+        if total >= 1.0:
+            raise ValueError("sum of recurrent gains must remain below 1")
+
+
+@dataclass(frozen=True)
+class MediaANNMetrics:
+    step: int
+    fixed_point_residual: float
+    consensus_spread: float
+    feature_spread: float
+    reconstruction_mse: float
+    elapsed_ms: float
+
+
+@dataclass(frozen=True)
+class MediaANNResult:
+    particles: tuple[Particle, ...]
+    metrics: tuple[MediaANNMetrics, ...]
+    training_loss: tuple[float, ...]
+    score: float
+
+
+def _normalize(value: np.ndarray) -> np.ndarray:
+    return value / (np.linalg.norm(value) + 1e-12)
+
+
+def _softmax(value: np.ndarray, axis: int = -1) -> np.ndarray:
+    shifted = value - np.max(value, axis=axis, keepdims=True)
+    exp = np.exp(shifted)
+    return exp / (np.sum(exp, axis=axis, keepdims=True) + 1e-12)
+
+
+def _to_bytes(value: Any) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    if isinstance(value, np.ndarray):
+        header = json.dumps(
+            {"shape": list(value.shape), "dtype": str(value.dtype)},
+            sort_keys=True,
+        ).encode("utf-8")
+        return header + b"\n" + value.tobytes()
+    return json.dumps(value, sort_keys=True, default=str).encode("utf-8")
+
+
+def byte_features(blob: bytes, width: int) -> np.ndarray:
+    if not blob:
+        blob = b"\x00"
+    values = np.frombuffer(blob, dtype=np.uint8).astype(np.float64) / 255.0
+    groups = max(1, width // 4)
+    chunks = np.array_split(values, groups)
+    means = np.array([chunk.mean() if len(chunk) else 0.0 for chunk in chunks])
+    stds = np.array([chunk.std() if len(chunk) else 0.0 for chunk in chunks])
+    rms = np.array([
+        math.sqrt(float(np.mean(chunk * chunk))) if len(chunk) else 0.0
+        for chunk in chunks
+    ])
+    maxima = np.array([chunk.max() if len(chunk) else 0.0 for chunk in chunks])
+    feature = np.concatenate([means, stds, rms, maxima])[:width]
+    if len(feature) < width:
+        feature = np.pad(feature, (0, width - len(feature)))
+    return _normalize(feature)
+
+
+def raw_coordinate(blob: bytes) -> np.ndarray:
+    digest = hashlib.sha256(blob if blob else b"\x00").digest()
+    values = np.frombuffer(digest[:6], dtype=np.uint16).astype(np.float64)
+    return 2.0 * values[:3] / 65535.0 - 1.0
+
+
+def virtual_xyz(position: np.ndarray) -> tuple[int, int, int]:
+    xyz = np.clip(
+        np.rint((position + 1.0) * 0.5 * (VIRTUAL_SIDE - 1)),
+        0,
+        VIRTUAL_SIDE - 1,
+    ).astype(int)
+    return int(xyz[0]), int(xyz[1]), int(xyz[2])
+
+
+class TinyAutoencoder:
+    """Small MLP autoencoder with explicit NumPy backpropagation."""
+
+    def __init__(self, input_dim: int, latent_dim: int, hidden_dim: int, seed: int = 42):
+        rng = np.random.default_rng(seed)
+        self.w1 = rng.normal(0, 0.16, (input_dim, hidden_dim))
+        self.b1 = np.zeros(hidden_dim)
+        self.w2 = rng.normal(0, 0.16, (hidden_dim, latent_dim))
+        self.b2 = np.zeros(latent_dim)
+        self.w3 = rng.normal(0, 0.16, (latent_dim, hidden_dim))
+        self.b3 = np.zeros(hidden_dim)
+        self.w4 = rng.normal(0, 0.16, (hidden_dim, input_dim))
+        self.b4 = np.zeros(input_dim)
+
+    def encode(self, x: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        hidden = np.tanh(x @ self.w1 + self.b1)
+        latent = np.tanh(hidden @ self.w2 + self.b2)
+        return hidden, latent
+
+    def decode(self, latent: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        hidden = np.tanh(latent @ self.w3 + self.b3)
+        output = np.tanh(hidden @ self.w4 + self.b4)
+        return hidden, output
+
+    def forward(self, x: np.ndarray):
+        h1, latent = self.encode(x)
+        h3, output = self.decode(latent)
+        return h1, latent, h3, output
+
+    def train(self, x: np.ndarray, epochs: int, learning_rate: float) -> tuple[float, ...]:
+        history: list[float] = []
+        n = x.shape[0]
+        for _ in range(epochs):
+            h1, latent, h3, output = self.forward(x)
+            error = output - x
+            history.append(float(np.mean(error * error)))
+            d_output = 2.0 * error / (n * x.shape[1])
+            da4 = d_output * (1.0 - output * output)
+            gw4, gb4 = h3.T @ da4, da4.sum(0)
+            dh3 = da4 @ self.w4.T
+            da3 = dh3 * (1.0 - h3 * h3)
+            gw3, gb3 = latent.T @ da3, da3.sum(0)
+            d_latent = da3 @ self.w3.T
+            da2 = d_latent * (1.0 - latent * latent)
+            gw2, gb2 = h1.T @ da2, da2.sum(0)
+            dh1 = da2 @ self.w2.T
+            da1 = dh1 * (1.0 - h1 * h1)
+            gw1, gb1 = x.T @ da1, da1.sum(0)
+            for name, gradient in (
+                ("w4", gw4), ("b4", gb4), ("w3", gw3), ("b3", gb3),
+                ("w2", gw2), ("b2", gb2), ("w1", gw1), ("b1", gb1),
+            ):
+                setattr(
+                    self,
+                    name,
+                    getattr(self, name) - learning_rate * np.clip(gradient, -1.0, 1.0),
+                )
+        return tuple(history)
+
+
+class MultimodalEncoder:
+    def __init__(self, config: MediaANNConfig):
+        self.config = config
+
+    def encode(self, modality: Modality, value: Any, source_id: str) -> Particle:
+        blob = _to_bytes(value)
+        feature = byte_features(blob, self.config.feature_dim)
+        raw = raw_coordinate(blob)
+        index = list(Modality).index(modality)
+        phase = (index + 1) / len(Modality)
+        bias = np.array([
+            math.sin(math.pi * phase),
+            math.cos(math.pi * phase),
+            2.0 * phase - 1.0,
+        ])
+        position = np.clip(0.30 * raw + 0.70 * bias, -1.0, 1.0)
+        return Particle(modality, position, feature, source_id)
+
+
+def attention(particles: Sequence[Particle], config: MediaANNConfig) -> np.ndarray:
+    features = np.stack([particle.feature for particle in particles])
+    positions = np.stack([particle.position for particle in particles])
+    normalized = features / (np.linalg.norm(features, axis=1, keepdims=True) + 1e-12)
+    semantic = normalized @ normalized.T
+    distance2 = ((positions[:, None, :] - positions[None, :, :]) ** 2).sum(-1)
+    logits = config.feature_gain * semantic - config.geometry_gain * distance2
+    if len(particles) > 1:
+        np.fill_diagonal(logits, -1e9)
+    return _softmax(logits, axis=1)
+
+
+class InwardMultimodalMediaANN:
+    def __init__(self, config: MediaANNConfig | None = None):
+        self.config = config or MediaANNConfig()
+        self.config.validate()
+        self.encoder = MultimodalEncoder(self.config)
+        self.autoencoder = TinyAutoencoder(
+            self.config.feature_dim,
+            self.config.latent_dim,
+            self.config.hidden_dim,
+        )
+
+    def encode_inputs(self, inputs: Mapping[Modality, Sequence[Any]]) -> list[Particle]:
+        particles = [
+            self.encoder.encode(modality, value, f"{modality.value}:{index}")
+            for modality, values in inputs.items()
+            for index, value in enumerate(values)
+        ]
+        if not particles:
+            raise ValueError("at least one input is required")
+        return particles
+
+    def inward_target(self, particle: Particle) -> tuple[np.ndarray, np.ndarray]:
+        _, latent = self.autoencoder.encode(particle.feature[None, :])
+        _, reconstructed = self.autoencoder.decode(latent)
+        reconstructed_feature = _normalize(reconstructed[0])
+        latent_position = np.zeros(3)
+        width = min(3, latent.shape[1])
+        latent_position[:width] = latent[0, :width]
+        latent_position = np.tanh(latent_position)
+        q = self.config.q_phi
+        position = q * particle.position + (1.0 - q) * latent_position
+        feature = _normalize(q * particle.feature + (1.0 - q) * reconstructed_feature)
+        return position, feature
+
+    def run(self, inputs: Mapping[Modality, Sequence[Any]], task: Any) -> MediaANNResult:
+        particles = self.encode_inputs(inputs)
+        features = np.stack([particle.feature for particle in particles])
+        training_loss = self.autoencoder.train(
+            features,
+            self.config.train_epochs,
+            self.config.learning_rate,
+        )
+        task_particle = self.encoder.encode(Modality.TEXT, task, "task")
+        memory_position = np.mean(np.stack([p.position for p in particles]), axis=0)
+        memory_feature = _normalize(np.mean(np.stack([p.feature for p in particles]), axis=0))
+        metrics: list[MediaANNMetrics] = []
+        start = time.perf_counter()
+
+        for step in range(self.config.inner_steps + 1):
+            positions = np.stack([p.position for p in particles])
+            features = np.stack([p.feature for p in particles])
+            graph = attention(particles, self.config)
+            residuals: list[float] = []
+            reconstruction_errors: list[float] = []
+            for particle in particles:
+                target_position, target_feature = self.inward_target(particle)
+                residuals.append(math.sqrt(
+                    float(np.sum((target_position - particle.position) ** 2))
+                    + float(np.sum((target_feature - particle.feature) ** 2))
+                ))
+                _, latent = self.autoencoder.encode(particle.feature[None, :])
+                _, reconstructed = self.autoencoder.decode(latent)
+                reconstruction_errors.append(float(np.mean((reconstructed[0] - particle.feature) ** 2)))
+            position_center = positions.mean(0)
+            feature_center = _normalize(features.mean(0))
+            metrics.append(MediaANNMetrics(
+                step=step,
+                fixed_point_residual=float(np.mean(residuals)),
+                consensus_spread=float(np.sqrt(np.mean(np.sum((positions - position_center) ** 2, axis=1)))),
+                feature_spread=float(np.sqrt(np.mean(np.sum((features - feature_center) ** 2, axis=1)))),
+                reconstruction_mse=float(np.mean(reconstruction_errors)),
+                elapsed_ms=(time.perf_counter() - start) * 1000.0,
+            ))
+            if step == self.config.inner_steps:
+                break
+            self_gain = 1.0 - (
+                self.config.task_gain + self.config.swarm_gain
+                + self.config.inward_gain + self.config.memory_gain
+            )
+            updated: list[Particle] = []
+            for index, particle in enumerate(particles):
+                target_position, target_feature = self.inward_target(particle)
+                graph_position = graph[index] @ positions
+                graph_feature = _normalize(graph[index] @ features)
+                candidate_position = (
+                    self_gain * particle.position
+                    + self.config.task_gain * task_particle.position
+                    + self.config.swarm_gain * graph_position
+                    + self.config.inward_gain * target_position
+                    + self.config.memory_gain * memory_position
+                )
+                candidate_feature = _normalize(
+                    self_gain * particle.feature
+                    + self.config.task_gain * task_particle.feature
+                    + self.config.swarm_gain * graph_feature
+                    + self.config.inward_gain * target_feature
+                    + self.config.memory_gain * memory_feature
+                )
+                position = (1.0 - self.config.dt) * particle.position + self.config.dt * candidate_position
+                feature = _normalize((1.0 - self.config.dt) * particle.feature + self.config.dt * candidate_feature)
+                updated.append(Particle(
+                    particle.modality,
+                    np.clip(position, -1.0, 1.0),
+                    feature,
+                    particle.source_id,
+                ))
+            particles = updated
+            positions = np.stack([p.position for p in particles])
+            features = np.stack([p.feature for p in particles])
+            rho = self.config.memory_retention
+            memory_position = rho * memory_position + (1.0 - rho) * positions.mean(0)
+            memory_feature = _normalize(rho * memory_feature + (1.0 - rho) * features.mean(0))
+
+        score = self.score(metrics[-1])
+        return MediaANNResult(tuple(particles), tuple(metrics), training_loss, score)
+
+    @staticmethod
+    def score(metrics: MediaANNMetrics) -> float:
+        penalty = (
+            4.0 * metrics.fixed_point_residual
+            + 2.0 * metrics.consensus_spread
+            + 1.5 * metrics.feature_spread
+            + 3.0 * metrics.reconstruction_mse
+        )
+        return 1.0 / (1.0 + penalty)
+
+
+def consensus_latent(result: MediaANNResult) -> np.ndarray:
+    return np.mean(np.stack([particle.position for particle in result.particles]), axis=0)
+
+
+def generate_rgb_frame(latent: np.ndarray, phase: float, size: int = 256) -> np.ndarray:
+    """Generate one RGB frame from the converged 3D latent state."""
+    yy, xx = np.mgrid[-1:1:complex(size), -1:1:complex(size)]
+    radius = np.sqrt(xx * xx + yy * yy)
+    angle = np.arctan2(yy, xx)
+    z0, z1, z2 = [float(value) for value in latent]
+    field = 0.5 + 0.5 * np.sin(16 * radius - phase - z0 * math.pi) * np.exp(-2.2 * radius)
+    field += 0.18 * np.cos(8 * angle + 2 * phase + z1 * math.pi)
+    field += 0.12 * np.sin(5 * xx * math.cos(phase) - 5 * yy * math.sin(phase) + z2 * math.pi)
+    field = (field - field.min()) / (np.ptp(field) + 1e-12)
+    red = np.clip(field, 0.0, 1.0)
+    green = np.clip(np.roll(field, int(10 + 8 * z1), axis=0), 0.0, 1.0)
+    blue = np.clip(np.roll(field, int(10 + 8 * z2), axis=1), 0.0, 1.0)
+    return np.uint8(np.stack([red, green, blue], axis=-1) * 255)
+
+
+def generate_pcm_audio(
+    latent: np.ndarray,
+    duration_seconds: float,
+    sample_rate: int = 16_000,
+) -> np.ndarray:
+    """Generate signed 16-bit PCM samples from the same 3D latent state."""
+    timeline = np.arange(int(duration_seconds * sample_rate)) / sample_rate
+    f0 = 180 + 100 * (latent[0] + 1)
+    f1 = 300 + 140 * (latent[1] + 1)
+    f2 = 420 + 160 * (latent[2] + 1)
+    signal = (
+        0.50 * np.sin(2 * np.pi * f0 * timeline)
+        + 0.23 * np.sin(2 * np.pi * f1 * timeline)
+        + 0.12 * np.sin(2 * np.pi * f2 * timeline)
+    )
+    signal /= np.max(np.abs(signal)) + 1e-12
+    return np.int16(signal * 30_000)
+
+
+def mutate_config(config: MediaANNConfig, rng: np.random.Generator) -> MediaANNConfig:
+    def perturb(value: float, low: float, high: float, sigma: float) -> float:
+        return float(np.clip(value + rng.normal(0.0, sigma), low, high))
+    candidate = replace(
+        config,
+        task_gain=perturb(config.task_gain, 0.05, 0.30, 0.02),
+        swarm_gain=perturb(config.swarm_gain, 0.03, 0.28, 0.02),
+        inward_gain=perturb(config.inward_gain, 0.18, 0.58, 0.03),
+        memory_gain=perturb(config.memory_gain, 0.01, 0.14, 0.012),
+        q_phi=perturb(config.q_phi, 0.20, 0.75, 0.035),
+        geometry_gain=perturb(config.geometry_gain, 0.05, 0.60, 0.04),
+        memory_retention=perturb(config.memory_retention, 0.65, 0.96, 0.025),
+    )
+    total = candidate.task_gain + candidate.swarm_gain + candidate.inward_gain + candidate.memory_gain
+    if total >= 0.95:
+        scale = 0.94 / total
+        candidate = replace(
+            candidate,
+            task_gain=candidate.task_gain * scale,
+            swarm_gain=candidate.swarm_gain * scale,
+            inward_gain=candidate.inward_gain * scale,
+            memory_gain=candidate.memory_gain * scale,
+        )
+    candidate.validate()
+    return candidate
+
+
+def bounded_optimize(
+    inputs: Mapping[Modality, Sequence[Any]],
+    task: Any,
+    initial: MediaANNConfig | None = None,
+    *,
+    generations: int = 4,
+    population: int = 8,
+    seed: int = 42,
+) -> tuple[MediaANNConfig, MediaANNResult, tuple[dict[str, Any], ...]]:
+    rng = np.random.default_rng(seed)
+    incumbent = initial or MediaANNConfig()
+    incumbent_result = InwardMultimodalMediaANN(incumbent).run(inputs, task)
+    audit: list[dict[str, Any]] = []
+    for generation in range(generations):
+        candidates = [incumbent] + [mutate_config(incumbent, rng) for _ in range(population - 1)]
+        best = None
+        for index, config in enumerate(candidates):
+            result = InwardMultimodalMediaANN(config).run(inputs, task)
+            fixed_point_ok = (
+                result.metrics[-1].fixed_point_residual
+                <= incumbent_result.metrics[-1].fixed_point_residual + 1e-12
+            )
+            improvement_ok = result.score > incumbent_result.score * 1.0025
+            promoted = bool(fixed_point_ok and improvement_ok and np.isfinite(result.score))
+            audit.append({
+                "generation": generation,
+                "candidate": index,
+                "score": result.score,
+                "fixed_point_residual": result.metrics[-1].fixed_point_residual,
+                "promoted": promoted,
+                "config": asdict(config),
+            })
+            if promoted and (best is None or result.score > best[1].score):
+                best = (config, result)
+        if best is not None:
+            incumbent, incumbent_result = best
+    return incumbent, incumbent_result, tuple(audit)
+
+
+__all__ = [
+    "MediaANNConfig",
+    "MediaANNMetrics",
+    "MediaANNResult",
+    "Modality",
+    "Particle",
+    "TinyAutoencoder",
+    "InwardMultimodalMediaANN",
+    "VIRTUAL_CELLS",
+    "VIRTUAL_SIDE",
+    "bounded_optimize",
+    "byte_features",
+    "consensus_latent",
+    "generate_pcm_audio",
+    "generate_rgb_frame",
+    "mutate_config",
+    "virtual_xyz",
+]

--- a/src/jarvisx/inward_multimodal_meta_optimizer.py
+++ b/src/jarvisx/inward_multimodal_meta_optimizer.py
@@ -1,0 +1,279 @@
+"""Candidate-first self-optimization for the inward multimodal 3D swarm runtime.
+
+This research-layer optimizer does not rewrite executable source code.  It treats a
+bounded subset of :class:`Swarm3DConfig` as a runtime genotype, evaluates mutated
+candidate configurations through a caller-supplied shadow evaluator, rejects
+candidates that violate stability/fixed-point/resource gates, and promotes only
+verified improvements.
+
+The intended outer loop is::
+
+    run -> measure -> mutate -> shadow evaluate -> verify -> promote/reject
+
+while the inner runtime remains::
+
+    encode -> 3D coordination -> inward E(D(z)) -> decode -> re-encode.
+
+This separation keeps adaptation auditable and consistent with Jarvis-X's
+candidate-first research/runtime boundary.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass, replace
+from typing import Callable
+
+from .inward_multimodal_swarm3d import Swarm3DConfig
+
+
+def _finite(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    value = _finite(value, name=name)
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
+
+
+def _unit(value: float, *, name: str) -> float:
+    value = _finite(value, name=name)
+    if not 0.0 <= value <= 1.0:
+        raise ValueError(f"{name} must lie within [0, 1]")
+    return value
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, float(value)))
+
+
+@dataclass(frozen=True)
+class MetaFitness:
+    """Measured fitness returned by a shadow runtime evaluation.
+
+    The three positive quality terms are normalized to [0, 1].  Fixed-point
+    error and resource cost are non-negative measured penalties.  ``stable`` is
+    a hard gate, not merely another weighted term.
+    """
+
+    task_score: float
+    semantic_coherence: float
+    feature_coherence: float
+    fixed_point_error: float
+    resource_cost: float
+    stable: bool
+
+    def __post_init__(self) -> None:
+        _unit(self.task_score, name="task_score")
+        _unit(self.semantic_coherence, name="semantic_coherence")
+        _unit(self.feature_coherence, name="feature_coherence")
+        _non_negative(self.fixed_point_error, name="fixed_point_error")
+        _non_negative(self.resource_cost, name="resource_cost")
+        if not isinstance(self.stable, bool):
+            raise TypeError("stable must be boolean")
+
+    @property
+    def score(self) -> float:
+        """Composite ranking score; promotion still requires all hard gates."""
+
+        stability = 1.0 / (1.0 + self.fixed_point_error)
+        efficiency = 1.0 / (1.0 + self.resource_cost)
+        return (
+            0.30 * self.task_score
+            + 0.25 * self.semantic_coherence
+            + 0.20 * self.feature_coherence
+            + 0.15 * stability
+            + 0.10 * efficiency
+        )
+
+
+RuntimeEvaluator = Callable[[Swarm3DConfig], MetaFitness]
+
+
+@dataclass(frozen=True)
+class MetaSearchConfig:
+    """Bounds for deterministic candidate-first meta optimization."""
+
+    generations: int = 6
+    branch_width: int = 10
+    seed: int = 42
+    mutation_fraction: float = 0.12
+    improvement_threshold: float = 0.0025
+    max_fixed_point_regression: float = 0.0
+    max_resource_regression: float = 0.25
+
+    def __post_init__(self) -> None:
+        for name in ("generations", "branch_width"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if isinstance(self.seed, bool) or not isinstance(self.seed, int):
+            raise TypeError("seed must be an integer")
+        if _finite(self.mutation_fraction, name="mutation_fraction") <= 0.0:
+            raise ValueError("mutation_fraction must be positive")
+        _non_negative(self.improvement_threshold, name="improvement_threshold")
+        _non_negative(self.max_fixed_point_regression, name="max_fixed_point_regression")
+        _non_negative(self.max_resource_regression, name="max_resource_regression")
+
+
+@dataclass(frozen=True)
+class CandidateEvaluation:
+    generation: int
+    candidate: int
+    config: Swarm3DConfig
+    fitness: MetaFitness
+    eligible: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class MetaOptimizationReport:
+    baseline_config: Swarm3DConfig
+    baseline_fitness: MetaFitness
+    final_config: Swarm3DConfig
+    final_fitness: MetaFitness
+    promoted: bool
+    evaluated_candidates: int
+    evaluations: tuple[CandidateEvaluation, ...]
+
+    @property
+    def relative_improvement(self) -> float:
+        baseline = self.baseline_fitness.score
+        if baseline == 0.0:
+            return math.inf if self.final_fitness.score > 0.0 else 0.0
+        return self.final_fitness.score / baseline - 1.0
+
+
+class InwardMultimodalMetaOptimizer:
+    """Bounded outer-loop optimizer for ``Swarm3DConfig``.
+
+    The evaluator is deliberately injected by the caller.  A production caller
+    can therefore run each candidate in an isolated shadow runtime, collect task,
+    semantic, feature, fixed-point and resource telemetry, and return only the
+    normalized ``MetaFitness`` contract to this optimizer.
+    """
+
+    def __init__(self, search: MetaSearchConfig | None = None) -> None:
+        self.search = search or MetaSearchConfig()
+
+    def candidate_configs(
+        self,
+        incumbent: Swarm3DConfig,
+        *,
+        generation: int,
+    ) -> tuple[Swarm3DConfig, ...]:
+        if generation < 0:
+            raise ValueError("generation must be non-negative")
+        rng = random.Random(self.search.seed + 104_729 * generation)
+        return tuple(self._mutate(incumbent, rng) for _ in range(self.search.branch_width))
+
+    def _mutate(self, config: Swarm3DConfig, rng: random.Random) -> Swarm3DConfig:
+        scale = self.search.mutation_fraction
+
+        def perturb(value: float, low: float, high: float, floor: float = 0.02) -> float:
+            sigma = scale * max(abs(float(value)), floor)
+            return _clamp(float(value) + rng.gauss(0.0, sigma), low, high)
+
+        step_factor = 1.0 + rng.gauss(0.0, scale)
+        max_steps = max(4, min(256, int(round(config.max_steps * step_factor))))
+
+        return replace(
+            config,
+            dt=perturb(config.dt, 1.0e-4, 0.50),
+            alpha_metric=perturb(config.alpha_metric, 0.0, 4.0),
+            task_gain=perturb(config.task_gain, 0.0, 4.0),
+            inward_gain=perturb(config.inward_gain, 0.0, 2.0),
+            swarm_gain=perturb(config.swarm_gain, 0.0, 2.0),
+            memory_gain=perturb(config.memory_gain, 0.0, 1.0),
+            feature_mix_gain=perturb(config.feature_mix_gain, 0.0, 1.0),
+            feature_similarity_gain=perturb(config.feature_similarity_gain, 0.0, 4.0),
+            geometry_distance_gain=perturb(config.geometry_distance_gain, 0.0, 4.0),
+            max_steps=max_steps,
+        )
+
+    def _eligible(self, incumbent: MetaFitness, candidate: MetaFitness) -> tuple[bool, str]:
+        if not candidate.stable:
+            return False, "candidate failed the stability gate"
+
+        fp_limit = incumbent.fixed_point_error + self.search.max_fixed_point_regression
+        if candidate.fixed_point_error > fp_limit + 1.0e-12:
+            return False, "candidate regressed fixed-point integrity"
+
+        resource_limit = incumbent.resource_cost * (1.0 + self.search.max_resource_regression)
+        if candidate.resource_cost > resource_limit + 1.0e-12:
+            return False, "candidate exceeded the resource-regression gate"
+
+        required = incumbent.score * (1.0 + self.search.improvement_threshold)
+        if candidate.score <= required:
+            return False, "candidate did not clear the minimum improvement threshold"
+
+        return True, "candidate passed stability, integrity, resource and fitness gates"
+
+    def optimize(
+        self,
+        incumbent: Swarm3DConfig,
+        evaluator: RuntimeEvaluator,
+    ) -> MetaOptimizationReport:
+        baseline_config = incumbent
+        baseline_fitness = evaluator(incumbent)
+        if not baseline_fitness.stable:
+            raise ValueError("incumbent runtime must be stable before meta optimization")
+
+        current_config = incumbent
+        current_fitness = baseline_fitness
+        evaluations: list[CandidateEvaluation] = []
+
+        for generation in range(self.search.generations):
+            best_config: Swarm3DConfig | None = None
+            best_fitness: MetaFitness | None = None
+
+            for index, candidate_config in enumerate(
+                self.candidate_configs(current_config, generation=generation)
+            ):
+                candidate_fitness = evaluator(candidate_config)
+                eligible, reason = self._eligible(current_fitness, candidate_fitness)
+                evaluations.append(
+                    CandidateEvaluation(
+                        generation=generation,
+                        candidate=index,
+                        config=candidate_config,
+                        fitness=candidate_fitness,
+                        eligible=eligible,
+                        reason=reason,
+                    )
+                )
+                if eligible and (
+                    best_fitness is None or candidate_fitness.score > best_fitness.score
+                ):
+                    best_config = candidate_config
+                    best_fitness = candidate_fitness
+
+            if best_config is not None and best_fitness is not None:
+                current_config = best_config
+                current_fitness = best_fitness
+
+        return MetaOptimizationReport(
+            baseline_config=baseline_config,
+            baseline_fitness=baseline_fitness,
+            final_config=current_config,
+            final_fitness=current_fitness,
+            promoted=current_config != baseline_config,
+            evaluated_candidates=len(evaluations),
+            evaluations=tuple(evaluations),
+        )
+
+
+__all__ = [
+    "CandidateEvaluation",
+    "InwardMultimodalMetaOptimizer",
+    "MetaFitness",
+    "MetaOptimizationReport",
+    "MetaSearchConfig",
+    "RuntimeEvaluator",
+]

--- a/src/jarvisx/inward_multimodal_swarm3d.py
+++ b/src/jarvisx/inward_multimodal_swarm3d.py
@@ -1,0 +1,771 @@
+"""Inward multiparallel multimodal 3D swarm reference runtime.
+
+This module is a bounded research layer. It treats 3D coordinates as a virtual
+semantic/control chart, not literal physical space. Modality codecs provide the
+boundary between real media representations and the shared 3D chart.
+
+The runtime implements the local-chart form of
+
+    dZ/dt = -G^-1 grad(J) + lambda(Phi(Z) - Z) - gamma L(Z) Z + F_memory
+
+with the rank-one Riemannian metric
+
+    G = I + alpha grad(phi) grad(phi)^T.
+
+It also exposes an RC-network analogue of the inward and graph-relaxation terms.
+That analogue is an algorithm-to-circuit correspondence; it is not a Maxwell
+field solver.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Mapping, Protocol, Sequence
+
+Vec3 = tuple[float, float, float]
+Feature = tuple[float, ...]
+Matrix3 = tuple[Vec3, Vec3, Vec3]
+
+
+def _finite_scalar(value: float, *, name: str) -> float:
+    value = float(value)
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite")
+    return value
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    value = _finite_scalar(value, name=name)
+    if value < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return value
+
+
+def _positive(value: float, *, name: str) -> float:
+    value = _finite_scalar(value, name=name)
+    if value <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return value
+
+
+def _vec3(values: Sequence[float], *, name: str) -> Vec3:
+    if len(values) != 3:
+        raise ValueError(f"{name} must contain exactly three coordinates")
+    result = tuple(_finite_scalar(value, name=name) for value in values)
+    return result[0], result[1], result[2]
+
+
+def _feature(values: Sequence[float], *, name: str = "feature") -> Feature:
+    result = tuple(_finite_scalar(value, name=name) for value in values)
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+def _add(left: Vec3, right: Vec3) -> Vec3:
+    return left[0] + right[0], left[1] + right[1], left[2] + right[2]
+
+
+def _sub(left: Vec3, right: Vec3) -> Vec3:
+    return left[0] - right[0], left[1] - right[1], left[2] - right[2]
+
+
+def _scale(value: Vec3, factor: float) -> Vec3:
+    return value[0] * factor, value[1] * factor, value[2] * factor
+
+
+def _dot(left: Vec3, right: Vec3) -> float:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def _norm(value: Vec3) -> float:
+    return math.sqrt(_dot(value, value))
+
+
+def _distance2(left: Vec3, right: Vec3) -> float:
+    delta = _sub(left, right)
+    return _dot(delta, delta)
+
+
+def _matvec(matrix: Matrix3, vector: Vec3) -> Vec3:
+    return (
+        _dot(matrix[0], vector),
+        _dot(matrix[1], vector),
+        _dot(matrix[2], vector),
+    )
+
+
+def _clamp_vec(value: Vec3, bound: float) -> Vec3:
+    return (
+        min(bound, max(-bound, value[0])),
+        min(bound, max(-bound, value[1])),
+        min(bound, max(-bound, value[2])),
+    )
+
+
+def _cap_norm(value: Vec3, maximum: float) -> Vec3:
+    norm = _norm(value)
+    if norm <= maximum or norm == 0.0:
+        return value
+    return _scale(value, maximum / norm)
+
+
+def _cosine(left: Feature, right: Feature) -> float:
+    if len(left) != len(right):
+        raise ValueError("all particles must use the same shared feature width")
+    dot = sum(a * b for a, b in zip(left, right))
+    ln = math.sqrt(sum(a * a for a in left))
+    rn = math.sqrt(sum(b * b for b in right))
+    if ln == 0.0 or rn == 0.0:
+        return 0.0
+    return dot / (ln * rn)
+
+
+def _softmax(values: Sequence[float]) -> tuple[float, ...]:
+    if not values:
+        return ()
+    maximum = max(values)
+    exps = tuple(math.exp(value - maximum) for value in values)
+    total = sum(exps)
+    return tuple(value / total for value in exps)
+
+
+class Modality(str, Enum):
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+    GEOMETRY = "geometry"
+    CODE = "code"
+    DATA = "data"
+
+
+class ModalityCodec(Protocol):
+    """Boundary adapter between one media modality and the shared 3D chart."""
+
+    def encode(self, value: object) -> Vec3:
+        """Map one modality value to a bounded virtual 3D coordinate."""
+
+    def decode(self, position: Vec3) -> object:
+        """Generate/project one modality value from a virtual 3D coordinate."""
+
+
+FeatureEncoder = Callable[[Modality, object, Vec3], Sequence[float]]
+TaskGradient = Callable[["Particle3D"], Vec3]
+PotentialGradient = Callable[["Particle3D"], Vec3]
+TaskEnergy = Callable[["Particle3D"], float]
+
+
+@dataclass(frozen=True)
+class Particle3D:
+    """One modality-tagged hypothesis in the shared virtual 3D chart."""
+
+    position: Vec3
+    feature: Feature
+    modality: Modality
+    confidence: float = 1.0
+    time_coordinate: float = 0.0
+    source_id: str = ""
+
+    def __post_init__(self) -> None:
+        position = _vec3(self.position, name="position")
+        feature = _feature(self.feature)
+        confidence = _finite_scalar(self.confidence, name="confidence")
+        time_coordinate = _finite_scalar(self.time_coordinate, name="time_coordinate")
+        if not 0.0 <= confidence <= 1.0:
+            raise ValueError("confidence must lie within [0, 1]")
+        if not isinstance(self.modality, Modality):
+            raise TypeError("modality must be a Modality")
+        object.__setattr__(self, "position", position)
+        object.__setattr__(self, "feature", feature)
+        object.__setattr__(self, "confidence", confidence)
+        object.__setattr__(self, "time_coordinate", time_coordinate)
+
+
+@dataclass(frozen=True)
+class Swarm3DConfig:
+    """Numerical and resource bounds for the inward swarm."""
+
+    dt: float = 0.05
+    alpha_metric: float = 0.40
+    task_gain: float = 1.0
+    inward_gain: float = 0.15
+    swarm_gain: float = 0.20
+    memory_gain: float = 0.10
+    feature_mix_gain: float = 0.10
+    feature_similarity_gain: float = 1.0
+    geometry_distance_gain: float = 0.25
+    position_bound: float = 1.0
+    max_position_step: float = 0.20
+    max_steps: int = 64
+    tolerance: float = 1.0e-5
+    max_particles: int = 16_384
+
+    def __post_init__(self) -> None:
+        _positive(self.dt, name="dt")
+        for name in (
+            "alpha_metric",
+            "task_gain",
+            "inward_gain",
+            "swarm_gain",
+            "memory_gain",
+            "feature_mix_gain",
+            "feature_similarity_gain",
+            "geometry_distance_gain",
+        ):
+            _non_negative(getattr(self, name), name=name)
+        _positive(self.position_bound, name="position_bound")
+        _positive(self.max_position_step, name="max_position_step")
+        _non_negative(self.tolerance, name="tolerance")
+        for name in ("max_steps", "max_particles"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class Swarm3DMetrics:
+    step: int
+    particle_count: int
+    energy: float
+    task_energy: float
+    cycle_energy: float
+    coupling_energy: float
+    fixed_point_error: float
+    consensus_error: float
+    max_displacement: float
+
+
+@dataclass(frozen=True)
+class Swarm3DState:
+    particles: tuple[Particle3D, ...]
+    metrics: Swarm3DMetrics
+
+    def __post_init__(self) -> None:
+        if not self.particles:
+            raise ValueError("swarm must contain at least one particle")
+        width = len(self.particles[0].feature)
+        if any(len(particle.feature) != width for particle in self.particles):
+            raise ValueError("all particles must use the same shared feature width")
+
+
+@dataclass(frozen=True)
+class Swarm3DResult:
+    state: Swarm3DState
+    energy_history: tuple[float, ...]
+    converged: bool
+
+
+@dataclass(frozen=True)
+class ElectricalAnalogueConfig:
+    """Bounded RC-network parameters for the structural hardware analogue."""
+
+    capacitance: float = 1.0
+    feedback_conductance: float = 0.15
+    coupling_conductance: float = 0.20
+    dt: float = 0.01
+    voltage_bound: float = 1.0
+
+    def __post_init__(self) -> None:
+        _positive(self.capacitance, name="capacitance")
+        _non_negative(self.feedback_conductance, name="feedback_conductance")
+        _non_negative(self.coupling_conductance, name="coupling_conductance")
+        _positive(self.dt, name="dt")
+        _positive(self.voltage_bound, name="voltage_bound")
+
+
+def riemannian_metric_inverse(gradient_phi: Vec3, *, alpha: float) -> Matrix3:
+    """Exact inverse of G = I + alpha grad(phi) grad(phi)^T."""
+
+    gradient_phi = _vec3(gradient_phi, name="gradient_phi")
+    alpha = _non_negative(alpha, name="alpha")
+    denominator = 1.0 + alpha * _dot(gradient_phi, gradient_phi)
+    factor = alpha / denominator
+    gx, gy, gz = gradient_phi
+    return (
+        (1.0 - factor * gx * gx, -factor * gx * gy, -factor * gx * gz),
+        (-factor * gy * gx, 1.0 - factor * gy * gy, -factor * gy * gz),
+        (-factor * gz * gx, -factor * gz * gy, 1.0 - factor * gz * gz),
+    )
+
+
+def local_riemannian_gradient(
+    euclidean_gradient: Vec3,
+    potential_gradient: Vec3,
+    *,
+    alpha: float,
+) -> Vec3:
+    """Return G^-1 grad(J) in the current local chart."""
+
+    inverse = riemannian_metric_inverse(potential_gradient, alpha=alpha)
+    return _matvec(inverse, _vec3(euclidean_gradient, name="euclidean_gradient"))
+
+
+class InwardMultimodalSwarm3D:
+    """Dependency-free multiparallel multimodal inward-relaxation runtime."""
+
+    def __init__(
+        self,
+        codecs: Mapping[Modality, ModalityCodec],
+        config: Swarm3DConfig | None = None,
+        *,
+        feature_encoder: FeatureEncoder | None = None,
+    ) -> None:
+        if not codecs:
+            raise ValueError("at least one modality codec is required")
+        normalized: dict[Modality, ModalityCodec] = {}
+        for modality, codec in codecs.items():
+            if not isinstance(modality, Modality):
+                raise TypeError("codec keys must be Modality values")
+            normalized[modality] = codec
+        self.codecs = normalized
+        self.config = config or Swarm3DConfig()
+        self.feature_encoder = feature_encoder
+
+    def encode_modalities(
+        self,
+        inputs: Mapping[Modality, Sequence[object]],
+    ) -> tuple[Particle3D, ...]:
+        """Encode all supplied modality items into one shared particle population."""
+
+        particles: list[Particle3D] = []
+        for modality, values in inputs.items():
+            if modality not in self.codecs:
+                raise KeyError(f"no codec registered for modality {modality.value}")
+            codec = self.codecs[modality]
+            for index, value in enumerate(values):
+                position = _clamp_vec(
+                    _vec3(codec.encode(value), name="encoded position"),
+                    self.config.position_bound,
+                )
+                raw_feature = (
+                    self.feature_encoder(modality, value, position)
+                    if self.feature_encoder is not None
+                    else position
+                )
+                particles.append(
+                    Particle3D(
+                        position=position,
+                        feature=_feature(raw_feature),
+                        modality=modality,
+                        source_id=f"{modality.value}:{index}",
+                    )
+                )
+                if len(particles) > self.config.max_particles:
+                    raise ValueError("encoded particle count exceeds max_particles")
+        if not particles:
+            raise ValueError("inputs must contain at least one modality item")
+        width = len(particles[0].feature)
+        if any(len(particle.feature) != width for particle in particles):
+            raise ValueError("feature_encoder must project all modalities to one shared width")
+        return tuple(particles)
+
+    def inward_target(self, particle: Particle3D) -> Vec3:
+        """Phi(z) = E_m(D_m(z)) for the particle's modality."""
+
+        codec = self.codecs.get(particle.modality)
+        if codec is None:
+            raise KeyError(f"no codec registered for modality {particle.modality.value}")
+        decoded = codec.decode(particle.position)
+        return _clamp_vec(
+            _vec3(codec.encode(decoded), name="inward target"),
+            self.config.position_bound,
+        )
+
+    def attention(self, particles: Sequence[Particle3D]) -> tuple[tuple[float, ...], ...]:
+        """Dynamic graph weights from shared features and chart distance."""
+
+        if not particles:
+            raise ValueError("particles must not be empty")
+        width = len(particles[0].feature)
+        if any(len(particle.feature) != width for particle in particles):
+            raise ValueError("all particles must use the same shared feature width")
+
+        rows: list[tuple[float, ...]] = []
+        count = len(particles)
+        for index, particle in enumerate(particles):
+            if count == 1:
+                rows.append((1.0,))
+                continue
+            scores: list[float] = []
+            destinations: list[int] = []
+            for other_index, other in enumerate(particles):
+                if other_index == index:
+                    continue
+                score = (
+                    self.config.feature_similarity_gain
+                    * _cosine(particle.feature, other.feature)
+                    - self.config.geometry_distance_gain
+                    * _distance2(particle.position, other.position)
+                )
+                scores.append(score)
+                destinations.append(other_index)
+            weights = _softmax(scores)
+            row = [0.0] * count
+            for destination, weight in zip(destinations, weights):
+                row[destination] = weight
+            rows.append(tuple(row))
+        return tuple(rows)
+
+    @staticmethod
+    def chart_consensus(particles: Sequence[Particle3D]) -> Vec3:
+        """Confidence-weighted local-chart consensus.
+
+        This is the Euclidean/tangent approximation to a Riemannian Frechet mean;
+        it is intentionally not advertised as an exact global Karcher solver.
+        """
+
+        if not particles:
+            raise ValueError("particles must not be empty")
+        weights = tuple(particle.confidence for particle in particles)
+        total = sum(weights)
+        if total == 0.0:
+            weights = (1.0,) * len(particles)
+            total = float(len(particles))
+        return (
+            sum(weight * particle.position[0] for weight, particle in zip(weights, particles))
+            / total,
+            sum(weight * particle.position[1] for weight, particle in zip(weights, particles))
+            / total,
+            sum(weight * particle.position[2] for weight, particle in zip(weights, particles))
+            / total,
+        )
+
+    def decode_consensus(
+        self,
+        particles: Sequence[Particle3D],
+        modalities: Sequence[Modality] | None = None,
+    ) -> dict[Modality, object]:
+        """Decode one consensus control state through multiple modality heads."""
+
+        consensus = self.chart_consensus(particles)
+        selected = tuple(modalities) if modalities is not None else tuple(self.codecs)
+        generated: dict[Modality, object] = {}
+        for modality in selected:
+            codec = self.codecs.get(modality)
+            if codec is None:
+                raise KeyError(f"no codec registered for modality {modality.value}")
+            generated[modality] = codec.decode(consensus)
+        return generated
+
+    def _metrics(
+        self,
+        particles: Sequence[Particle3D],
+        inward_targets: Sequence[Vec3],
+        adjacency: Sequence[Sequence[float]],
+        *,
+        step: int,
+        task_energy: TaskEnergy | None,
+        max_displacement: float,
+    ) -> Swarm3DMetrics:
+        count = len(particles)
+        task_value = (
+            sum(_finite_scalar(task_energy(particle), name="task_energy") for particle in particles)
+            / count
+            if task_energy is not None
+            else 0.0
+        )
+        cycle_value = sum(
+            _distance2(particle.position, target)
+            for particle, target in zip(particles, inward_targets)
+        ) / count
+        coupling_value = 0.0
+        for i, particle in enumerate(particles):
+            coupling_value += sum(
+                adjacency[i][j] * _distance2(particle.position, other.position)
+                for j, other in enumerate(particles)
+            )
+        coupling_value /= count
+
+        consensus = self.chart_consensus(particles)
+        consensus_error = math.sqrt(
+            sum(_distance2(particle.position, consensus) for particle in particles) / count
+        )
+        fixed_point_error = math.sqrt(cycle_value)
+        energy = (
+            self.config.task_gain * task_value
+            + self.config.inward_gain * cycle_value
+            + 0.5 * self.config.swarm_gain * coupling_value
+        )
+        return Swarm3DMetrics(
+            step=step,
+            particle_count=count,
+            energy=energy,
+            task_energy=task_value,
+            cycle_energy=cycle_value,
+            coupling_energy=coupling_value,
+            fixed_point_error=fixed_point_error,
+            consensus_error=consensus_error,
+            max_displacement=max_displacement,
+        )
+
+    def initial_state(
+        self,
+        particles: Sequence[Particle3D],
+        *,
+        task_energy: TaskEnergy | None = None,
+    ) -> Swarm3DState:
+        particles = tuple(particles)
+        if not particles:
+            raise ValueError("particles must not be empty")
+        if len(particles) > self.config.max_particles:
+            raise ValueError("particle count exceeds max_particles")
+        width = len(particles[0].feature)
+        if any(len(particle.feature) != width for particle in particles):
+            raise ValueError("all particles must use the same shared feature width")
+        targets = tuple(self.inward_target(particle) for particle in particles)
+        adjacency = self.attention(particles)
+        metrics = self._metrics(
+            particles,
+            targets,
+            adjacency,
+            step=0,
+            task_energy=task_energy,
+            max_displacement=0.0,
+        )
+        return Swarm3DState(particles, metrics)
+
+    def step(
+        self,
+        state: Swarm3DState,
+        *,
+        task_gradient: TaskGradient | None = None,
+        potential_gradient: PotentialGradient | None = None,
+        task_energy: TaskEnergy | None = None,
+        memory_targets: Mapping[str, Vec3] | None = None,
+    ) -> Swarm3DState:
+        """Advance the local-chart swarm by one bounded explicit-Euler step."""
+
+        particles = state.particles
+        adjacency = self.attention(particles)
+        inward_targets = tuple(self.inward_target(particle) for particle in particles)
+        memory_targets = memory_targets or {}
+        updated: list[Particle3D] = []
+        maximum_displacement = 0.0
+
+        for i, particle in enumerate(particles):
+            euclidean_gradient = (
+                _vec3(task_gradient(particle), name="task gradient")
+                if task_gradient is not None
+                else (0.0, 0.0, 0.0)
+            )
+            metric_gradient = (
+                _vec3(potential_gradient(particle), name="potential gradient")
+                if potential_gradient is not None
+                else euclidean_gradient
+            )
+            riemannian_gradient = local_riemannian_gradient(
+                euclidean_gradient,
+                metric_gradient,
+                alpha=self.config.alpha_metric,
+            )
+            task_force = _scale(riemannian_gradient, -self.config.task_gain)
+            inward_force = _scale(
+                _sub(inward_targets[i], particle.position),
+                self.config.inward_gain,
+            )
+
+            swarm_force: Vec3 = (0.0, 0.0, 0.0)
+            neighbor_feature = [0.0] * len(particle.feature)
+            for j, other in enumerate(particles):
+                weight = adjacency[i][j]
+                if weight == 0.0:
+                    continue
+                swarm_force = _add(
+                    swarm_force,
+                    _scale(_sub(other.position, particle.position), weight),
+                )
+                for k, value in enumerate(other.feature):
+                    neighbor_feature[k] += weight * value
+            swarm_force = _scale(swarm_force, self.config.swarm_gain)
+
+            memory_force: Vec3 = (0.0, 0.0, 0.0)
+            if particle.source_id in memory_targets:
+                target = _vec3(memory_targets[particle.source_id], name="memory target")
+                memory_force = _scale(
+                    _sub(target, particle.position),
+                    self.config.memory_gain,
+                )
+
+            force = _add(_add(task_force, inward_force), _add(swarm_force, memory_force))
+            displacement = _cap_norm(
+                _scale(force, self.config.dt),
+                self.config.max_position_step,
+            )
+            new_position = _clamp_vec(
+                _add(particle.position, displacement),
+                self.config.position_bound,
+            )
+            actual_displacement = _norm(_sub(new_position, particle.position))
+            maximum_displacement = max(maximum_displacement, actual_displacement)
+
+            if len(particles) == 1:
+                new_feature = particle.feature
+            else:
+                feature_rate = self.config.dt * self.config.feature_mix_gain
+                new_feature = tuple(
+                    current + feature_rate * (neighbor - current)
+                    for current, neighbor in zip(particle.feature, neighbor_feature)
+                )
+            updated.append(
+                Particle3D(
+                    position=new_position,
+                    feature=new_feature,
+                    modality=particle.modality,
+                    confidence=particle.confidence,
+                    time_coordinate=particle.time_coordinate + self.config.dt,
+                    source_id=particle.source_id,
+                )
+            )
+
+        updated_particles = tuple(updated)
+        updated_targets = tuple(self.inward_target(particle) for particle in updated_particles)
+        updated_adjacency = self.attention(updated_particles)
+        metrics = self._metrics(
+            updated_particles,
+            updated_targets,
+            updated_adjacency,
+            step=state.metrics.step + 1,
+            task_energy=task_energy,
+            max_displacement=maximum_displacement,
+        )
+        return Swarm3DState(updated_particles, metrics)
+
+    def relax(
+        self,
+        particles: Sequence[Particle3D],
+        *,
+        task_gradient: TaskGradient | None = None,
+        potential_gradient: PotentialGradient | None = None,
+        task_energy: TaskEnergy | None = None,
+        memory_targets: Mapping[str, Vec3] | None = None,
+    ) -> Swarm3DResult:
+        """Run bounded inward relaxation until tolerance or max_steps."""
+
+        state = self.initial_state(particles, task_energy=task_energy)
+        history = [state.metrics.energy]
+        converged = False
+
+        for _ in range(self.config.max_steps):
+            state = self.step(
+                state,
+                task_gradient=task_gradient,
+                potential_gradient=potential_gradient,
+                task_energy=task_energy,
+                memory_targets=memory_targets,
+            )
+            history.append(state.metrics.energy)
+            movement_ok = state.metrics.max_displacement <= self.config.tolerance
+            inward_ok = (
+                self.config.inward_gain == 0.0
+                or state.metrics.fixed_point_error <= self.config.tolerance
+            )
+            if movement_ok and inward_ok:
+                converged = True
+                break
+
+        return Swarm3DResult(state=state, energy_history=tuple(history), converged=converged)
+
+
+def electrical_rhs(
+    voltages: Sequence[Vec3],
+    phi_voltages: Sequence[Vec3],
+    adjacency: Sequence[Sequence[float]],
+    config: ElectricalAnalogueConfig,
+    *,
+    external_currents: Sequence[Vec3] | None = None,
+) -> tuple[Vec3, ...]:
+    """Return dV/dt for the RC analogue.
+
+    Implements, component-wise,
+
+        C dV_i/dt =
+            g_phi (V_phi_i - V_i)
+            + g_c sum_j A_ij (V_j - V_i)
+            + I_ext_i.
+
+    Voltages encode algorithmic state. This helper does not solve Maxwell's
+    field equations and does not identify semantic coordinates with spacetime.
+    """
+
+    values = tuple(_vec3(value, name="voltage") for value in voltages)
+    targets = tuple(_vec3(value, name="phi_voltage") for value in phi_voltages)
+    if not values:
+        raise ValueError("voltages must not be empty")
+    if len(targets) != len(values):
+        raise ValueError("phi_voltages must match voltage count")
+    if len(adjacency) != len(values) or any(len(row) != len(values) for row in adjacency):
+        raise ValueError("adjacency must be a square matrix matching voltage count")
+    for row in adjacency:
+        if any(not math.isfinite(float(weight)) or float(weight) < 0.0 for weight in row):
+            raise ValueError("adjacency weights must be finite and non-negative")
+
+    if external_currents is None:
+        currents = ((0.0, 0.0, 0.0),) * len(values)
+    else:
+        currents = tuple(_vec3(value, name="external current") for value in external_currents)
+        if len(currents) != len(values):
+            raise ValueError("external_currents must match voltage count")
+
+    derivatives: list[Vec3] = []
+    for i, value in enumerate(values):
+        feedback = _scale(
+            _sub(targets[i], value),
+            config.feedback_conductance,
+        )
+        coupling: Vec3 = (0.0, 0.0, 0.0)
+        for j, other in enumerate(values):
+            coupling = _add(
+                coupling,
+                _scale(_sub(other, value), float(adjacency[i][j])),
+            )
+        coupling = _scale(coupling, config.coupling_conductance)
+        total_current = _add(_add(feedback, coupling), currents[i])
+        derivatives.append(_scale(total_current, 1.0 / config.capacitance))
+    return tuple(derivatives)
+
+
+def electrical_step(
+    voltages: Sequence[Vec3],
+    phi_voltages: Sequence[Vec3],
+    adjacency: Sequence[Sequence[float]],
+    config: ElectricalAnalogueConfig,
+    *,
+    external_currents: Sequence[Vec3] | None = None,
+) -> tuple[Vec3, ...]:
+    """Advance the bounded RC analogue by one explicit-Euler integration step."""
+
+    values = tuple(_vec3(value, name="voltage") for value in voltages)
+    derivatives = electrical_rhs(
+        values,
+        phi_voltages,
+        adjacency,
+        config,
+        external_currents=external_currents,
+    )
+    return tuple(
+        _clamp_vec(_add(value, _scale(rate, config.dt)), config.voltage_bound)
+        for value, rate in zip(values, derivatives)
+    )
+
+
+__all__ = [
+    "ElectricalAnalogueConfig",
+    "Feature",
+    "InwardMultimodalSwarm3D",
+    "Matrix3",
+    "Modality",
+    "ModalityCodec",
+    "Particle3D",
+    "Swarm3DConfig",
+    "Swarm3DMetrics",
+    "Swarm3DResult",
+    "Swarm3DState",
+    "Vec3",
+    "electrical_rhs",
+    "electrical_step",
+    "local_riemannian_gradient",
+    "riemannian_metric_inverse",
+]

--- a/tests/test_inward_multimodal_media_ann.py
+++ b/tests/test_inward_multimodal_media_ann.py
@@ -1,0 +1,89 @@
+import numpy as np
+
+from jarvisx.inward_multimodal_media_ann import (
+    InwardMultimodalMediaANN,
+    MediaANNConfig,
+    Modality,
+    TinyAutoencoder,
+    bounded_optimize,
+    consensus_latent,
+    generate_pcm_audio,
+    generate_rgb_frame,
+    virtual_xyz,
+)
+
+
+def _inputs():
+    x = np.linspace(-1.0, 1.0, 16)
+    image = np.outer(np.sin(2 * x), np.cos(3 * x)).astype(np.float32)
+    audio = np.sin(2 * np.pi * 220 * np.arange(2000) / 8000).astype(np.float32)
+    return {
+        Modality.TEXT: ["multimodal 3D test"],
+        Modality.IMAGE: [image],
+        Modality.AUDIO: [audio],
+        Modality.VIDEO: [{"frames": 8, "motion": "orbit"}],
+        Modality.GEOMETRY: [{"primitive": "torus"}],
+        Modality.CODE: ["def f(x): return x * x"],
+        Modality.DATA: [{"scene": "test"}],
+    }
+
+
+def _config():
+    return MediaANNConfig(
+        feature_dim=16,
+        latent_dim=8,
+        hidden_dim=20,
+        train_epochs=60,
+        inner_steps=8,
+        learning_rate=0.04,
+    )
+
+
+def test_tiny_autoencoder_training_reduces_loss():
+    rng = np.random.default_rng(7)
+    x = rng.normal(0.0, 0.25, (8, 16))
+    ae = TinyAutoencoder(16, 8, 20, seed=7)
+    history = ae.train(x, epochs=80, learning_rate=0.04)
+    assert history[-1] < history[0]
+
+
+def test_inward_runtime_reduces_fixed_point_residual():
+    result = InwardMultimodalMediaANN(_config()).run(
+        _inputs(),
+        "produce a coherent verified multimodal representation",
+    )
+    assert result.training_loss[-1] < result.training_loss[0]
+    assert result.metrics[-1].fixed_point_residual < result.metrics[0].fixed_point_residual
+    assert 0.0 < result.score <= 1.0
+
+
+def test_media_surfaces_share_one_3d_consensus_latent():
+    result = InwardMultimodalMediaANN(_config()).run(_inputs(), "shared media state")
+    latent = consensus_latent(result)
+    frame = generate_rgb_frame(latent, phase=0.25, size=48)
+    pcm = generate_pcm_audio(latent, duration_seconds=0.05, sample_rate=8000)
+    xyz = virtual_xyz(latent)
+
+    assert frame.shape == (48, 48, 3)
+    assert frame.dtype == np.uint8
+    assert pcm.dtype == np.int16
+    assert pcm.shape == (400,)
+    assert all(0 <= value < 8192 for value in xyz)
+
+
+def test_bounded_optimizer_does_not_regress_fixed_point_integrity():
+    config = _config()
+    baseline = InwardMultimodalMediaANN(config).run(_inputs(), "optimize safely")
+    _, optimized, audit = bounded_optimize(
+        _inputs(),
+        "optimize safely",
+        initial=config,
+        generations=2,
+        population=4,
+        seed=11,
+    )
+    assert audit
+    assert (
+        optimized.metrics[-1].fixed_point_residual
+        <= baseline.metrics[-1].fixed_point_residual + 1e-12
+    )

--- a/tests/test_inward_multimodal_meta_optimizer.py
+++ b/tests/test_inward_multimodal_meta_optimizer.py
@@ -1,0 +1,124 @@
+import pytest
+
+from jarvisx.inward_multimodal_meta_optimizer import (
+    InwardMultimodalMetaOptimizer,
+    MetaFitness,
+    MetaSearchConfig,
+)
+from jarvisx.inward_multimodal_swarm3d import Swarm3DConfig
+
+
+def fitness(
+    task_score: float,
+    *,
+    fixed_point_error: float = 0.10,
+    resource_cost: float = 0.20,
+    stable: bool = True,
+) -> MetaFitness:
+    return MetaFitness(
+        task_score=task_score,
+        semantic_coherence=0.80,
+        feature_coherence=0.80,
+        fixed_point_error=fixed_point_error,
+        resource_cost=resource_cost,
+        stable=stable,
+    )
+
+
+def test_candidate_generation_is_deterministic_for_generation_and_seed():
+    optimizer = InwardMultimodalMetaOptimizer(
+        MetaSearchConfig(generations=2, branch_width=6, seed=17)
+    )
+    config = Swarm3DConfig()
+
+    left = optimizer.candidate_configs(config, generation=3)
+    right = optimizer.candidate_configs(config, generation=3)
+    other = optimizer.candidate_configs(config, generation=4)
+
+    assert left == right
+    assert left != other
+    assert len(left) == 6
+
+
+def test_optimizer_promotes_only_verified_fitness_improvement():
+    optimizer = InwardMultimodalMetaOptimizer(
+        MetaSearchConfig(
+            generations=4,
+            branch_width=20,
+            seed=9,
+            mutation_fraction=0.50,
+            improvement_threshold=0.0,
+        )
+    )
+    baseline = Swarm3DConfig(task_gain=1.0)
+
+    def evaluator(config: Swarm3DConfig) -> MetaFitness:
+        task_score = min(1.0, 0.35 + 0.25 * config.task_gain)
+        return fitness(task_score)
+
+    report = optimizer.optimize(baseline, evaluator)
+
+    assert report.evaluated_candidates == 80
+    assert report.final_fitness.score >= report.baseline_fitness.score
+    assert report.promoted
+    assert report.final_config.task_gain > baseline.task_gain
+
+
+def test_fixed_point_integrity_gate_blocks_better_scalar_score():
+    optimizer = InwardMultimodalMetaOptimizer(
+        MetaSearchConfig(
+            generations=3,
+            branch_width=24,
+            seed=11,
+            mutation_fraction=0.60,
+            improvement_threshold=0.0,
+            max_fixed_point_regression=0.0,
+        )
+    )
+    baseline = Swarm3DConfig(task_gain=1.0)
+
+    def evaluator(config: Swarm3DConfig) -> MetaFitness:
+        if config.task_gain > baseline.task_gain:
+            return fitness(
+                min(1.0, 0.85 + 0.05 * config.task_gain),
+                fixed_point_error=0.20,
+            )
+        return fitness(
+            max(0.0, 0.80 - 0.10 * (baseline.task_gain - config.task_gain)),
+            fixed_point_error=0.10,
+        )
+
+    report = optimizer.optimize(baseline, evaluator)
+
+    assert not report.promoted
+    assert report.final_config == baseline
+    assert report.final_fitness == report.baseline_fitness
+    assert any(
+        "fixed-point" in evaluation.reason
+        for evaluation in report.evaluations
+        if evaluation.config.task_gain > baseline.task_gain
+    )
+
+
+def test_unstable_incumbent_cannot_enter_self_optimization():
+    optimizer = InwardMultimodalMetaOptimizer(
+        MetaSearchConfig(generations=1, branch_width=2)
+    )
+
+    with pytest.raises(ValueError, match="incumbent runtime must be stable"):
+        optimizer.optimize(
+            Swarm3DConfig(),
+            lambda _: fitness(0.8, stable=False),
+        )
+
+
+def test_meta_fitness_rejects_invalid_normalized_quality():
+    with pytest.raises(ValueError, match="task_score"):
+        MetaFitness(
+            task_score=1.1,
+            semantic_coherence=0.8,
+            feature_coherence=0.8,
+            fixed_point_error=0.1,
+            resource_cost=0.2,
+            stable=True,
+        )

--- a/tests/test_inward_multimodal_swarm3d.py
+++ b/tests/test_inward_multimodal_swarm3d.py
@@ -34,13 +34,13 @@ class ContractiveCodec:
 
 def test_rank_one_metric_inverse_and_riemannian_gradient_are_exact():
     inverse = riemannian_metric_inverse((2.0, 0.0, 0.0), alpha=1.0)
-    assert inverse == pytest.approx(
-        (
-            (0.2, 0.0, 0.0),
-            (0.0, 1.0, 0.0),
-            (0.0, 0.0, 1.0),
-        )
+    expected = (
+        (0.2, 0.0, 0.0),
+        (0.0, 1.0, 0.0),
+        (0.0, 0.0, 1.0),
     )
+    for row, expected_row in zip(inverse, expected):
+        assert row == pytest.approx(expected_row)
 
     gradient = local_riemannian_gradient(
         (1.0, 1.0, 0.0),

--- a/tests/test_inward_multimodal_swarm3d.py
+++ b/tests/test_inward_multimodal_swarm3d.py
@@ -1,0 +1,173 @@
+import math
+
+import pytest
+
+from jarvisx.inward_multimodal_swarm3d import (
+    ElectricalAnalogueConfig,
+    InwardMultimodalSwarm3D,
+    Modality,
+    Particle3D,
+    Swarm3DConfig,
+    electrical_step,
+    local_riemannian_gradient,
+    riemannian_metric_inverse,
+)
+
+
+class IdentityCodec:
+    def encode(self, value: object):
+        values = tuple(float(x) for x in value)  # type: ignore[arg-type]
+        return values[0], values[1], values[2]
+
+    def decode(self, position):
+        return position
+
+
+class ContractiveCodec:
+    def encode(self, value: object):
+        values = tuple(float(x) for x in value)  # type: ignore[arg-type]
+        return 0.5 * values[0], 0.5 * values[1], 0.5 * values[2]
+
+    def decode(self, position):
+        return position
+
+
+def test_rank_one_metric_inverse_and_riemannian_gradient_are_exact():
+    inverse = riemannian_metric_inverse((2.0, 0.0, 0.0), alpha=1.0)
+    assert inverse == pytest.approx(
+        (
+            (0.2, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+            (0.0, 0.0, 1.0),
+        )
+    )
+
+    gradient = local_riemannian_gradient(
+        (1.0, 1.0, 0.0),
+        (2.0, 0.0, 0.0),
+        alpha=1.0,
+    )
+    assert gradient == pytest.approx((0.2, 1.0, 0.0))
+
+
+def test_parallel_swarm_coupling_reduces_consensus_error():
+    runtime = InwardMultimodalSwarm3D(
+        {Modality.TEXT: IdentityCodec()},
+        Swarm3DConfig(
+            dt=0.1,
+            inward_gain=0.0,
+            swarm_gain=0.5,
+            feature_mix_gain=0.0,
+            max_steps=10,
+        ),
+    )
+    particles = (
+        Particle3D((-1.0, 0.0, 0.0), (1.0, 0.0), Modality.TEXT, source_id="a"),
+        Particle3D((1.0, 0.0, 0.0), (1.0, 0.0), Modality.TEXT, source_id="b"),
+    )
+
+    state = runtime.initial_state(particles)
+    candidate = runtime.step(state)
+
+    assert candidate.metrics.consensus_error < state.metrics.consensus_error
+    assert candidate.particles[0].position[0] > -1.0
+    assert candidate.particles[1].position[0] < 1.0
+
+
+def test_inward_decode_reencode_loop_converges_for_contractive_codec():
+    runtime = InwardMultimodalSwarm3D(
+        {Modality.TEXT: ContractiveCodec()},
+        Swarm3DConfig(
+            dt=0.2,
+            inward_gain=0.8,
+            swarm_gain=0.0,
+            feature_mix_gain=0.0,
+            max_steps=200,
+            tolerance=1.0e-4,
+        ),
+    )
+    particle = Particle3D((0.5, 0.0, 0.0), (1.0,), Modality.TEXT)
+
+    result = runtime.relax((particle,))
+
+    assert result.converged
+    assert result.state.metrics.fixed_point_error <= runtime.config.tolerance
+    assert abs(result.state.particles[0].position[0]) < 3.0e-4
+
+
+def test_multimodal_encoding_uses_one_shared_feature_width():
+    runtime = InwardMultimodalSwarm3D(
+        {
+            Modality.TEXT: IdentityCodec(),
+            Modality.IMAGE: IdentityCodec(),
+        },
+        feature_encoder=lambda modality, value, position: (
+            position[0],
+            position[1],
+            position[2],
+            1.0 if modality is Modality.TEXT else -1.0,
+        ),
+    )
+
+    particles = runtime.encode_modalities(
+        {
+            Modality.TEXT: ((0.1, 0.2, 0.3),),
+            Modality.IMAGE: ((-0.1, 0.2, 0.3),),
+        }
+    )
+
+    assert len(particles) == 2
+    assert all(len(particle.feature) == 4 for particle in particles)
+    assert {particle.modality for particle in particles} == {Modality.TEXT, Modality.IMAGE}
+
+
+def test_consensus_can_decode_through_multiple_modality_heads():
+    runtime = InwardMultimodalSwarm3D(
+        {
+            Modality.TEXT: IdentityCodec(),
+            Modality.IMAGE: IdentityCodec(),
+        }
+    )
+    particles = (
+        Particle3D((0.2, 0.4, 0.6), (1.0,), Modality.TEXT),
+    )
+
+    generated = runtime.decode_consensus(particles)
+
+    assert generated[Modality.TEXT] == pytest.approx((0.2, 0.4, 0.6))
+    assert generated[Modality.IMAGE] == pytest.approx((0.2, 0.4, 0.6))
+
+
+def test_rc_analogue_preserves_pair_mean_and_relaxes_voltage_difference():
+    config = ElectricalAnalogueConfig(
+        capacitance=1.0,
+        feedback_conductance=0.0,
+        coupling_conductance=0.5,
+        dt=0.1,
+    )
+    voltages = ((-1.0, 0.0, 0.0), (1.0, 0.0, 0.0))
+    adjacency = ((0.0, 1.0), (1.0, 0.0))
+
+    candidate = electrical_step(voltages, voltages, adjacency, config)
+
+    assert candidate[0][0] > -1.0
+    assert candidate[1][0] < 1.0
+    assert math.isclose(candidate[0][0] + candidate[1][0], 0.0, abs_tol=1.0e-12)
+    assert abs(candidate[1][0] - candidate[0][0]) < 2.0
+
+
+def test_runtime_rejects_unbounded_or_incompatible_inputs():
+    with pytest.raises(ValueError, match="positive integer"):
+        Swarm3DConfig(max_steps=0)
+
+    runtime = InwardMultimodalSwarm3D({Modality.TEXT: IdentityCodec()})
+    with pytest.raises(KeyError, match="no codec"):
+        runtime.encode_modalities({Modality.AUDIO: ((0.0, 0.0, 0.0),)})
+
+    with pytest.raises(ValueError, match="shared feature width"):
+        runtime.initial_state(
+            (
+                Particle3D((0.0, 0.0, 0.0), (1.0,), Modality.TEXT),
+                Particle3D((0.1, 0.0, 0.0), (1.0, 2.0), Modality.TEXT),
+            )
+        )


### PR DESCRIPTION
## Summary

Permeates the inward 3D multimodal/swarm model into Jarvis-X as an isolated research runtime, consistent with ADR-001, extends it with bounded second-order meta-optimization, adds a literal electronic lowering boundary, and now adds a trainable multimodal media ANN whose converged 3D state can drive synchronized RGB and PCM generation.

### Runtime
- modality-tagged `Particle3D` / `Particle` states for text/image/audio/video/geometry/code/data
- exact rank-one inverse metric `G^-1` for `G = I + alpha grad(phi) grad(phi)^T`
- local Riemannian task preconditioning
- dynamic cross-modal adjacency from shared-feature cosine similarity and 3D chart distance
- multiparticle graph relaxation and bounded shared-feature mixing
- decode -> re-encode inward loop with `Phi(z) = E(D(z))`
- bounded source-keyed memory forcing and consensus decoding

### Trainable multimodal media ANN
- adds `src/jarvisx/inward_multimodal_media_ann.py`
- includes a small real NumPy MLP autoencoder with explicit backpropagation
- preserves rich information in high-D feature fibers while using 3D coordinates as a coordination chart
- maps latent AE channels back into a bounded 3D inward target
- exposes synchronized media surfaces from one converged 3D consensus state:
  - `generate_rgb_frame(...) -> uint8[H,W,3]`
  - `generate_pcm_audio(...) -> int16[N]`
- keeps MP4/container packaging outside the core library so model dynamics do not launch host processes
- adds `docs/INWARD_MULTIMODAL_MEDIA_ANN.md`
- adds 4 focused tests for AE learning, inward residual reduction, shared latent media surfaces, and optimizer non-regression

The media loop is:

`multimodal inputs -> feature AE -> 3D graph -> E(D(z)) -> memory -> consensus latent -> RGB/PCM -> external container`

### Second-order inward self-optimization
- adds `inward_multimodal_meta_optimizer.py`
- treats only declared numerical runtime parameters as a bounded genotype
- deterministic candidate generation under an explicit seed
- caller-supplied shadow evaluation
- promotion gates for stability, fixed-point integrity, resources and minimum fitness
- defaults to zero fixed-point regression allowance
- does not rewrite source code, deployment controls, permissions or canonical VM state

Outer loop:

`run -> measure -> bounded candidate -> shadow evaluate -> verify -> promote/reject -> run again`

Inner loop:

`encode -> 3D coordination -> E(D(z)) -> decode -> re-encode`

### Literal electronic actuation boundary
- adds `src/jarvisx/electronic_actuation_runtime.py`
- bounded scalar <-> voltage mapping via `VoltageCodec`
- CMOS logic thresholding plus `1/2 C (Delta V)^2` switching-energy and `alpha C V^2 f` dynamic-power estimates
- normalized PWM command representation and auditable `ElectronicActuationTrace`
- explicitly separates semantic variables from their electrical implementation
- research representation only; no GPIO, device-driver, or unrestricted hardware writes

Practical lowering chain:

`semantic/task state -> numeric tensors -> bits/encoded voltages -> logic/memory transitions -> electrical switching -> I/O representation -> observation -> re-encoding`

### Electromagnetic boundary
- retains the RC-network analogue:
  `C dV_i/dt = g_phi(V_phi_i - V_i) + g_c sum_j A_ij(V_j - V_i) + I_ext_i`
- does not identify semantic 3D coordinates with physical spacetime or claim to solve Maxwell fields
- aligns with `docs/research/DR_MOAGI_3D_ELECTROMAGNETIC_OPERATION.md`

### Verification and docs
- original focused swarm suite: 7 tests
- bounded meta-optimization suite: 5 tests
- multimodal media ANN suite: 4 tests
- adds `docs/INWARD_MULTIMODAL_SWARM3D.md`
- adds `docs/INWARD_MULTIMODAL_META_OPTIMIZATION.md`
- adds `docs/INWARD_MULTIMODAL_MEDIA_ANN.md`
- adds `docs/ELECTRONIC_ACTUATION_RUNTIME.md`
- adds ADR-013 and ADR-014

## Local prototype evidence

Before repository permeation, the standalone multimedia prototype successfully generated an MP4 through an external FFmpeg packaging step. In that prototype run:

- logical virtual volume: `8192^3 = 549,755,813,888` cells, not densely allocated
- AE reconstruction MSE: `0.0436708 -> 0.00321634`
- inward fixed-point residual: `0.550212 -> 0.117584`
- consensus virtual cell: `(4555, 4905, 3929)`

These measurements are prototype evidence, not repository CI guarantees.

## Validation

The original focused swarm suite was locally executed before PR creation with `7 passed in 0.05s`. The new media ANN and meta-optimization tests are committed for repository CI; full-suite CI remains authoritative for integration.