### PR TITLE
Unify bounded 3D auto-optimization and inward recursive AE/AD

### DIFF
--- a/.github/workflows/empirical-validation.yml
+++ b/.github/workflows/empirical-validation.yml
@@ -43,11 +43,17 @@ jobs:
         run: python -m pip install -e ".[test]"
 
       - name: Test the evidence harness
-        run: pytest tests/test_empirical_validation.py -q --no-cov
+        run: >-
+          pytest
+          tests/test_empirical_validation.py
+          tests/test_candidate_contract.py
+          tests/test_candidate_adapters.py
+          tests/test_empirical_validation_v2.py
+          -q --no-cov
 
       - name: Generate machine-readable evidence
         run: >-
-          python -m jarvisx.empirical_validation
+          python -m jarvisx.empirical_validation_v2
           --repetitions 64
           --octree-max-depth 6
           --output artifacts/empirical-validation.json
@@ -67,6 +73,7 @@ jobs:
           lines = [
               "## Jarvis-X empirical validation",
               "",
+              f"**Schema:** `{payload['schema_version']}`",
               f"**Result:** {'PASS' if summary['passed'] else 'FAIL'}",
               f"**Checks:** {summary['checks_passed']}/{summary['checks_total']}",
               "",

--- a/docs/DR_MOAGI_INWARD_3D_BITS.md
+++ b/docs/DR_MOAGI_INWARD_3D_BITS.md
@@ -1,0 +1,162 @@
+# Inward Recursive 3D Bit AE/AD
+
+## Scope
+
+`jarvisx.dr_moagi_inward_3d_bits` is a deterministic, finite-materialization
+reference for repeatedly feeding a decoded 3D bit volume back into its own encoder.
+It is deliberately distinct from the anchored virtual 3D codec: the authoritative
+feedback anchor is the current state `X_t`, not the original source `X_0`.
+
+The runtime does not allocate the symbolic virtual universe and does not claim a
+trained neural representation. It executes a bounded active tile.
+
+## Recurrence
+
+For each active 3D coordinate `p`,
+
+\[
+Z_t(p)=E(X_t(p)).
+\]
+
+The latent bit field is synchronously coupled across the six-neighbour lattice:
+
+\[
+\widetilde Z_t=C_{\alpha,\mathcal N_6}(Z_t).
+\]
+
+The decoder reconstructs a source-width bit word:
+
+\[
+\widehat X_t(p)=D(\widetilde Z_t(p)).
+\]
+
+The residual-memory plane is
+
+\[
+\Omega_{t+1}(p)=X_t(p)\oplus\widehat X_t(p).
+\]
+
+For a deterministic coordinate-specific reconstruction mask `M_beta(p)`, the
+self-referential update is
+
+\[
+X_{t+1}(p)=
+\left(X_t(p)\land\neg M_\beta(p)\right)
+\lor
+\left(\widehat X_t(p)\land M_\beta(p)\right).
+\]
+
+An optional, independently generated mask can inject selected residual-memory bits:
+
+\[
+X_{t+1}(p)\leftarrow
+X_{t+1}(p)\oplus
+\left(\Omega_{t+1}(p)\land M_\Omega(p)\right).
+\]
+
+The decoder output therefore does not terminate the computation:
+
+\[
+X_t\to E\to C_{3D}\to D\to\widehat X_t\to X_{t+1}\to E\to\cdots
+\]
+
+## Why this is different from the anchored codec
+
+The anchored virtual codec uses original source bits outside the feedback mask. In
+that form, majority-group reconstruction can become a one-shot projection followed
+by a fixed-point check.
+
+The inward runtime instead preserves unselected bits from `X_t`:
+
+\[
+X_{t+1}=(X_t\land\neg M)\lor(\widehat X_t\land M).
+\]
+
+Spatially changed latent majorities can therefore influence later encodes and later
+neighbour interactions. The recurrence is genuinely state recursive rather than a
+repeated projection against `X_0`.
+
+## Authoritative state and atomicity
+
+The authoritative state is the tuple
+
+\[
+S_t=(X_t,\Omega_t,Z_t).
+\]
+
+A step computes the complete candidate tuple first. Bit widths, coordinate support
+and any external gate are validated before publication. Rejection leaves the prior
+state untouched.
+
+The runtime hashes the complete tuple using canonical JSON-compatible state records.
+This makes replay and cycle detection independent of Python dictionary insertion
+order.
+
+## Fixed points and cycles
+
+A zero source-state gap alone is insufficient when residual or latent state can
+change future behavior. The reference therefore requires equality of the complete
+authoritative tuple:
+
+\[
+S_{t+1}=S_t
+\]
+
+and the configured source-state tolerance
+
+\[
+\Delta_X\le\varepsilon.
+\]
+
+A previously observed candidate hash that differs from the current full-state hash
+is classified as a non-fixed synchronous cycle. The candidate is not published.
+This prevents a period-2 or longer oscillation from being reported as convergence.
+
+## Telemetry
+
+Each step reports:
+
+- reconstruction loss against the original deterministic source;
+- self-reconstruction loss against `X_t`;
+- codec latent-cycle loss;
+- 3D spatial disagreement;
+- latent balance/collapse loss;
+- source-state reality gap `Delta_X`;
+- latent transition gap `Delta_Z`;
+- raw-to-coupled latent gap;
+- residual-memory density;
+- changed source and latent bits;
+- input and candidate authority hashes;
+- commit, fixed-point and cycle status.
+
+The current grouped majority codec satisfies `E(D(z)) = z` for valid latent words,
+so its codec-cycle loss is a consistency check rather than evidence of learned cycle
+quality.
+
+## CLI
+
+```bash
+python -m jarvisx.dr_moagi_inward_3d_bits \
+  --tile 8 \
+  --bits 64 \
+  --latent 16 \
+  --iterations 32 \
+  --alpha 0.65 \
+  --beta 0.50 \
+  --json
+```
+
+Optional residual feedback can be enabled explicitly:
+
+```bash
+python -m jarvisx.dr_moagi_inward_3d_bits --omega-feedback 0.15 --json
+```
+
+## Capability boundary
+
+This module demonstrates deterministic recursive bit-state dynamics, spatial latent
+coupling, bounded residual feedback, atomic state publication, full-state fixed-point
+checks and non-fixed-cycle detection. It does not establish gradient-trained
+representation learning, universal convergence, semantic intelligence, physical
+allocation of the virtual address space, or superiority over conventional neural
+codecs.

--- a/docs/DR_MOAGI_VIRTUAL_3D_AE_OPTIMIZATION.md
+++ b/docs/DR_MOAGI_VIRTUAL_3D_AE_OPTIMIZATION.md
@@ -1,0 +1,103 @@
+# Bounded 3D Auto-Optimization for the Virtual Bitstream AE/AD
+
+## Scope
+
+`jarvisx.dr_moagi_virtual_3d_ae` is a deterministic sparse 3D bitstream codec
+laboratory. It does **not** claim a learned neural representation. The refinement
+adds a bounded self-tuning layer around the existing encode-couple-decode-feedback
+recurrence while preserving finite materialization, deterministic replay and an
+explicit capability boundary.
+
+## 1. Active 3D coupling
+
+For latent bit \(j\) at lattice point \(p\), map the bit to a spin
+\(s_j(p)\in\{-1,+1\}\). With six-neighbour mean
+
+\[
+m_j(p)=\frac{1}{|\mathcal N_6(p)|}\sum_{q\in\mathcal N_6(p)}s_j(q),
+\]
+
+the synchronous coupled bit is
+
+\[
+\widetilde z_j(p)=
+\mathbf 1\left[(1-\alpha)s_j(p)+\alpha m_j(p)\ge 0\right].
+\]
+
+When \(\alpha<0.5\), even unanimous opposing neighbours cannot flip the current
+spin, so the operator is inert. The reference default is therefore moved to
+\(\alpha=0.65\), where sufficiently strong six-neighbour consensus can alter a
+latent bit.
+
+## 2. Measured objective
+
+Each candidate is evaluated from the same deterministic source tile. The score is
+
+\[
+J =
+w_r L_{\rm rec}
++w_s L_{\rm spatial}
++w_b L_{\rm balance}
++w_g \bar{\Delta}.
+\]
+
+The terms are:
+
+- \(L_{\rm rec}\): normalized Hamming reconstruction loss against the deterministic
+  source stream;
+- \(L_{\rm spatial}\): mean latent Hamming disagreement across positive x/y/z
+  lattice edges;
+- \(L_{\rm balance}=1-4p(1-p)\), where \(p\) is the latent one-bit fraction. This is
+  zero at 50/50 occupancy and one at all-zero or all-one collapse;
+- \(\bar{\Delta}\): mean reality gap across the bounded recurrence.
+
+Default weights are \(w_r=1.0\), \(w_s=0.25\), \(w_b=0.25\), \(w_g=0.10\).
+
+## 3. Deterministic bounded search
+
+`DrMoagiVirtual3DAE.optimize()` evaluates a finite Cartesian grid of
+\((\alpha,\beta)\) pairs. The current pair is always included as the baseline.
+Candidate ordering and tie-breaking are deterministic. A new pair is committed
+only when
+
+\[
+J_{\rm candidate} < J_{\rm baseline}-10^{-12}.
+\]
+
+Otherwise the engine keeps the baseline configuration. Rebuilding after a commit
+clears transient materialized state so the subsequent run starts from the same
+coordinate-derived source field.
+
+Default candidate sets are:
+
+\[
+\alpha\in\{0.55,0.65,0.80\},\qquad
+\beta\in\{0.35,0.50,0.65,0.80\}.
+\]
+
+This is twelve bounded candidates plus the baseline only when it is not already in
+the grid.
+
+## 4. CLI
+
+Run the normal reference:
+
+```bash
+python -m jarvisx.dr_moagi_virtual_3d_ae --json
+```
+
+Run bounded auto-optimization before the recurrence:
+
+```bash
+python -m jarvisx.dr_moagi_virtual_3d_ae --auto-optimize --json
+```
+
+The JSON summary records the chosen parameters, baseline and final scores,
+candidate count, component losses and whether an improvement was committed.
+
+## 5. Safety and interpretation boundary
+
+The optimizer searches two explicit scalar controls; it does not rewrite its own
+source code, train weights by gradient descent, allocate the symbolic logical
+universe, or guarantee improved reconstruction in isolation. It optimizes the
+declared multi-objective score under finite candidate, pass and tile bounds.

--- a/docs/EMPIRICAL_VALIDATION.md
+++ b/docs/EMPIRICAL_VALIDATION.md
@@ -42,7 +42,8 @@ Hard constraints are evaluated separately from the scalar objective. An optimize
 | 7 | Field Runtime transaction | Run identical sparse field steps from opposite insertion orders, then force validator rejection | Identical state/metrics, bounded support and exact rollback | `dr_moagi_field_runtime.py` | Identity-codec fixture does not prove arbitrary learned-codec stability |
 | 8 | DM-DD atomic adaptation | Execute identical residual-learning steps, then reject an adaptive proposal | State, Ω memory and Θ parameters evolve deterministically and roll back as one tuple on rejection | `dr_moagi_deep_distiller.py` | Tests the bounded scalar-gain reference learner, not large-model quality |
 | 9 | Virtual 3D optimizer admission | Run bounded α/β search twice and adapt the result into the common candidate receipt | Same selected result and receipt; non-regressive score; shared decision agreement; zero terminal reality gap | `dr_moagi_virtual_3d_ae.py`, `candidate_adapters.py` | Bounded scalar search is not unrestricted self-modification or gradient-trained representation learning |
-| 10 | Orthogonal quantization precision | Verify an orthonormal DCT-II basis and nearest-neighbour quantization reconstruction | Orthogonality passes and spatial residual remains within the deterministic L2 envelope | `orthogonal_quantization.py` | Transform correctness is not a production codec or perceptual benchmark |
+| 10 | Inward 3D bit recursive re-entry | Execute two inward AE/AD iterations in two fresh engines, then force a gate rejection | First candidate authority hash equals the next iteration input hash; replay is identical; active state stays bit-width bounded; X/Ω/Z roll back atomically on rejection | `dr_moagi_inward_3d_bits.py` | Establishes bounded deterministic self-reentry for the declared bit codec, not universal convergence or learned representation quality |
+| 11 | Orthogonal quantization precision | Verify an orthonormal DCT-II basis and nearest-neighbour quantization reconstruction | Orthogonality passes and spatial residual remains within the deterministic L2 envelope | `orthogonal_quantization.py` | Transform correctness is not a production codec or perceptual benchmark |
 
 ## Machine-readable report
 
@@ -62,6 +63,8 @@ Every check contains:
 
 Candidate-admission receipts additionally contain parent/candidate state hashes, operator identity, objective before/after, component metrics, hard-constraint outcomes, resource envelope/usage, decision, rejection reasons and a deterministic SHA-256 receipt hash.
 
+The inward 3D recursion evidence additionally binds consecutive full-state hashes so a committed `(X, Ω, Z)` tuple is demonstrably the next iteration's encoder input. Non-fixed repeated full-state hashes are treated as cycles, not convergence.
+
 Timing fields remain observations only. Shared CI runners are not controlled benchmark hardware, so the evidence gate does not impose portable throughput claims.
 
 ## Interpretation
@@ -75,6 +78,7 @@ A green empirical-validation workflow establishes that the checked implementatio
 - physical realization of a virtual lattice;
 - cross-platform floating-point bit identity;
 - statistically significant model-quality superiority;
+- universal convergence of recursive bit-state dynamics;
 - safety merely because a policy or coherence gate exists.
 
 Claims outside the evidence matrix remain specifications, hypotheses or future experiments until a protocol, baseline, dataset and reproducible result are added.

--- a/docs/EMPIRICAL_VALIDATION.md
+++ b/docs/EMPIRICAL_VALIDATION.md
@@ -1,46 +1,68 @@
 # Jarvis-X Empirical Validation
 
-This document consolidates the executable evidence for canonical Jarvis-X capabilities. The evidence gate is deliberately narrower than the project vision: every row names a falsifiable software claim, an observable protocol, a pass criterion and a boundary that the result does **not** establish.
+This document defines the executable evidence gate for canonical Jarvis-X capabilities. The gate is deliberately narrower than the project vision: every check names a falsifiable software claim, an observable protocol, a pass criterion and a boundary that the result does **not** establish.
 
 ## Run the evidence gate
 
 ```bash
 python -m pip install -e ".[test]"
-python -m jarvisx.empirical_validation \
+python -m jarvisx.empirical_validation_v2 \
   --repetitions 64 \
   --octree-max-depth 6 \
   --output artifacts/empirical-validation.json
 ```
 
-The command exits with status `0` only when every required check passes. The JSON artifact records the commit, interpreter, platform, protocol, observations and boundaries. GitHub Actions uploads the report from each validation run.
+The command exits with status `0` only when every required check passes. The JSON artifact records the commit, interpreter, platform, protocol, observations and inference boundaries. GitHub Actions validates and uploads the report from each evidence run.
+
+## Evidence architecture
+
+Version 2 preserves every v1 core check and adds system-wide adaptive checks. The governing rule is:
+
+```text
+parent state
+  -> bounded candidate
+  -> hard constraints / resource projection
+  -> objective improvement gate
+  -> COMMIT or ROLLBACK
+  -> deterministic receipt / evidence
+```
+
+Hard constraints are evaluated separately from the scalar objective. An optimizer cannot compensate for a failed resource, policy or integrity gate by obtaining a better score.
 
 ## Consolidated evidence matrix
 
-| Capability claim | Observable protocol | Required result | Canonical implementation | Boundary |
-|---|---|---|---|---|
-| Deterministic VM replay | Assemble one fixed five-word program and run it in 64 fresh VMs | Complete final states and traces are identical; all ledgers verify | `src/jarvisx/core.py`, parser, assembler, decoder and executor | Exercises the implemented ISA path; it is not a general performance or intelligence claim |
-| Ω journal integrity | Build a deterministic three-entry hash chain, then mutate the middle state | Valid chain passes before mutation and fails afterward | `src/jarvisx/ledger.py` | Integrity is not confidentiality, trusted time or remote replication |
-| Sparse transactional field | Reverse observation insertion order, replay a checkpoint and force an invalid candidate | State/journal digests remain equal; checkpoint restores; rejected persistent state rolls back | `src/jarvisx/dr_moagi_billion_field.py` | `1000³` is virtual address-space extent; active coordinates alone are materialized |
-| Recursive octree geometry | Materialize depths 0–6 and compare measured metrics with closed forms | Nodes `(4^(D+1)-1)/3`, leaves `4^D`, volume `2^-D` at every depth | `src/jarvisx/fractal_octree.py` | Geometric self-similarity does not by itself prove long-memory quality |
-| Fractional numerical invariants | Smooth a `4×4×4` impulse and compare split versus combined spectral steps | Mass drift `<1e-9`; variance and gradient energy decrease; semigroup error `<1e-10`; trace is canonical | `src/jarvisx/fractional_smoothing_3d.py` | Small-grid direct-DFT correctness is not production FFT performance or calibrated physics |
+| # | Capability claim | Observable protocol | Required result | Canonical implementation | Boundary |
+|---:|---|---|---|---|---|
+| 1 | Deterministic VM replay | Assemble one fixed five-word program and run it in fresh VMs | Complete final states and traces are identical; all ledgers verify | `core.py`, parser, assembler, decoder, executor | Exercises the implemented ISA path; not a general performance or intelligence claim |
+| 2 | Ω journal integrity | Build a deterministic three-entry hash chain, then mutate historical state | Valid chain passes before mutation and fails afterward | `ledger.py` | Integrity is not confidentiality, trusted time or remote replication |
+| 3 | Sparse transactional field | Reverse insertion order, replay a checkpoint and force an invalid persistent candidate | State/journal digests remain equal; checkpoint restores; rejected state rolls back | `dr_moagi_billion_field.py` | `1000³` is virtual address extent; active coordinates alone are materialized |
+| 4 | Recursive octree geometry | Materialize bounded depths and compare with exact recursive closed forms | Node, leaf and retained-volume formulas match at every tested depth | `fractal_octree.py` | Geometric self-similarity does not prove long-memory quality |
+| 5 | Fractional numerical invariants | Smooth a small 3D impulse and compare split versus combined spectral steps | Mass, dissipation, semigroup and trace invariants pass declared tolerances | `fractional_smoothing_3d.py` | Small-grid direct-DFT correctness is not production FFT performance or calibrated physics |
+| 6 | Shared candidate admission | Evaluate an admissible improving candidate and a better-scoring candidate that violates a hard constraint | Admissible candidate commits; hard-constraint candidate rolls back; receipts verify and replay identically | `candidate_contract.py` | Establishes the common admission primitive, not migration of every research runtime |
+| 7 | Field Runtime transaction | Run identical sparse field steps from opposite insertion orders, then force validator rejection | Identical state/metrics, bounded support and exact rollback | `dr_moagi_field_runtime.py` | Identity-codec fixture does not prove arbitrary learned-codec stability |
+| 8 | DM-DD atomic adaptation | Execute identical residual-learning steps, then reject an adaptive proposal | State, Ω memory and Θ parameters evolve deterministically and roll back as one tuple on rejection | `dr_moagi_deep_distiller.py` | Tests the bounded scalar-gain reference learner, not large-model quality |
+| 9 | Virtual 3D optimizer admission | Run bounded α/β search twice and adapt the result into the common candidate receipt | Same selected result and receipt; non-regressive score; shared decision agreement; zero terminal reality gap | `dr_moagi_virtual_3d_ae.py`, `candidate_adapters.py` | Bounded scalar search is not unrestricted self-modification or gradient-trained representation learning |
+| 10 | Orthogonal quantization precision | Verify an orthonormal DCT-II basis and nearest-neighbour quantization reconstruction | Orthogonality passes and spatial residual remains within the deterministic L2 envelope | `orthogonal_quantization.py` | Transform correctness is not a production codec or perceptual benchmark |
 
 ## Machine-readable report
 
 The report schema identifier is:
 
 ```text
-jarvisx.empirical-validation.v1
+jarvisx.empirical-validation.v2
 ```
 
 Every check contains:
 
-- `claim`: the exact proposition being tested;
-- `protocol`: the executed experiment;
-- `passed`: the boolean gate result;
-- `metrics`: raw observations and deterministic digests;
-- `boundary`: the inference limit.
+- `claim`: exact proposition being tested;
+- `protocol`: executed experiment;
+- `passed`: boolean gate result;
+- `metrics`: observations and deterministic digests;
+- `boundary`: explicit inference limit.
 
-Timing fields are reported as observations only. No fixed throughput threshold is used because shared CI runners are not controlled benchmark hardware.
+Candidate-admission receipts additionally contain parent/candidate state hashes, operator identity, objective before/after, component metrics, hard-constraint outcomes, resource envelope/usage, decision, rejection reasons and a deterministic SHA-256 receipt hash.
+
+Timing fields remain observations only. Shared CI runners are not controlled benchmark hardware, so the evidence gate does not impose portable throughput claims.
 
 ## Interpretation
 
@@ -52,7 +74,8 @@ A green empirical-validation workflow establishes that the checked implementatio
 - production security certification;
 - physical realization of a virtual lattice;
 - cross-platform floating-point bit identity;
-- statistically significant model-quality improvement.
+- statistically significant model-quality superiority;
+- safety merely because a policy or coherence gate exists.
 
 Claims outside the evidence matrix remain specifications, hypotheses or future experiments until a protocol, baseline, dataset and reproducible result are added.
 
@@ -62,10 +85,11 @@ A new claim should be promoted only with:
 
 1. a falsifiable statement;
 2. an executable protocol;
-3. a documented baseline or closed-form reference;
+3. a documented baseline, invariant or closed-form reference;
 4. explicit pass/fail tolerances;
 5. deterministic inputs or a declared stochastic seed protocol;
 6. a machine-readable artifact;
-7. an inference boundary preventing overstatement.
+7. an inference boundary preventing overstatement;
+8. a shared candidate receipt when the subsystem can modify authoritative adaptive state.
 
-Performance comparisons should additionally include warm-up policy, sample count, hardware and software environment, uncertainty estimates and a named baseline implementation.
+Performance comparisons should additionally include warm-up policy, sample count, hardware/software environment, uncertainty estimates and a named baseline implementation.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -30,7 +30,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Trace and Omega journal | Stable reference | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
 | SystemRuntime control plane | Stable reference | `system_runtime.py`, `test_system_runtime.py`, ADR-007 | bounded task authority around the VM; not a host process sandbox |
 | Shared candidate admission receipt | Integration candidate | `candidate_contract.py`, `candidate_adapters.py`, focused tests, ADR-013 | backend-neutral commit/rollback evidence; migration of every optimizer is not yet complete |
-| Consolidated empirical validation v2 | Integration candidate | `empirical_validation_v2.py`, focused tests, retained JSON workflow artifact | verifies ten bounded software invariants only; no AGI, safety or production-performance inference |
+| Consolidated empirical validation v2 | Integration candidate | `empirical_validation_v2.py`, focused tests, retained JSON workflow artifact | verifies eleven bounded software invariants only; no AGI, safety or production-performance inference |
 | C++ inward processor | Reference laboratory | `cpp_runtime/`, CTest, cross-platform workflow | sparse virtual `8192³` domain; bounded parameter/schedule search; cross-platform floating-point bit identity is not claimed |
 | C++ trainable 3D autoencoder | Reference laboratory | `cpp_runtime/`, CTest, reconstruction-error tests | trainable reference kernel; model quality is not established against external baselines |
 | C++ transactional 4D multimodal runtime | Reference laboratory | `cpp_runtime/`, CTest, checkpoint and scheduler tests | four deterministic modality fixtures; not a production multimodal foundation model |
@@ -43,6 +43,7 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Dr Moagi 3D OS control plane | Reference laboratory | `dr_moagi_os.py`, focused lifecycle/transaction tests | user-space sparse control plane; not a replacement host kernel and does not execute arbitrary host commands |
 | Dr Moagi 3D meta-optimizer | Reference laboratory | `dr_moagi_meta_optimizer.py`, focused tests | bounded configuration search; external SOTA superiority is not claimed |
 | Virtual 3D bitstream AE/AD auto-optimizer | Integration candidate | `dr_moagi_virtual_3d_ae.py`, optimizer tests, shared receipt adapter, empirical-v2 integration | bounded deterministic bitstream laboratory; not gradient-trained learning or dense realization of symbolic scale |
+| Inward recursive 3D bit AE/AD loop | Integration candidate | `dr_moagi_inward_3d_bits.py`, focused tests, empirical-v2 integration, `DR_MOAGI_INWARD_3D_BITS.md` | decoded bit state re-enters its encoder with full `(X,Omega,Z)` transaction/cycle checks; no universal convergence or learned-codec claim |
 | 10x10x10 inward 4D graph ANN | Reference laboratory | `inward4d_ann.py`, `test_inward4d_ann.py`, ADR-010 | same-width 1,000-node graph autoencoder; `R^4` is feature geometry; no universal convergence, compression or performance claim |
 | Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures |
 | Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, focused tests, ADR-005, empirical-v2 integration | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production codec kernel |
@@ -61,7 +62,7 @@ python -m jarvisx.empirical_validation_v2 \
   --output artifacts/empirical-validation.json
 ```
 
-Empirical Validation v2 executes ten falsifiable checks:
+Empirical Validation v2 executes eleven falsifiable checks:
 
 1. deterministic VM state and trace replay;
 2. Omega journal tamper detection;
@@ -72,7 +73,8 @@ Empirical Validation v2 executes ten falsifiable checks:
 7. Dr Moagi Field Runtime deterministic sparse transition and validator rollback;
 8. Deep Distiller atomic state/Omega/Theta adaptation and rollback;
 9. virtual-3D optimizer/shared-admission agreement with fixed-point closure;
-10. orthogonal-transform quantization precision within the deterministic L2 envelope.
+10. inward 3D bit-state recursive re-entry, boundedness and atomic `(X,Omega,Z)` rollback;
+11. orthogonal-transform quantization precision within the deterministic L2 envelope.
 
 The inward 4D graph ANN and Moagi-Helmholtz orchestration runtime remain covered by focused unit tests but are not yet represented in the consolidated v2 artifact. The shared candidate contract is likewise an incremental migration boundary: an adaptive subsystem is not considered migrated until an adapter or native integration is tested.
 
@@ -82,7 +84,7 @@ The `Empirical Validation` GitHub Actions workflow publishes the machine-readabl
 
 | Issue / PR | Capability | Current classification | Required before completion |
 |---|---|---|---|
-| #223 | shared 3D optimizer admission + empirical evidence v2 | Integration candidate | all repository checks green, review and merge |
+| #223 | shared 3D optimizer admission + inward recursive 3D bit AE/AD + empirical evidence v2 | Integration candidate | all repository checks green, review and merge |
 | #48 | pull-request backlog consolidation | Governance work | classify overlaps, preserve unique evidence and reduce active drafts below ten |
 | #49 | branch protection and security settings | Repository administration | protect `main`, require CI/evidence/security checks and prevent unreviewed authority changes |
 | #50 | public GitHub profile README | Profile administration | create `Lord-Xido/Lord-Xido`, pin active repositories and review public metadata |
@@ -115,6 +117,7 @@ Jarvis-X does not currently claim:
 - bit-exact cross-platform floating-point results from the C++ research processor;
 - production-scale fractional PDE performance or physical validity from the numerical reference solver;
 - convergence of arbitrary learned Dr Moagi codecs from the reference explicit-step guard alone;
+- universal convergence of the inward recursive 3D bit-state loop;
 - universal convergence or compression from the same-width inward 4D graph autoencoder;
 - that an `R^4` feature coordinate establishes a physical fourth spatial dimension;
 - empirical superiority of fractal or hierarchical memory over transformer, state-space or retrieval baselines.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -1,9 +1,9 @@
 # Jarvis-X Project Status
 
-**Last reviewed:** 2026-08-28
+**Last reviewed:** 2026-09-05
 **Release line:** `0.1.x` alpha
 
-This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation.
+This document is the authoritative implemented-versus-experimental capability matrix. Names, diagrams and specifications do not imply implementation. Entries in a pull request describe the intended post-merge default-branch state and become canonical only when merged.
 
 ## Status definitions
 
@@ -18,58 +18,73 @@ This document is the authoritative implemented-versus-experimental capability ma
 | Specification | documented mathematical or architectural proposal |
 | Future work | issue or roadmap item without a canonical implementation |
 
-## Default-branch capabilities
+## Canonical and integration capabilities
 
 | Capability | Status | Evidence | Boundary |
 |---|---|---|---|
 | Assembly parser and assembler | Alpha | `src/jarvisx/parser.py`, `assembler.py`, tests | grammar and diagnostics remain minimal |
 | 64-bit bytecode decode | Alpha | `decoder.py`, `instruction.py` | versioned external byte envelope is not yet canonical |
-| Register VM | Alpha | `core.py`, `executor.py` | canonical ISA currently has a small instruction surface |
+| Register VM | Alpha | `core.py`, `executor.py`, VM transaction tests | canonical ISA currently has a small instruction surface |
 | Lambda instruction policy | Alpha | `ethics.py` | application-level guard, not a security sandbox |
 | Cycle sandbox | Stable reference | `sandbox.py` | cycle bound only; no process isolation |
 | Trace and Omega journal | Stable reference | `tracer.py`, `ledger.py`, `ledger_store.py` | persistence is opt-in; timestamps are environmental inputs |
-| Consolidated empirical validation | Stable reference | `empirical_validation.py`, focused tests, JSON artifact workflow | verifies bounded software invariants only; no AGI, safety or production-performance inference |
-| C++ inward processor | Reference laboratory | `cpp_runtime/`, CTest, cross-platform workflow | sparse virtual `8192³` domain; bounded parameter/schedule search; floating-point bit identity across platforms is not claimed |
+| SystemRuntime control plane | Stable reference | `system_runtime.py`, `test_system_runtime.py`, ADR-007 | bounded task authority around the VM; not a host process sandbox |
+| Shared candidate admission receipt | Integration candidate | `candidate_contract.py`, `candidate_adapters.py`, focused tests, ADR-013 | backend-neutral commit/rollback evidence; migration of every optimizer is not yet complete |
+| Consolidated empirical validation v2 | Integration candidate | `empirical_validation_v2.py`, focused tests, retained JSON workflow artifact | verifies ten bounded software invariants only; no AGI, safety or production-performance inference |
+| C++ inward processor | Reference laboratory | `cpp_runtime/`, CTest, cross-platform workflow | sparse virtual `8192³` domain; bounded parameter/schedule search; cross-platform floating-point bit identity is not claimed |
+| C++ trainable 3D autoencoder | Reference laboratory | `cpp_runtime/`, CTest, reconstruction-error tests | trainable reference kernel; model quality is not established against external baselines |
+| C++ transactional 4D multimodal runtime | Reference laboratory | `cpp_runtime/`, CTest, checkpoint and scheduler tests | four deterministic modality fixtures; not a production multimodal foundation model |
 | Fractional 3D smoothing | Numerical reference | `fractional_smoothing_3d.py`, independent DFT/stencil/semigroup tests | dense periodic scalar grids and separable `O(N⁴)` cubic DFT; not a production FFT or calibrated physical model |
 | Fractal octree | Stable reference | `fractal_octree.py`, invariant tests | geometric reference, not a general sparse database or proof of long-memory quality |
 | Sparse billion-address field | Stable reference | `dr_moagi_billion_field.py`, transaction/digest/checkpoint tests | virtual `1000³` address space; active sparse coordinates alone are materialized |
-| Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, `test_dr_moagi_field_runtime.py`, ADR-003 | same-space sparse field equation; codec-dependent stability beyond the conservative reference guard remains empirical |
-| 10x10x10 inward 4D graph ANN | Reference laboratory | `inward4d_ann.py`, `test_inward4d_ann.py`, ADR-010 | same-width 1,000-node graph autoencoder; `R^4` is feature geometry; no universal convergence, compression, or performance claim |
-| Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures, not production neural or MP4 implementations |
-| Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, `test_orthogonal_quantization.py`, ADR-005 | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production DCT/video codec kernel |
+| Dr Moagi Field Runtime v2 | Reference laboratory | `dr_moagi_field_runtime.py`, focused tests, ADR-003, empirical-v2 integration | same-space sparse field equation; learned-codec stability remains empirical |
+| Dr Moagi Deep Distiller | Reference laboratory | `dr_moagi_deep_distiller.py`, focused tests, empirical-v2 integration | bounded scalar-gain adaptive reference; not a high-capacity neural representation learner |
+| DM-vOmegaXi+ fixed-point engine | Reference laboratory | `dm_vomegaxi_fixed_point.py`, focused tests | internal operator fixed point only; semantic floor prevents equating self-consistency with external truth |
+| Dr Moagi 3D OS control plane | Reference laboratory | `dr_moagi_os.py`, focused lifecycle/transaction tests | user-space sparse control plane; not a replacement host kernel and does not execute arbitrary host commands |
+| Dr Moagi 3D meta-optimizer | Reference laboratory | `dr_moagi_meta_optimizer.py`, focused tests | bounded configuration search; external SOTA superiority is not claimed |
+| Virtual 3D bitstream AE/AD auto-optimizer | Integration candidate | `dr_moagi_virtual_3d_ae.py`, optimizer tests, shared receipt adapter, empirical-v2 integration | bounded deterministic bitstream laboratory; not gradient-trained learning or dense realization of symbolic scale |
+| 10x10x10 inward 4D graph ANN | Reference laboratory | `inward4d_ann.py`, `test_inward4d_ann.py`, ADR-010 | same-width 1,000-node graph autoencoder; `R^4` is feature geometry; no universal convergence, compression or performance claim |
+| Moagi-Helmholtz orchestration runtime | Reference laboratory | `moagi_helmholtz.py`, `test_moagi_helmholtz.py`, ADR-004 | deterministic orchestration contract; bundled renderer/archive/inverse components are conformance fixtures |
+| Orthogonal quantization precision gate | Numerical reference | `orthogonal_quantization.py`, focused tests, ADR-005, empirical-v2 integration | proves normalization and nearest-neighbour error bounds for declared orthonormal transforms; not a production codec kernel |
 | Hugging Face exporter | Stable reference | `scripts/export_huggingface_model.py` | initialized weights are not trained weights |
 | Reality-grounded observer dynamics | Specification | `docs/REALITY_GROUNDED_OBSERVER_DYNAMICS.md` | proposed formal framework |
 | 3D swarm bytecode architecture | Specification | `docs/DR_MOAGI_3D_SWARM_BYTECODE_ISA.md` | document does not establish hardware performance |
 
 ## Empirical evidence gate
 
-The canonical evidence command is:
+The proposed canonical evidence command on this integration branch is:
 
 ```bash
-python -m jarvisx.empirical_validation \
+python -m jarvisx.empirical_validation_v2 \
   --repetitions 64 \
   --octree-max-depth 6 \
   --output artifacts/empirical-validation.json
 ```
 
-The gate currently tests five falsifiable properties:
+Empirical Validation v2 executes ten falsifiable checks:
 
 1. deterministic VM state and trace replay;
 2. Omega journal tamper detection;
-3. sparse-field insertion-order invariance, checkpoint replay and atomic rollback;
+3. sparse billion-address insertion-order invariance, checkpoint replay and atomic rollback;
 4. fractal-octree agreement with exact recursive closed forms;
-5. fractional-smoothing conservation, dissipation and semigroup tolerances.
+5. fractional-smoothing conservation, dissipation and semigroup tolerances;
+6. deterministic shared candidate receipts and hard-constraint precedence;
+7. Dr Moagi Field Runtime deterministic sparse transition and validator rollback;
+8. Deep Distiller atomic state/Omega/Theta adaptation and rollback;
+9. virtual-3D optimizer/shared-admission agreement with fixed-point closure;
+10. orthogonal-transform quantization precision within the deterministic L2 envelope.
 
-The Field Runtime v2, inward 4D graph ANN, Moagi-Helmholtz orchestration runtime and orthogonal quantization precision gate are covered by focused unit tests in the normal CI suite. They are not yet promoted into the consolidated empirical-validation artifact; that remains a follow-up integration target.
+The inward 4D graph ANN and Moagi-Helmholtz orchestration runtime remain covered by focused unit tests but are not yet represented in the consolidated v2 artifact. The shared candidate contract is likewise an incremental migration boundary: an adaptive subsystem is not considered migrated until an adapter or native integration is tested.
 
 The `Empirical Validation` GitHub Actions workflow publishes the machine-readable report as a retained workflow artifact. See [Empirical Validation](EMPIRICAL_VALIDATION.md) for protocols, thresholds and inference boundaries.
 
 ## Active integration and administration work
 
-| Issue | Capability | Current classification | Required before completion |
+| Issue / PR | Capability | Current classification | Required before completion |
 |---|---|---|---|
+| #223 | shared 3D optimizer admission + empirical evidence v2 | Integration candidate | all repository checks green, review and merge |
 | #48 | pull-request backlog consolidation | Governance work | classify overlaps, preserve unique evidence and reduce active drafts below ten |
-| #49 | branch protection and security settings | Repository administration | enable required checks, scanning and private reporting in GitHub settings |
+| #49 | branch protection and security settings | Repository administration | protect `main`, require CI/evidence/security checks and prevent unreviewed authority changes |
 | #50 | public GitHub profile README | Profile administration | create `Lord-Xido/Lord-Xido`, pin active repositories and review public metadata |
 
 Other long-lived draft pull requests are research branches until explicitly classified, rebased and validated.
@@ -92,11 +107,11 @@ Jarvis-X does not currently claim:
 - global invertibility of ordinary RGB/video rendering to the original 3D mesh;
 - that MP4 is itself a global 3D-DCT codec;
 - that every transform used by a production codec is orthogonal or governed by ADR-005;
-- that a failed orthogonal precision gate may be repaired by simply doubling the admissible quantization threshold;
+- that a failed orthogonal precision gate may be repaired by simply widening its admissible error envelope;
 - unique convergence of arbitrary learned Moagi-Helmholtz pipelines without sufficient mathematical assumptions;
 - physical hardware performance from a virtual address-space description;
 - trained model quality from deterministic initialized weights;
-- safety certification from the presence of a policy or coherence gate;
+- safety certification from the presence of a policy, candidate or coherence gate;
 - bit-exact cross-platform floating-point results from the C++ research processor;
 - production-scale fractional PDE performance or physical validity from the numerical reference solver;
 - convergence of arbitrary learned Dr Moagi codecs from the reference explicit-step guard alone;
@@ -119,7 +134,8 @@ A capability moves to `main` only when all applicable items are satisfied:
 - [ ] machine-readable evidence artifact for empirical claims;
 - [ ] explicit inference boundary preventing overstatement;
 - [ ] security analysis for untrusted inputs;
-- [ ] migration or compatibility note when replacing an existing subsystem.
+- [ ] migration or compatibility note when replacing an existing subsystem;
+- [ ] shared candidate receipt or explicit reason why the subsystem is non-adaptive.
 
 ## Release-readiness targets
 
@@ -145,6 +161,7 @@ A capability moves to `main` only when all applicable items are satisfied:
 
 ### `0.4.0` — Bounded adaptive laboratory
 
+- shared candidate/admission receipt across adaptive subsystems;
 - shadow evaluation API;
 - reproducible candidate generation;
 - rollback-complete state transitions;
@@ -152,6 +169,10 @@ A capability moves to `main` only when all applicable items are satisfied:
 - Moagi-Helmholtz conditioner/geometry/renderer/archive backend adapters with measured capability boundaries;
 - orthogonal transform receipts carrying basis/version, step vector, rounding rule, `B_Q` and `Lambda_Q`;
 - rate-distortion and cycle-reconstruction telemetry separated from transform precision telemetry;
-- anchor-drift and reconstruction telemetry in the consolidated empirical evidence artifact;
+- anchor-drift and reconstruction telemetry in consolidated empirical evidence;
 - metric-hacking tests;
 - experiment manifests and replay.
+
+## Immediate governance blocker
+
+The software transaction model requires verified candidates before authority changes. Repository governance should enforce the same rule. `main` should therefore require pull requests plus the Jarvis-X CI, Empirical Validation and CodeQL checks before merge. Until repository-level protection is enabled, the source-control authority boundary is weaker than the runtime authority boundary.

--- a/docs/adr/0013-shared-candidate-admission-contract.md
+++ b/docs/adr/0013-shared-candidate-admission-contract.md
@@ -1,0 +1,105 @@
+# ADR-0013: Shared candidate admission and evidence contract
+
+Status: accepted
+
+## Context
+
+Jarvis-X contains multiple bounded adaptive mechanisms: deterministic planners,
+field-runtime validators, residual learning, fixed-point refinement, 3D parameter
+search, graph-ANN training, C++ genome/schedule search and multimodal candidate
+orchestration. They share the architectural principle that a proposal is not
+authoritative until it passes validation, but historically each subsystem encoded
+that boundary using its own result type, objective semantics and provenance shape.
+
+That duplication creates two risks:
+
+1. semantic drift, where two optimizers interpret `commit` differently; and
+2. metric hacking, where a scalar objective can accidentally substitute for a hard
+   safety, integrity or resource constraint.
+
+## Decision
+
+Jarvis-X adopts a backend-neutral candidate admission contract for adaptive research
+systems. A candidate transition is represented as:
+
+```text
+parent state
+  -> candidate proposal
+  -> hard constraint checks
+  -> resource-envelope checks
+  -> objective-improvement gate
+  -> COMMIT or ROLLBACK
+  -> deterministic receipt
+```
+
+The canonical reference implementation is `jarvisx.candidate_contract`.
+
+A `CandidateProposal` binds:
+
+- subsystem, candidate and operator identity;
+- parent-state and candidate-state digests;
+- objective before and after the proposal;
+- named component metrics;
+- hard constraint results;
+- declared resource envelope and observed deterministic usage.
+
+A `CandidateReceipt` binds the proposal to the final decision, objective improvement,
+rejection reasons and a deterministic SHA-256 receipt digest.
+
+Hard constraints are authoritative predicates. They are evaluated independently from
+the scalar objective. A candidate that violates a hard constraint or resource bound
+must roll back even if its scalar objective is superior.
+
+For the default lower-is-better policy, an admissible proposal commits only when:
+
+```text
+J_parent - J_candidate > minimum_improvement + epsilon
+```
+
+Subsystems may retain specialized search algorithms and metrics. Grid search,
+gradient descent, evolutionary search, symbolic planning and hardware-specific
+candidate generation are all compatible with this ADR provided their promotion
+boundary can be represented by the shared receipt.
+
+## Consequences
+
+### Positive
+
+- one auditable definition of proposal versus authority;
+- deterministic cross-runtime promotion receipts;
+- hard policy/resource constraints cannot be hidden inside weighted fitness terms;
+- subsystem-local optimizer decisions can be independently checked for semantic drift;
+- empirical validation can aggregate heterogeneous adaptive systems using one evidence
+  shape;
+- future Python, C++, CUDA, FPGA and distributed backends can preserve common
+  authority semantics without sharing an optimization algorithm.
+
+### Costs
+
+- existing adaptive runtimes require adapters or native migration;
+- objective direction and metric semantics must be declared explicitly;
+- state identities used in receipts must be serialized canonically before hashing;
+- a receipt proves the declared admission computation, not the truth or completeness of
+  the constraints themselves.
+
+## Validation
+
+The initial integration provides:
+
+- deterministic commit and rollback receipt tests;
+- a test proving a better objective cannot override a failed hard constraint;
+- resource-overrun rollback tests;
+- deterministic metric normalization and receipt hashing;
+- a virtual-3D optimizer adapter that requires local promotion semantics to agree with
+  the shared contract;
+- Empirical Validation v2 evidence for the common contract plus selected adaptive
+  runtimes.
+
+The migration is intentionally incremental. A subsystem is not considered migrated
+merely because this ADR exists; its tests or adapter must demonstrate conformance.
+
+## Boundary
+
+This contract is an application-level authority and evidence mechanism. It is not a
+hostile-code sandbox, a proof that an objective is well specified, an AGI or safety
+certification, or permission for unrestricted source-code self-modification.

--- a/src/jarvisx/candidate_adapters.py
+++ b/src/jarvisx/candidate_adapters.py
@@ -1,0 +1,102 @@
+"""Adapters from existing Jarvis-X optimizers into the shared candidate contract."""
+
+from __future__ import annotations
+
+from .candidate_contract import (
+    AdmissionPolicy,
+    CandidateProposal,
+    CandidateReceipt,
+    ConstraintResult,
+    ResourceEnvelope,
+    ResourceUsage,
+    admit_candidate,
+    canonical_state_hash,
+    normalize_metrics,
+)
+from .dr_moagi_virtual_3d_ae import Config, TuningResult
+
+
+def virtual_3d_tuning_receipt(config: Config, result: TuningResult) -> CandidateReceipt:
+    """Translate a virtual-3D tuning result into the global admission receipt.
+
+    The adapter deliberately re-evaluates the optimizer's promotion decision from
+    objective values and resource bounds. This lets system evidence detect drift
+    between a subsystem-local commit rule and the repository-wide contract.
+    """
+
+    pairs = {(config.alpha, config.beta)}
+    pairs.update(
+        (alpha, beta)
+        for alpha in config.alpha_candidates
+        for beta in config.beta_candidates
+    )
+    candidate_count = len(pairs)
+
+    parent = {
+        "subsystem": "dr_moagi_virtual_3d_ae",
+        "alpha": config.alpha,
+        "beta": config.beta,
+        "seed": config.seed,
+        "tile": config.tile,
+        "bits": config.bits,
+        "latent": config.latent,
+    }
+    candidate = {
+        **parent,
+        "alpha": result.alpha,
+        "beta": result.beta,
+        "score": result.score,
+    }
+
+    constraints = (
+        ConstraintResult(
+            "candidate_budget",
+            result.candidates_evaluated <= candidate_count,
+            observed=result.candidates_evaluated,
+            limit=candidate_count,
+        ),
+        ConstraintResult(
+            "bounded_alpha",
+            0.0 <= result.alpha <= 1.0,
+            observed=result.alpha,
+            limit="[0,1]",
+        ),
+        ConstraintResult(
+            "bounded_beta",
+            0.0 <= result.beta <= 1.0,
+            observed=result.beta,
+            limit="[0,1]",
+        ),
+    )
+    proposal = CandidateProposal(
+        subsystem="dr_moagi_virtual_3d_ae",
+        candidate_id=f"alpha={result.alpha:.17g};beta={result.beta:.17g}",
+        operator_version="virtual-3d-ae-v2",
+        parent_state_hash=canonical_state_hash(parent),
+        candidate_state_hash=canonical_state_hash(candidate),
+        objective_before=float(result.baseline_score),
+        objective_after=float(result.score),
+        metrics=normalize_metrics(
+            {
+                "reconstruction_loss": result.reconstruction_loss,
+                "spatial_loss": result.spatial_loss,
+                "latent_balance_loss": result.latent_balance_loss,
+                "mean_reality_gap": result.mean_reality_gap,
+            }
+        ),
+        constraints=constraints,
+        resource_envelope=ResourceEnvelope(
+            max_work_units=candidate_count,
+            max_resident_units=config.tile**3,
+            max_output_bytes=0,
+        ),
+        resource_usage=ResourceUsage(
+            work_units=result.candidates_evaluated,
+            resident_units=config.tile**3,
+            output_bytes=0,
+        ),
+    )
+    return admit_candidate(
+        proposal,
+        policy=AdmissionPolicy(min_improvement=0.0, improvement_epsilon=1.0e-12),
+    )

--- a/src/jarvisx/candidate_contract.py
+++ b/src/jarvisx/candidate_contract.py
@@ -1,0 +1,259 @@
+"""Shared deterministic candidate/admission contract for Jarvis-X research runtimes.
+
+The contract is intentionally backend-neutral. A subsystem may use grid search,
+gradient descent, evolutionary search, symbolic planning or another bounded
+proposal mechanism, but promotion always follows the same authority boundary:
+
+    parent state -> candidate -> hard constraints -> objective gate
+                 -> COMMIT or ROLLBACK -> deterministic receipt
+
+Hard constraints are never converted into soft objective penalties.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Iterable, Mapping
+
+
+class CandidateDecision(str, Enum):
+    COMMIT = "commit"
+    ROLLBACK = "rollback"
+
+
+@dataclass(frozen=True)
+class ResourceEnvelope:
+    """Declared upper bounds for one candidate evaluation."""
+
+    max_work_units: int
+    max_resident_units: int
+    max_output_bytes: int
+
+    def __post_init__(self) -> None:
+        for name in ("max_work_units", "max_resident_units", "max_output_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class ResourceUsage:
+    """Observed deterministic resource counters for a candidate."""
+
+    work_units: int = 0
+    resident_units: int = 0
+    output_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("work_units", "resident_units", "output_bytes"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+
+
+@dataclass(frozen=True)
+class ConstraintResult:
+    """One hard admission predicate evaluated before objective comparison."""
+
+    name: str
+    passed: bool
+    observed: float | int | str | bool | None = None
+    limit: float | int | str | bool | None = None
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name.strip():
+            raise ValueError("constraint name cannot be empty")
+
+
+@dataclass(frozen=True)
+class CandidateProposal:
+    """Backend-neutral identity and evidence for one proposed state."""
+
+    subsystem: str
+    candidate_id: str
+    operator_version: str
+    parent_state_hash: str
+    candidate_state_hash: str
+    objective_before: float
+    objective_after: float
+    metrics: tuple[tuple[str, float], ...] = ()
+    constraints: tuple[ConstraintResult, ...] = ()
+    resource_envelope: ResourceEnvelope | None = None
+    resource_usage: ResourceUsage = ResourceUsage()
+
+    def __post_init__(self) -> None:
+        for name in ("subsystem", "candidate_id", "operator_version"):
+            value = getattr(self, name)
+            if not str(value).strip():
+                raise ValueError(f"{name} cannot be empty")
+        for name in ("parent_state_hash", "candidate_state_hash"):
+            value = getattr(self, name)
+            if not _looks_like_digest(str(value)):
+                raise ValueError(f"{name} must be a lowercase hexadecimal digest")
+        for name in ("objective_before", "objective_after"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        seen: set[str] = set()
+        for key, value in self.metrics:
+            if not key or key in seen:
+                raise ValueError("metric names must be non-empty and unique")
+            seen.add(key)
+            if not math.isfinite(float(value)):
+                raise ValueError(f"metric {key!r} must be finite")
+
+
+@dataclass(frozen=True)
+class AdmissionPolicy:
+    """Global lower-is-better objective gate.
+
+    ``min_improvement`` is an absolute objective decrease required for promotion.
+    Hard constraints and resource limits are checked before this objective gate.
+    """
+
+    min_improvement: float = 0.0
+    improvement_epsilon: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.min_improvement) or self.min_improvement < 0.0:
+            raise ValueError("min_improvement must be finite and non-negative")
+        if not math.isfinite(self.improvement_epsilon) or self.improvement_epsilon < 0.0:
+            raise ValueError("improvement_epsilon must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class CandidateReceipt:
+    """Deterministic admission result suitable for journaling or evidence artifacts."""
+
+    schema_version: str
+    proposal: CandidateProposal
+    decision: CandidateDecision
+    improvement: float
+    rejection_reasons: tuple[str, ...]
+    receipt_hash: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "proposal": _proposal_payload(self.proposal),
+            "decision": self.decision.value,
+            "improvement": self.improvement,
+            "rejection_reasons": list(self.rejection_reasons),
+            "receipt_hash": self.receipt_hash,
+        }
+
+    def verify(self) -> bool:
+        payload = self.to_dict()
+        receipt_hash = str(payload.pop("receipt_hash"))
+        return receipt_hash == _sha256(payload)
+
+
+SCHEMA_VERSION = "jarvisx.candidate-receipt.v1"
+
+
+def canonical_state_hash(value: object) -> str:
+    """Hash a JSON-native authoritative state using canonical JSON."""
+
+    return _sha256(value)
+
+
+def normalize_metrics(
+    metrics: Mapping[str, float] | Iterable[tuple[str, float]],
+) -> tuple[tuple[str, float], ...]:
+    """Return metrics in deterministic lexicographic order."""
+
+    items = metrics.items() if isinstance(metrics, Mapping) else metrics
+    materialized = [(str(key), float(value)) for key, value in items]
+    return tuple(sorted(materialized))
+
+
+def admit_candidate(
+    proposal: CandidateProposal,
+    *,
+    policy: AdmissionPolicy | None = None,
+) -> CandidateReceipt:
+    """Apply hard constraints, resource bounds and a non-regressive objective gate."""
+
+    resolved = policy or AdmissionPolicy()
+    reasons: list[str] = []
+
+    for constraint in proposal.constraints:
+        if not constraint.passed:
+            reasons.append(f"constraint:{constraint.name}")
+
+    envelope = proposal.resource_envelope
+    usage = proposal.resource_usage
+    if envelope is not None:
+        if usage.work_units > envelope.max_work_units:
+            reasons.append("resource:max_work_units")
+        if usage.resident_units > envelope.max_resident_units:
+            reasons.append("resource:max_resident_units")
+        if usage.output_bytes > envelope.max_output_bytes:
+            reasons.append("resource:max_output_bytes")
+
+    improvement = float(proposal.objective_before) - float(proposal.objective_after)
+    threshold = resolved.min_improvement + resolved.improvement_epsilon
+    if improvement <= threshold:
+        reasons.append("objective:no_material_improvement")
+
+    decision = CandidateDecision.ROLLBACK if reasons else CandidateDecision.COMMIT
+    body = {
+        "schema_version": SCHEMA_VERSION,
+        "proposal": _proposal_payload(proposal),
+        "decision": decision.value,
+        "improvement": improvement,
+        "rejection_reasons": reasons,
+    }
+    return CandidateReceipt(
+        schema_version=SCHEMA_VERSION,
+        proposal=proposal,
+        decision=decision,
+        improvement=improvement,
+        rejection_reasons=tuple(reasons),
+        receipt_hash=_sha256(body),
+    )
+
+
+def _proposal_payload(proposal: CandidateProposal) -> dict[str, object]:
+    return {
+        "subsystem": proposal.subsystem,
+        "candidate_id": proposal.candidate_id,
+        "operator_version": proposal.operator_version,
+        "parent_state_hash": proposal.parent_state_hash,
+        "candidate_state_hash": proposal.candidate_state_hash,
+        "objective_before": proposal.objective_before,
+        "objective_after": proposal.objective_after,
+        "metrics": {key: value for key, value in proposal.metrics},
+        "constraints": [asdict(item) for item in proposal.constraints],
+        "resource_envelope": (
+            asdict(proposal.resource_envelope) if proposal.resource_envelope is not None else None
+        ),
+        "resource_usage": asdict(proposal.resource_usage),
+    }
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _looks_like_digest(value: str) -> bool:
+    return (
+        len(value) >= 16
+        and value == value.lower()
+        and all(char in "0123456789abcdef" for char in value)
+    )

--- a/src/jarvisx/dr_moagi_inward_3d_bits.py
+++ b/src/jarvisx/dr_moagi_inward_3d_bits.py
@@ -17,7 +17,7 @@ import argparse
 import hashlib
 import json
 from dataclasses import asdict, dataclass
-from typing import Callable, Iterator
+from typing import Callable, Iterator, cast
 
 from .candidate_contract import canonical_state_hash
 from .dr_moagi_virtual_3d_ae import (
@@ -53,7 +53,10 @@ class Inward3DBitConfig:
             raise ValueError("invalid dimensions")
         if self.iterations < 1:
             raise ValueError("iterations must be >= 1")
-        if any(not 0.0 <= value <= 1.0 for value in (self.alpha, self.beta, self.omega_feedback)):
+        if any(
+            not 0.0 <= value <= 1.0
+            for value in (self.alpha, self.beta, self.omega_feedback)
+        ):
             raise ValueError("alpha, beta and omega_feedback must be in [0,1]")
         if self.epsilon < 0.0:
             raise ValueError("epsilon must be >= 0")
@@ -86,7 +89,13 @@ def hamming_fraction(left: int, right: int, width: int) -> float:
     return (left ^ right).bit_count() / width if width else 0.0
 
 
-def _exact_mask(point: Coord, width: int, fraction: float, seed: int, channel: str) -> int:
+def _exact_mask(
+    point: Coord,
+    width: int,
+    fraction: float,
+    seed: int,
+    channel: str,
+) -> int:
     """Select exactly round(fraction*width) deterministic bit positions per coordinate."""
 
     count = round(fraction * width)
@@ -120,12 +129,15 @@ def _authority_hash(
     omega: dict[Coord, int],
     latent: dict[Coord, int],
 ) -> str:
-    return canonical_state_hash(
-        {
-            "state": _volume_payload(state),
-            "omega": _volume_payload(omega),
-            "latent": _volume_payload(latent),
-        }
+    return cast(
+        str,
+        canonical_state_hash(
+            {
+                "state": _volume_payload(state),
+                "omega": _volume_payload(omega),
+                "latent": _volume_payload(latent),
+            }
+        ),
     )
 
 
@@ -139,8 +151,6 @@ class Inward3DBitLoop:
         gate: Gate | None = None,
     ) -> None:
         self.c = config or Inward3DBitConfig()
-        # Tile consumes the compatible virtual-3D config surface. Only the
-        # attributes used by Tile are required here.
         from .dr_moagi_virtual_3d_ae import Config as TileConfig
 
         self.tile = Tile(
@@ -200,7 +210,7 @@ class Inward3DBitLoop:
 
     def _coupled_latent(self, state: dict[Coord, int]) -> dict[Coord, int]:
         raw = self.encode_state(state)
-        return couple(self.tile, raw, self.c.latent, self.c.alpha)
+        return cast(dict[Coord, int], couple(self.tile, raw, self.c.latent, self.c.alpha))
 
     def decode_latent(self, latent: dict[Coord, int]) -> dict[Coord, int]:
         return {point: self.codec.decode(latent[point]) for point in self.tile.coords}
@@ -210,9 +220,9 @@ class Inward3DBitLoop:
         current: dict[Coord, int],
         decoded: dict[Coord, int],
     ) -> dict[Coord, int]:
-        # One-step residual memory. It remains part of the authoritative state
-        # and becomes stationary whenever the self-reconstruction residual does.
-        return {point: (current[point] ^ decoded[point]) & self.full for point in self.tile.coords}
+        return {
+            point: (current[point] ^ decoded[point]) & self.full for point in self.tile.coords
+        }
 
     def _feedback(
         self,
@@ -223,10 +233,18 @@ class Inward3DBitLoop:
         out: dict[Coord, int] = {}
         for point in self.tile.coords:
             reconstruction_mask = _exact_mask(
-                point, self.c.bits, self.c.beta, self.c.seed, "reconstruction"
+                point,
+                self.c.bits,
+                self.c.beta,
+                self.c.seed,
+                "reconstruction",
             )
             omega_mask = _exact_mask(
-                point, self.c.bits, self.c.omega_feedback, self.c.seed, "omega"
+                point,
+                self.c.bits,
+                self.c.omega_feedback,
+                self.c.seed,
+                "omega",
             )
             value = (
                 (current[point] & (self.full ^ reconstruction_mask))
@@ -242,7 +260,9 @@ class Inward3DBitLoop:
             return False
         maximum = (1 << width) - 1
         return all(
-            isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= maximum
+            isinstance(value, int)
+            and not isinstance(value, bool)
+            and 0 <= value <= maximum
             for value in volume.values()
         )
 
@@ -253,7 +273,10 @@ class Inward3DBitLoop:
         input_hash = _authority_hash(current, current_omega, previous_latent)
 
         raw_latent = self.encode_state(current)
-        coupled_latent = couple(self.tile, raw_latent, self.c.latent, self.c.alpha)
+        coupled_latent = cast(
+            dict[Coord, int],
+            couple(self.tile, raw_latent, self.c.latent, self.c.alpha),
+        )
         decoded = self.decode_latent(coupled_latent)
         next_omega = self._next_omega(current, decoded)
         candidate = self._feedback(current, decoded, next_omega)
@@ -279,7 +302,8 @@ class Inward3DBitLoop:
             for point in self.tile.coords
         )
         coupling_changed_bits = sum(
-            (raw_latent[point] ^ coupled_latent[point]).bit_count() for point in self.tile.coords
+            (raw_latent[point] ^ coupled_latent[point]).bit_count()
+            for point in self.tile.coords
         )
         omega_bits = sum(value.bit_count() for value in next_omega.values())
 

--- a/src/jarvisx/dr_moagi_inward_3d_bits.py
+++ b/src/jarvisx/dr_moagi_inward_3d_bits.py
@@ -1,0 +1,423 @@
+"""Transactional inward-looped 3D bit autoencoder/decoder reference.
+
+The decoded 3D bit volume becomes the next encoder input. Unlike the anchored
+virtual codec, the recurrence is self-referential at the authoritative state
+boundary::
+
+    X_t -> E -> C_3D -> D -> X_hat_t -> feedback -> X_{t+1} -> E -> ...
+
+Only a finite active tile is materialized. The implementation is deterministic,
+bit-width bounded and detects non-fixed synchronous cycles rather than treating
+oscillation as convergence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from typing import Callable, Iterator
+
+from .candidate_contract import canonical_state_hash
+from .dr_moagi_virtual_3d_ae import (
+    Codec,
+    Coord,
+    Tile,
+    couple,
+    latent_balance_loss,
+    spatial_loss,
+    stream,
+)
+
+Gate = Callable[[dict[Coord, int], dict[Coord, int]], bool]
+
+
+@dataclass(frozen=True)
+class Inward3DBitConfig:
+    tile: int = 8
+    bits: int = 64
+    latent: int = 16
+    iterations: int = 32
+    alpha: float = 0.65
+    beta: float = 0.50
+    omega_feedback: float = 0.0
+    seed: int = 1337
+    origin: Coord = (0, 0, 0)
+    periodic: bool = True
+    epsilon: float = 0.0
+    detect_cycles: bool = True
+
+    def __post_init__(self) -> None:
+        if self.tile < 1 or self.bits < 2 or not 1 <= self.latent <= self.bits:
+            raise ValueError("invalid dimensions")
+        if self.iterations < 1:
+            raise ValueError("iterations must be >= 1")
+        if any(not 0.0 <= value <= 1.0 for value in (self.alpha, self.beta, self.omega_feedback)):
+            raise ValueError("alpha, beta and omega_feedback must be in [0,1]")
+        if self.epsilon < 0.0:
+            raise ValueError("epsilon must be >= 0")
+
+
+@dataclass(frozen=True)
+class Inward3DBitMetrics:
+    iteration: int
+    committed: bool
+    reconstruction_loss: float
+    self_reconstruction_loss: float
+    codec_cycle_loss: float
+    spatial_loss: float
+    latent_balance_loss: float
+    reality_gap: float
+    latent_reality_gap: float
+    coupling_gap: float
+    omega_density: float
+    changed_bits: int
+    latent_changed_bits: int
+    active_cells: int
+    fixed_point: bool
+    cycle_detected: bool
+    input_hash: str
+    candidate_hash: str
+    rejection_reason: str | None
+
+
+def hamming_fraction(left: int, right: int, width: int) -> float:
+    return (left ^ right).bit_count() / width if width else 0.0
+
+
+def _exact_mask(point: Coord, width: int, fraction: float, seed: int, channel: str) -> int:
+    """Select exactly round(fraction*width) deterministic bit positions per coordinate."""
+
+    count = round(fraction * width)
+    if count <= 0:
+        return 0
+    if count >= width:
+        return (1 << width) - 1
+
+    ranked: list[tuple[int, int]] = []
+    for bit in range(width):
+        payload = f"{seed}|{point[0]}|{point[1]}|{point[2]}|{channel}|{bit}".encode()
+        score = int.from_bytes(
+            hashlib.blake2b(payload, digest_size=8, person=b"DM-IN3D-MASK").digest(),
+            "little",
+        )
+        ranked.append((score, bit))
+    ranked.sort()
+
+    mask = 0
+    for _, bit in ranked[:count]:
+        mask |= 1 << bit
+    return mask
+
+
+def _volume_payload(volume: dict[Coord, int]) -> list[list[int]]:
+    return [[point[0], point[1], point[2], volume[point]] for point in sorted(volume)]
+
+
+def _authority_hash(
+    state: dict[Coord, int],
+    omega: dict[Coord, int],
+    latent: dict[Coord, int],
+) -> str:
+    return canonical_state_hash(
+        {
+            "state": _volume_payload(state),
+            "omega": _volume_payload(omega),
+            "latent": _volume_payload(latent),
+        }
+    )
+
+
+class Inward3DBitLoop:
+    """Finite 3D bit-volume recursion with atomic candidate publication."""
+
+    def __init__(
+        self,
+        config: Inward3DBitConfig | None = None,
+        *,
+        gate: Gate | None = None,
+    ) -> None:
+        self.c = config or Inward3DBitConfig()
+        # Tile consumes the compatible virtual-3D config surface. Only the
+        # attributes used by Tile are required here.
+        from .dr_moagi_virtual_3d_ae import Config as TileConfig
+
+        self.tile = Tile(
+            TileConfig(
+                tile=self.c.tile,
+                bits=self.c.bits,
+                latent=self.c.latent,
+                passes=max(1, self.c.iterations),
+                alpha=self.c.alpha,
+                beta=self.c.beta,
+                seed=self.c.seed,
+                origin=self.c.origin,
+                periodic=self.c.periodic,
+                epsilon=self.c.epsilon,
+            )
+        )
+        self.codec = Codec(self.c.bits, self.c.latent)
+        self.full = (1 << self.c.bits) - 1
+        self.gate = gate
+        self.original: dict[Coord, int] = {}
+        self.state: dict[Coord, int] = {}
+        self.omega: dict[Coord, int] = {}
+        self.latent: dict[Coord, int] = {}
+        self.iteration = 0
+        self._seen: set[str] = set()
+        self.materialize()
+
+    @property
+    def active_cells(self) -> int:
+        return len(self.tile)
+
+    def materialize(self) -> None:
+        self.original = {
+            point: stream(point, self.c.bits, self.c.seed) for point in self.tile.coords
+        }
+        self.state = dict(self.original)
+        self.omega = {point: 0 for point in self.tile.coords}
+        self.latent = self._coupled_latent(self.state)
+        self.iteration = 0
+        self._seen = {self.authority_hash()}
+
+    def snapshot(self) -> dict[Coord, int]:
+        return dict(self.state)
+
+    def omega_snapshot(self) -> dict[Coord, int]:
+        return dict(self.omega)
+
+    def latent_snapshot(self) -> dict[Coord, int]:
+        return dict(self.latent)
+
+    def authority_hash(self) -> str:
+        return _authority_hash(self.state, self.omega, self.latent)
+
+    def encode_state(self, state: dict[Coord, int] | None = None) -> dict[Coord, int]:
+        source = self.state if state is None else state
+        return {point: self.codec.encode(source[point]) for point in self.tile.coords}
+
+    def _coupled_latent(self, state: dict[Coord, int]) -> dict[Coord, int]:
+        raw = self.encode_state(state)
+        return couple(self.tile, raw, self.c.latent, self.c.alpha)
+
+    def decode_latent(self, latent: dict[Coord, int]) -> dict[Coord, int]:
+        return {point: self.codec.decode(latent[point]) for point in self.tile.coords}
+
+    def _next_omega(
+        self,
+        current: dict[Coord, int],
+        decoded: dict[Coord, int],
+    ) -> dict[Coord, int]:
+        # One-step residual memory. It remains part of the authoritative state
+        # and becomes stationary whenever the self-reconstruction residual does.
+        return {point: (current[point] ^ decoded[point]) & self.full for point in self.tile.coords}
+
+    def _feedback(
+        self,
+        current: dict[Coord, int],
+        decoded: dict[Coord, int],
+        omega: dict[Coord, int],
+    ) -> dict[Coord, int]:
+        out: dict[Coord, int] = {}
+        for point in self.tile.coords:
+            reconstruction_mask = _exact_mask(
+                point, self.c.bits, self.c.beta, self.c.seed, "reconstruction"
+            )
+            omega_mask = _exact_mask(
+                point, self.c.bits, self.c.omega_feedback, self.c.seed, "omega"
+            )
+            value = (
+                (current[point] & (self.full ^ reconstruction_mask))
+                | (decoded[point] & reconstruction_mask)
+            ) & self.full
+            if omega_mask:
+                value ^= omega[point] & omega_mask
+            out[point] = value & self.full
+        return out
+
+    def _valid_volume(self, volume: dict[Coord, int], width: int) -> bool:
+        if set(volume) != set(self.tile.coords):
+            return False
+        maximum = (1 << width) - 1
+        return all(
+            isinstance(value, int) and not isinstance(value, bool) and 0 <= value <= maximum
+            for value in volume.values()
+        )
+
+    def step(self) -> Inward3DBitMetrics:
+        current = dict(self.state)
+        current_omega = dict(self.omega)
+        previous_latent = dict(self.latent)
+        input_hash = _authority_hash(current, current_omega, previous_latent)
+
+        raw_latent = self.encode_state(current)
+        coupled_latent = couple(self.tile, raw_latent, self.c.latent, self.c.alpha)
+        decoded = self.decode_latent(coupled_latent)
+        next_omega = self._next_omega(current, decoded)
+        candidate = self._feedback(current, decoded, next_omega)
+        candidate_latent = self._coupled_latent(candidate)
+        candidate_hash = _authority_hash(candidate, next_omega, candidate_latent)
+
+        total_source_bits = len(self.tile) * self.c.bits
+        total_latent_bits = len(self.tile) * self.c.latent
+        reconstruction_loss = sum(
+            (self.original[point] ^ decoded[point]).bit_count() for point in self.tile.coords
+        ) / total_source_bits
+        self_reconstruction_loss = sum(
+            (current[point] ^ decoded[point]).bit_count() for point in self.tile.coords
+        ) / total_source_bits
+        codec_cycle_loss = sum(
+            self.codec.cycle_loss(coupled_latent[point]) for point in self.tile.coords
+        ) / len(self.tile)
+        changed_bits = sum(
+            (current[point] ^ candidate[point]).bit_count() for point in self.tile.coords
+        )
+        latent_changed_bits = sum(
+            (previous_latent[point] ^ candidate_latent[point]).bit_count()
+            for point in self.tile.coords
+        )
+        coupling_changed_bits = sum(
+            (raw_latent[point] ^ coupled_latent[point]).bit_count() for point in self.tile.coords
+        )
+        omega_bits = sum(value.bit_count() for value in next_omega.values())
+
+        reality_gap = changed_bits / total_source_bits
+        latent_gap = latent_changed_bits / total_latent_bits
+        coupling_gap = coupling_changed_bits / total_latent_bits
+        omega_density = omega_bits / total_source_bits
+        full_fixed = candidate_hash == input_hash
+        cycle_detected = self.c.detect_cycles and candidate_hash in self._seen and not full_fixed
+
+        rejection_reason: str | None = None
+        committed = True
+        if not self._valid_volume(candidate, self.c.bits):
+            committed = False
+            rejection_reason = "candidate state violates bit-width/coordinate contract"
+        elif not self._valid_volume(next_omega, self.c.bits):
+            committed = False
+            rejection_reason = "omega state violates bit-width/coordinate contract"
+        elif not self._valid_volume(candidate_latent, self.c.latent):
+            committed = False
+            rejection_reason = "latent state violates bit-width/coordinate contract"
+        elif self.gate is not None and not self.gate(candidate, next_omega):
+            committed = False
+            rejection_reason = "external gate rejected candidate"
+        elif cycle_detected:
+            committed = False
+            rejection_reason = "non-fixed recursive cycle detected"
+
+        fixed_point = committed and full_fixed and reality_gap <= self.c.epsilon
+        if committed:
+            self.state = candidate
+            self.omega = next_omega
+            self.latent = candidate_latent
+            self.iteration += 1
+            self._seen.add(candidate_hash)
+
+        return Inward3DBitMetrics(
+            iteration=self.iteration,
+            committed=committed,
+            reconstruction_loss=reconstruction_loss,
+            self_reconstruction_loss=self_reconstruction_loss,
+            codec_cycle_loss=codec_cycle_loss,
+            spatial_loss=spatial_loss(self.tile, coupled_latent, self.c.latent),
+            latent_balance_loss=latent_balance_loss(coupled_latent, self.c.latent),
+            reality_gap=reality_gap,
+            latent_reality_gap=latent_gap,
+            coupling_gap=coupling_gap,
+            omega_density=omega_density,
+            changed_bits=changed_bits,
+            latent_changed_bits=latent_changed_bits,
+            active_cells=len(self.tile),
+            fixed_point=fixed_point,
+            cycle_detected=cycle_detected,
+            input_hash=input_hash,
+            candidate_hash=candidate_hash,
+            rejection_reason=rejection_reason,
+        )
+
+    def run(self) -> Iterator[Inward3DBitMetrics]:
+        for _ in range(self.c.iterations):
+            metric = self.step()
+            yield metric
+            if not metric.committed or metric.fixed_point:
+                break
+
+    def summary(self, history: list[Inward3DBitMetrics]) -> dict[str, object]:
+        return {
+            "mode": "inward-recursive-3d-bit-ae-ad",
+            "active_cells": self.active_cells,
+            "source_bits": self.active_cells * self.c.bits,
+            "latent_bits": self.active_cells * self.c.latent,
+            "nominal_representation_ratio": self.c.bits / self.c.latent,
+            "alpha": self.c.alpha,
+            "beta": self.c.beta,
+            "omega_feedback": self.c.omega_feedback,
+            "iterations_committed": self.iteration,
+            "authority_hash": self.authority_hash(),
+            "final": asdict(history[-1]) if history else None,
+        }
+
+
+def _origin(value: str) -> Coord:
+    point = tuple(map(int, value.split(",")))
+    if len(point) != 3:
+        raise argparse.ArgumentTypeError("origin must be x,y,z")
+    return point[0], point[1], point[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tile", type=int, default=8)
+    parser.add_argument("--bits", type=int, default=64)
+    parser.add_argument("--latent", type=int, default=16)
+    parser.add_argument("--iterations", type=int, default=32)
+    parser.add_argument("--alpha", type=float, default=0.65)
+    parser.add_argument("--beta", type=float, default=0.50)
+    parser.add_argument("--omega-feedback", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--origin", type=_origin, default=(0, 0, 0))
+    parser.add_argument("--epsilon", type=float, default=0.0)
+    parser.add_argument("--no-periodic", action="store_true")
+    parser.add_argument("--no-cycle-detection", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    engine = Inward3DBitLoop(
+        Inward3DBitConfig(
+            tile=args.tile,
+            bits=args.bits,
+            latent=args.latent,
+            iterations=args.iterations,
+            alpha=args.alpha,
+            beta=args.beta,
+            omega_feedback=args.omega_feedback,
+            seed=args.seed,
+            origin=args.origin,
+            periodic=not args.no_periodic,
+            epsilon=args.epsilon,
+            detect_cycles=not args.no_cycle_detection,
+        )
+    )
+    history = list(engine.run())
+    for metric in history:
+        print(
+            f"t={metric.iteration:03d} "
+            f"commit={metric.committed} "
+            f"rec={metric.reconstruction_loss:.6f} "
+            f"self_rec={metric.self_reconstruction_loss:.6f} "
+            f"dX={metric.reality_gap:.6f} "
+            f"dZ={metric.latent_reality_gap:.6f} "
+            f"coupling={metric.coupling_gap:.6f} "
+            f"omega={metric.omega_density:.6f} "
+            f"fixed={metric.fixed_point} "
+            f"cycle={metric.cycle_detected}"
+        )
+    if args.json:
+        print(json.dumps(engine.summary(history), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/dr_moagi_virtual_3d_ae.py
+++ b/src/jarvisx/dr_moagi_virtual_3d_ae.py
@@ -1,140 +1,552 @@
-"""Sparse virtual 3D bitstream AE/AD with inward fixed-point feedback.
+"""Sparse virtual 3D bitstream AE/AD with bounded inward auto-optimization.
 
-The septillion^septillion value is a symbolic logical address-space contract;
-only a finite active tile is ever materialized.
+The enormous logical stream count is a virtual address-space contract. Only a finite
+active tile is materialized. The optimizer is deterministic and bounded: it searches
+a finite alpha/beta grid and commits a candidate only when the measured objective
+improves.
 """
-from __future__ import annotations
-import argparse, hashlib, json, math, random, time
-from dataclasses import dataclass, asdict
 
-Coord=tuple[int,int,int]
-LOGICAL_STREAM_COUNT="(10^24)^(10^24) = 10^(24 * 10^24)"
-VIRTUAL_SIDE_LENGTH="10^(8 * 10^24)"
-N6=((1,0,0),(-1,0,0),(0,1,0),(0,-1,0),(0,0,1),(0,0,-1))
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import random
+import time
+from dataclasses import asdict, dataclass, replace
+from typing import Iterable
+
+Coord = tuple[int, int, int]
+LOGICAL_STREAM_COUNT = "(10^24)^(10^24) = 10^(24 * 10^24)"
+VIRTUAL_SIDE_LENGTH = "10^(8 * 10^24)"
+N6 = ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+POSITIVE_3 = ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+
 
 @dataclass(frozen=True)
 class Config:
-    tile:int=8; bits:int=256; latent:int=32; passes:int=5
-    alpha:float=.35; beta:float=.65; curvature:float=1.; seed:int=1337
-    origin:Coord=(0,0,0); periodic:bool=True; epsilon:float=1e-3
-    def __post_init__(self):
-        if self.tile<1 or self.bits<2 or not 1<=self.latent<=self.bits or self.passes<1: raise ValueError("invalid dimensions")
-        if any(not 0<=x<=1 for x in (self.alpha,self.beta,self.curvature)): raise ValueError("alpha,beta,curvature must be in [0,1]")
-        if self.epsilon<0: raise ValueError("epsilon must be >= 0")
+    tile: int = 8
+    bits: int = 256
+    latent: int = 32
+    passes: int = 5
+    alpha: float = 0.65
+    beta: float = 0.65
+    curvature: float = 1.0
+    seed: int = 1337
+    origin: Coord = (0, 0, 0)
+    periodic: bool = True
+    epsilon: float = 1e-3
+    alpha_candidates: tuple[float, ...] = (0.55, 0.65, 0.80)
+    beta_candidates: tuple[float, ...] = (0.35, 0.50, 0.65, 0.80)
+    reconstruction_weight: float = 1.0
+    spatial_weight: float = 0.25
+    balance_weight: float = 0.25
+    stability_weight: float = 0.10
+
+    def __post_init__(self) -> None:
+        if self.tile < 1 or self.bits < 2 or not 1 <= self.latent <= self.bits:
+            raise ValueError("invalid dimensions")
+        if self.passes < 1:
+            raise ValueError("passes must be >= 1")
+        bounded = (self.alpha, self.beta, self.curvature, *self.alpha_candidates, *self.beta_candidates)
+        if any(not 0.0 <= value <= 1.0 for value in bounded):
+            raise ValueError("alpha, beta, curvature and candidates must be in [0, 1]")
+        if self.epsilon < 0.0:
+            raise ValueError("epsilon must be >= 0")
+        weights = (
+            self.reconstruction_weight,
+            self.spatial_weight,
+            self.balance_weight,
+            self.stability_weight,
+        )
+        if any(value < 0.0 for value in weights) or sum(weights) <= 0.0:
+            raise ValueError("objective weights must be non-negative with positive total")
+
 
 @dataclass(frozen=True)
 class Metrics:
-    pass_index:int; reconstruction_loss:float; cycle_loss:float; reality_gap:float
-    changed_bits:int; active_streams:int; seconds:float; updates_per_second:float
+    pass_index: int
+    reconstruction_loss: float
+    cycle_loss: float
+    reality_gap: float
+    changed_bits: int
+    active_streams: int
+    seconds: float
+    updates_per_second: float
+    spatial_loss: float
+    latent_balance_loss: float
+    objective: float
 
-def hd(a:int,b:int)->int:return (a^b).bit_count()
-def hf(a:int,b:int,n:int)->float:return hd(a,b)/n if n else 0.
 
-def stream(coord:Coord,n:int,seed:int)->int:
-    need=(n+7)//8; raw=bytearray(); k=0
-    while len(raw)<need:
-        p=f"{seed}|{coord[0]}|{coord[1]}|{coord[2]}|{k}".encode(); k+=1
-        raw.extend(hashlib.blake2b(p,digest_size=64,person=b"DM3D-AE-v1").digest())
-    return int.from_bytes(raw[:need],"little")&((1<<n)-1)
+@dataclass(frozen=True)
+class TuningResult:
+    baseline_alpha: float
+    baseline_beta: float
+    baseline_score: float
+    alpha: float
+    beta: float
+    score: float
+    reconstruction_loss: float
+    spatial_loss: float
+    latent_balance_loss: float
+    mean_reality_gap: float
+    passes: int
+    candidates_evaluated: int
+    improved: bool
 
-def feedback_mask(n:int,beta:float,seed:int)->int:
-    rng=random.Random(seed^0xD34D1A61); out=0
-    for b in rng.sample(range(n),round(beta*n)):out|=1<<b
+
+def hd(a: int, b: int) -> int:
+    return (a ^ b).bit_count()
+
+
+def hf(a: int, b: int, n: int) -> float:
+    return hd(a, b) / n if n else 0.0
+
+
+def stream(coord: Coord, n: int, seed: int) -> int:
+    need = (n + 7) // 8
+    raw = bytearray()
+    block = 0
+    while len(raw) < need:
+        payload = f"{seed}|{coord[0]}|{coord[1]}|{coord[2]}|{block}".encode()
+        block += 1
+        raw.extend(hashlib.blake2b(payload, digest_size=64, person=b"DM3D-AE-v1").digest())
+    return int.from_bytes(raw[:need], "little") & ((1 << n) - 1)
+
+
+def feedback_mask(n: int, beta: float, seed: int) -> int:
+    rng = random.Random(seed ^ 0xD34D1A61)
+    out = 0
+    for bit in rng.sample(range(n), round(beta * n)):
+        out |= 1 << bit
     return out
+
 
 class Codec:
-    def __init__(self,n:int,d:int):
-        self.n=n;self.d=d;self.full=(1<<n)-1; q,r=divmod(n,d);s=0;self.groups=[]
-        for j in range(d):
-            w=q+(j<r);m=((1<<w)-1)<<s;s+=w;self.groups.append((w,m))
-    def encode(self,x:int)->int:
-        z=0
-        for j,(w,m) in enumerate(self.groups):
-            if (x&m).bit_count()*2>=w:z|=1<<j
+    def __init__(self, n: int, d: int):
+        self.n = n
+        self.d = d
+        self.full = (1 << n) - 1
+        quotient, remainder = divmod(n, d)
+        shift = 0
+        self.groups: list[tuple[int, int]] = []
+        for index in range(d):
+            width = quotient + (index < remainder)
+            mask = ((1 << width) - 1) << shift
+            shift += width
+            self.groups.append((width, mask))
+
+    def encode(self, x: int) -> int:
+        z = 0
+        for index, (width, mask) in enumerate(self.groups):
+            if (x & mask).bit_count() * 2 >= width:
+                z |= 1 << index
         return z
-    def decode(self,z:int)->int:
-        x=0
-        for j,(_,m) in enumerate(self.groups):
-            if z>>j&1:x|=m
-        return x&self.full
-    def cycle_loss(self,z:int)->float:return hf(z,self.encode(self.decode(z)),self.d)
+
+    def decode(self, z: int) -> int:
+        x = 0
+        for index, (_, mask) in enumerate(self.groups):
+            if z >> index & 1:
+                x |= mask
+        return x & self.full
+
+    def cycle_loss(self, z: int) -> float:
+        return hf(z, self.encode(self.decode(z)), self.d)
+
 
 class Tile:
-    def __init__(self,c:Config):
-        self.c=c;ox,oy,oz=c.origin;n=c.tile
-        self.coords=[(ox+x,oy+y,oz+z) for z in range(n) for y in range(n) for x in range(n)]
-    def __len__(self):return len(self.coords)
-    def local(self,p):ox,oy,oz=self.c.origin;return p[0]-ox,p[1]-oy,p[2]-oz
-    def global_(self,p):ox,oy,oz=self.c.origin;return p[0]+ox,p[1]+oy,p[2]+oz
-    def neighbours(self,p):
-        x,y,z=self.local(p);n=self.c.tile;out=[]
-        for dx,dy,dz in N6:
-            q=(x+dx,y+dy,z+dz)
-            if self.c.periodic:out.append(self.global_((q[0]%n,q[1]%n,q[2]%n)))
-            elif all(0<=v<n for v in q):out.append(self.global_(q))
+    def __init__(self, config: Config):
+        self.c = config
+        ox, oy, oz = config.origin
+        n = config.tile
+        self.coords = [
+            (ox + x, oy + y, oz + z)
+            for z in range(n)
+            for y in range(n)
+            for x in range(n)
+        ]
+
+    def __len__(self) -> int:
+        return len(self.coords)
+
+    def local(self, point: Coord) -> Coord:
+        ox, oy, oz = self.c.origin
+        return point[0] - ox, point[1] - oy, point[2] - oz
+
+    def global_(self, point: Coord) -> Coord:
+        ox, oy, oz = self.c.origin
+        return point[0] + ox, point[1] + oy, point[2] + oz
+
+    def _offsets(self, point: Coord, offsets: Iterable[Coord]) -> list[Coord]:
+        x, y, z = self.local(point)
+        n = self.c.tile
+        out: list[Coord] = []
+        for dx, dy, dz in offsets:
+            q = (x + dx, y + dy, z + dz)
+            if self.c.periodic:
+                out.append(self.global_((q[0] % n, q[1] % n, q[2] % n)))
+            elif all(0 <= value < n for value in q):
+                out.append(self.global_(q))
         return out
 
-def couple(tile:Tile,Z:dict[Coord,int],d:int,a:float)->dict[Coord,int]:
-    if not a:return dict(Z)
-    out={}
-    for p in tile.coords:
-        ns=tile.neighbours(p);z=0
-        for j in range(d):
-            s=1 if Z[p]>>j&1 else -1
-            m=sum(1 if Z[q]>>j&1 else -1 for q in ns)/len(ns) if ns else s
-            if (1-a)*s+a*m>=0:z|=1<<j
-        out[p]=z
+    def neighbours(self, point: Coord) -> list[Coord]:
+        return self._offsets(point, N6)
+
+    def positive_neighbours(self, point: Coord) -> list[Coord]:
+        return self._offsets(point, POSITIVE_3)
+
+
+def couple(tile: Tile, latent: dict[Coord, int], d: int, alpha: float) -> dict[Coord, int]:
+    """Apply synchronous six-neighbour Ising-like coupling to each latent bit."""
+
+    if not alpha:
+        return dict(latent)
+
+    out: dict[Coord, int] = {}
+    for point in tile.coords:
+        neighbours = tile.neighbours(point)
+        z = 0
+        for bit in range(d):
+            current = 1 if latent[point] >> bit & 1 else -1
+            mean = (
+                sum(1 if latent[q] >> bit & 1 else -1 for q in neighbours) / len(neighbours)
+                if neighbours
+                else current
+            )
+            if (1.0 - alpha) * current + alpha * mean >= 0.0:
+                z |= 1 << bit
+        out[point] = z
     return out
 
-def embed(local:Coord,n:int,k:float,r:float=22.,ratio:float=1.)->tuple[float,float,float]:
-    if n<=1:x=y=z=0.
-    else:x,y,z=((v/(n-1))*2-1 for v in local)
-    if k<=1e-12:return x*r,y*r*.5,z*r*.5
-    th=x*math.pi*k;minor=2.5*max(.15,ratio)
-    return r*math.sin(th),y*8+math.cos(2*th)*1.5*k,-r*(1-math.cos(th))+z*minor
+
+def spatial_loss(tile: Tile, latent: dict[Coord, int], d: int) -> float:
+    """Mean latent Hamming disagreement along the positive x/y/z lattice edges."""
+
+    disagreements = 0
+    compared_bits = 0
+    for point in tile.coords:
+        for neighbour in tile.positive_neighbours(point):
+            disagreements += hd(latent[point], latent[neighbour])
+            compared_bits += d
+    return disagreements / compared_bits if compared_bits else 0.0
+
+
+def latent_balance_loss(latent: dict[Coord, int], d: int) -> float:
+    """Penalize all-zero/all-one latent collapse while preserving a 50/50 bit balance."""
+
+    total = len(latent) * d
+    if not total:
+        return 0.0
+    p = sum(value.bit_count() for value in latent.values()) / total
+    return 1.0 - 4.0 * p * (1.0 - p)
+
+
+def objective(
+    config: Config,
+    reconstruction: float,
+    spatial: float,
+    balance: float,
+    stability: float,
+) -> float:
+    return (
+        config.reconstruction_weight * reconstruction
+        + config.spatial_weight * spatial
+        + config.balance_weight * balance
+        + config.stability_weight * stability
+    )
+
+
+def embed(
+    local: Coord,
+    n: int,
+    curvature: float,
+    radius: float = 22.0,
+    ratio: float = 1.0,
+) -> tuple[float, float, float]:
+    if n <= 1:
+        x = y = z = 0.0
+    else:
+        x, y, z = ((value / (n - 1)) * 2.0 - 1.0 for value in local)
+    if curvature <= 1e-12:
+        return x * radius, y * radius * 0.5, z * radius * 0.5
+    theta = x * math.pi * curvature
+    minor = 2.5 * max(0.15, ratio)
+    return (
+        radius * math.sin(theta),
+        y * 8.0 + math.cos(2.0 * theta) * 1.5 * curvature,
+        -radius * (1.0 - math.cos(theta)) + z * minor,
+    )
+
 
 class DrMoagiVirtual3DAE:
-    def __init__(self,c:Config|None=None):
-        self.c=c or Config();self.tile=Tile(self.c);self.codec=Codec(self.c.bits,self.c.latent)
-        self.full=(1<<self.c.bits)-1;self.mask=feedback_mask(self.c.bits,self.c.beta,self.c.seed)
-        self.original={};self.state={};self.latent={};self.coupled={};self.decoded={}
+    def __init__(self, config: Config | None = None):
+        self.c = config or Config()
+        self.tuning: TuningResult | None = None
+        self.original: dict[Coord, int] = {}
+        self.state: dict[Coord, int] = {}
+        self.latent: dict[Coord, int] = {}
+        self.coupled: dict[Coord, int] = {}
+        self.decoded: dict[Coord, int] = {}
+        self._rebuild()
+
+    def _rebuild(self) -> None:
+        self.tile = Tile(self.c)
+        self.codec = Codec(self.c.bits, self.c.latent)
+        self.full = (1 << self.c.bits) - 1
+        self.mask = feedback_mask(self.c.bits, self.c.beta, self.c.seed)
+        self.original.clear()
+        self.state.clear()
+        self.latent.clear()
+        self.coupled.clear()
+        self.decoded.clear()
+
     @property
-    def active_streams(self):return len(self.tile)
-    def materialize(self):
-        for p in self.tile.coords:self.original[p]=self.state[p]=stream(p,self.c.bits,self.c.seed)
-    def run(self)->list[Metrics]:
-        if not self.state:self.materialize()
-        hist=[]
-        for k in range(self.c.passes):
-            t=time.perf_counter();self.latent={p:self.codec.encode(x) for p,x in self.state.items()}
-            self.coupled=couple(self.tile,self.latent,self.c.latent,self.c.alpha)
-            self.decoded={p:self.codec.decode(z) for p,z in self.coupled.items()}
-            rec=sum(hf(self.original[p],self.decoded[p],self.c.bits) for p in self.tile.coords)/len(self.tile)
-            cyc=sum(self.codec.cycle_loss(self.coupled[p]) for p in self.tile.coords)/len(self.tile)
-            nxt={};changed=0;anchor=self.full^self.mask
-            for p in self.tile.coords:
-                v=((self.original[p]&anchor)|(self.decoded[p]&self.mask))&self.full
-                changed+=hd(self.state[p],v);nxt[p]=v
-            self.state=nxt;gap=changed/(len(self.tile)*self.c.bits);dt=max(time.perf_counter()-t,1e-12)
-            hist.append(Metrics(k,rec,cyc,gap,changed,len(self.tile),dt,len(self.tile)/dt))
-            if gap<=self.c.epsilon:break
-        return hist
-    def geometry(self,count:int=6):
-        ratio=max(.15,(self.c.latent/self.c.bits)**(1/3));out=[]
-        for p in self.tile.coords[:count]:
-            q=self.tile.local(p);out.append({"virtual_coord":p,"input_position_3d":embed(q,self.c.tile,self.c.curvature),"latent_position_3d":embed(q,self.c.tile,self.c.curvature,22*ratio,ratio)})
+    def active_streams(self) -> int:
+        return len(self.tile)
+
+    def materialize(self) -> None:
+        for point in self.tile.coords:
+            value = stream(point, self.c.bits, self.c.seed)
+            self.original[point] = value
+            self.state[point] = value
+
+    def run(self) -> list[Metrics]:
+        if not self.state:
+            self.materialize()
+
+        history: list[Metrics] = []
+        for pass_index in range(self.c.passes):
+            started = time.perf_counter()
+            self.latent = {point: self.codec.encode(x) for point, x in self.state.items()}
+            self.coupled = couple(self.tile, self.latent, self.c.latent, self.c.alpha)
+            self.decoded = {point: self.codec.decode(z) for point, z in self.coupled.items()}
+
+            reconstruction = sum(
+                hf(self.original[point], self.decoded[point], self.c.bits)
+                for point in self.tile.coords
+            ) / len(self.tile)
+            cycle = sum(
+                self.codec.cycle_loss(self.coupled[point]) for point in self.tile.coords
+            ) / len(self.tile)
+            spatial = spatial_loss(self.tile, self.coupled, self.c.latent)
+            balance = latent_balance_loss(self.coupled, self.c.latent)
+
+            next_state: dict[Coord, int] = {}
+            changed = 0
+            anchor = self.full ^ self.mask
+            for point in self.tile.coords:
+                value = (
+                    (self.original[point] & anchor) | (self.decoded[point] & self.mask)
+                ) & self.full
+                changed += hd(self.state[point], value)
+                next_state[point] = value
+
+            self.state = next_state
+            gap = changed / (len(self.tile) * self.c.bits)
+            elapsed = max(time.perf_counter() - started, 1e-12)
+            score = objective(self.c, reconstruction, spatial, balance, gap)
+            history.append(
+                Metrics(
+                    pass_index=pass_index,
+                    reconstruction_loss=reconstruction,
+                    cycle_loss=cycle,
+                    reality_gap=gap,
+                    changed_bits=changed,
+                    active_streams=len(self.tile),
+                    seconds=elapsed,
+                    updates_per_second=len(self.tile) / elapsed,
+                    spatial_loss=spatial,
+                    latent_balance_loss=balance,
+                    objective=score,
+                )
+            )
+            if gap <= self.c.epsilon:
+                break
+        return history
+
+    def _score_history(self, history: list[Metrics]) -> tuple[float, float]:
+        if not history:
+            return math.inf, math.inf
+        mean_gap = sum(metric.reality_gap for metric in history) / len(history)
+        final = history[-1]
+        score = objective(
+            self.c,
+            final.reconstruction_loss,
+            final.spatial_loss,
+            final.latent_balance_loss,
+            mean_gap,
+        )
+        return score, mean_gap
+
+    def _evaluate(self, alpha: float, beta: float) -> tuple[float, float, list[Metrics]]:
+        candidate_config = replace(self.c, alpha=alpha, beta=beta)
+        candidate = DrMoagiVirtual3DAE(candidate_config)
+        history = candidate.run()
+        score, mean_gap = candidate._score_history(history)
+        return score, mean_gap, history
+
+    def optimize(self) -> TuningResult:
+        """Search a finite deterministic alpha/beta grid and commit only improvement."""
+
+        pairs = {(self.c.alpha, self.c.beta)}
+        pairs.update(
+            (alpha, beta)
+            for alpha in self.c.alpha_candidates
+            for beta in self.c.beta_candidates
+        )
+
+        evaluated: list[tuple[float, float, float, float, float, float, float, int]] = []
+        for alpha, beta in sorted(pairs):
+            score, mean_gap, history = self._evaluate(alpha, beta)
+            final = history[-1]
+            evaluated.append(
+                (
+                    score,
+                    final.reconstruction_loss,
+                    final.spatial_loss,
+                    final.latent_balance_loss,
+                    mean_gap,
+                    alpha,
+                    beta,
+                    len(history),
+                )
+            )
+
+        baseline = next(
+            row
+            for row in evaluated
+            if row[5] == self.c.alpha and row[6] == self.c.beta
+        )
+        best = min(evaluated, key=lambda row: (row[0], row[1], row[2], row[5], row[6]))
+        improved = best[0] < baseline[0] - 1e-12
+
+        chosen = best if improved else baseline
+        result = TuningResult(
+            baseline_alpha=self.c.alpha,
+            baseline_beta=self.c.beta,
+            baseline_score=baseline[0],
+            alpha=chosen[5],
+            beta=chosen[6],
+            score=chosen[0],
+            reconstruction_loss=chosen[1],
+            spatial_loss=chosen[2],
+            latent_balance_loss=chosen[3],
+            mean_reality_gap=chosen[4],
+            passes=chosen[7],
+            candidates_evaluated=len(evaluated),
+            improved=improved,
+        )
+
+        if improved:
+            self.c = replace(self.c, alpha=result.alpha, beta=result.beta)
+            self._rebuild()
+        self.tuning = result
+        return result
+
+    def geometry(self, count: int = 6) -> list[dict[str, object]]:
+        ratio = max(0.15, (self.c.latent / self.c.bits) ** (1.0 / 3.0))
+        out: list[dict[str, object]] = []
+        for point in self.tile.coords[:count]:
+            local = self.tile.local(point)
+            out.append(
+                {
+                    "virtual_coord": point,
+                    "input_position_3d": embed(local, self.c.tile, self.c.curvature),
+                    "latent_position_3d": embed(
+                        local,
+                        self.c.tile,
+                        self.c.curvature,
+                        22.0 * ratio,
+                        ratio,
+                    ),
+                }
+            )
         return out
-    def summary(self,h):
-        return {"logical_stream_universe":LOGICAL_STREAM_COUNT,"virtual_cube_side":VIRTUAL_SIDE_LENGTH,"active_streams":len(self.tile),"codec":[self.c.bits,self.c.latent,self.c.bits],"compression_ratio":self.c.bits/self.c.latent,"alpha":self.c.alpha,"beta":self.c.beta,"curvature":self.c.curvature,"passes":len(h),"final":asdict(h[-1]) if h else None,"geometry":self.geometry()}
 
-def _origin(s):
-    p=tuple(map(int,s.split(',')))
-    if len(p)!=3:raise argparse.ArgumentTypeError("origin must be x,y,z")
-    return p
+    def summary(self, history: list[Metrics]) -> dict[str, object]:
+        return {
+            "logical_stream_universe": LOGICAL_STREAM_COUNT,
+            "virtual_cube_side": VIRTUAL_SIDE_LENGTH,
+            "active_streams": len(self.tile),
+            "codec": [self.c.bits, self.c.latent, self.c.bits],
+            "compression_ratio": self.c.bits / self.c.latent,
+            "alpha": self.c.alpha,
+            "beta": self.c.beta,
+            "curvature": self.c.curvature,
+            "passes": len(history),
+            "tuning": asdict(self.tuning) if self.tuning else None,
+            "final": asdict(history[-1]) if history else None,
+            "geometry": self.geometry(),
+        }
 
-def main():
-    p=argparse.ArgumentParser();p.add_argument('--tile',type=int,default=8);p.add_argument('--bits',type=int,default=256);p.add_argument('--latent',type=int,default=32);p.add_argument('--passes',type=int,default=5);p.add_argument('--alpha',type=float,default=.35);p.add_argument('--beta',type=float,default=.65);p.add_argument('--curvature',type=float,default=1.);p.add_argument('--seed',type=int,default=1337);p.add_argument('--origin',type=_origin,default=(0,0,0));p.add_argument('--epsilon',type=float,default=1e-3);p.add_argument('--no-periodic',action='store_true');p.add_argument('--json',action='store_true');a=p.parse_args()
-    e=DrMoagiVirtual3DAE(Config(a.tile,a.bits,a.latent,a.passes,a.alpha,a.beta,a.curvature,a.seed,a.origin,not a.no_periodic,a.epsilon));h=e.run()
-    for m in h:print(f"pass={m.pass_index:02d} rec={m.reconstruction_loss:.6f} cycle={m.cycle_loss:.6f} gap={m.reality_gap:.6f} changed={m.changed_bits:,} updates/s={m.updates_per_second:,.0f}")
-    if a.json:print(json.dumps(e.summary(h),indent=2))
-if __name__=='__main__':main()
+
+def _origin(value: str) -> Coord:
+    point = tuple(map(int, value.split(",")))
+    if len(point) != 3:
+        raise argparse.ArgumentTypeError("origin must be x,y,z")
+    return point[0], point[1], point[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tile", type=int, default=8)
+    parser.add_argument("--bits", type=int, default=256)
+    parser.add_argument("--latent", type=int, default=32)
+    parser.add_argument("--passes", type=int, default=5)
+    parser.add_argument("--alpha", type=float, default=0.65)
+    parser.add_argument("--beta", type=float, default=0.65)
+    parser.add_argument("--curvature", type=float, default=1.0)
+    parser.add_argument("--seed", type=int, default=1337)
+    parser.add_argument("--origin", type=_origin, default=(0, 0, 0))
+    parser.add_argument("--epsilon", type=float, default=1e-3)
+    parser.add_argument("--no-periodic", action="store_true")
+    parser.add_argument("--auto-optimize", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    engine = DrMoagiVirtual3DAE(
+        Config(
+            tile=args.tile,
+            bits=args.bits,
+            latent=args.latent,
+            passes=args.passes,
+            alpha=args.alpha,
+            beta=args.beta,
+            curvature=args.curvature,
+            seed=args.seed,
+            origin=args.origin,
+            periodic=not args.no_periodic,
+            epsilon=args.epsilon,
+        )
+    )
+    if args.auto_optimize:
+        tuning = engine.optimize()
+        print(
+            "tune "
+            f"baseline={tuning.baseline_score:.6f} "
+            f"score={tuning.score:.6f} "
+            f"alpha={tuning.alpha:.3f} "
+            f"beta={tuning.beta:.3f} "
+            f"improved={tuning.improved}"
+        )
+
+    history = engine.run()
+    for metric in history:
+        print(
+            f"pass={metric.pass_index:02d} "
+            f"rec={metric.reconstruction_loss:.6f} "
+            f"cycle={metric.cycle_loss:.6f} "
+            f"spatial={metric.spatial_loss:.6f} "
+            f"balance={metric.latent_balance_loss:.6f} "
+            f"gap={metric.reality_gap:.6f} "
+            f"objective={metric.objective:.6f} "
+            f"changed={metric.changed_bits:,} "
+            f"updates/s={metric.updates_per_second:,.0f}"
+        )
+    if args.json:
+        print(json.dumps(engine.summary(history), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/empirical_validation_v2.py
+++ b/src/jarvisx/empirical_validation_v2.py
@@ -53,7 +53,7 @@ from .orthogonal_quantization import (
 def _candidate_contract_check() -> ValidationCheck:
     parent_hash = canonical_state_hash({"value": 1})
     candidate_hash = canonical_state_hash({"value": 2})
-    base = dict(
+    accepted_proposal = CandidateProposal(
         subsystem="empirical-fixture",
         candidate_id="candidate-1",
         operator_version="fixture-v1",
@@ -61,29 +61,25 @@ def _candidate_contract_check() -> ValidationCheck:
         candidate_state_hash=candidate_hash,
         objective_before=1.0,
         objective_after=0.5,
+        constraints=(ConstraintResult("finite", True),),
         resource_envelope=ResourceEnvelope(10, 10, 10),
         resource_usage=ResourceUsage(1, 1, 1),
     )
-    accepted = admit_candidate(
-        CandidateProposal(
-            **base,
-            constraints=(ConstraintResult("finite", True),),
-        )
+    rejected_proposal = CandidateProposal(
+        subsystem=accepted_proposal.subsystem,
+        candidate_id=accepted_proposal.candidate_id,
+        operator_version=accepted_proposal.operator_version,
+        parent_state_hash=accepted_proposal.parent_state_hash,
+        candidate_state_hash=accepted_proposal.candidate_state_hash,
+        objective_before=1.0,
+        objective_after=0.0,
+        constraints=(ConstraintResult("hard_guard", False),),
+        resource_envelope=accepted_proposal.resource_envelope,
+        resource_usage=accepted_proposal.resource_usage,
     )
-    rejected_base = dict(base)
-    rejected_base["objective_after"] = 0.0
-    rejected = admit_candidate(
-        CandidateProposal(
-            **rejected_base,
-            constraints=(ConstraintResult("hard_guard", False),),
-        )
-    )
-    repeated = admit_candidate(
-        CandidateProposal(
-            **base,
-            constraints=(ConstraintResult("finite", True),),
-        )
-    )
+    accepted = admit_candidate(accepted_proposal)
+    rejected = admit_candidate(rejected_proposal)
+    repeated = admit_candidate(accepted_proposal)
     passed = (
         accepted.decision is CandidateDecision.COMMIT
         and rejected.decision is CandidateDecision.ROLLBACK

--- a/src/jarvisx/empirical_validation_v2.py
+++ b/src/jarvisx/empirical_validation_v2.py
@@ -1,0 +1,402 @@
+"""System-wide empirical evidence for Jarvis-X canonical and adaptive invariants.
+
+Version 2 composes the original canonical validation harness with adaptive,
+transactional and precision checks. It remains deliberately bounded: passing
+this suite establishes the declared software invariants only, not intelligence,
+production safety, physical performance or superiority over external baselines.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import platform
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+from .candidate_adapters import virtual_3d_tuning_receipt
+from .candidate_contract import (
+    CandidateDecision,
+    CandidateProposal,
+    ConstraintResult,
+    ResourceEnvelope,
+    ResourceUsage,
+    admit_candidate,
+    canonical_state_hash,
+)
+from .dr_moagi_deep_distiller import (
+    DeepDistiller,
+    DeepDistillerConfig,
+    DeepDistillerTheta,
+)
+from .dr_moagi_field_runtime import (
+    DrMoagiFieldConfig,
+    DrMoagiFieldRuntime,
+    IdentityFieldCodec,
+)
+from .dr_moagi_virtual_3d_ae import Config as Virtual3DConfig
+from .dr_moagi_virtual_3d_ae import DrMoagiVirtual3DAE
+from .empirical_validation import (
+    ValidationCheck,
+    ValidationReport,
+    run_validation as run_core_validation,
+    write_report,
+)
+from .orthogonal_quantization import (
+    dct2_orthonormal_basis,
+    orthogonal_quantization_trace,
+)
+
+
+def _candidate_contract_check() -> ValidationCheck:
+    parent_hash = canonical_state_hash({"value": 1})
+    candidate_hash = canonical_state_hash({"value": 2})
+    base = dict(
+        subsystem="empirical-fixture",
+        candidate_id="candidate-1",
+        operator_version="fixture-v1",
+        parent_state_hash=parent_hash,
+        candidate_state_hash=candidate_hash,
+        objective_before=1.0,
+        objective_after=0.5,
+        resource_envelope=ResourceEnvelope(10, 10, 10),
+        resource_usage=ResourceUsage(1, 1, 1),
+    )
+    accepted = admit_candidate(
+        CandidateProposal(
+            **base,
+            constraints=(ConstraintResult("finite", True),),
+        )
+    )
+    rejected_base = dict(base)
+    rejected_base["objective_after"] = 0.0
+    rejected = admit_candidate(
+        CandidateProposal(
+            **rejected_base,
+            constraints=(ConstraintResult("hard_guard", False),),
+        )
+    )
+    repeated = admit_candidate(
+        CandidateProposal(
+            **base,
+            constraints=(ConstraintResult("finite", True),),
+        )
+    )
+    passed = (
+        accepted.decision is CandidateDecision.COMMIT
+        and rejected.decision is CandidateDecision.ROLLBACK
+        and accepted.verify()
+        and rejected.verify()
+        and accepted.receipt_hash == repeated.receipt_hash
+        and "constraint:hard_guard" in rejected.rejection_reasons
+    )
+    return ValidationCheck(
+        name="shared_candidate_admission_contract",
+        claim=(
+            "Jarvis-X candidate receipts are deterministic and hard constraints "
+            "cannot be overridden by a better objective."
+        ),
+        protocol=(
+            "Evaluate one admissible improving proposal twice and one larger-improvement "
+            "proposal that violates a hard constraint; verify deterministic hashes and "
+            "require the violating proposal to roll back."
+        ),
+        passed=passed,
+        metrics={
+            "accepted_decision": accepted.decision.value,
+            "rejected_decision": rejected.decision.value,
+            "deterministic_receipt": accepted.receipt_hash == repeated.receipt_hash,
+            "accepted_receipt_hash": accepted.receipt_hash,
+            "rejected_receipt_hash": rejected.receipt_hash,
+        },
+        boundary=(
+            "This validates the common software admission primitive. It does not prove "
+            "that every subsystem has already been migrated to the primitive."
+        ),
+    )
+
+
+def _field_runtime_check() -> ValidationCheck:
+    field = {(3, 3, 3): 0.75, (4, 3, 3): -0.25}
+    config = DrMoagiFieldConfig(
+        side=8,
+        alpha=1.0,
+        lambda_residual=0.1,
+        eta=0.1,
+        dt=0.02,
+        max_active_cells=64,
+    )
+    first = DrMoagiFieldRuntime(IdentityFieldCodec(), config)
+    second = DrMoagiFieldRuntime(IdentityFieldCodec(), config)
+    first.load(field)
+    second.load(dict(reversed(tuple(field.items()))))
+    first_metrics = first.step()
+    second_metrics = second.step()
+
+    rejected = DrMoagiFieldRuntime(IdentityFieldCodec(), config)
+    rejected.load(field)
+    before = rejected.snapshot()
+    rejection = rejected.step(validator=lambda candidate, metrics: False)
+
+    deterministic = first.snapshot() == second.snapshot() and first_metrics == second_metrics
+    rollback = not rejection.committed and rejected.snapshot() == before
+    bounded = first_metrics.support_cells <= config.max_active_cells
+    passed = deterministic and rollback and bounded and first_metrics.committed
+    return ValidationCheck(
+        name="field_runtime_candidate_transaction",
+        claim=(
+            "The sparse 3D field transition is deterministic, support-bounded and "
+            "retains the authoritative state when its candidate validator rejects."
+        ),
+        protocol=(
+            "Run one field step from identical states supplied in opposite insertion order, "
+            "compare metrics/state, then force validator rejection and require exact rollback."
+        ),
+        passed=passed,
+        metrics={
+            "deterministic": deterministic,
+            "rollback_atomic": rollback,
+            "support_cells": first_metrics.support_cells,
+            "max_active_cells": config.max_active_cells,
+            "reconstruction_mse": first_metrics.reconstruction_mse,
+            "anchor_mse": first_metrics.anchor_mse,
+        },
+        boundary=(
+            "The identity codec fixture verifies sparse transition semantics only; it does not "
+            "establish stability for arbitrary learned codecs or production-scale throughput."
+        ),
+    )
+
+
+def _deep_distiller_check() -> ValidationCheck:
+    field = {
+        (0, 0, 0): 1.0,
+        (1, 0, 0): 0.5,
+        (0, 1, 0): -0.25,
+    }
+    config = DeepDistillerConfig(
+        logical_side=8,
+        max_active_cells=16,
+        max_latent_cells=16,
+        max_iterations=8,
+        learning_rate=0.05,
+        omega_gain=0.25,
+        rho=0.5,
+    )
+    first = DeepDistiller(config, theta=DeepDistillerTheta(0.8, 0.8))
+    second = DeepDistiller(config, theta=DeepDistillerTheta(0.8, 0.8))
+    first.load(field)
+    second.load(field)
+    first_report = first.step()
+    second_report = second.step()
+    deterministic = (
+        first_report.committed
+        and second_report.committed
+        and first.snapshot() == second.snapshot()
+        and first.omega_snapshot() == second.omega_snapshot()
+        and first.theta == second.theta
+        and math.isclose(first_report.loss, second_report.loss, rel_tol=0.0, abs_tol=0.0)
+    )
+
+    rejecting = DeepDistiller(
+        config,
+        theta=DeepDistillerTheta(0.8, 0.8),
+        gate=lambda candidate: getattr(candidate, "latent_cells") == 0,
+    )
+    original_state = rejecting.load(field)
+    original_omega = rejecting.omega_snapshot()
+    original_theta = rejecting.theta
+    rejected_report = rejecting.step()
+    atomic = (
+        not rejected_report.committed
+        and rejecting.snapshot() == original_state
+        and rejecting.omega_snapshot() == original_omega
+        and rejecting.theta == original_theta
+    )
+    return ValidationCheck(
+        name="deep_distiller_atomic_adaptation",
+        claim=(
+            "DM-DD deterministically couples state, residual memory and learnable parameters, "
+            "and rolls all three back together when Pi_Lambda rejects a proposal."
+        ),
+        protocol=(
+            "Execute identical residual-learning steps in two fresh engines, compare state/memory/"
+            "parameters, then reject a proposal after initial admission and require tuple-level rollback."
+        ),
+        passed=deterministic and atomic,
+        metrics={
+            "deterministic": deterministic,
+            "atomic_rollback": atomic,
+            "residual_rms": first_report.residual_rms,
+            "encoder_gain_after": first.theta.encoder_gain,
+            "decoder_gain_after": first.theta.decoder_gain,
+            "rejected_iteration": rejected_report.iteration,
+        },
+        boundary=(
+            "This checks the bounded scalar-gain reference learner, not high-capacity neural model "
+            "quality or convergence for arbitrary adaptive codecs."
+        ),
+    )
+
+
+def _virtual_3d_optimizer_check() -> ValidationCheck:
+    config = Virtual3DConfig(
+        tile=3,
+        bits=24,
+        latent=6,
+        passes=4,
+        alpha=0.65,
+        beta=0.65,
+        alpha_candidates=(0.55, 0.65, 0.80),
+        beta_candidates=(0.35, 0.50, 0.65),
+        epsilon=0.0,
+    )
+    first_engine = DrMoagiVirtual3DAE(config)
+    first = first_engine.optimize()
+    second = DrMoagiVirtual3DAE(config).optimize()
+    receipt = virtual_3d_tuning_receipt(config, first)
+    repeated_receipt = virtual_3d_tuning_receipt(config, second)
+    history = first_engine.run()
+
+    expected = CandidateDecision.COMMIT if first.improved else CandidateDecision.ROLLBACK
+    passed = (
+        first == second
+        and first.score <= first.baseline_score
+        and receipt.decision is expected
+        and receipt.verify()
+        and receipt.receipt_hash == repeated_receipt.receipt_hash
+        and history[-1].reality_gap == 0.0
+    )
+    return ValidationCheck(
+        name="virtual_3d_optimizer_admission",
+        claim=(
+            "The virtual 3D AE search is deterministic, non-regressive, agrees with the shared "
+            "candidate-admission contract and preserves fixed-point closure."
+        ),
+        protocol=(
+            "Optimize the same bounded alpha/beta lattice twice, adapt the result into the global "
+            "candidate receipt, compare hashes/decisions and run the promoted engine to zero reality gap."
+        ),
+        passed=passed,
+        metrics={
+            "baseline_score": first.baseline_score,
+            "selected_score": first.score,
+            "selected_alpha": first.alpha,
+            "selected_beta": first.beta,
+            "candidates_evaluated": first.candidates_evaluated,
+            "receipt_decision": receipt.decision.value,
+            "receipt_hash": receipt.receipt_hash,
+            "final_reality_gap": history[-1].reality_gap,
+        },
+        boundary=(
+            "This is bounded scalar parameter search for a deterministic bitstream codec laboratory; "
+            "it does not establish gradient-trained representation learning or unrestricted self-modification."
+        ),
+    )
+
+
+def _orthogonal_precision_check() -> ValidationCheck:
+    values = (0.25, -0.75, 1.5, 0.125, -0.5, 0.9, 0.0, 0.33)
+    basis = dct2_orthonormal_basis(len(values))
+    trace = orthogonal_quantization_trace(values, basis, 0.125)
+    passed = (
+        trace.committed
+        and trace.gate_ratio <= 1.0 + 1.0e-12
+        and trace.orthogonality_error <= 1.0e-10
+        and trace.residual_norm <= trace.deterministic_bound + 1.0e-12
+    )
+    return ValidationCheck(
+        name="orthogonal_quantization_precision_gate",
+        claim=(
+            "The declared orthonormal transform obeys the deterministic nearest-neighbour "
+            "quantization error envelope before transpose-as-inverse reconstruction is admitted."
+        ),
+        protocol=(
+            "Build an 8-point orthonormal DCT-II basis, quantize with a fixed step and verify "
+            "orthogonality plus the spatial L2 residual bound."
+        ),
+        passed=passed,
+        metrics={
+            "dimension": len(values),
+            "orthogonality_error": trace.orthogonality_error,
+            "residual_norm": trace.residual_norm,
+            "deterministic_bound": trace.deterministic_bound,
+            "gate_ratio": trace.gate_ratio,
+        },
+        boundary=(
+            "This is a deterministic transform/quantization correctness check, not a production "
+            "video-codec benchmark or perceptual-quality claim."
+        ),
+    )
+
+
+def run_validation(
+    *,
+    repetitions: int = 64,
+    octree_max_depth: int = 6,
+) -> ValidationReport:
+    """Run core v1 evidence plus adaptive/system-wide v2 checks."""
+
+    core = run_core_validation(
+        repetitions=repetitions,
+        octree_max_depth=octree_max_depth,
+    )
+    checks = (
+        *core.checks,
+        _candidate_contract_check(),
+        _field_runtime_check(),
+        _deep_distiller_check(),
+        _virtual_3d_optimizer_check(),
+        _orthogonal_precision_check(),
+    )
+    return ValidationReport(
+        schema_version="jarvisx.empirical-validation.v2",
+        project="Jarvis-X",
+        commit=os.environ.get("GITHUB_SHA", "unknown"),
+        python_version=platform.python_version(),
+        platform=platform.platform(),
+        checks=checks,
+    )
+
+
+def _render_summary(report: ValidationReport) -> str:
+    lines = [
+        f"Jarvis-X empirical validation v2: {'PASS' if report.passed else 'FAIL'}",
+        f"Commit: {report.commit}",
+        f"Checks: {sum(check.passed for check in report.checks)}/{len(report.checks)}",
+    ]
+    lines.extend(
+        f"- {'PASS' if check.passed else 'FAIL'}: {check.name}" for check in report.checks
+    )
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/empirical-validation.json"),
+        help="JSON report destination",
+    )
+    parser.add_argument("--repetitions", type=int, default=64)
+    parser.add_argument("--octree-max-depth", type=int, default=6)
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    report = run_validation(
+        repetitions=args.repetitions,
+        octree_max_depth=args.octree_max_depth,
+    )
+    write_report(report, args.output)
+    print(_render_summary(report))
+    print(f"Evidence artifact: {args.output}")
+    return 0 if report.passed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/jarvisx/empirical_validation_v2.py
+++ b/src/jarvisx/empirical_validation_v2.py
@@ -36,6 +36,7 @@ from .dr_moagi_field_runtime import (
     DrMoagiFieldRuntime,
     IdentityFieldCodec,
 )
+from .dr_moagi_inward_3d_bits import Inward3DBitConfig, Inward3DBitLoop
 from .dr_moagi_virtual_3d_ae import Config as Virtual3DConfig
 from .dr_moagi_virtual_3d_ae import DrMoagiVirtual3DAE
 from .empirical_validation import (
@@ -293,6 +294,86 @@ def _virtual_3d_optimizer_check() -> ValidationCheck:
     )
 
 
+def _inward_3d_bits_check() -> ValidationCheck:
+    config = Inward3DBitConfig(
+        tile=3,
+        bits=24,
+        latent=6,
+        iterations=6,
+        alpha=0.65,
+        beta=0.50,
+        omega_feedback=0.0,
+        seed=1337,
+        epsilon=0.0,
+    )
+    first = Inward3DBitLoop(config)
+    second = Inward3DBitLoop(config)
+
+    first_step = first.step()
+    second_step = first.step()
+    mirror_first = second.step()
+    mirror_second = second.step()
+
+    deterministic = (
+        first_step == mirror_first
+        and second_step == mirror_second
+        and first.authority_hash() == second.authority_hash()
+    )
+    reentry = first_step.committed and second_step.input_hash == first_step.candidate_hash
+    bounded = (
+        first.active_cells == config.tile**3
+        and all(0 <= value < (1 << config.bits) for value in first.state.values())
+        and all(0 <= value < (1 << config.bits) for value in first.omega.values())
+        and all(0 <= value < (1 << config.latent) for value in first.latent.values())
+    )
+
+    rejecting = Inward3DBitLoop(config, gate=lambda candidate, omega: False)
+    before_state = rejecting.snapshot()
+    before_omega = rejecting.omega_snapshot()
+    before_latent = rejecting.latent_snapshot()
+    before_hash = rejecting.authority_hash()
+    rejected = rejecting.step()
+    atomic = (
+        not rejected.committed
+        and rejecting.snapshot() == before_state
+        and rejecting.omega_snapshot() == before_omega
+        and rejecting.latent_snapshot() == before_latent
+        and rejecting.authority_hash() == before_hash
+    )
+
+    passed = deterministic and reentry and bounded and atomic
+    return ValidationCheck(
+        name="inward_3d_bit_recursive_reentry",
+        claim=(
+            "The inward 3D bit AE/AD deterministically re-enters each committed full state as the "
+            "next encoder input, stays bit-width bounded and rolls back atomically on gate rejection."
+        ),
+        protocol=(
+            "Execute two inward steps in two fresh engines, require the first candidate authority hash "
+            "to equal the next iteration input hash, compare deterministic replay, verify finite 3D bit "
+            "bounds, then force an external rejection and require X/Omega/Z rollback."
+        ),
+        passed=passed,
+        metrics={
+            "deterministic": deterministic,
+            "recursive_reentry": reentry,
+            "atomic_rollback": atomic,
+            "active_cells": first.active_cells,
+            "source_bits": first.active_cells * config.bits,
+            "latent_bits": first.active_cells * config.latent,
+            "first_reality_gap": first_step.reality_gap,
+            "second_reality_gap": second_step.reality_gap,
+            "first_candidate_hash": first_step.candidate_hash,
+            "second_input_hash": second_step.input_hash,
+        },
+        boundary=(
+            "This establishes bounded deterministic self-reentry for the declared grouped-majority bit "
+            "codec. It does not prove universal convergence, learned representation quality or physical "
+            "realization of a large virtual address space."
+        ),
+    )
+
+
 def _orthogonal_precision_check() -> ValidationCheck:
     values = (0.25, -0.75, 1.5, 0.125, -0.5, 0.9, 0.0, 0.33)
     basis = dct2_orthonormal_basis(len(values))
@@ -345,6 +426,7 @@ def run_validation(
         _field_runtime_check(),
         _deep_distiller_check(),
         _virtual_3d_optimizer_check(),
+        _inward_3d_bits_check(),
         _orthogonal_precision_check(),
     )
     return ValidationReport(

--- a/tests/test_candidate_adapters.py
+++ b/tests/test_candidate_adapters.py
@@ -1,0 +1,40 @@
+from jarvisx.candidate_adapters import virtual_3d_tuning_receipt
+from jarvisx.candidate_contract import CandidateDecision
+from jarvisx.dr_moagi_virtual_3d_ae import Config, DrMoagiVirtual3DAE
+
+
+def _config():
+    return Config(
+        tile=3,
+        bits=24,
+        latent=6,
+        passes=4,
+        alpha=0.65,
+        beta=0.65,
+        alpha_candidates=(0.55, 0.65, 0.80),
+        beta_candidates=(0.35, 0.50, 0.65),
+    )
+
+
+def test_virtual_3d_optimizer_agrees_with_global_candidate_contract():
+    config = _config()
+    result = DrMoagiVirtual3DAE(config).optimize()
+    receipt = virtual_3d_tuning_receipt(config, result)
+
+    expected = CandidateDecision.COMMIT if result.improved else CandidateDecision.ROLLBACK
+    assert receipt.decision is expected
+    assert receipt.verify()
+    assert receipt.proposal.objective_after <= receipt.proposal.objective_before
+    assert receipt.proposal.resource_usage.work_units == result.candidates_evaluated
+
+
+def test_virtual_3d_receipt_is_deterministic():
+    config = _config()
+    first_result = DrMoagiVirtual3DAE(config).optimize()
+    second_result = DrMoagiVirtual3DAE(config).optimize()
+
+    first = virtual_3d_tuning_receipt(config, first_result)
+    second = virtual_3d_tuning_receipt(config, second_result)
+
+    assert first.receipt_hash == second.receipt_hash
+    assert first.to_dict() == second.to_dict()

--- a/tests/test_candidate_contract.py
+++ b/tests/test_candidate_contract.py
@@ -1,0 +1,87 @@
+from jarvisx.candidate_contract import (
+    AdmissionPolicy,
+    CandidateDecision,
+    CandidateProposal,
+    ConstraintResult,
+    ResourceEnvelope,
+    ResourceUsage,
+    admit_candidate,
+    canonical_state_hash,
+    normalize_metrics,
+)
+
+
+def _proposal(**overrides):
+    parent = canonical_state_hash({"state": [1, 2, 3]})
+    candidate = canonical_state_hash({"state": [1, 2, 4]})
+    values = dict(
+        subsystem="fixture",
+        candidate_id="candidate-001",
+        operator_version="fixture-v1",
+        parent_state_hash=parent,
+        candidate_state_hash=candidate,
+        objective_before=1.0,
+        objective_after=0.75,
+        metrics=normalize_metrics({"reconstruction": 0.2, "stability": 0.1}),
+        constraints=(ConstraintResult("finite", True),),
+        resource_envelope=ResourceEnvelope(100, 20, 1024),
+        resource_usage=ResourceUsage(10, 5, 128),
+    )
+    values.update(overrides)
+    return CandidateProposal(**values)
+
+
+def test_improving_admissible_candidate_commits_with_verifiable_receipt():
+    receipt = admit_candidate(_proposal())
+
+    assert receipt.decision is CandidateDecision.COMMIT
+    assert receipt.improvement == 0.25
+    assert receipt.rejection_reasons == ()
+    assert receipt.verify()
+    assert receipt.to_dict()["proposal"]["metrics"] == {
+        "reconstruction": 0.2,
+        "stability": 0.1,
+    }
+
+
+def test_hard_constraint_failure_cannot_be_bought_by_better_objective():
+    proposal = _proposal(
+        objective_after=0.0,
+        constraints=(ConstraintResult("anchor_drift", False, observed=0.2, limit=0.1),),
+    )
+    receipt = admit_candidate(proposal)
+
+    assert receipt.decision is CandidateDecision.ROLLBACK
+    assert "constraint:anchor_drift" in receipt.rejection_reasons
+    assert receipt.verify()
+
+
+def test_resource_overrun_rolls_back_even_when_objective_improves():
+    proposal = _proposal(resource_usage=ResourceUsage(101, 5, 128))
+    receipt = admit_candidate(proposal)
+
+    assert receipt.decision is CandidateDecision.ROLLBACK
+    assert receipt.rejection_reasons == ("resource:max_work_units",)
+
+
+def test_non_improving_candidate_rolls_back_deterministically():
+    proposal = _proposal(objective_after=1.0)
+    first = admit_candidate(proposal)
+    second = admit_candidate(proposal)
+
+    assert first.decision is CandidateDecision.ROLLBACK
+    assert first.receipt_hash == second.receipt_hash
+    assert first.rejection_reasons == ("objective:no_material_improvement",)
+
+
+def test_minimum_improvement_policy_is_enforced():
+    proposal = _proposal(objective_before=1.0, objective_after=0.95)
+    receipt = admit_candidate(proposal, policy=AdmissionPolicy(min_improvement=0.1))
+
+    assert receipt.decision is CandidateDecision.ROLLBACK
+
+
+def test_metric_normalization_is_order_invariant():
+    assert normalize_metrics({"b": 2.0, "a": 1.0}) == normalize_metrics(
+        [("a", 1.0), ("b", 2.0)]
+    )

--- a/tests/test_dr_moagi_inward_3d_bits.py
+++ b/tests/test_dr_moagi_inward_3d_bits.py
@@ -1,0 +1,104 @@
+from jarvisx.dr_moagi_inward_3d_bits import Inward3DBitConfig, Inward3DBitLoop
+
+
+def _config(**overrides):
+    values = dict(
+        tile=3,
+        bits=24,
+        latent=6,
+        iterations=8,
+        alpha=0.65,
+        beta=0.50,
+        omega_feedback=0.0,
+        seed=1337,
+        epsilon=0.0,
+    )
+    values.update(overrides)
+    return Inward3DBitConfig(**values)
+
+
+def test_inward_loop_reenters_committed_state_on_next_iteration():
+    engine = Inward3DBitLoop(_config())
+    initial = engine.snapshot()
+
+    first = engine.step()
+
+    assert first.committed
+    assert engine.snapshot() != initial
+    committed_hash = engine.authority_hash()
+
+    second = engine.step()
+
+    assert second.input_hash == committed_hash
+    assert second.active_cells == 27
+
+
+def test_inward_loop_is_deterministic_across_fresh_engines():
+    config = _config(iterations=6)
+
+    first_engine = Inward3DBitLoop(config)
+    second_engine = Inward3DBitLoop(config)
+    first = list(first_engine.run())
+    second = list(second_engine.run())
+
+    assert first == second
+    assert first_engine.snapshot() == second_engine.snapshot()
+    assert first_engine.omega_snapshot() == second_engine.omega_snapshot()
+    assert first_engine.latent_snapshot() == second_engine.latent_snapshot()
+    assert first_engine.authority_hash() == second_engine.authority_hash()
+
+
+def test_external_gate_rejection_is_atomic():
+    engine = Inward3DBitLoop(_config(), gate=lambda candidate, omega: False)
+    before_state = engine.snapshot()
+    before_omega = engine.omega_snapshot()
+    before_latent = engine.latent_snapshot()
+    before_hash = engine.authority_hash()
+
+    report = engine.step()
+
+    assert not report.committed
+    assert report.rejection_reason == "external gate rejected candidate"
+    assert engine.snapshot() == before_state
+    assert engine.omega_snapshot() == before_omega
+    assert engine.latent_snapshot() == before_latent
+    assert engine.authority_hash() == before_hash
+    assert engine.iteration == 0
+
+
+def test_full_fixed_point_includes_residual_memory_not_only_x_gap():
+    engine = Inward3DBitLoop(_config(beta=0.0, iterations=4))
+
+    first = engine.step()
+    second = engine.step()
+
+    assert first.committed
+    assert first.reality_gap == 0.0
+    assert not first.fixed_point
+    assert second.committed
+    assert second.reality_gap == 0.0
+    assert second.fixed_point
+
+
+def test_all_materialized_states_remain_within_declared_bit_widths():
+    engine = Inward3DBitLoop(_config(omega_feedback=0.25))
+
+    history = list(engine.run())
+
+    assert history
+    assert engine.active_cells == engine.c.tile**3
+    assert all(0 <= value < (1 << engine.c.bits) for value in engine.state.values())
+    assert all(0 <= value < (1 << engine.c.bits) for value in engine.omega.values())
+    assert all(0 <= value < (1 << engine.c.latent) for value in engine.latent.values())
+
+
+def test_summary_separates_source_and_latent_extent():
+    engine = Inward3DBitLoop(_config(tile=2, bits=16, latent=4, iterations=2))
+    history = list(engine.run())
+    summary = engine.summary(history)
+
+    assert summary["active_cells"] == 8
+    assert summary["source_bits"] == 128
+    assert summary["latent_bits"] == 32
+    assert summary["nominal_representation_ratio"] == 4.0
+    assert summary["mode"] == "inward-recursive-3d-bit-ae-ad"

--- a/tests/test_dr_moagi_virtual_3d_ae_optimization.py
+++ b/tests/test_dr_moagi_virtual_3d_ae_optimization.py
@@ -1,0 +1,95 @@
+from jarvisx.dr_moagi_virtual_3d_ae import (
+    Config,
+    DrMoagiVirtual3DAE,
+    Tile,
+    couple,
+    latent_balance_loss,
+)
+
+
+def test_default_spatial_coupling_is_in_active_regime():
+    assert Config().alpha > 0.5
+
+
+def test_six_neighbour_coupling_can_flip_surrounded_latent_bit():
+    config = Config(tile=3, bits=12, latent=1, alpha=0.65, beta=0.5)
+    tile = Tile(config)
+    latent = {point: 0 for point in tile.coords}
+    center = (1, 1, 1)
+    latent[center] = 1
+
+    coupled = couple(tile, latent, d=1, alpha=config.alpha)
+
+    assert coupled[center] == 0
+
+
+def test_latent_balance_penalty_rejects_collapse():
+    balanced = {(0, 0, 0): 0b01, (1, 0, 0): 0b10}
+    collapsed = {(0, 0, 0): 0, (1, 0, 0): 0}
+
+    assert latent_balance_loss(balanced, 2) == 0.0
+    assert latent_balance_loss(collapsed, 2) == 1.0
+
+
+def test_bounded_optimizer_is_deterministic_and_non_regressive():
+    config = Config(
+        tile=3,
+        bits=24,
+        latent=6,
+        passes=4,
+        alpha=0.65,
+        beta=0.65,
+        alpha_candidates=(0.55, 0.65, 0.80),
+        beta_candidates=(0.35, 0.50, 0.65),
+    )
+
+    first = DrMoagiVirtual3DAE(config)
+    first_result = first.optimize()
+    second_result = DrMoagiVirtual3DAE(config).optimize()
+
+    assert first_result == second_result
+    assert first_result.score <= first_result.baseline_score
+    assert first.c.alpha == first_result.alpha
+    assert first.c.beta == first_result.beta
+    assert first_result.candidates_evaluated == 9
+
+
+def test_optimized_engine_still_reaches_fixed_point():
+    config = Config(
+        tile=3,
+        bits=24,
+        latent=6,
+        passes=4,
+        alpha=0.65,
+        beta=0.65,
+        alpha_candidates=(0.55, 0.65),
+        beta_candidates=(0.35, 0.65),
+        epsilon=0.0,
+    )
+    engine = DrMoagiVirtual3DAE(config)
+    tuning = engine.optimize()
+    history = engine.run()
+
+    assert tuning.score <= tuning.baseline_score
+    assert history[-1].reality_gap == 0.0
+    assert history[-1].changed_bits == 0
+
+
+def test_summary_exposes_optimization_provenance():
+    engine = DrMoagiVirtual3DAE(
+        Config(
+            tile=2,
+            bits=16,
+            latent=4,
+            passes=3,
+            alpha_candidates=(0.55, 0.65),
+            beta_candidates=(0.35, 0.65),
+        )
+    )
+    engine.optimize()
+    summary = engine.summary(engine.run())
+
+    assert summary["tuning"] is not None
+    assert summary["tuning"]["candidates_evaluated"] == 4
+    assert summary["alpha"] == engine.c.alpha
+    assert summary["beta"] == engine.c.beta

--- a/tests/test_empirical_validation_v2.py
+++ b/tests/test_empirical_validation_v2.py
@@ -1,0 +1,18 @@
+from jarvisx.empirical_validation_v2 import run_validation
+
+
+def test_v2_empirical_validation_aggregates_core_and_adaptive_evidence():
+    report = run_validation(repetitions=2, octree_max_depth=1)
+    names = {check.name for check in report.checks}
+
+    assert report.schema_version == "jarvisx.empirical-validation.v2"
+    assert len(report.checks) == 10
+    assert report.passed
+    assert {
+        "vm_deterministic_replay",
+        "shared_candidate_admission_contract",
+        "field_runtime_candidate_transaction",
+        "deep_distiller_atomic_adaptation",
+        "virtual_3d_optimizer_admission",
+        "orthogonal_quantization_precision_gate",
+    } <= names

--- a/tests/test_empirical_validation_v2.py
+++ b/tests/test_empirical_validation_v2.py
@@ -6,7 +6,7 @@ def test_v2_empirical_validation_aggregates_core_and_adaptive_evidence():
     names = {check.name for check in report.checks}
 
     assert report.schema_version == "jarvisx.empirical-validation.v2"
-    assert len(report.checks) == 10
+    assert len(report.checks) == 11
     assert report.passed
     assert {
         "vm_deterministic_replay",
@@ -14,5 +14,6 @@ def test_v2_empirical_validation_aggregates_core_and_adaptive_evidence():
         "field_runtime_candidate_transaction",
         "deep_distiller_atomic_adaptation",
         "virtual_3d_optimizer_admission",
+        "inward_3d_bit_recursive_reentry",
         "orthogonal_quantization_precision_gate",
     } <= names


### PR DESCRIPTION
## Summary

Refines the sparse virtual 3D bitstream AE/AD into an auditable system-wide 3D integration: active neighbour coupling, bounded auto-optimization, a shared candidate admission/receipt contract, an inward recursive `(X, Omega, Z)` bit-state loop, and Empirical Validation v2.

## 1. Virtual 3D AE/AD refinement

- move six-neighbour coupling into an active default regime (`alpha=0.65`), fixing the mathematically inert default below the `alpha=0.5` threshold;
- add spatial disagreement telemetry and latent-collapse/balance penalty;
- score candidates with `J = L_rec + 0.25 L_spatial + 0.25 L_balance + 0.10 mean(Delta)`;
- perform deterministic bounded Cartesian search over `(alpha, beta)` with stable tie-breaking;
- commit tuned parameters only for material objective improvement and rebuild transient state after promotion;
- expose tuning provenance through CLI/JSON and retain fixed-point regression coverage.

## 2. Inward recursive 3D bit AE/AD

Adds `jarvisx.dr_moagi_inward_3d_bits` with the actual self-reentry recurrence:

`X_t -> E -> C_3D -> D -> X_hat_t -> feedback -> X_{t+1} -> E -> ...`

The important authority change is that feedback preserves unselected bits from `X_t`, not the original `X_0`:

`X_{t+1} = (X_t & ~M_beta) | (X_hat_t & M_beta)`

with optional bounded residual-memory injection from `Omega_{t+1} = X_t XOR X_hat_t`.

The authoritative tuple is `(X, Omega, Z)`. Every step computes the complete candidate before publication, validates coordinate/bit-width contracts plus any external gate, hashes the full state deterministically, and commits atomically. A repeated non-current authority hash is classified as a non-fixed synchronous cycle and is rejected rather than reported as convergence.

Telemetry separates source reconstruction, self-reconstruction, codec-cycle consistency, 3D spatial disagreement, latent balance, `Delta_X`, `Delta_Z`, coupling change and residual-memory density.

## 3. Shared candidate admission contract

Adds `jarvisx.candidate_contract` with the backend-neutral authority boundary:

`parent state -> candidate -> hard constraints/resource projection -> objective gate -> COMMIT/ROLLBACK -> deterministic receipt`

The receipt binds subsystem/candidate/operator identity, parent/candidate state hashes, objective before/after, component metrics, hard-constraint results, declared resource envelope and observed usage, decision/rejection reasons, and a deterministic SHA-256 receipt hash. Hard constraints are separate from objective scoring and cannot be compensated for by a better scalar score.

ADR-013 records this repository-wide direction.

## 4. Empirical Validation v2

The retained evidence artifact now contains 11 falsifiable checks:

1. deterministic VM replay;
2. Omega journal tamper detection;
3. sparse billion-address transactionality;
4. fractal closed-form geometry;
5. fractional smoothing invariants;
6. shared candidate admission and hard-constraint precedence;
7. Dr Moagi Field Runtime determinism/bounded rollback;
8. DM-DD state/Omega/Theta atomic adaptation;
9. virtual-3D optimizer/shared-receipt agreement plus fixed-point closure;
10. inward 3D bit recursive re-entry, finite bit bounds and atomic `(X, Omega, Z)` rollback;
11. orthogonal quantization precision bound.

For check 10, the first committed candidate authority hash must equal the next iteration input hash, directly verifying that the decoded/feedback state has turned inward and re-entered its encoder.

## Documentation

- `docs/DR_MOAGI_VIRTUAL_3D_AE_OPTIMIZATION.md`
- `docs/DR_MOAGI_INWARD_3D_BITS.md`
- `docs/EMPIRICAL_VALIDATION.md`
- `docs/PROJECT_STATUS.md`
- `docs/adr/0013-shared-candidate-admission-contract.md`

## Validation

Current head: `729a7376abf48a6430395e752c909ea57850bc2a`

- Jarvis-X CI: PASS;
- Python 3.10, 3.11, 3.12 and 3.13 test matrix: PASS;
- compile / undefined-name / formatting / import-order / mypy quality gate: PASS;
- package build, metadata validation and wheel smoke test: PASS;
- dependency audit: PASS;
- Empirical Validation v2 (11 checks): PASS;
- CodeQL: PASS.

During validation, mypy identified two `Any`-return boundary leaks in the new inward module. They were corrected with explicit typed casts at the imported shared-hash/coupling boundaries before this green head was accepted.

## Capability boundary

This remains alpha research software. The inward loop demonstrates deterministic recursive bit-state dynamics and transactional self-reentry; it does not establish universal convergence, gradient-trained representation learning, AGI, hostile-code isolation, unrestricted source-code self-rewriting, or physical allocation of the symbolic virtual address space.

## Repository governance follow-up

`main` remains unprotected. Issue #49 remains the repository-administration closure: protect `main` and require Jarvis-X CI, Empirical Validation and CodeQL before merge.