### PR TITLE
Add bounded FMDR and inward 3D bit recurrence

### DIFF
--- a/.github/workflows/dr-moagi-fmdr.yml
+++ b/.github/workflows/dr-moagi-fmdr.yml
@@ -1,0 +1,65 @@
+name: Dr Moagi Fourier-Markov Diffusion Resonance
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_fmdr.py"
+      - "tests/test_dr_moagi_fmdr.py"
+      - "docs/adr/0013-fourier-markov-diffusion-resonance-loop.md"
+      - ".github/workflows/dr-moagi-fmdr.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_fmdr.py"
+      - "tests/test_dr_moagi_fmdr.py"
+      - "docs/adr/0013-fourier-markov-diffusion-resonance-loop.md"
+      - ".github/workflows/dr-moagi-fmdr.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dr-moagi-fmdr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify bounded FMDR recurrence
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install development dependencies
+        run: python -m pip install -e ".[dev]"
+
+      - name: Compile runtime and tests
+        run: >-
+          python -m py_compile
+          src/jarvisx/dr_moagi_fmdr.py
+          tests/test_dr_moagi_fmdr.py
+
+      - name: Check formatting
+        run: >-
+          black --check --diff
+          src/jarvisx/dr_moagi_fmdr.py
+          tests/test_dr_moagi_fmdr.py
+
+      - name: Check import order
+        run: >-
+          isort --check-only --diff
+          src/jarvisx/dr_moagi_fmdr.py
+          tests/test_dr_moagi_fmdr.py
+
+      - name: Type-check FMDR runtime
+        run: mypy src/jarvisx/dr_moagi_fmdr.py --ignore-missing-imports
+
+      - name: Run focused invariant tests
+        run: pytest -q -o addopts='' tests/test_dr_moagi_fmdr.py

--- a/.github/workflows/dr-moagi-fmdr.yml
+++ b/.github/workflows/dr-moagi-fmdr.yml
@@ -5,14 +5,20 @@ on:
     branches: [main]
     paths:
       - "src/jarvisx/dr_moagi_fmdr.py"
+      - "src/jarvisx/dr_moagi_inward_bit_engine.py"
       - "tests/test_dr_moagi_fmdr.py"
+      - "tests/test_dr_moagi_inward_bit_engine.py"
+      - "docs/DR_MOAGI_INWARD_3D_BIT_ENGINE.md"
       - "docs/adr/0013-fourier-markov-diffusion-resonance-loop.md"
       - ".github/workflows/dr-moagi-fmdr.yml"
   pull_request:
     branches: [main]
     paths:
       - "src/jarvisx/dr_moagi_fmdr.py"
+      - "src/jarvisx/dr_moagi_inward_bit_engine.py"
       - "tests/test_dr_moagi_fmdr.py"
+      - "tests/test_dr_moagi_inward_bit_engine.py"
+      - "docs/DR_MOAGI_INWARD_3D_BIT_ENGINE.md"
       - "docs/adr/0013-fourier-markov-diffusion-resonance-loop.md"
       - ".github/workflows/dr-moagi-fmdr.yml"
 
@@ -25,7 +31,7 @@ concurrency:
 
 jobs:
   verify:
-    name: Verify bounded FMDR recurrence
+    name: Verify bounded FMDR and inward-bit recurrences
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -40,26 +46,39 @@ jobs:
       - name: Install development dependencies
         run: python -m pip install -e ".[dev]"
 
-      - name: Compile runtime and tests
+      - name: Compile runtimes and tests
         run: >-
           python -m py_compile
           src/jarvisx/dr_moagi_fmdr.py
+          src/jarvisx/dr_moagi_inward_bit_engine.py
           tests/test_dr_moagi_fmdr.py
+          tests/test_dr_moagi_inward_bit_engine.py
 
       - name: Check formatting
         run: >-
           black --check --diff
           src/jarvisx/dr_moagi_fmdr.py
+          src/jarvisx/dr_moagi_inward_bit_engine.py
           tests/test_dr_moagi_fmdr.py
+          tests/test_dr_moagi_inward_bit_engine.py
 
       - name: Check import order
         run: >-
           isort --check-only --diff
           src/jarvisx/dr_moagi_fmdr.py
+          src/jarvisx/dr_moagi_inward_bit_engine.py
           tests/test_dr_moagi_fmdr.py
+          tests/test_dr_moagi_inward_bit_engine.py
 
-      - name: Type-check FMDR runtime
-        run: mypy src/jarvisx/dr_moagi_fmdr.py --ignore-missing-imports
+      - name: Type-check reference runtimes
+        run: >-
+          mypy
+          src/jarvisx/dr_moagi_fmdr.py
+          src/jarvisx/dr_moagi_inward_bit_engine.py
+          --ignore-missing-imports
 
       - name: Run focused invariant tests
-        run: pytest -q -o addopts='' tests/test_dr_moagi_fmdr.py
+        run: >-
+          pytest -q -o addopts=''
+          tests/test_dr_moagi_fmdr.py
+          tests/test_dr_moagi_inward_bit_engine.py

--- a/docs/DR_MOAGI_INWARD_3D_BIT_ENGINE.md
+++ b/docs/DR_MOAGI_INWARD_3D_BIT_ENGINE.md
@@ -1,0 +1,192 @@
+# Dr Moagi inward-looped 3D bit engine
+
+This document specifies the bounded discrete reference implemented in
+`src/jarvisx/dr_moagi_inward_bit_engine.py`.
+
+The engine is a deterministic research recurrence over a finite cubic bit field.
+It is not a claim of lossless compression, universal convergence, physical
+resonance, or unrestricted self-modification.
+
+## 1. State and recurrence
+
+The complete dynamical state is
+
+```text
+S_t = (X_t, Z_t, Omega_t)
+```
+
+where:
+
+- `X_t[x,y,z]` is a fixed-width source/state word;
+- `Z_t[x,y,z]` is a smaller latent word;
+- `Omega_t[x,y,z]` is bounded recursive reconstruction-error memory.
+
+One synchronous cycle is
+
+```text
+X_t
+-> E
+-> Z_t
+-> C_6N
+-> Z~_t
+-> D
+-> X_hat_t
+-> Omega_t+1
+-> bounded inward feedback
+-> X_t+1.
+```
+
+The executable fixed-point condition is therefore
+
+```text
+S* = M(S*)
+```
+
+rather than only `X* = M(X*)`.
+
+## 2. Tie-neutral bit encoding
+
+Each source word is partitioned into `latent_bits` contiguous groups. One latent
+bit summarizes each group.
+
+Strict majority is used when the group contains more zeros than ones or more
+ones than zeros. For an even-width exact tie, the first source bit in that group
+resolves the tie.
+
+For a uniformly distributed four-bit group this produces exactly eight latent
+zeros and eight latent ones over the complete 16-word domain. This removes the
+one-bias caused by the earlier `ones >= width/2` rule.
+
+The decoder expands a latent bit to an all-zero or all-one source group. For this
+codec,
+
+```text
+E(D(z)) = z
+```
+
+for every valid latent word. Consequently latent-cycle loss is an algebraic
+identity and is reported separately from the nontrivial six-neighbour coupling
+loss.
+
+## 3. Six-neighbour latent coupling
+
+For latent bit `b` at lattice point `p`, map bits to spins in `{-1,+1}` and
+compute
+
+```text
+h_b(p) = (1-alpha) s_b(p)
+       + alpha * mean_{q in N6(p)} s_b(q).
+```
+
+The coupled bit is one when `h_b(p) >= 0` and zero otherwise.
+
+Every cycle reads a frozen latent field and writes a new complete coupled field;
+partial writes are never fed back during the same cycle.
+
+## 4. Contractive error memory
+
+The previous pure rotate/XOR memory could perpetually remix historical parity.
+The refined reference separates retention from capture:
+
+```text
+Omega_rot     = ROTL_1(Omega_t)
+Omega_keep    = Omega_rot & M_retention
+error_t       = X_t XOR X_hat_t
+error_capture = error_t & M_capture
+Omega_t+1     = Omega_keep XOR error_capture.
+```
+
+In the absence of new reconstruction error, masking cannot increase the Hamming
+weight of memory. This is a contractive unforced-memory property; it is not a
+proof that the complete forced recurrence converges.
+
+## 5. Precomputed deterministic masks
+
+Reconstruction replacement, memory injection, memory retention and error capture
+use deterministic BLAKE2b-ranked bit masks. These masks depend only on immutable
+configuration and coordinate data, so the implementation computes them once at
+materialization time instead of hashing and sorting on every recurrence step.
+
+The hot path therefore contains primarily integer bit operations and the 3D
+six-neighbour coupling.
+
+## 6. Inward feedback
+
+For each coordinate, the next source/state word is constructed as
+
+```text
+candidate = preserve_unselected(X_t)
+candidate |= selected_reconstruction(X_hat_t)
+candidate ^= selected_memory(Omega_t+1)
+X_t+1 = candidate & full_width_mask.
+```
+
+`beta` controls the reconstruction replacement fraction and `omega_gain` controls
+the memory-injection fraction.
+
+## 7. Metrics
+
+The reference separates metrics that were previously conflated:
+
+```text
+L_local  = Hamming(X_t, X_hat_t) / source_bits
+L_anchor = Hamming(X_0, X_hat_t) / source_bits
+D_anchor = Hamming(X_0, X_t+1) / source_bits
+L_cycle  = Hamming(Z~_t, E(D(Z~_t))) / latent_bits
+L_couple = Hamming(Z_t, Z~_t) / latent_bits
+Delta_X  = Hamming(X_t, X_t+1) / source_bits
+Delta_O  = Hamming(Omega_t, Omega_t+1) / source_bits.
+```
+
+The full-state gap is
+
+```text
+Delta_S = (dX + dZ + dOmega)
+        / (2 * total_source_bits + total_latent_bits).
+```
+
+A fixed point is declared only when `Delta_S <= tolerance`.
+
+## 8. FMDR bridge
+
+`bitplane_field(bit, latent=False, spins=True)` exposes any source or latent
+bitplane as a scalar 3D field with values in `{-1,+1}` by default. That field can
+be passed directly into the Fourier-Markov-diffusion-resonance reference in
+`dr_moagi_fmdr.py`.
+
+The combined observation path is therefore
+
+```text
+bit recurrence
+-> selected 3D bitplane
+-> spatial Fourier modes
+-> dominant-mode Markov transitions
+-> diffusion attenuation
+-> temporal resonance/coherence
+-> bounded FMDR proposal.
+```
+
+FMDR remains an analysis/control layer. It does not bypass the bit engine's
+finite-width projection or Jarvis-X transaction and validation boundaries.
+
+## 9. Required invariants
+
+The focused tests require:
+
+1. exact unbiased tie resolution over the complete four-bit fixture domain;
+2. exact latent cycle identity for the deterministic codec;
+3. deterministic precomputed feedback masks with declared cardinality;
+4. non-increasing unforced Omega Hamming weight after retention masking;
+5. fixed-point detection over source, latent and memory state;
+6. separated local reconstruction, anchor reconstruction and anchor drift metrics;
+7. valid state and latent bitplane export for FMDR analysis;
+8. deterministic bounded recurrence for identical configuration and seed;
+9. malformed configuration rejection.
+
+## 10. Boundary
+
+The default recurrence may approach an attractor or limit cycle rather than an
+exact fixed point. Contractive memory in the unforced case does not imply global
+contraction of the coupled codec-memory-feedback map. Any convergence claim must
+be established for a declared configuration with measured or analytical
+evidence.

--- a/docs/adr/0013-fourier-markov-diffusion-resonance-loop.md
+++ b/docs/adr/0013-fourier-markov-diffusion-resonance-loop.md
@@ -56,7 +56,16 @@ The empirical transition law is
 P_ij = count(q_t=i, q_t+1=j) / count(q_t=i)
 ```
 
-for rows with observed outgoing transitions. Unobserved rows use an identity row in the reference implementation so the matrix remains stochastic without inventing cross-mode evidence.
+for rows with observed outgoing transitions. Unobserved rows use an identity row in the reported transition matrix so the matrix remains stochastic without inventing cross-mode evidence.
+
+For resonance ranking, a mode-specific persistence estimate is kept separate from that reporting convention:
+
+```text
+p_k = count(k -> k) / count(outgoing from k),  if outgoing evidence exists
+p_k = 0.5,                                      otherwise.
+```
+
+The neutral `0.5` fallback prevents an unobserved mode from receiving artificial resonance reinforcement merely because its displayed Markov row is the identity.
 
 This is a finite-window empirical Markov model. It is not a claim that the complete underlying process is first-order Markov.
 
@@ -109,12 +118,12 @@ R_k = C_k * sqrt(peak_power_k) * S_k / (gamma + k^T D k)
 where
 
 ```text
-S_k = 0.5 + 0.5 P_kk
+S_k = 0.5 + 0.5 p_k
 ```
 
 and `gamma > 0` is a configured damping floor.
 
-This score is an engineering ranking functional, not a universal physical definition of resonance. It deliberately rewards temporally concentrated, mode-persistent energy and penalizes damping plus diffusive loss.
+This score is an engineering ranking functional, not a universal physical definition of resonance. It deliberately rewards temporally concentrated, empirically persistent energy and penalizes damping plus diffusive loss.
 
 ### Inward feedback
 
@@ -123,10 +132,10 @@ The highest-scoring mode may propose a same-space field correction. The referenc
 The feedback sign is determined by
 
 ```text
-s_k = 2 P_kk - 1.
+s_k = 2 p_k - 1.
 ```
 
-Persistent modes (`P_kk > 0.5`) are eligible for reinforcement; rapidly switching modes (`P_kk < 0.5`) are eligible for suppression.
+Persistent modes (`p_k > 0.5`) are eligible for reinforcement; rapidly switching modes (`p_k < 0.5`) are eligible for suppression; modes without transition evidence are neutral.
 
 The raw feedback is scaled by the configured feedback gain and normalized resonance score, then clipped per coordinate:
 
@@ -134,7 +143,7 @@ The raw feedback is scaled by the configured feedback gain and normalized resona
 |Delta Psi(r)| <= max_feedback_delta.
 ```
 
-The resulting value is projected into the configured value interval before it can become a candidate.
+Every initial field and every observation is also projected into the configured value interval before publication, including cycles that have not yet accumulated enough history to activate resonance feedback.
 
 ### Candidate-first recurrence
 
@@ -142,16 +151,18 @@ The operational recurrence is
 
 ```text
 observation_t
--> append to bounded history
+-> finite/resource validation
+-> value projection Pi_Lambda
+-> append to bounded pending history
 -> Fourier coefficients
 -> dominant-mode sequence
--> empirical Markov matrix
+-> empirical Markov matrix and persistence
 -> diffusion rates
 -> temporal resonance scores
--> selected modal correction
--> value/resource projection
+-> selected modal correction when min_history is satisfied
+-> bounded value projection
 -> optional external validator
--> COMMIT or ROLLBACK.
+-> COMMIT state and history or ROLLBACK both.
 ```
 
 A rejected candidate does not mutate either the published FMDR state or its history buffer.
@@ -205,14 +216,15 @@ The reference uses direct sparse Fourier sums and a naive short-window temporal 
 2. Diffusion coefficients are finite and non-negative.
 3. Damping is finite and strictly positive.
 4. Field values are finite and active support is resource-bounded.
-5. Markov rows are stochastic.
-6. Resonance is reported separately from Fourier amplitude and diffusion attenuation.
-7. Feedback is same-space and bounded per active coordinate.
-8. Value projection occurs before candidate publication.
-9. The history window is explicitly bounded.
-10. Validator rejection atomically preserves the prior published state and history.
-11. No FMDR result silently rewrites the canonical VM, source code, policy, provenance or transaction layers.
-12. Physical resonance, production performance and learned-model quality require separate evidence.
+5. Reported Markov rows are stochastic.
+6. Unobserved transition rows do not create artificial persistence in resonance ranking.
+7. Resonance is reported separately from Fourier amplitude and diffusion attenuation.
+8. Feedback is same-space and bounded per active coordinate.
+9. Value projection applies before every published state, even before feedback activation.
+10. The history window is explicitly bounded.
+11. Validator rejection atomically preserves the prior published state and history.
+12. No FMDR result silently rewrites the canonical VM, source code, policy, provenance or transaction layers.
+13. Physical resonance, production performance and learned-model quality require separate evidence.
 
 ## Validation
 
@@ -223,7 +235,9 @@ Acceptance requires focused tests for:
 - diffusion attenuation against the analytic exponential;
 - deterministic temporal resonance detection on a synthetic traveling mode;
 - stochastic Markov rows and persistent-mode self-transition probability;
+- neutral persistence when a mode has no outgoing transition evidence;
 - bounded per-cell reinforce/suppress feedback;
+- value projection before minimum-history feedback activation;
 - delayed feedback until the configured minimum history exists;
 - bounded history retention;
 - atomic rollback of state and history on validator rejection;

--- a/docs/adr/0013-fourier-markov-diffusion-resonance-loop.md
+++ b/docs/adr/0013-fourier-markov-diffusion-resonance-loop.md
@@ -1,0 +1,249 @@
+# ADR-013: Add the bounded Fourier-Markov-diffusion-resonance inward loop
+
+**Status:** Proposed  
+**Date:** 2026-09-05  
+**Extends:** ADR-003, ADR-006, ADR-007
+
+## Context
+
+Jarvis-X already has a same-space sparse 3D field runtime, a bounded geometric-diffusion research runtime, and candidate-first control-plane semantics. The next step is to make a recurring analytical pattern explicit:
+
+```text
+field history
+-> Fourier modal decomposition
+-> Markov mode-transition model
+-> diffusion loss estimate
+-> temporal resonance detection
+-> bounded modal feedback
+-> projection / validation
+-> commit or rollback
+-> repeat
+```
+
+Without a precise contract, Fourier analysis, stochastic transition modeling, diffusion and resonance can be conflated into one metaphorical operator. This ADR separates them and defines exactly where feedback may re-enter the field runtime.
+
+The new layer is a numerical analysis and control reference. It does not claim that a neural model physically stores its hidden state in Euclidean 3D space, that a short-window DFT identifies a unique physical resonance, or that modal reinforcement is universally beneficial.
+
+## Decision
+
+Jarvis-X adopts a Layer 5 **Fourier-Markov-diffusion-resonance (FMDR) analysis loop** over bounded histories of sparse 3D scalar fields.
+
+For a configured spatial wavevector
+
+```text
+k = (kx, ky, kz)
+```
+
+and sparse scalar field `Psi_t(r)`, the reference spatial coefficient is
+
+```text
+A_k(t) = (1 / |support_t|) * sum_r Psi_t(r) exp(-i k dot r).
+```
+
+The active-support normalization is part of the reference implementation. It is not interchangeable with full-volume FFT normalization when support changes.
+
+### Markov mode dynamics
+
+At every observation, the configured mode with the largest current Fourier amplitude becomes the discrete dominant-mode state
+
+```text
+q_t = argmax_k |A_k(t)|.
+```
+
+The empirical transition law is
+
+```text
+P_ij = count(q_t=i, q_t+1=j) / count(q_t=i)
+```
+
+for rows with observed outgoing transitions. Unobserved rows use an identity row in the reference implementation so the matrix remains stochastic without inventing cross-mode evidence.
+
+This is a finite-window empirical Markov model. It is not a claim that the complete underlying process is first-order Markov.
+
+### Diffusion loss
+
+For a diagonal anisotropic diffusion tensor
+
+```text
+D = diag(Dx, Dy, Dz),
+```
+
+the per-mode linear diffusion rate is
+
+```text
+lambda_D(k) = k^T D k
+```
+
+and the exact one-step attenuation for the linear diffusion equation is
+
+```text
+a_D(k) = exp(-k^T D k * dt).
+```
+
+The reference implementation reports this attenuation; it does not silently apply diffusion to the authoritative field.
+
+### Temporal resonance analysis
+
+For each configured spatial mode, a short positive-frequency temporal DFT is applied to the complex coefficient history `A_k(t)`.
+
+Let
+
+```text
+omega_k* = argmax_omega |A_tilde_k(omega)|^2.
+```
+
+Define spectral coherence as
+
+```text
+C_k = peak_power_k / total_nonzero_frequency_power_k
+```
+
+when nonzero-frequency power exists.
+
+The reference resonance score is
+
+```text
+R_k = C_k * sqrt(peak_power_k) * S_k / (gamma + k^T D k)
+```
+
+where
+
+```text
+S_k = 0.5 + 0.5 P_kk
+```
+
+and `gamma > 0` is a configured damping floor.
+
+This score is an engineering ranking functional, not a universal physical definition of resonance. It deliberately rewards temporally concentrated, mode-persistent energy and penalizes damping plus diffusive loss.
+
+### Inward feedback
+
+The highest-scoring mode may propose a same-space field correction. The reference modal component is reconstructed on the currently active support from the current complex Fourier coefficient.
+
+The feedback sign is determined by
+
+```text
+s_k = 2 P_kk - 1.
+```
+
+Persistent modes (`P_kk > 0.5`) are eligible for reinforcement; rapidly switching modes (`P_kk < 0.5`) are eligible for suppression.
+
+The raw feedback is scaled by the configured feedback gain and normalized resonance score, then clipped per coordinate:
+
+```text
+|Delta Psi(r)| <= max_feedback_delta.
+```
+
+The resulting value is projected into the configured value interval before it can become a candidate.
+
+### Candidate-first recurrence
+
+The operational recurrence is
+
+```text
+observation_t
+-> append to bounded history
+-> Fourier coefficients
+-> dominant-mode sequence
+-> empirical Markov matrix
+-> diffusion rates
+-> temporal resonance scores
+-> selected modal correction
+-> value/resource projection
+-> optional external validator
+-> COMMIT or ROLLBACK.
+```
+
+A rejected candidate does not mutate either the published FMDR state or its history buffer.
+
+## Relationship to the Dr Moagi field and autoencoding loops
+
+FMDR is an analysis/control operator, not a replacement codec. It may be inserted after an encoder has produced a same-space sparse latent field and before a decoder, or it may analyze the field-runtime state directly.
+
+A compositional form is
+
+```text
+Z_t        = E_theta(X_t)
+A_k(t)     = F_3D[Z_t]
+P_t        = Markov(argmax_k |A_k|)
+R_t        = Resonance(A_k history, P_t, D)
+Z_t'       = Pi_Lambda[Z_t + bounded_feedback(R_t)]
+X_hat_t    = D_phi(Z_t')
+e_t        = X_t - X_hat_t
+parameters = candidate-first update(e_t, telemetry)
+```
+
+Encoder, decoder, spectral analysis, Markov estimation, diffusion accounting and feedback remain distinct contracts.
+
+The higher-level self-referential recurrence may therefore be written
+
+```text
+S_t+1 = G(S_t, spectrum(S_t), transitions(S_t), diffusion(S_t), resonance(S_t), error(S_t))
+```
+
+but every executable term must still satisfy the same-space/type/resource rules established by ADR-003 and the bounded authority rules established by ADR-007.
+
+## Reference implementation
+
+The dependency-free reference is:
+
+```text
+src/jarvisx/dr_moagi_fmdr.py
+```
+
+with focused tests in:
+
+```text
+tests/test_dr_moagi_fmdr.py
+```
+
+The reference uses direct sparse Fourier sums and a naive short-window temporal DFT. It is correctness-oriented and intentionally does not claim production FFT throughput.
+
+## Required invariants
+
+1. Every configured wavevector is finite, three-dimensional and nonzero.
+2. Diffusion coefficients are finite and non-negative.
+3. Damping is finite and strictly positive.
+4. Field values are finite and active support is resource-bounded.
+5. Markov rows are stochastic.
+6. Resonance is reported separately from Fourier amplitude and diffusion attenuation.
+7. Feedback is same-space and bounded per active coordinate.
+8. Value projection occurs before candidate publication.
+9. The history window is explicitly bounded.
+10. Validator rejection atomically preserves the prior published state and history.
+11. No FMDR result silently rewrites the canonical VM, source code, policy, provenance or transaction layers.
+12. Physical resonance, production performance and learned-model quality require separate evidence.
+
+## Validation
+
+Acceptance requires focused tests for:
+
+- axis wavevector construction;
+- sparse spatial Fourier mode discrimination;
+- diffusion attenuation against the analytic exponential;
+- deterministic temporal resonance detection on a synthetic traveling mode;
+- stochastic Markov rows and persistent-mode self-transition probability;
+- bounded per-cell reinforce/suppress feedback;
+- delayed feedback until the configured minimum history exists;
+- bounded history retention;
+- atomic rollback of state and history on validator rejection;
+- malformed configuration rejection.
+
+## Consequences
+
+### Positive
+
+- Fourier, Markov, diffusion and resonance semantics become individually testable;
+- the engine can identify coherent spatiotemporal modes without treating resonance as raw amplitude alone;
+- diffusion provides an explicit modal dissipation term;
+- mode switching supplies a measurable stochastic stability signal;
+- feedback remains bounded, same-space and reversible by transaction rollback;
+- the loop composes naturally with existing encoder/decoder and field-runtime boundaries.
+
+### Negative
+
+- the direct sparse Fourier sum and naive temporal DFT scale poorly for large mode sets and long windows;
+- active-support normalization can change amplitude when the support changes and must therefore be interpreted carefully;
+- an empirical dominant-mode chain may discard important multimodal structure;
+- the reference resonance ranking is an engineering heuristic, not a proof of a physical eigenfrequency;
+- reinforcing a persistent mode can still be undesirable for a task objective, so external validation remains necessary.

--- a/src/jarvisx/dr_moagi_fmdr.py
+++ b/src/jarvisx/dr_moagi_fmdr.py
@@ -289,7 +289,11 @@ def analyze_history(
 
         rate = diffusion_rate(wavevector, config.diffusion)
         attenuation = math.exp(-rate * config.dt)
-        self_probability = matrix[index][index]
+        self_probability = (
+            self_counts[index] / transition_counts[index]
+            if transition_counts[index]
+            else 0.5
+        )
         current = series[-1]
         stability = 0.5 + 0.5 * self_probability
         score = (
@@ -337,12 +341,23 @@ def _clamp(value: float, lower: float, upper: float) -> float:
     return max(lower, min(upper, value))
 
 
+def _project_field(field: SparseField, config: FMDRConfig) -> SparseField:
+    projected: SparseField = {}
+    for coordinate, value in field.items():
+        updated = _clamp(value, config.value_min, config.value_max)
+        if updated != 0.0:
+            projected[coordinate] = updated
+    return projected
+
+
 def feedback_candidate(
     field: Mapping[Coordinate, float], report: FMDRReport, config: FMDRConfig
 ) -> SparseField:
     """Apply bounded reinforce/suppress feedback for the selected resonant mode."""
 
-    source = _field(field, max_active_cells=config.max_active_cells)
+    source = _project_field(
+        _field(field, max_active_cells=config.max_active_cells), config
+    )
     if not source:
         return {}
 
@@ -382,7 +397,9 @@ class FourierMarkovDiffusionResonanceEngine:
     )
 
     def __init__(self, initial_field: Mapping[Coordinate, float], config: FMDRConfig) -> None:
-        initial = _field(initial_field, max_active_cells=config.max_active_cells)
+        initial = _project_field(
+            _field(initial_field, max_active_cells=config.max_active_cells), config
+        )
         self.config = config
         self._history: tuple[SparseField, ...] = (initial,)
         report = analyze_history(self._history, config)
@@ -402,7 +419,10 @@ class FourierMarkovDiffusionResonanceEngine:
         *,
         validator: FieldValidator | None = None,
     ) -> FMDRState:
-        observed = _field(observation, max_active_cells=self.config.max_active_cells)
+        observed = _project_field(
+            _field(observation, max_active_cells=self.config.max_active_cells),
+            self.config,
+        )
         pending_history = (*self._history, observed)[-self.config.max_history :]
         report = analyze_history(pending_history, self.config)
         candidate = (

--- a/src/jarvisx/dr_moagi_fmdr.py
+++ b/src/jarvisx/dr_moagi_fmdr.py
@@ -1,0 +1,421 @@
+"""Fourier-Markov-diffusion-resonance analysis and bounded inward feedback.
+
+This dependency-free reference module operates on a short history of sparse 3D
+scalar fields. It intentionally separates four operations:
+
+1. Fourier analysis: measure configured spatial wave-vector modes.
+2. Markov analysis: model transitions between dominant spatial modes.
+3. Diffusion: compute per-mode attenuation under a diagonal diffusion tensor.
+4. Resonance: detect temporally coherent modal oscillation and score it against
+   damping plus diffusive loss.
+
+The optional inward loop feeds only a bounded modal correction into the current
+field. Candidate-first validation preserves the Jarvis-X research authority
+boundary: analysis may propose a state, but it cannot publish an unbounded or
+validator-rejected candidate.
+
+This is a numerical reference, not a production FFT, PDE solver, neural model,
+or claim that model hidden states physically inhabit Euclidean 3D space.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from .dr_moagi_field_runtime import Coordinate, SparseField
+
+WaveVector = tuple[float, float, float]
+DiffusionDiagonal = tuple[float, float, float]
+FieldValidator = Callable[[Mapping[Coordinate, float], "FMDRReport"], bool]
+
+
+def _finite(value: float, *, name: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _positive(value: float, *, name: str) -> float:
+    result = _finite(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _non_negative(value: float, *, name: str) -> float:
+    result = _finite(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _wavevector(values: Sequence[float]) -> WaveVector:
+    result = tuple(_finite(value, name="wavevector component") for value in values)
+    if len(result) != 3:
+        raise ValueError("wavevector must contain exactly three components")
+    if result == (0.0, 0.0, 0.0):
+        raise ValueError("zero wavevector is not a resonance-analysis mode")
+    return (result[0], result[1], result[2])
+
+
+def _field(field: Mapping[Coordinate, float], *, max_active_cells: int) -> SparseField:
+    if len(field) > max_active_cells:
+        raise RuntimeError("field exceeds configured active-cell budget")
+    result: SparseField = {}
+    for coordinate, raw_value in field.items():
+        if len(coordinate) != 3:
+            raise ValueError("field coordinates must be 3D")
+        if any(isinstance(item, bool) or not isinstance(item, int) for item in coordinate):
+            raise TypeError("field coordinates must contain integers")
+        value = _finite(raw_value, name="field value")
+        if value != 0.0:
+            result[(int(coordinate[0]), int(coordinate[1]), int(coordinate[2]))] = value
+    return result
+
+
+def axis_wavevectors(side: int, harmonics: int = 1) -> tuple[WaveVector, ...]:
+    """Return positive axis-aligned Fourier modes for a cubic logical side."""
+
+    if isinstance(side, bool) or not isinstance(side, int) or side <= 1:
+        raise ValueError("side must be an integer greater than one")
+    if isinstance(harmonics, bool) or not isinstance(harmonics, int) or harmonics <= 0:
+        raise ValueError("harmonics must be a positive integer")
+    vectors: list[WaveVector] = []
+    for harmonic in range(1, harmonics + 1):
+        k = 2.0 * math.pi * harmonic / side
+        vectors.extend(((k, 0.0, 0.0), (0.0, k, 0.0), (0.0, 0.0, k)))
+    return tuple(vectors)
+
+
+def spatial_fourier(field: Mapping[Coordinate, float], wavevector: WaveVector) -> complex:
+    """Return the active-support-normalized sparse spatial Fourier coefficient."""
+
+    if not field:
+        return 0.0j
+    kx, ky, kz = _wavevector(wavevector)
+    total = 0.0j
+    for (x, y, z), value in field.items():
+        phase = -(kx * x + ky * y + kz * z)
+        total += float(value) * cmath.exp(1j * phase)
+    return total / len(field)
+
+
+def diffusion_rate(wavevector: WaveVector, diagonal: DiffusionDiagonal) -> float:
+    """Return k^T D k for diagonal anisotropic diffusion."""
+
+    kx, ky, kz = _wavevector(wavevector)
+    if len(diagonal) != 3:
+        raise ValueError("diffusion diagonal must contain exactly three values")
+    dx, dy, dz = (_non_negative(value, name="diffusion coefficient") for value in diagonal)
+    return dx * kx * kx + dy * ky * ky + dz * kz * kz
+
+
+def diffusion_attenuation(
+    wavevector: WaveVector, diagonal: DiffusionDiagonal, dt: float
+) -> float:
+    """Return exp(-k^T D k dt), the exact linear diffusion multiplier per mode."""
+
+    return math.exp(-diffusion_rate(wavevector, diagonal) * _positive(dt, name="dt"))
+
+
+def _temporal_spectrum(
+    samples: Sequence[complex], dt: float
+) -> tuple[tuple[float, complex, float], ...]:
+    """Naive positive-frequency DFT for a short conformance window."""
+
+    count = len(samples)
+    if count < 2:
+        return ()
+    dt = _positive(dt, name="dt")
+    bins: list[tuple[float, complex, float]] = []
+    for index in range(1, count // 2 + 1):
+        coefficient = sum(
+            sample * cmath.exp(-2j * math.pi * index * n / count)
+            for n, sample in enumerate(samples)
+        ) / count
+        omega = 2.0 * math.pi * index / (count * dt)
+        power = abs(coefficient) ** 2
+        bins.append((omega, coefficient, power))
+    return tuple(bins)
+
+
+def _transition_matrix(states: Sequence[int], state_count: int) -> tuple[tuple[float, ...], ...]:
+    counts = [[0 for _ in range(state_count)] for _ in range(state_count)]
+    for left, right in zip(states, states[1:]):
+        counts[left][right] += 1
+
+    rows: list[tuple[float, ...]] = []
+    for index, row in enumerate(counts):
+        total = sum(row)
+        if total == 0:
+            rows.append(tuple(1.0 if j == index else 0.0 for j in range(state_count)))
+        else:
+            rows.append(tuple(value / total for value in row))
+    return tuple(rows)
+
+
+@dataclass(frozen=True)
+class FMDRConfig:
+    """Numerical, resource and inward-feedback bounds."""
+
+    wavevectors: tuple[WaveVector, ...] = ()
+    dt: float = 1.0
+    diffusion: DiffusionDiagonal = (0.05, 0.05, 0.05)
+    damping: float = 0.05
+    feedback_gain: float = 0.10
+    max_feedback_delta: float = 0.10
+    value_min: float = -1.0
+    value_max: float = 1.0
+    min_history: int = 4
+    max_history: int = 32
+    max_active_cells: int = 100_000
+
+    def __post_init__(self) -> None:
+        if not self.wavevectors:
+            raise ValueError("wavevectors must contain at least one non-zero 3D mode")
+        normalized = tuple(_wavevector(vector) for vector in self.wavevectors)
+        object.__setattr__(self, "wavevectors", normalized)
+
+        _positive(self.dt, name="dt")
+        if len(self.diffusion) != 3:
+            raise ValueError("diffusion must contain exactly three diagonal coefficients")
+        diffusion = tuple(
+            _non_negative(value, name="diffusion coefficient") for value in self.diffusion
+        )
+        object.__setattr__(self, "diffusion", (diffusion[0], diffusion[1], diffusion[2]))
+        _positive(self.damping, name="damping")
+        _non_negative(self.feedback_gain, name="feedback_gain")
+        _non_negative(self.max_feedback_delta, name="max_feedback_delta")
+        _finite(self.value_min, name="value_min")
+        _finite(self.value_max, name="value_max")
+        if self.value_min >= self.value_max:
+            raise ValueError("value_min must be smaller than value_max")
+
+        for name in ("min_history", "max_history", "max_active_cells"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.min_history > self.max_history:
+            raise ValueError("min_history cannot exceed max_history")
+
+
+@dataclass(frozen=True)
+class ModeReport:
+    index: int
+    wavevector: WaveVector
+    current_coefficient_real: float
+    current_coefficient_imag: float
+    current_amplitude: float
+    diffusion_rate: float
+    diffusion_attenuation: float
+    dominant_omega: float
+    temporal_peak_power: float
+    spectral_coherence: float
+    self_transition_probability: float
+    resonance_score: float
+
+
+@dataclass(frozen=True)
+class FMDRReport:
+    sample_count: int
+    dominant_mode_index: int
+    selected_mode_index: int
+    markov_transition_matrix: tuple[tuple[float, ...], ...]
+    markov_persistence: float
+    modes: tuple[ModeReport, ...]
+
+    @property
+    def selected_mode(self) -> ModeReport:
+        return self.modes[self.selected_mode_index]
+
+
+@dataclass(frozen=True)
+class FMDRState:
+    cycle: int
+    field: SparseField
+    report: FMDRReport
+
+
+def analyze_history(
+    history: Sequence[Mapping[Coordinate, float]], config: FMDRConfig
+) -> FMDRReport:
+    """Analyze sparse-field history with Fourier, Markov, diffusion and resonance."""
+
+    if not history:
+        raise ValueError("history must contain at least one field")
+    fields = tuple(
+        _field(field, max_active_cells=config.max_active_cells) for field in history
+    )
+    mode_series: list[list[complex]] = [[] for _ in config.wavevectors]
+    dominant_states: list[int] = []
+
+    for field in fields:
+        coefficients = [
+            spatial_fourier(field, wavevector) for wavevector in config.wavevectors
+        ]
+        for index, coefficient in enumerate(coefficients):
+            mode_series[index].append(coefficient)
+        dominant_states.append(
+            max(range(len(coefficients)), key=lambda index: abs(coefficients[index]))
+        )
+
+    matrix = _transition_matrix(dominant_states, len(config.wavevectors))
+    transition_counts = [0 for _ in config.wavevectors]
+    self_counts = [0 for _ in config.wavevectors]
+    for left, right in zip(dominant_states, dominant_states[1:]):
+        transition_counts[left] += 1
+        if left == right:
+            self_counts[left] += 1
+    total_transitions = sum(transition_counts)
+    markov_persistence = (
+        sum(self_counts) / total_transitions if total_transitions else 1.0
+    )
+
+    reports: list[ModeReport] = []
+    for index, (wavevector, series) in enumerate(zip(config.wavevectors, mode_series)):
+        spectrum = _temporal_spectrum(series, config.dt)
+        total_power = sum(power for _, _, power in spectrum)
+        if spectrum and total_power > 0.0:
+            omega, _, peak_power = max(spectrum, key=lambda item: item[2])
+            coherence = peak_power / total_power
+        else:
+            omega = 0.0
+            peak_power = 0.0
+            coherence = 0.0
+
+        rate = diffusion_rate(wavevector, config.diffusion)
+        attenuation = math.exp(-rate * config.dt)
+        self_probability = matrix[index][index]
+        current = series[-1]
+        stability = 0.5 + 0.5 * self_probability
+        score = (
+            coherence
+            * math.sqrt(peak_power)
+            * stability
+            / (config.damping + rate)
+        )
+        reports.append(
+            ModeReport(
+                index=index,
+                wavevector=wavevector,
+                current_coefficient_real=current.real,
+                current_coefficient_imag=current.imag,
+                current_amplitude=abs(current),
+                diffusion_rate=rate,
+                diffusion_attenuation=attenuation,
+                dominant_omega=omega,
+                temporal_peak_power=peak_power,
+                spectral_coherence=coherence,
+                self_transition_probability=self_probability,
+                resonance_score=score,
+            )
+        )
+
+    current_coefficients = [series[-1] for series in mode_series]
+    dominant_mode = max(
+        range(len(current_coefficients)),
+        key=lambda index: abs(current_coefficients[index]),
+    )
+    selected_mode = max(
+        range(len(reports)), key=lambda index: reports[index].resonance_score
+    )
+    return FMDRReport(
+        sample_count=len(fields),
+        dominant_mode_index=dominant_mode,
+        selected_mode_index=selected_mode,
+        markov_transition_matrix=matrix,
+        markov_persistence=markov_persistence,
+        modes=tuple(reports),
+    )
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def feedback_candidate(
+    field: Mapping[Coordinate, float], report: FMDRReport, config: FMDRConfig
+) -> SparseField:
+    """Apply bounded reinforce/suppress feedback for the selected resonant mode."""
+
+    source = _field(field, max_active_cells=config.max_active_cells)
+    if not source:
+        return {}
+
+    mode = report.selected_mode
+    maximum_score = max((item.resonance_score for item in report.modes), default=0.0)
+    normalized_resonance = (
+        mode.resonance_score / (1.0 + maximum_score) if maximum_score > 0.0 else 0.0
+    )
+    signed_stability = 2.0 * mode.self_transition_probability - 1.0
+    gain = config.feedback_gain * normalized_resonance * signed_stability
+    coefficient = complex(mode.current_coefficient_real, mode.current_coefficient_imag)
+    kx, ky, kz = mode.wavevector
+
+    candidate: SparseField = {}
+    for coordinate, value in source.items():
+        x, y, z = coordinate
+        phase = kx * x + ky * y + kz * z
+        modal_component = (coefficient * cmath.exp(1j * phase)).real
+        delta = _clamp(
+            gain * modal_component,
+            -config.max_feedback_delta,
+            config.max_feedback_delta,
+        )
+        updated = _clamp(value + delta, config.value_min, config.value_max)
+        if updated != 0.0:
+            candidate[coordinate] = updated
+    return candidate
+
+
+class FourierMarkovDiffusionResonanceEngine:
+    """Bounded analyze -> feedback -> validate -> commit inward loop."""
+
+    LAW_ID = "DM-vOmegaXi+-FOURIER-MARKOV-DIFFUSION-RESONANCE"
+    RECURRENCE = (
+        "Psi[t] -> F_k -> P_t -> exp(-k^T D k dt) -> R(k,omega) "
+        "-> bounded modal feedback -> Pi_Lambda -> Psi[t+1]"
+    )
+
+    def __init__(self, initial_field: Mapping[Coordinate, float], config: FMDRConfig) -> None:
+        initial = _field(initial_field, max_active_cells=config.max_active_cells)
+        self.config = config
+        self._history: tuple[SparseField, ...] = (initial,)
+        report = analyze_history(self._history, config)
+        self._state = FMDRState(0, initial, report)
+
+    @property
+    def history(self) -> tuple[SparseField, ...]:
+        return self._history
+
+    @property
+    def state(self) -> FMDRState:
+        return self._state
+
+    def step(
+        self,
+        observation: Mapping[Coordinate, float],
+        *,
+        validator: FieldValidator | None = None,
+    ) -> FMDRState:
+        observed = _field(observation, max_active_cells=self.config.max_active_cells)
+        pending_history = (*self._history, observed)[-self.config.max_history :]
+        report = analyze_history(pending_history, self.config)
+        candidate = (
+            feedback_candidate(observed, report, self.config)
+            if len(pending_history) >= self.config.min_history
+            else observed
+        )
+        if len(candidate) > self.config.max_active_cells:
+            raise RuntimeError("feedback candidate exceeds configured active-cell budget")
+        if validator is not None and not bool(validator(candidate, report)):
+            raise RuntimeError("FMDR candidate rejected by validator")
+
+        pending = FMDRState(self._state.cycle + 1, candidate, report)
+        self._history = tuple(dict(field) for field in pending_history)
+        self._state = pending
+        return pending

--- a/src/jarvisx/dr_moagi_inward_bit_engine.py
+++ b/src/jarvisx/dr_moagi_inward_bit_engine.py
@@ -1,0 +1,471 @@
+"""Bounded inward-looped 3D bit autoencoder/autodecoder reference runtime.
+
+The runtime implements a deterministic discrete recurrence over a finite 3D bit
+field while keeping codec, six-neighbour coupling, error memory and inward
+feedback as separate operations.
+
+The reference intentionally avoids claiming convergence for arbitrary settings.
+Its full dynamical state is ``(X_t, Z_t, Omega_t)``; fixed-point detection is
+therefore performed over all three components rather than ``X_t`` alone.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from typing import Mapping
+
+Coord = tuple[int, int, int]
+
+N6 = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+
+@dataclass(frozen=True)
+class Config:
+    """Numerical and resource contract for the inward 3D bit recurrence."""
+
+    side: int = 8
+    bits: int = 64
+    latent_bits: int = 16
+    iterations: int = 32
+    alpha: float = 0.65
+    beta: float = 0.50
+    omega_gain: float = 0.15
+    omega_retention: float = 0.50
+    omega_capture: float = 0.50
+    seed: int = 1337
+    tolerance: float = 0.0
+    periodic: bool = True
+
+    def __post_init__(self) -> None:
+        for name in ("side", "bits", "latent_bits", "iterations"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+        if self.latent_bits > self.bits:
+            raise ValueError("latent_bits must satisfy 1 <= latent_bits <= bits")
+
+        for name in (
+            "alpha",
+            "beta",
+            "omega_gain",
+            "omega_retention",
+            "omega_capture",
+        ):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+                raise ValueError(f"{name} must be finite and within [0, 1]")
+
+        if not math.isfinite(self.tolerance) or self.tolerance < 0.0:
+            raise ValueError("tolerance must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class IterationMetrics:
+    """Auditable telemetry for one complete inward iteration."""
+
+    iteration: int
+    local_reconstruction_loss: float
+    anchor_reconstruction_loss: float
+    anchor_drift: float
+    latent_cycle_loss: float
+    latent_coupling_loss: float
+    reality_gap: float
+    omega_gap: float
+    full_state_gap: float
+    changed_bits: int
+    latent_changed_bits: int
+    omega_changed_bits: int
+    omega_active_bits: int
+    active_cells: int
+    fixed_point: bool
+
+    @property
+    def reconstruction_loss(self) -> float:
+        """Backward-compatible alias for anchor reconstruction loss."""
+
+        return self.anchor_reconstruction_loss
+
+    @property
+    def cycle_loss(self) -> float:
+        """Backward-compatible alias for the algebraic latent-cycle loss."""
+
+        return self.latent_cycle_loss
+
+
+def deterministic_bits(coord: Coord, bits: int, seed: int) -> int:
+    """Generate a deterministic finite-width source word for one 3D coordinate."""
+
+    required = (bits + 7) // 8
+    data = bytearray()
+    counter = 0
+    while len(data) < required:
+        payload = f"{seed}|{coord[0]}|{coord[1]}|{coord[2]}|{counter}".encode()
+        data.extend(
+            hashlib.blake2b(
+                payload,
+                digest_size=64,
+                person=b"DM-INWARD-3D",
+            ).digest()
+        )
+        counter += 1
+    return int.from_bytes(data[:required], "little") & ((1 << bits) - 1)
+
+
+class Grid3D:
+    """Finite cubic lattice with periodic or bounded six-neighbour topology."""
+
+    def __init__(self, config: Config):
+        self.c = config
+        self.coords = [
+            (x, y, z)
+            for z in range(config.side)
+            for y in range(config.side)
+            for x in range(config.side)
+        ]
+
+    def neighbour(self, point: Coord, direction: Coord) -> Coord | None:
+        x = point[0] + direction[0]
+        y = point[1] + direction[1]
+        z = point[2] + direction[2]
+
+        if self.c.periodic:
+            side = self.c.side
+            return x % side, y % side, z % side
+
+        if 0 <= x < self.c.side and 0 <= y < self.c.side and 0 <= z < self.c.side:
+            return x, y, z
+        return None
+
+    def neighbours(self, point: Coord) -> list[Coord]:
+        result: list[Coord] = []
+        for direction in N6:
+            neighbour = self.neighbour(point, direction)
+            if neighbour is not None:
+                result.append(neighbour)
+        return result
+
+
+class BitAutoEncoder:
+    """Deterministic majority codec with tie-neutral source-bit resolution."""
+
+    def __init__(self, source_bits: int, latent_bits: int):
+        if source_bits < 1 or latent_bits < 1 or latent_bits > source_bits:
+            raise ValueError("require 1 <= latent_bits <= source_bits")
+
+        self.source_bits = source_bits
+        self.latent_bits = latent_bits
+        quotient, remainder = divmod(source_bits, latent_bits)
+        start = 0
+        self.groups: list[tuple[int, int, int]] = []
+
+        for index in range(latent_bits):
+            width = quotient + int(index < remainder)
+            mask = ((1 << width) - 1) << start
+            self.groups.append((start, width, mask))
+            start += width
+
+    def encode(self, source: int) -> int:
+        """Compress each source group to one latent bit.
+
+        Strict majorities map normally. For an even-width exact tie, the first
+        source bit in the group resolves the tie. Under an unbiased random
+        source this preserves a 0.5 latent-one probability instead of biasing
+        ties toward one.
+        """
+
+        latent = 0
+        for index, (start, width, mask) in enumerate(self.groups):
+            ones = (source & mask).bit_count()
+            tied_one = 2 * ones == width and ((source >> start) & 1)
+            if 2 * ones > width or tied_one:
+                latent |= 1 << index
+        return latent
+
+    def decode(self, latent: int) -> int:
+        """Expand each latent bit across the corresponding source-bit group."""
+
+        source = 0
+        for index, (_, _, mask) in enumerate(self.groups):
+            if (latent >> index) & 1:
+                source |= mask
+        return source
+
+    def latent_cycle(self, latent: int) -> int:
+        """Return E(D(z)); this codec makes the latent cycle an exact identity."""
+
+        return self.encode(self.decode(latent))
+
+
+class Inward3DBitEngine:
+    """Deterministic encode -> couple -> decode -> memory -> feedback recurrence."""
+
+    LAW_ID = "DM-vOmegaXi+-INWARD-3D-BIT"
+    RECURRENCE = (
+        "X[t] -> E -> Z[t] -> C_6N -> Z~[t] -> D -> X_hat[t] -> "
+        "Omega[t+1] -> bounded feedback -> X[t+1]"
+    )
+
+    def __init__(self, config: Config = Config()):
+        self.c = config
+        self.grid = Grid3D(config)
+        self.codec = BitAutoEncoder(config.bits, config.latent_bits)
+        self.full_mask = (1 << config.bits) - 1
+        self.state: dict[Coord, int] = {}
+        self.original: dict[Coord, int] = {}
+        self.omega: dict[Coord, int] = {}
+        self.latent: dict[Coord, int] = {}
+        self.iteration = 0
+        self.reconstruction_masks: dict[Coord, int] = {}
+        self.omega_injection_masks: dict[Coord, int] = {}
+        self.omega_retention_masks: dict[Coord, int] = {}
+        self.omega_capture_masks: dict[Coord, int] = {}
+        self.materialize()
+
+    def materialize(self) -> None:
+        """Reset the deterministic source, memory, latent state and cached masks."""
+
+        self.original = {
+            point: deterministic_bits(point, self.c.bits, self.c.seed)
+            for point in self.grid.coords
+        }
+        self.state = dict(self.original)
+        self.omega = {point: 0 for point in self.grid.coords}
+        self.latent = {}
+        self.iteration = 0
+        self._precompute_masks()
+
+    def encode_volume(self, state: Mapping[Coord, int]) -> dict[Coord, int]:
+        return {point: self.codec.encode(source) for point, source in state.items()}
+
+    def couple_volume(self, latent: Mapping[Coord, int]) -> dict[Coord, int]:
+        """Apply synchronous six-neighbour binary-spin coupling."""
+
+        result: dict[Coord, int] = {}
+        alpha = self.c.alpha
+
+        for point in self.grid.coords:
+            center = latent[point]
+            neighbours = self.grid.neighbours(point)
+            coupled = 0
+
+            for bit in range(self.c.latent_bits):
+                center_spin = 1 if (center >> bit) & 1 else -1
+                neighbour_sum = sum(
+                    1 if (latent[neighbour] >> bit) & 1 else -1
+                    for neighbour in neighbours
+                )
+                mean_spin = neighbour_sum / len(neighbours) if neighbours else 0.0
+                field = (1.0 - alpha) * center_spin + alpha * mean_spin
+                if field >= 0.0:
+                    coupled |= 1 << bit
+
+            result[point] = coupled
+        return result
+
+    def decode_volume(self, latent: Mapping[Coord, int]) -> dict[Coord, int]:
+        return {point: self.codec.decode(value) for point, value in latent.items()}
+
+    def update_omega(
+        self,
+        state: Mapping[Coord, int],
+        decoded: Mapping[Coord, int],
+    ) -> dict[Coord, int]:
+        """Update bounded recursive error memory.
+
+        In the absence of new error, the rotation followed by a retention mask
+        cannot increase Hamming weight. This makes memory contractive in the
+        unforced case while still permitting fresh reconstruction error to enter
+        through a separate capture mask.
+        """
+
+        next_omega: dict[Coord, int] = {}
+        for point in self.grid.coords:
+            error = state[point] ^ decoded[point]
+            previous = self.omega[point]
+            if self.c.bits == 1:
+                rotated = previous
+            else:
+                rotated = (
+                    (previous << 1) | (previous >> (self.c.bits - 1))
+                ) & self.full_mask
+
+            retained = rotated & self.omega_retention_masks[point]
+            captured = error & self.omega_capture_masks[point]
+            next_omega[point] = (retained ^ captured) & self.full_mask
+        return next_omega
+
+    def bit_selection_mask(self, coord: Coord, fraction: float, channel: str) -> int:
+        """Return a deterministic finite-width mask selecting a bit fraction."""
+
+        count = round(fraction * self.c.bits)
+        if count <= 0:
+            return 0
+        if count >= self.c.bits:
+            return self.full_mask
+
+        scored: list[tuple[int, int]] = []
+        for bit in range(self.c.bits):
+            payload = f"{self.c.seed}|{coord}|{channel}|{bit}".encode()
+            score = int.from_bytes(
+                hashlib.blake2b(
+                    payload,
+                    digest_size=8,
+                    person=b"DM-MASK-3D",
+                ).digest(),
+                "little",
+            )
+            scored.append((score, bit))
+
+        scored.sort()
+        mask = 0
+        for _, bit in scored[:count]:
+            mask |= 1 << bit
+        return mask
+
+    def _precompute_masks(self) -> None:
+        """Move deterministic hashing out of the hot recurrence loop."""
+
+        self.reconstruction_masks = {
+            point: self.bit_selection_mask(point, self.c.beta, "reconstruction")
+            for point in self.grid.coords
+        }
+        self.omega_injection_masks = {
+            point: self.bit_selection_mask(point, self.c.omega_gain, "omega-injection")
+            for point in self.grid.coords
+        }
+        self.omega_retention_masks = {
+            point: self.bit_selection_mask(point, self.c.omega_retention, "omega-retention")
+            for point in self.grid.coords
+        }
+        self.omega_capture_masks = {
+            point: self.bit_selection_mask(point, self.c.omega_capture, "omega-capture")
+            for point in self.grid.coords
+        }
+
+    def feedback(
+        self,
+        current: Mapping[Coord, int],
+        decoded: Mapping[Coord, int],
+        omega: Mapping[Coord, int],
+    ) -> dict[Coord, int]:
+        """Apply deterministic bounded reconstruction and memory feedback."""
+
+        next_state: dict[Coord, int] = {}
+        for point in self.grid.coords:
+            reconstruction_mask = self.reconstruction_masks[point]
+            omega_mask = self.omega_injection_masks[point]
+            candidate = current[point] & ~reconstruction_mask
+            candidate |= decoded[point] & reconstruction_mask
+            candidate ^= omega[point] & omega_mask
+            next_state[point] = candidate & self.full_mask
+        return next_state
+
+    def bitplane_field(
+        self,
+        bit: int,
+        *,
+        latent: bool = False,
+        spins: bool = True,
+    ) -> dict[Coord, float]:
+        """Expose one state/latent bitplane as a scalar 3D field for FMDR analysis."""
+
+        width = self.c.latent_bits if latent else self.c.bits
+        if isinstance(bit, bool) or not isinstance(bit, int) or not 0 <= bit < width:
+            raise ValueError(f"bit must satisfy 0 <= bit < {width}")
+
+        source = self.latent if latent else self.state
+        if latent and not source:
+            raise RuntimeError("latent field is unavailable before the first step")
+
+        off = -1.0 if spins else 0.0
+        return {
+            point: 1.0 if (source[point] >> bit) & 1 else off
+            for point in self.grid.coords
+        }
+
+    @staticmethod
+    def _hamming(left: Mapping[Coord, int], right: Mapping[Coord, int]) -> int:
+        return sum((left[point] ^ right[point]).bit_count() for point in left)
+
+    def step(self) -> IterationMetrics:
+        """Execute one synchronous inward iteration and atomically commit it."""
+
+        current = dict(self.state)
+        previous_omega = dict(self.omega)
+
+        latent_raw = self.encode_volume(current)
+        latent_coupled = self.couple_volume(latent_raw)
+        decoded = self.decode_volume(latent_coupled)
+        omega_next = self.update_omega(current, decoded)
+        state_next = self.feedback(current, decoded, omega_next)
+
+        source_bit_count = len(self.grid.coords) * self.c.bits
+        latent_bit_count = len(self.grid.coords) * self.c.latent_bits
+
+        local_reconstruction_loss = self._hamming(current, decoded) / source_bit_count
+        anchor_reconstruction_loss = self._hamming(self.original, decoded) / source_bit_count
+        anchor_drift = self._hamming(self.original, state_next) / source_bit_count
+
+        latent_cycle_bits = sum(
+            (latent_coupled[point] ^ self.codec.latent_cycle(latent_coupled[point])).bit_count()
+            for point in self.grid.coords
+        )
+        latent_cycle_loss = latent_cycle_bits / latent_bit_count
+        latent_coupling_loss = self._hamming(latent_raw, latent_coupled) / latent_bit_count
+
+        changed_bits = self._hamming(current, state_next)
+        omega_changed_bits = self._hamming(previous_omega, omega_next)
+        omega_active_bits = sum(value.bit_count() for value in omega_next.values())
+
+        if self.latent:
+            latent_changed_bits = self._hamming(self.latent, latent_coupled)
+        else:
+            latent_changed_bits = latent_bit_count
+
+        reality_gap = changed_bits / source_bit_count
+        omega_gap = omega_changed_bits / source_bit_count
+        full_state_gap = (
+            changed_bits + latent_changed_bits + omega_changed_bits
+        ) / (2 * source_bit_count + latent_bit_count)
+
+        pending = IterationMetrics(
+            iteration=self.iteration + 1,
+            local_reconstruction_loss=local_reconstruction_loss,
+            anchor_reconstruction_loss=anchor_reconstruction_loss,
+            anchor_drift=anchor_drift,
+            latent_cycle_loss=latent_cycle_loss,
+            latent_coupling_loss=latent_coupling_loss,
+            reality_gap=reality_gap,
+            omega_gap=omega_gap,
+            full_state_gap=full_state_gap,
+            changed_bits=changed_bits,
+            latent_changed_bits=latent_changed_bits,
+            omega_changed_bits=omega_changed_bits,
+            omega_active_bits=omega_active_bits,
+            active_cells=len(self.grid.coords),
+            fixed_point=full_state_gap <= self.c.tolerance,
+        )
+
+        self.state = state_next
+        self.omega = omega_next
+        self.latent = latent_coupled
+        self.iteration += 1
+        return pending
+
+    def run(self):
+        """Iterate until the configured bound or a full-state fixed point."""
+
+        for _ in range(self.c.iterations):
+            metrics = self.step()
+            yield metrics
+            if metrics.fixed_point:
+                break

--- a/tests/test_dr_moagi_fmdr.py
+++ b/tests/test_dr_moagi_fmdr.py
@@ -65,6 +65,8 @@ def test_history_analysis_detects_temporal_resonance_and_markov_persistence():
     assert report.selected_mode_index == 0
     assert report.markov_persistence == pytest.approx(1.0)
     assert report.markov_transition_matrix[0][0] == pytest.approx(1.0)
+    assert report.markov_transition_matrix[1][1] == pytest.approx(1.0)
+    assert report.modes[1].self_transition_probability == pytest.approx(0.5)
     assert selected.spectral_coherence == pytest.approx(1.0)
     assert selected.dominant_omega == pytest.approx(math.pi / 2)
     assert selected.resonance_score > 0.0
@@ -119,6 +121,21 @@ def test_engine_waits_for_history_then_closes_the_inward_loop():
     for frame in frames[4:]:
         engine.step(frame)
     assert len(engine.history) == config.max_history
+
+
+def test_engine_projects_values_even_before_resonance_feedback_activates():
+    x_mode, y_mode, _ = axis_wavevectors(8)
+    config = FMDRConfig(
+        wavevectors=(x_mode, y_mode),
+        value_min=-0.25,
+        value_max=0.25,
+        min_history=4,
+    )
+    engine = FourierMarkovDiffusionResonanceEngine({(0, 0, 0): 2.0}, config)
+
+    assert engine.state.field[(0, 0, 0)] == pytest.approx(0.25)
+    state = engine.step({(0, 0, 0): -2.0})
+    assert state.field[(0, 0, 0)] == pytest.approx(-0.25)
 
 
 def test_validator_rejection_rolls_back_state_and_history_atomically():

--- a/tests/test_dr_moagi_fmdr.py
+++ b/tests/test_dr_moagi_fmdr.py
@@ -1,0 +1,154 @@
+import math
+
+import pytest
+
+from jarvisx.dr_moagi_fmdr import (
+    FMDRConfig,
+    FourierMarkovDiffusionResonanceEngine,
+    analyze_history,
+    axis_wavevectors,
+    diffusion_attenuation,
+    feedback_candidate,
+    spatial_fourier,
+)
+
+
+def wave_field(side: int, *, phase: float = 0.0, amplitude: float = 0.5):
+    k = 2.0 * math.pi / side
+    return {
+        (x, 0, 0): amplitude * math.cos(k * x + phase)
+        for x in range(side)
+    }
+
+
+def test_axis_wavevectors_and_sparse_fourier_identify_x_mode():
+    wavevectors = axis_wavevectors(8)
+    field = wave_field(8)
+
+    assert len(wavevectors) == 3
+    x_mode = spatial_fourier(field, wavevectors[0])
+    y_mode = spatial_fourier(field, wavevectors[1])
+    z_mode = spatial_fourier(field, wavevectors[2])
+
+    assert abs(x_mode) == pytest.approx(0.25)
+    assert abs(y_mode) < 1.0e-12
+    assert abs(z_mode) < 1.0e-12
+
+
+def test_diffusion_multiplier_matches_exponential_mode_decay():
+    wavevector = axis_wavevectors(8)[0]
+    observed = diffusion_attenuation(wavevector, (0.1, 0.2, 0.3), 0.5)
+    k = 2.0 * math.pi / 8
+    expected = math.exp(-0.1 * k * k * 0.5)
+
+    assert observed == pytest.approx(expected)
+    assert 0.0 < observed < 1.0
+
+
+def test_history_analysis_detects_temporal_resonance_and_markov_persistence():
+    x_mode, y_mode, _ = axis_wavevectors(8)
+    config = FMDRConfig(
+        wavevectors=(x_mode, y_mode),
+        dt=1.0,
+        diffusion=(0.01, 0.01, 0.01),
+        damping=0.05,
+    )
+    history = [
+        wave_field(8, phase=index * math.pi / 2)
+        for index in range(8)
+    ]
+
+    report = analyze_history(history, config)
+    selected = report.selected_mode
+
+    assert report.dominant_mode_index == 0
+    assert report.selected_mode_index == 0
+    assert report.markov_persistence == pytest.approx(1.0)
+    assert report.markov_transition_matrix[0][0] == pytest.approx(1.0)
+    assert selected.spectral_coherence == pytest.approx(1.0)
+    assert selected.dominant_omega == pytest.approx(math.pi / 2)
+    assert selected.resonance_score > 0.0
+
+
+def test_feedback_is_bounded_per_cell_and_within_value_projection():
+    x_mode, y_mode, _ = axis_wavevectors(8)
+    config = FMDRConfig(
+        wavevectors=(x_mode, y_mode),
+        diffusion=(0.01, 0.01, 0.01),
+        damping=0.05,
+        feedback_gain=0.5,
+        max_feedback_delta=0.02,
+        value_min=-0.75,
+        value_max=0.75,
+    )
+    history = [wave_field(8, phase=index * math.pi / 2) for index in range(8)]
+    report = analyze_history(history, config)
+    source = history[-1]
+    candidate = feedback_candidate(source, report, config)
+
+    assert candidate != source
+    for coordinate, value in source.items():
+        updated = candidate.get(coordinate, 0.0)
+        assert abs(updated - value) <= config.max_feedback_delta + 1.0e-12
+        assert config.value_min <= updated <= config.value_max
+
+
+def test_engine_waits_for_history_then_closes_the_inward_loop():
+    x_mode, y_mode, _ = axis_wavevectors(8)
+    config = FMDRConfig(
+        wavevectors=(x_mode, y_mode),
+        diffusion=(0.01, 0.01, 0.01),
+        damping=0.05,
+        feedback_gain=0.25,
+        max_feedback_delta=0.02,
+        min_history=4,
+        max_history=6,
+    )
+    frames = [wave_field(8, phase=index * math.pi / 2) for index in range(7)]
+    engine = FourierMarkovDiffusionResonanceEngine(frames[0], config)
+
+    first = engine.step(frames[1])
+    second = engine.step(frames[2])
+    third = engine.step(frames[3])
+
+    assert first.field == frames[1]
+    assert second.field == frames[2]
+    assert third.field != frames[3]
+    assert third.report.sample_count == 4
+
+    for frame in frames[4:]:
+        engine.step(frame)
+    assert len(engine.history) == config.max_history
+
+
+def test_validator_rejection_rolls_back_state_and_history_atomically():
+    x_mode, y_mode, _ = axis_wavevectors(8)
+    config = FMDRConfig(
+        wavevectors=(x_mode, y_mode),
+        min_history=4,
+        max_history=8,
+    )
+    frames = [wave_field(8, phase=index * math.pi / 2) for index in range(4)]
+    engine = FourierMarkovDiffusionResonanceEngine(frames[0], config)
+    engine.step(frames[1])
+    engine.step(frames[2])
+    previous_state = engine.state
+    previous_history = engine.history
+
+    with pytest.raises(RuntimeError, match="validator"):
+        engine.step(frames[3], validator=lambda _candidate, _report: False)
+
+    assert engine.state is previous_state
+    assert engine.history == previous_history
+
+
+def test_configuration_rejects_zero_mode_and_invalid_history_window():
+    with pytest.raises(ValueError, match="zero wavevector"):
+        FMDRConfig(wavevectors=((0.0, 0.0, 0.0),))
+
+    with pytest.raises(ValueError, match="min_history"):
+        FMDRConfig(
+            wavevectors=((1.0, 0.0, 0.0),),
+            min_history=5,
+            max_history=4,
+        )

--- a/tests/test_dr_moagi_inward_bit_engine.py
+++ b/tests/test_dr_moagi_inward_bit_engine.py
@@ -1,0 +1,136 @@
+import math
+
+import pytest
+
+from jarvisx.dr_moagi_inward_bit_engine import (
+    BitAutoEncoder,
+    Config,
+    Inward3DBitEngine,
+)
+
+
+def test_even_group_tie_resolution_is_unbiased_over_complete_four_bit_domain():
+    codec = BitAutoEncoder(source_bits=4, latent_bits=1)
+    encoded_ones = sum(codec.encode(source) for source in range(16))
+    assert encoded_ones == 8
+
+
+def test_latent_cycle_is_exact_identity_but_is_not_used_as_coupling_metric():
+    codec = BitAutoEncoder(source_bits=16, latent_bits=4)
+    assert all(codec.latent_cycle(latent) == latent for latent in range(16))
+
+    engine = Inward3DBitEngine(Config(side=3, bits=16, latent_bits=4, iterations=1))
+    metrics = engine.step()
+    assert metrics.latent_cycle_loss == 0.0
+    assert metrics.latent_coupling_loss >= 0.0
+
+
+def test_precomputed_masks_are_deterministic_and_have_expected_cardinality():
+    config = Config(side=2, bits=16, latent_bits=4, beta=0.5, omega_gain=0.25)
+    left = Inward3DBitEngine(config)
+    right = Inward3DBitEngine(config)
+
+    assert left.reconstruction_masks == right.reconstruction_masks
+    assert left.omega_injection_masks == right.omega_injection_masks
+    assert all(mask.bit_count() == 8 for mask in left.reconstruction_masks.values())
+    assert all(mask.bit_count() == 4 for mask in left.omega_injection_masks.values())
+
+
+def test_omega_memory_is_contractive_when_reconstruction_error_is_zero():
+    config = Config(
+        side=2,
+        bits=16,
+        latent_bits=4,
+        omega_retention=0.5,
+        omega_capture=1.0,
+    )
+    engine = Inward3DBitEngine(config)
+    engine.omega = {point: engine.full_mask for point in engine.grid.coords}
+
+    next_omega = engine.update_omega(engine.state, engine.state)
+    before = sum(value.bit_count() for value in engine.omega.values())
+    after = sum(value.bit_count() for value in next_omega.values())
+
+    assert after <= before
+    assert all(value.bit_count() <= 8 for value in next_omega.values())
+
+
+def test_fixed_point_requires_source_latent_and_omega_state_to_stop_changing():
+    engine = Inward3DBitEngine(
+        Config(
+            side=2,
+            bits=8,
+            latent_bits=4,
+            iterations=4,
+            alpha=0.0,
+            beta=0.0,
+            omega_gain=0.0,
+            omega_retention=0.0,
+            omega_capture=0.0,
+            tolerance=0.0,
+        )
+    )
+
+    first = engine.step()
+    second = engine.step()
+
+    assert not first.fixed_point
+    assert first.changed_bits == 0
+    assert first.latent_changed_bits > 0
+    assert second.fixed_point
+    assert second.changed_bits == 0
+    assert second.latent_changed_bits == 0
+    assert second.omega_changed_bits == 0
+
+
+def test_metrics_separate_local_anchor_and_drift_errors():
+    engine = Inward3DBitEngine(Config(side=3, bits=16, latent_bits=4, iterations=2))
+    first = engine.step()
+    second = engine.step()
+
+    for metrics in (first, second):
+        assert 0.0 <= metrics.local_reconstruction_loss <= 1.0
+        assert 0.0 <= metrics.anchor_reconstruction_loss <= 1.0
+        assert 0.0 <= metrics.anchor_drift <= 1.0
+        assert 0.0 <= metrics.full_state_gap <= 1.0
+        assert math.isfinite(metrics.full_state_gap)
+
+    assert first.local_reconstruction_loss == first.anchor_reconstruction_loss
+
+
+def test_bitplane_adapter_exposes_state_and_latent_for_spectral_analysis():
+    engine = Inward3DBitEngine(Config(side=2, bits=8, latent_bits=4, iterations=1))
+    state_plane = engine.bitplane_field(0)
+    assert set(state_plane) == set(engine.grid.coords)
+    assert set(state_plane.values()) <= {-1.0, 1.0}
+
+    with pytest.raises(RuntimeError, match="before the first step"):
+        engine.bitplane_field(0, latent=True)
+
+    engine.step()
+    latent_plane = engine.bitplane_field(0, latent=True, spins=False)
+    assert set(latent_plane.values()) <= {0.0, 1.0}
+
+
+def test_default_recurrence_is_deterministic_and_bounded():
+    config = Config(side=3, bits=16, latent_bits=4, iterations=8)
+    left = Inward3DBitEngine(config)
+    right = Inward3DBitEngine(config)
+
+    left_metrics = list(left.run())
+    right_metrics = list(right.run())
+
+    assert left_metrics == right_metrics
+    assert left.state == right.state
+    assert left.omega == right.omega
+    assert left.latent == right.latent
+    assert all(0 <= value <= left.full_mask for value in left.state.values())
+
+
+def test_invalid_configuration_is_rejected():
+    with pytest.raises(ValueError):
+        Config(bits=8, latent_bits=9)
+    with pytest.raises(ValueError):
+        Config(omega_retention=1.1)
+    with pytest.raises(ValueError):
+        Config(iterations=0)


### PR DESCRIPTION
## Summary

Permeates two coupled Layer 5 research components into Jarvis-X:

1. a Fourier–Markov–Diffusion–Resonance (FMDR) analysis/control loop over bounded sparse 3D field histories; and
2. a refined inward-looped 3D bit autoencoder/autodecoder that can expose source or latent bitplanes directly to FMDR.

The combined path is:

```text
X_t bit volume
-> tie-neutral bit encode
-> six-neighbour latent coupling
-> decode
-> contractive bounded Omega memory
-> deterministic inward feedback
-> X_t+1
-> selected state/latent bitplane
-> spatial Fourier modes
-> dominant-mode Markov transition model
-> anisotropic diffusion loss k^T D k
-> temporal resonance/coherence ranking
-> bounded FMDR proposal
-> Pi_Lambda / validator
-> COMMIT or ROLLBACK
-> repeat
```

## Inward bit recurrence refinements

The bit engine now removes the previous majority-tie one-bias by resolving exact even-width ties with the first source bit in each group. Over the complete four-bit fixture domain this gives 8 latent zeros and 8 latent ones.

Omega memory is separated into retention and fresh-error capture:

```text
Omega_rot     = ROTL_1(Omega_t)
Omega_keep    = Omega_rot & M_retention
error_t       = X_t XOR X_hat_t
error_capture = error_t & M_capture
Omega_t+1     = Omega_keep XOR error_capture
```

This makes memory non-expansive in Hamming weight when unforced, without claiming global convergence of the full recurrence.

Fixed-point detection now operates on the complete state `(X_t, Z_t, Omega_t)` through a normalized full-state Hamming gap rather than checking `X_t` alone.

Telemetry separates:

- local reconstruction loss `H(X_t, X_hat_t)`;
- anchor reconstruction loss `H(X_0, X_hat_t)`;
- anchor drift `H(X_0, X_t+1)`;
- algebraic latent-cycle loss;
- nontrivial latent-coupling loss;
- source, latent and Omega state gaps.

Deterministic reconstruction, Omega-injection, retention and capture masks are precomputed at materialization time so BLAKE2b ranking is removed from the hot recurrence loop.

## FMDR mathematical contract

For each configured wavevector `k`, the reference computes

```text
A_k(t) = mean_active Psi_t(r) exp(-i k dot r)
lambda_D(k) = k^T D k
a_D(k) = exp(-lambda_D(k) dt)
```

and ranks temporal modal coherence with damping, diffusion and empirical Markov persistence separated in telemetry.

The inward FMDR feedback path is bounded per active coordinate and is neutral when a mode has no outgoing transition evidence. Every initial/observed field is projected into configured value bounds before publication, including cycles before minimum-history resonance feedback activates.

## Files

- `src/jarvisx/dr_moagi_fmdr.py` — dependency-free FMDR engine and candidate-first loop
- `tests/test_dr_moagi_fmdr.py` — Fourier, diffusion, resonance, Markov, projection, history and rollback invariants
- `src/jarvisx/dr_moagi_inward_bit_engine.py` — refined deterministic 3D bit recurrence
- `tests/test_dr_moagi_inward_bit_engine.py` — tie neutrality, Omega contraction, full-state fixed point, mask caching, telemetry and bitplane invariants
- `docs/DR_MOAGI_INWARD_3D_BIT_ENGINE.md` — executable bit-engine contract and FMDR bridge
- `docs/adr/0013-fourier-markov-diffusion-resonance-loop.md` — FMDR architectural contract and inference boundaries
- `.github/workflows/dr-moagi-fmdr.yml` — compile, format, import-order, mypy and focused pytest gate for both runtimes

## Preflight

The inward-bit focused suite passed 9/9 locally before publication. The reference verifies unbiased four-bit tie resolution, exact latent-cycle identity, deterministic mask cardinality, unforced Omega contraction, full-state fixed-point semantics, separated telemetry, bitplane export, deterministic recurrence and malformed-config rejection.

The FMDR synthetic traveling-mode fixture discriminates the expected Fourier mode, detects its temporal peak, reports analytic diffusion attenuation, closes bounded feedback after `min_history`, and atomically rolls back a validator-rejected candidate.

## Boundaries

These are numerical/reference runtimes, not production FFT/PDE solvers, physical-resonance claims, universal convergence proofs, lossless arbitrary compression claims, or unrestricted self-modification mechanisms. The implementation extends ADR-003/006/007 semantics and preserves the canonical VM, policy, transaction, provenance and rollback boundaries.