### PR TITLE
feat: permeate Dr Moagi 3D continuum kernel

### DIFF
--- a/docs/DR_MOAGI_CONTINUUM_KERNEL.md
+++ b/docs/DR_MOAGI_CONTINUUM_KERNEL.md
@@ -1,0 +1,157 @@
+# Dr. Moagi 3D Continuum Kernel
+
+## Canonical state equation
+
+The runtime kernel operationalizes
+
+\[
+\Psi(t)=\int_{\Omega}\left(\Phi_{\mathrm{in}}(\mathbf r,t)\otimes
+\Lambda_{\mathrm{in}}^{-1}(\mathbf r,t)\right)e^{-\gamma t}\,d\Omega
++\Theta_{\mathrm{core}}.
+\]
+
+For the executable 3D reference implementation, the operator product is made explicit as
+
+\[
+\Lambda_v^{+}\Phi_v,
+\]
+
+where \(\Lambda_v^{+}\) is a regularized left pseudoinverse. This avoids an undefined literal inverse when a voxel transform is singular or ill-conditioned.
+
+## Discrete 3D form
+
+For active voxels \(v=1,\ldots,N\) with voxel volume \(\Delta V\),
+
+\[
+\boxed{
+\Psi(t)=\Theta_{\mathrm{core}}+
+ e^{-\gamma t}\Delta V
+ \sum_{v=1}^{N}\Lambda_v^{+}\Phi_v
+}
+\]
+
+with
+
+\[
+\Lambda_v^{+}
+=
+\left(\Lambda_v^T\Lambda_v+\epsilon I\right)^{-1}\Lambda_v^T,
+\qquad \epsilon>0.
+\]
+
+The state is three-dimensional:
+
+\[
+\Phi_v,\Psi,\Theta_{\mathrm{core}}\in\mathbb R^3,
+\qquad
+\Lambda_v\in\mathbb R^{3\times3}.
+\]
+
+## Runtime map
+
+The implementation lives in `src/jarvisx/moagi_continuum.py` and exposes:
+
+- `ContinuumConfig`: \(\gamma\), \(\Delta V\), and regularization \(\epsilon\).
+- `regularized_pseudoinverse`: stable \(3\times3\) inverse operator.
+- `continuum_step`: one complete domain integration.
+- `homogeneous_recurrence`: inward recursive state evolution.
+
+No NumPy dependency is required by the core implementation.
+
+## Inward recurrence
+
+For recursive execution, the output becomes the next global state:
+
+\[
+\Psi_{k+1}=\mathcal M(\Psi_k).
+\]
+
+The reference homogeneous field broadcasts a voxel-count-normalized state,
+
+\[
+\Phi_{v,k}=\frac{\Psi_k}{N},
+\]
+
+therefore
+
+\[
+\boxed{
+\Psi_{k+1}
+=
+\Theta_{\mathrm{core}}
++
+e^{-\gamma\Delta t}\frac{\Delta V}{N}
+\sum_{v=1}^{N}\Lambda_v^{+}\Psi_k
+}
+\]
+
+and a fixed point satisfies
+
+\[
+\boxed{\Psi^*=\mathcal M(\Psi^*)}.
+\]
+
+The normalization prevents the recurrence gain from increasing solely because the active sparse tile contains more voxels.
+
+## Stability condition
+
+Define
+
+\[
+A=
+e^{-\gamma\Delta t}\frac{\Delta V}{N}
+\sum_{v=1}^{N}\Lambda_v^{+}.
+\]
+
+Then
+
+\[
+\Psi_{k+1}=A\Psi_k+\Theta_{\mathrm{core}}.
+\]
+
+A sufficient convergence condition is
+
+\[
+\rho(A)<1,
+\]
+
+where \(\rho(A)\) is the spectral radius. Under that condition,
+
+\[
+\Psi^*=(I-A)^{-1}\Theta_{\mathrm{core}}.
+\]
+
+This connects the continuum kernel directly to the Jarvis-X fixed-point integrity contract.
+
+## Verification
+
+`tests/test_moagi_continuum.py` verifies:
+
+1. the single-voxel arithmetic form;
+2. discrete voxel-volume integration;
+3. singular-transform regularization;
+4. damping toward `Theta_core`;
+5. a contractive inward recurrence; and
+6. field-shape validation.
+
+## Relationship to the virtual 3D AE/AD runtime
+
+`dr_moagi_virtual_3d_ae.py` remains the bitwise sparse auto-encoding/decoding implementation. The continuum kernel is a continuous-valued state-transition primitive that can sit before, after, or around that codec without changing the codec's deterministic bitstream contract.
+
+The intended composition is
+
+\[
+\text{3D input field}
+\rightarrow \mathcal E
+\rightarrow \Phi
+\rightarrow \mathcal M_{\mathrm{continuum}}
+\rightarrow \Psi
+\rightarrow \mathcal D
+\rightarrow \widehat X,
+\]
+
+with the recursive path
+
+\[
+\Psi_k\rightarrow\mathcal M_{\mathrm{continuum}}\rightarrow\Psi_{k+1}.
+\]

--- a/src/jarvisx/dr_moagi_virtual_3d_ae.py
+++ b/src/jarvisx/dr_moagi_virtual_3d_ae.py
@@ -97,7 +97,7 @@ class DrMoagiVirtual3DAE:
     def __init__(self,c:Config|None=None):
         self.c=c or Config();self.tile=Tile(self.c);self.codec=Codec(self.c.bits,self.c.latent)
         self.full=(1<<self.c.bits)-1;self.mask=feedback_mask(self.c.bits,self.c.beta,self.c.seed)
-        self.original={};self.state={};self.latent={};self.coupled={};self.decoded={}
+        self.original:dict[Coord,int]={};self.state:dict[Coord,int]={};self.latent:dict[Coord,int]={};self.coupled:dict[Coord,int]={};self.decoded:dict[Coord,int]={}
     @property
     def active_streams(self):return len(self.tile)
     def materialize(self):

--- a/src/jarvisx/moagi_continuum.py
+++ b/src/jarvisx/moagi_continuum.py
@@ -1,0 +1,166 @@
+"""Dr. Moagi 3D continuum integration kernel.
+
+Implements the discrete operational form
+
+    Psi(t) = exp(-gamma*t) * dV * sum_v Lambda_v^+ Phi_v + Theta_core
+
+where each voxel carries a 3-vector ``Phi_v`` and a 3x3 transform
+``Lambda_v``. ``Lambda_v^+`` is represented by a Tikhonov-regularized
+left pseudoinverse so singular or nearly singular transforms remain numerically
+well-defined without adding a NumPy runtime dependency.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+Vector3 = tuple[float, float, float]
+Matrix3 = tuple[Vector3, Vector3, Vector3]
+
+
+@dataclass(frozen=True)
+class ContinuumConfig:
+    gamma: float = 0.2
+    voxel_volume: float = 1.0
+    inverse_epsilon: float = 1e-6
+
+    def __post_init__(self) -> None:
+        if self.gamma < 0.0:
+            raise ValueError("gamma must be >= 0")
+        if self.voxel_volume <= 0.0:
+            raise ValueError("voxel_volume must be > 0")
+        if self.inverse_epsilon <= 0.0:
+            raise ValueError("inverse_epsilon must be > 0")
+
+
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return float(sum(x * y for x, y in zip(a, b)))
+
+
+def _transpose(m: Matrix3) -> Matrix3:
+    return (
+        (m[0][0], m[1][0], m[2][0]),
+        (m[0][1], m[1][1], m[2][1]),
+        (m[0][2], m[1][2], m[2][2]),
+    )
+
+
+def _matmul(a: Matrix3, b: Matrix3) -> Matrix3:
+    bt = _transpose(b)
+    return tuple(tuple(_dot(row, col) for col in bt) for row in a)  # type: ignore[return-value]
+
+
+def _matvec(m: Matrix3, v: Vector3) -> Vector3:
+    return tuple(_dot(row, v) for row in m)  # type: ignore[return-value]
+
+
+def _inverse3(m: Matrix3) -> Matrix3:
+    a, b, c = m[0]
+    d, e, f = m[1]
+    g, h, i = m[2]
+    det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g)
+    if abs(det) <= 1e-18:
+        raise ValueError("matrix is singular")
+    inv_det = 1.0 / det
+    return (
+        ((e * i - f * h) * inv_det, (c * h - b * i) * inv_det, (b * f - c * e) * inv_det),
+        ((f * g - d * i) * inv_det, (a * i - c * g) * inv_det, (c * d - a * f) * inv_det),
+        ((d * h - e * g) * inv_det, (b * g - a * h) * inv_det, (a * e - b * d) * inv_det),
+    )
+
+
+def regularized_pseudoinverse(m: Matrix3, epsilon: float = 1e-6) -> Matrix3:
+    """Return ``(M^T M + epsilon I)^-1 M^T`` for a 3x3 transform."""
+    if epsilon <= 0.0:
+        raise ValueError("epsilon must be > 0")
+    mt = _transpose(m)
+    gram = _matmul(mt, m)
+    regularized: Matrix3 = (
+        (gram[0][0] + epsilon, gram[0][1], gram[0][2]),
+        (gram[1][0], gram[1][1] + epsilon, gram[1][2]),
+        (gram[2][0], gram[2][1], gram[2][2] + epsilon),
+    )
+    return _matmul(_inverse3(regularized), mt)
+
+
+def continuum_step(
+    phi_field: Iterable[Vector3],
+    lambda_field: Iterable[Matrix3],
+    theta_core: Vector3,
+    t: float,
+    config: ContinuumConfig | None = None,
+) -> Vector3:
+    """Evaluate one discrete 3D continuum integration step.
+
+    ``phi_field`` and ``lambda_field`` must contain the same number of voxels.
+    The tensor/operator product is concretized as ``Lambda_v^+ @ Phi_v``.
+    """
+    cfg = config or ContinuumConfig()
+    if t < 0.0:
+        raise ValueError("t must be >= 0")
+
+    phis = tuple(phi_field)
+    lambdas = tuple(lambda_field)
+    if len(phis) != len(lambdas):
+        raise ValueError("phi_field and lambda_field must have equal length")
+    if not phis:
+        return theta_core
+
+    sx = sy = sz = 0.0
+    for phi, transform in zip(phis, lambdas):
+        pinv = regularized_pseudoinverse(transform, cfg.inverse_epsilon)
+        x, y, z = _matvec(pinv, phi)
+        sx += x
+        sy += y
+        sz += z
+
+    decay = math.exp(-cfg.gamma * t)
+    scale = decay * cfg.voxel_volume
+    return (
+        theta_core[0] + scale * sx,
+        theta_core[1] + scale * sy,
+        theta_core[2] + scale * sz,
+    )
+
+
+def homogeneous_recurrence(
+    psi0: Vector3,
+    lambda_field: Sequence[Matrix3],
+    theta_core: Vector3,
+    steps: int,
+    dt: float = 1.0,
+    config: ContinuumConfig | None = None,
+) -> list[Vector3]:
+    """Run the inward recurrence ``Psi_(k+1) = M(Psi_k)``.
+
+    The previous global state is broadcast uniformly across the active voxels,
+    normalized by voxel count so the recursive map does not scale merely because
+    the active tile contains more voxels.
+    """
+    if steps < 0:
+        raise ValueError("steps must be >= 0")
+    if dt <= 0.0:
+        raise ValueError("dt must be > 0")
+    if not lambda_field:
+        return [psi0]
+
+    cfg = config or ContinuumConfig()
+    history = [psi0]
+    psi = psi0
+    n = len(lambda_field)
+    for _ in range(steps):
+        phi = (psi[0] / n, psi[1] / n, psi[2] / n)
+        psi = continuum_step((phi for _ in range(n)), lambda_field, theta_core, dt, cfg)
+        history.append(psi)
+    return history
+
+
+__all__ = [
+    "ContinuumConfig",
+    "Matrix3",
+    "Vector3",
+    "continuum_step",
+    "homogeneous_recurrence",
+    "regularized_pseudoinverse",
+]

--- a/tests/test_moagi_continuum.py
+++ b/tests/test_moagi_continuum.py
@@ -1,0 +1,85 @@
+import math
+
+import pytest
+
+from jarvisx.moagi_continuum import (
+    ContinuumConfig,
+    continuum_step,
+    homogeneous_recurrence,
+    regularized_pseudoinverse,
+)
+
+
+def diag(x: float, y: float, z: float):
+    return ((x, 0.0, 0.0), (0.0, y, 0.0), (0.0, 0.0, z))
+
+
+def test_single_voxel_matches_operational_equation():
+    cfg = ContinuumConfig(gamma=0.2, inverse_epsilon=1e-12)
+    psi = continuum_step(
+        [(2.0, 4.0, 6.0)],
+        [diag(2.0, 4.0, 3.0)],
+        theta_core=(0.5, 0.2, -0.1),
+        t=3.0,
+        config=cfg,
+    )
+    decay = math.exp(-0.6)
+    assert psi == pytest.approx((0.5 + decay, 0.2 + decay, -0.1 + 2.0 * decay))
+
+
+def test_discrete_integral_scales_with_voxel_volume():
+    cfg = ContinuumConfig(gamma=0.0, voxel_volume=0.5, inverse_epsilon=1e-12)
+    identity = diag(1.0, 1.0, 1.0)
+    psi = continuum_step(
+        [(1.0, 2.0, 3.0), (3.0, 2.0, 1.0)],
+        [identity, identity],
+        theta_core=(1.0, 1.0, 1.0),
+        t=0.0,
+        config=cfg,
+    )
+    assert psi == pytest.approx((3.0, 3.0, 3.0))
+
+
+def test_regularized_pseudoinverse_handles_singular_transform():
+    singular = ((1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (0.0, 0.0, 2.0))
+    pinv = regularized_pseudoinverse(singular, epsilon=1e-6)
+    assert all(math.isfinite(value) for row in pinv for value in row)
+    assert pinv[0][0] == pytest.approx(1.0, rel=1e-5)
+    assert pinv[1][1] == pytest.approx(0.0, abs=1e-12)
+    assert pinv[2][2] == pytest.approx(0.5, rel=1e-5)
+
+
+def test_large_time_converges_to_theta_core():
+    cfg = ContinuumConfig(gamma=1.0)
+    theta = (0.5, -0.25, 0.125)
+    psi = continuum_step(
+        [(100.0, 100.0, 100.0)],
+        [diag(1.0, 1.0, 1.0)],
+        theta_core=theta,
+        t=100.0,
+        config=cfg,
+    )
+    assert psi == pytest.approx(theta, abs=1e-12)
+
+
+def test_homogeneous_inward_recurrence_is_contracting_for_identity_field():
+    cfg = ContinuumConfig(gamma=math.log(2.0), inverse_epsilon=1e-12)
+    history = homogeneous_recurrence(
+        psi0=(8.0, 4.0, 2.0),
+        lambda_field=[diag(1.0, 1.0, 1.0)] * 8,
+        theta_core=(0.0, 0.0, 0.0),
+        steps=4,
+        dt=1.0,
+        config=cfg,
+    )
+    assert history[-1] == pytest.approx((0.5, 0.25, 0.125), rel=1e-9)
+
+
+def test_field_lengths_must_match():
+    with pytest.raises(ValueError, match="equal length"):
+        continuum_step(
+            [(1.0, 2.0, 3.0)],
+            [],
+            theta_core=(0.0, 0.0, 0.0),
+            t=0.0,
+        )


### PR DESCRIPTION
## Summary

Operationalizes the continuum state equation

`Psi(t) = Theta_core + exp(-gamma*t) * dV * sum_v Lambda_v^+ Phi_v`

as a dependency-free 3D runtime primitive.

### What changed
- added `src/jarvisx/moagi_continuum.py`
  - 3D vector / 3x3 matrix contracts
  - Tikhonov-regularized pseudoinverse `(L^T L + eps I)^-1 L^T`
  - discrete voxel-domain integration
  - exponential temporal damping
  - persistent `Theta_core`
  - inward homogeneous recurrence `Psi_(k+1) = M(Psi_k)`
- added arithmetic and stability tests in `tests/test_moagi_continuum.py`
- added the mathematical/runtime specification in `docs/DR_MOAGI_CONTINUUM_KERNEL.md`

## Mathematical contract

For active voxels `v = 1..N`:

`Psi(t) = Theta_core + exp(-gamma*t) * DeltaV * sum_v Lambda_v^+ Phi_v`

The recursive reference normalizes broadcast state by `N`, yielding the affine map

`Psi_(k+1) = A Psi_k + Theta_core`

with the documented sufficient convergence criterion `rho(A) < 1`.

## Verification

Tests cover:
1. single-voxel arithmetic;
2. voxel-volume scaling;
3. singular-transform regularization;
4. asymptotic damping toward `Theta_core`;
5. contractive fixed-point recurrence;
6. field-shape validation.

## Boundary

This is a continuous-valued state-transition primitive. It does not replace the existing deterministic bitwise `dr_moagi_virtual_3d_ae` codec; it is designed to compose before, after, or around that codec.