### PR TITLE
feat: permeate inward-recursive 3D autoencoding runtime

### DIFF
--- a/docs/adr/0013-inward-recursive-3d-runtime.md
+++ b/docs/adr/0013-inward-recursive-3d-runtime.md
@@ -1,0 +1,106 @@
+# ADR-013: Bound the inward-recursive 3D runtime as a reference laboratory
+
+**Status:** Proposed  
+**Date:** 2026-09-05  
+**Extends:** ADR-002, ADR-010
+
+## Context
+
+Jarvis-X has several spatial and inward-processing references, but the current design work requires a narrower mechanism that can be falsified end to end:
+
+1. map bytes into explicit 3D bit planes;
+2. contract those planes into a learned latent state;
+3. update that state recursively using the previous 3D reconstruction error;
+4. decode back into a bit volume;
+5. measure differentiable reconstruction quality separately from exact Hamming/SHA identity; and
+6. reject training mutations that worsen an immutable validation score.
+
+Earlier prototypes re-encoded the same input at each recursion depth. That is error-conditioned repetition, not true latent-state inheritance. This ADR requires the recurrent state itself to advance:
+
+\[
+z_{r+1}=z_r+g_r\,S_\psi(z_r,e_r)
+\]
+
+with
+
+\[
+\hat x_r=D_\phi(z_{r+1}),\qquad e_r=x-\hat x_r.
+\]
+
+## Decision
+
+Adopt `src/jarvisx/dr_moagi_inward3d_runtime.py` as a bounded **reference laboratory**, subject to the following contract.
+
+### Binary boundary
+
+A byte payload is expanded into eight least-significant-bit-first planes:
+
+\[
+B\in\{0,1\}^{8\times N\times N\times N}.
+\]
+
+The reference exposes and tests the binary dot-product identity
+
+\[
+q(a)^Tq(b)=2\,\operatorname{popcount}(\operatorname{XNOR}(a,b))-n.
+\]
+
+The learned convolutional path is still ordinary floating-point PyTorch. XNOR/POPCOUNT is therefore a verified primitive, **not** a claim that the neural kernel itself is binary.
+
+### Inward recurrence
+
+The encoder is evaluated once for the initial state. Each recursive fold inherits the previous latent state and applies an error-conditioned correction. Telemetry records gate strength, correction RMS, reconstruction-error RMS and the actual latent-state displacement.
+
+### Objective and guarded adaptation
+
+Training may optimize reconstruction, cycle, spatial-gradient, self-consistency and latent-energy terms. Acceptance is evaluated with a separate immutable composite score. A candidate update is committed only when that score improves; otherwise model and optimizer state are rolled back.
+
+### Exact reconstruction boundary
+
+Approximate neural loss must never be reported as lossless identity. Exact output is measured independently using:
+
+- byte accuracy;
+- bit Hamming distance;
+- bit accuracy; and
+- SHA-256 equality.
+
+The terminal lossless condition is:
+
+\[
+H(B,\hat B)=0
+\]
+
+and matching SHA-256 digests.
+
+### Virtual scale boundary
+
+Large volumetric labels describe a virtual streamed address space. This implementation materializes finite tiles only. It does not establish a literal `1000 TB^3` allocation, distributed shard topology, hardware throughput or global physical storage geometry.
+
+### Tile boundary
+
+The present three-stage stride-2 encoder requires `tile_edge >= 16` and divisibility by eight. This explicitly closes the `8^3 -> 1^3` normalization/degeneracy boundary encountered in earlier prototypes.
+
+## Verification
+
+Focused tests cover:
+
+1. byte -> 3D bit-plane -> byte exact round trip;
+2. XNOR/POPCOUNT equivalence to the bipolar dot product;
+3. exact Hamming/SHA identity telemetry;
+4. the minimum tile-size boundary;
+5. non-zero inherited latent displacement across recursive folds; and
+6. guarded optimization: an accepted update cannot have a worse validation score.
+
+## Consequences
+
+The runtime may be described as a self-correcting 3D neural codec laboratory with explicit bit boundaries and true latent recurrence.
+
+It must **not** be described as evidence of:
+
+- lossless learned compression before exact identity is achieved;
+- a production binary neural accelerator;
+- arbitrary self-improvement or unrestricted source mutation;
+- physical allocation of the virtual large-volume label; or
+- consciousness, phenomenology or other non-computational properties.
+
+Promotion beyond reference-laboratory status requires held-out benchmarks, rollback replay tests, persistent checkpoint/version binding, a binary-kernel implementation if XNOR/POPCOUNT execution is claimed, and inclusion in the consolidated empirical-validation artifact.

--- a/src/jarvisx/dr_moagi_inward3d_runtime.py
+++ b/src/jarvisx/dr_moagi_inward3d_runtime.py
@@ -1,0 +1,427 @@
+"""Bounded inward-recursive 3D autoencoding laboratory for Jarvis-X.
+
+The runtime is deliberately explicit about its limits:
+
+* the advertised large matrix is a virtual streamed address space, not a literal
+  contiguous allocation;
+* byte payloads are represented as eight binary bit-planes in a finite 3D tile;
+* the learned path uses ordinary PyTorch floating-point convolutions; a separate
+  XNOR/POPCOUNT primitive is provided and tested, but is not claimed as the
+  neural execution kernel;
+* recursion is true latent-state recursion: ``z_{r+1}`` inherits ``z_r`` rather
+  than re-encoding the same input on every fold;
+* acceptance is guarded by an immutable composite validation score and exact
+  bit/Hamming telemetry is reported separately from differentiable loss.
+
+This module requires the optional ``jarvisx[torch]`` dependency.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import math
+import random
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class Inward3DConfig:
+    """Configuration for the bounded 3D reference runtime."""
+
+    tile_edge: int = 16
+    base_channels: int = 8
+    latent_channels: int = 16
+    recursion_depth: int = 3
+    learning_rate: float = 1.0e-3
+    weight_decay: float = 1.0e-5
+    recon_weight: float = 1.0
+    cycle_weight: float = 0.15
+    gradient_weight: float = 0.05
+    self_weight: float = 0.03
+    latent_weight: float = 1.0e-5
+    grad_clip: float = 1.0
+    seed: int = 7
+
+    def validate(self) -> None:
+        if self.tile_edge < 16 or self.tile_edge % 8:
+            raise ValueError("tile_edge must be >= 16 and divisible by 8")
+        if self.base_channels <= 0 or self.latent_channels <= 0:
+            raise ValueError("channel counts must be positive")
+        if self.recursion_depth <= 0:
+            raise ValueError("recursion_depth must be positive")
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+
+
+@dataclass(frozen=True)
+class BitIdentity:
+    """Exact byte/bit reconstruction telemetry."""
+
+    total_bits: int
+    differing_bits: int
+    bit_accuracy: float
+    byte_accuracy: float
+    sha256_original: str
+    sha256_reconstructed: str
+
+    @property
+    def exact(self) -> bool:
+        return self.differing_bits == 0 and self.sha256_original == self.sha256_reconstructed
+
+
+@dataclass(frozen=True)
+class FoldTelemetry:
+    """One inward recursion step."""
+
+    depth: int
+    gate_mean: float
+    correction_rms: float
+    error_rms: float
+    latent_delta_rms: float
+
+
+@dataclass(frozen=True)
+class ScoreTelemetry:
+    """Differentiable validation terms plus the immutable composite score."""
+
+    score: float
+    reconstruction: float
+    cycle: float
+    gradient: float
+    self_consistency: float
+    latent_energy: float
+    error_roughness: float
+
+
+class VirtualBitVolume:
+    """Map byte streams into streamed 3D bit-plane tiles and back."""
+
+    def __init__(self, edge: int) -> None:
+        if edge < 1:
+            raise ValueError("edge must be positive")
+        self.edge = edge
+        self.tile_bytes = edge**3
+
+    @staticmethod
+    def _byte_bits(values: np.ndarray) -> np.ndarray:
+        shifts = np.arange(8, dtype=np.uint8)
+        return ((values[:, None] >> shifts[None, :]) & 1).astype(np.float32)
+
+    def encode(self, payload: bytes) -> list[np.ndarray]:
+        if not payload:
+            return []
+        tiles: list[np.ndarray] = []
+        for start in range(0, len(payload), self.tile_bytes):
+            chunk = np.frombuffer(payload[start : start + self.tile_bytes], dtype=np.uint8)
+            padded = np.zeros(self.tile_bytes, dtype=np.uint8)
+            padded[: chunk.size] = chunk
+            bits = self._byte_bits(padded)
+            volume = bits.T.reshape(8, self.edge, self.edge, self.edge)
+            tiles.append(volume)
+        return tiles
+
+    def decode(self, tiles: Iterable[np.ndarray], original_length: int) -> bytes:
+        if original_length < 0:
+            raise ValueError("original_length must be non-negative")
+        values: list[np.ndarray] = []
+        weights = (1 << np.arange(8, dtype=np.uint16)).reshape(8, 1)
+        for tile in tiles:
+            if tile.shape != (8, self.edge, self.edge, self.edge):
+                raise ValueError("tile shape does not match configured bit volume")
+            bit_matrix = (tile.reshape(8, -1) >= 0.5).astype(np.uint16)
+            byte_values = np.sum(bit_matrix * weights, axis=0).astype(np.uint8)
+            values.append(byte_values)
+        if not values:
+            return b""
+        return np.concatenate(values)[:original_length].tobytes()
+
+
+def xnor_popcount_dot(a: np.ndarray, b: np.ndarray) -> int:
+    """Return the bipolar dot product using the XNOR/POPCOUNT identity."""
+
+    aa = np.asarray(a, dtype=np.uint8).reshape(-1)
+    bb = np.asarray(b, dtype=np.uint8).reshape(-1)
+    if aa.shape != bb.shape:
+        raise ValueError("bit vectors must have equal length")
+    if not np.all((aa == 0) | (aa == 1)) or not np.all((bb == 0) | (bb == 1)):
+        raise ValueError("xnor_popcount_dot accepts binary values only")
+    matches = int(np.count_nonzero(aa == bb))
+    return 2 * matches - int(aa.size)
+
+
+def bit_identity(original: bytes, reconstructed: bytes) -> BitIdentity:
+    """Measure exact Hamming and digest identity for equal-length byte strings."""
+
+    if len(original) != len(reconstructed):
+        raise ValueError("bit identity requires equal-length byte strings")
+    a = np.frombuffer(original, dtype=np.uint8)
+    b = np.frombuffer(reconstructed, dtype=np.uint8)
+    xor = np.bitwise_xor(a, b)
+    differing = int(sum(int(value).bit_count() for value in xor.tolist()))
+    total = len(original) * 8
+    bit_accuracy = 1.0 if total == 0 else 1.0 - differing / total
+    byte_accuracy = 1.0 if len(original) == 0 else float(np.mean(a == b))
+    return BitIdentity(
+        total_bits=total,
+        differing_bits=differing,
+        bit_accuracy=bit_accuracy,
+        byte_accuracy=byte_accuracy,
+        sha256_original=hashlib.sha256(original).hexdigest(),
+        sha256_reconstructed=hashlib.sha256(reconstructed).hexdigest(),
+    )
+
+
+def _gradient3d(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    dx = x[..., :, :, 1:] - x[..., :, :, :-1]
+    dy = x[..., :, 1:, :] - x[..., :, :-1, :]
+    dz = x[..., 1:, :, :] - x[..., :-1, :, :]
+    return dx, dy, dz
+
+
+def _rms(x: torch.Tensor) -> torch.Tensor:
+    return torch.sqrt(torch.mean(x.square()) + 1.0e-12)
+
+
+def _roughness(x: torch.Tensor) -> torch.Tensor:
+    return sum(component.abs().mean() for component in _gradient3d(x)) / 3.0
+
+
+class _Block3D(nn.Module):
+    def __init__(self, channels_in: int, channels_out: int, stride: int = 1) -> None:
+        super().__init__()
+        self.body = nn.Sequential(
+            nn.Conv3d(channels_in, channels_out, 3, stride=stride, padding=1),
+            nn.SiLU(),
+            nn.Conv3d(channels_out, channels_out, 3, padding=1),
+            nn.SiLU(),
+        )
+        self.skip: nn.Module
+        if channels_in == channels_out and stride == 1:
+            self.skip = nn.Identity()
+        else:
+            self.skip = nn.Conv3d(channels_in, channels_out, 1, stride=stride)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.body(x) + self.skip(x)
+
+
+class _Encoder3D(nn.Module):
+    def __init__(self, base: int, latent: int) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            _Block3D(8, base),
+            _Block3D(base, base * 2, 2),
+            _Block3D(base * 2, base * 4, 2),
+            _Block3D(base * 4, latent, 2),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class _Decoder3D(nn.Module):
+    def __init__(self, base: int, latent: int) -> None:
+        super().__init__()
+        self.pre = _Block3D(latent, base * 4)
+        self.net = nn.Sequential(
+            nn.ConvTranspose3d(base * 4, base * 2, 4, 2, 1),
+            nn.SiLU(),
+            nn.ConvTranspose3d(base * 2, base, 4, 2, 1),
+            nn.SiLU(),
+            nn.ConvTranspose3d(base, base, 4, 2, 1),
+            nn.SiLU(),
+            nn.Conv3d(base, 8, 3, padding=1),
+        )
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return self.net(self.pre(z))
+
+
+class _LatentSelfModel(nn.Module):
+    def __init__(self, latent: int) -> None:
+        super().__init__()
+        hidden = max(16, latent)
+        self.error_embed = nn.Sequential(nn.Conv3d(8, latent, 1), nn.SiLU())
+        self.core = nn.Sequential(
+            _Block3D(latent * 2, hidden),
+            _Block3D(hidden, hidden),
+        )
+        self.delta = nn.Conv3d(hidden, latent, 1)
+        self.gate = nn.Sequential(
+            nn.AdaptiveAvgPool3d(1),
+            nn.Conv3d(hidden, 1, 1),
+            nn.Sigmoid(),
+        )
+
+    def forward(self, z: torch.Tensor, error: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        pooled = F.adaptive_avg_pool3d(error, z.shape[-3:])
+        embedded = self.error_embed(pooled)
+        state = self.core(torch.cat([z, embedded], dim=1))
+        return torch.tanh(self.delta(state)), self.gate(state)
+
+
+class InwardRecursive3DModel(nn.Module):
+    """Encoder, true latent recurrence, self-model and decoder."""
+
+    def __init__(self, config: Inward3DConfig) -> None:
+        super().__init__()
+        config.validate()
+        self.encoder = _Encoder3D(config.base_channels, config.latent_channels)
+        self.decoder = _Decoder3D(config.base_channels, config.latent_channels)
+        self.self_model = _LatentSelfModel(config.latent_channels)
+
+    def forward_recursive(
+        self,
+        x: torch.Tensor,
+        depth: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, list[FoldTelemetry]]:
+        if depth <= 0:
+            raise ValueError("depth must be positive")
+        z = self.encoder(x)
+        error = torch.zeros_like(x)
+        telemetry: list[FoldTelemetry] = []
+        logits = torch.zeros_like(x)
+
+        for index in range(depth):
+            previous_z = z
+            delta, gate = self.self_model(z, error)
+            z = z + gate * delta
+            logits = self.decoder(z)
+            if logits.shape[-3:] != x.shape[-3:]:
+                logits = F.interpolate(logits, size=x.shape[-3:], mode="trilinear", align_corners=False)
+            reconstruction = torch.sigmoid(logits)
+            error = x - reconstruction
+            telemetry.append(
+                FoldTelemetry(
+                    depth=index,
+                    gate_mean=float(gate.detach().mean().cpu()),
+                    correction_rms=float(_rms(delta).detach().cpu()),
+                    error_rms=float(_rms(error).detach().cpu()),
+                    latent_delta_rms=float(_rms(z - previous_z).detach().cpu()),
+                )
+            )
+
+        return z, logits, telemetry
+
+
+class InwardRecursive3DRuntime:
+    """Guarded training and reconstruction wrapper around the 3D model."""
+
+    def __init__(self, config: Inward3DConfig | None = None, device: str = "cpu") -> None:
+        self.config = config or Inward3DConfig()
+        self.config.validate()
+        random.seed(self.config.seed)
+        np.random.seed(self.config.seed)
+        torch.manual_seed(self.config.seed)
+        self.device = torch.device(device)
+        self.volume = VirtualBitVolume(self.config.tile_edge)
+        self.model = InwardRecursive3DModel(self.config).to(self.device)
+        self.optimizer = torch.optim.AdamW(
+            self.model.parameters(),
+            lr=self.config.learning_rate,
+            weight_decay=self.config.weight_decay,
+        )
+
+    def _tensor(self, tile: np.ndarray) -> torch.Tensor:
+        return torch.from_numpy(tile).unsqueeze(0).to(self.device)
+
+    def _score(self, x: torch.Tensor) -> tuple[torch.Tensor, ScoreTelemetry]:
+        z, logits, _ = self.model.forward_recursive(x, self.config.recursion_depth)
+        reconstruction = torch.sigmoid(logits)
+        recon = F.binary_cross_entropy_with_logits(logits, x)
+        z_cycle = self.model.encoder(reconstruction)
+        cycle = F.mse_loss(z_cycle, z.detach())
+        grad = sum(
+            F.l1_loss(a, b) for a, b in zip(_gradient3d(x), _gradient3d(reconstruction))
+        ) / 3.0
+        error = x - reconstruction
+        correction, _ = self.model.self_model(z_cycle, error)
+        self_consistency = correction.square().mean()
+        latent = z.square().mean()
+        rough = _roughness(error)
+        total = (
+            self.config.recon_weight * recon
+            + self.config.cycle_weight * cycle
+            + self.config.gradient_weight * grad
+            + self.config.self_weight * self_consistency
+            + self.config.latent_weight * latent
+        )
+        immutable_score = recon + 0.25 * cycle + 0.10 * grad + 0.05 * self_consistency + 0.02 * rough
+        return total, ScoreTelemetry(
+            score=float(immutable_score.detach().cpu()),
+            reconstruction=float(recon.detach().cpu()),
+            cycle=float(cycle.detach().cpu()),
+            gradient=float(grad.detach().cpu()),
+            self_consistency=float(self_consistency.detach().cpu()),
+            latent_energy=float(latent.detach().cpu()),
+            error_roughness=float(rough.detach().cpu()),
+        )
+
+    @torch.no_grad()
+    def evaluate_tile(self, tile: np.ndarray) -> ScoreTelemetry:
+        self.model.eval()
+        _, score = self._score(self._tensor(tile))
+        return score
+
+    def train_tile(self, tile: np.ndarray, steps: int = 1) -> ScoreTelemetry:
+        if steps <= 0:
+            raise ValueError("steps must be positive")
+        x = self._tensor(tile)
+        self.model.train()
+        telemetry: ScoreTelemetry | None = None
+        for _ in range(steps):
+            self.optimizer.zero_grad(set_to_none=True)
+            loss, telemetry = self._score(x)
+            loss.backward()
+            torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.config.grad_clip)
+            self.optimizer.step()
+        assert telemetry is not None
+        return telemetry
+
+    def guarded_train_tile(self, tile: np.ndarray, steps: int = 1) -> tuple[bool, float, float]:
+        """Accept only if the immutable validation score improves; otherwise rollback."""
+
+        before = self.evaluate_tile(tile).score
+        model_snapshot = copy.deepcopy(self.model.state_dict())
+        optimizer_snapshot = copy.deepcopy(self.optimizer.state_dict())
+        self.train_tile(tile, steps=steps)
+        after = self.evaluate_tile(tile).score
+        if math.isfinite(after) and after < before:
+            return True, before, after
+        self.model.load_state_dict(model_snapshot)
+        self.optimizer.load_state_dict(optimizer_snapshot)
+        return False, before, self.evaluate_tile(tile).score
+
+    @torch.no_grad()
+    def reconstruct_tile(self, tile: np.ndarray) -> tuple[np.ndarray, list[FoldTelemetry]]:
+        self.model.eval()
+        x = self._tensor(tile)
+        _, logits, telemetry = self.model.forward_recursive(x, self.config.recursion_depth)
+        return torch.sigmoid(logits).squeeze(0).cpu().numpy(), telemetry
+
+    def process_bytes(
+        self,
+        payload: bytes,
+        *,
+        training_steps: int = 0,
+    ) -> tuple[bytes, BitIdentity, list[FoldTelemetry]]:
+        if training_steps < 0:
+            raise ValueError("training_steps must be non-negative")
+        tiles = self.volume.encode(payload)
+        outputs: list[np.ndarray] = []
+        folds: list[FoldTelemetry] = []
+        for tile in tiles:
+            if training_steps:
+                self.guarded_train_tile(tile, steps=training_steps)
+            output, tile_folds = self.reconstruct_tile(tile)
+            outputs.append(output)
+            folds.extend(tile_folds)
+        reconstructed = self.volume.decode(outputs, len(payload))
+        return reconstructed, bit_identity(payload, reconstructed), folds

--- a/tests/test_dr_moagi_inward3d_runtime.py
+++ b/tests/test_dr_moagi_inward3d_runtime.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pytest
+
+pytest.importorskip("torch")
+
+from jarvisx.dr_moagi_inward3d_runtime import (
+    Inward3DConfig,
+    InwardRecursive3DRuntime,
+    VirtualBitVolume,
+    bit_identity,
+    xnor_popcount_dot,
+)
+
+
+def test_virtual_bit_volume_round_trip_and_mapping() -> None:
+    payload = b"def"
+    volume = VirtualBitVolume(16)
+    tiles = volume.encode(payload)
+    assert len(tiles) == 1
+    assert tiles[0].shape == (8, 16, 16, 16)
+    assert volume.decode(tiles, len(payload)) == payload
+    assert tiles[0][:, 0, 0, 0].astype(int).tolist() == [0, 0, 1, 0, 0, 1, 1, 0]
+
+
+def test_xnor_popcount_matches_bipolar_dot_product() -> None:
+    a = np.array([1, 0, 1, 1, 0, 0, 1, 0], dtype=np.uint8)
+    b = np.array([1, 1, 1, 0, 0, 0, 1, 1], dtype=np.uint8)
+    expected = int(np.dot(2 * a.astype(int) - 1, 2 * b.astype(int) - 1))
+    assert xnor_popcount_dot(a, b) == expected == 2
+
+
+def test_exact_identity_gate() -> None:
+    payload = b"Jarvis-X"
+    exact = bit_identity(payload, payload)
+    assert exact.exact
+    assert exact.differing_bits == 0
+    changed = bit_identity(payload, b"Jarvis-Y")
+    assert not changed.exact
+    assert changed.differing_bits > 0
+
+
+def test_tile_edge_boundary_is_explicit() -> None:
+    with pytest.raises(ValueError, match="tile_edge"):
+        Inward3DConfig(tile_edge=8).validate()
+
+
+def test_true_latent_recursion_changes_state() -> None:
+    config = Inward3DConfig(base_channels=2, latent_channels=4, recursion_depth=3, seed=11)
+    runtime = InwardRecursive3DRuntime(config)
+    tile = runtime.volume.encode(b"print('echo')\n")[0]
+    _, folds = runtime.reconstruct_tile(tile)
+    assert len(folds) == 3
+    assert all(fold.latent_delta_rms > 0 for fold in folds)
+
+
+def test_guarded_training_never_returns_worse_accepted_score() -> None:
+    config = Inward3DConfig(base_channels=2, latent_channels=4, recursion_depth=2, seed=3)
+    runtime = InwardRecursive3DRuntime(config)
+    tile = runtime.volume.encode(b"def f(x):\n    return x + 1\n")[0]
+    accepted, before, after = runtime.guarded_train_tile(tile, steps=1)
+    if accepted:
+        assert after < before
+    else:
+        assert after == pytest.approx(before)


### PR DESCRIPTION
Permeates the current inward-recursive 3D autoencoding design into Jarvis-X as a bounded reference laboratory.

What changed:
- adds explicit byte -> 8 bit-plane -> 3D tile mapping;
- implements true latent-state inheritance `z_{r+1} = z_r + g_r S(z_r, e_r)`;
- keeps learned Conv3D execution honestly float/PyTorch while exposing a separately verified XNOR/POPCOUNT primitive;
- adds exact Hamming, byte-accuracy and SHA-256 identity telemetry so approximate neural loss is never confused with losslessness;
- adds guarded training with full model/optimizer rollback when an immutable validation score does not improve;
- closes the earlier `8^3` boundary by requiring `tile_edge >= 16` and divisibility by 8;
- documents virtual-scale limits: streamed tiles are not a literal `1000 TB^3` allocation;
- adds ADR-013 and six focused tests.

Local verification performed before publication: 6/6 focused tests passed, including round-trip bit mapping, XNOR/POPCOUNT equivalence, exact identity telemetry, latent recursion, boundary validation and guarded-score monotonicity.

This PR does not claim lossless learned compression, a binary neural execution kernel, production-scale distributed storage, or unrestricted self-improvement.