### PR TITLE
feat(graphics): permeate DM3D evidence-guided self-optimizing runtime

### DIFF
--- a/apps/qsol-graphics-codec/Program.cs
+++ b/apps/qsol-graphics-codec/Program.cs
@@ -3,6 +3,7 @@ using QSol.GraphicsCodec.Codec;
 using QSol.GraphicsCodec.Core;
 using QSol.GraphicsCodec.Export;
 using QSol.GraphicsCodec.Procedural;
+using QSol.GraphicsCodec.Runtime;
 
 namespace QSol.GraphicsCodec;
 
@@ -14,6 +15,21 @@ internal static class Program
         {
             if (args.Contains("--self-test", StringComparer.OrdinalIgnoreCase))
                 return SelfTest();
+
+            if (args.Contains("--dm3d-self-test", StringComparer.OrdinalIgnoreCase))
+                return Dm3dSelfOptimizingRuntime.SelfTest();
+
+            var romPath = GetOption(args, "--dm3d-rom");
+            if (romPath is not null)
+            {
+                var rom = Dm3dRomImage.Build();
+                var directory = Path.GetDirectoryName(romPath);
+                if (!string.IsNullOrEmpty(directory))
+                    Directory.CreateDirectory(directory);
+                File.WriteAllBytes(romPath, rom);
+                Console.WriteLine($"DM3D ROM {rom.Length}B sha256={Dm3dRomImage.Sha256Hex(rom)} -> {Path.GetFullPath(romPath)}");
+                return 0;
+            }
 
             var decodePath = GetOption(args, "--decode");
             if (decodePath is not null)
@@ -92,6 +108,7 @@ internal static class Program
         Console.WriteLine(FormattableString.Invariant($"selected={result.Encoded.QuantizationBits} bits maxError={result.MaxVertexError:G6}"));
 
         Dmkb1.DmkbSelfTest.Run();
+        Dm3dSelfOptimizingRuntime.SelfTest();
         return 0;
     }
 

--- a/apps/qsol-graphics-codec/README.md
+++ b/apps/qsol-graphics-codec/README.md
@@ -15,6 +15,11 @@ Executable .NET 8 reference implementation of the inward kinetic encoding model 
 - Transform and kinetic velocity state preserved in the stream.
 - OBJ export from the decoded state for inspection in Blender, Unity, Unreal import pipelines, MeshLab, etc.
 - Deterministic self-test suitable for CI.
+- DM3D evidence/graphics runtime with 20-bit-per-axis Morton addressing over a virtual 1,024,000³ lattice.
+- 256-bit XNOR/POPCOUNT evidence similarity and authority/graph gates.
+- Inward prefix refinement that reduces local 3D candidate volume by approximately 8× per resolved XYZ bit triplet.
+- Deterministic 128 KiB DM3D ROM image generation with immutable bytecode, self-integrity hashing, inverse-render verification opcodes and bounded runtime optimization.
+- Transactional runtime tuning: candidate configurations are committed only when verification quality stays above the declared guardrail; otherwise they roll back.
 
 ## Operational loop
 
@@ -42,6 +47,82 @@ Z* = argmin |Z_b|
 ```
 
 This makes compaction measurable rather than symbolic: a lower-bit representation is promoted only if its decoded geometry remains inside the declared error tolerance.
+
+## DM3D inward evidence / graphics loop
+
+The DM3D control plane extends the same measurable encode/decode invariant to evidence-localized graphics generation:
+
+```text
+input/evidence
+  -> INT8 encode
+  -> 256-bit latent code
+  -> project to 3D
+  -> Morton3D(20 bits/axis)
+  -> octree/prefix-localized retrieval
+  -> XNOR + POPCOUNT ranking
+  -> authority + graph + contradiction gates
+  -> structured claim decode
+  -> verification
+  -> latent correction
+  -> resolve +1 prefix bit on X/Y/Z
+  -> contract Top-K by ~8x
+  -> repeat
+  -> parameter decode
+  -> vector render
+  -> inverse render
+  -> spatial error field
+  -> freeze low-error cells / refine high-error cells
+  -> profile latency + memory + verification quality
+  -> guarded config commit or rollback
+```
+
+The virtual address manifold is:
+
+```text
+axis = 1,024,000 cells
+bits/axis = 20
+virtual cells = 1,024,000^3 = 1,073,741,824,000,000,000
+```
+
+The lattice is procedural; the implementation does **not** allocate a dense exabyte-scale backing store.
+
+For the initial 16 resolved bits per axis, four bits remain free on each axis:
+
+```text
+free bits:        12 -> 9 -> 6 -> 3
+candidate cells: 4096 -> 512 -> 64 -> 8
+```
+
+Each inward iteration resolves one additional bit on all three axes, giving an approximately 8× reduction in the local 3D candidate volume.
+
+### Run the DM3D self-test
+
+```bash
+dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- --dm3d-self-test
+```
+
+It verifies:
+
+1. the 4096 → 512 → 64 → 8 inward volume schedule;
+2. Morton XYZ bit interleave invariants;
+3. 256-bit XNOR/POPCOUNT identity and complement scores;
+4. evidence graph/contradiction gating;
+5. the optimizer never commits below the 0.95 verification guardrail;
+6. the bounded objective improves over the baseline configuration;
+7. ROM generation is deterministic.
+
+The regular `--self-test` also executes the DM3D test.
+
+### Generate the deterministic DM3D ROM
+
+```bash
+dotnet run --project apps/qsol-graphics-codec/QSol.GraphicsCodec.csproj -c Release -- \
+  --dm3d-rom artifacts/qsol-graphics-codec/dm3d-self-optimizing-v2.rom
+```
+
+The generated ROM is 128 KiB and contains fixed-width 16-byte instructions for evidence encoding, Morton localization, XNOR/POPCOUNT retrieval, graph validation, inward contraction, parameter decoding, vector rendering, inverse rendering, spatial-error refinement, profiling and guarded commit/rollback optimization.
+
+The executable bytecode is immutable at runtime. Only bounded configuration, cache and latent state are adaptive.
 
 ## Build
 
@@ -112,3 +193,5 @@ The `.q3d` stream contains:
 ## Scope
 
 This is a fully executable **graphics-state codec and kinetic animation reference core**. It does not claim that the codec itself performs photorealistic rasterization or path tracing. The decoded scene state is deliberately renderer-agnostic so GPU backends (Direct3D 12, Vulkan, WebGPU, Unity/Unreal adapters, ray/path tracers, neural renderers) can be attached without changing the Q3D encode/decode invariant.
+
+The DM3D evidence layer is likewise a deterministic reference control plane. `HOST_SEARCH` is a host integration boundary: production deployments must supply validated evidence and provenance rather than treating the ROM itself as a web client or source of truth.

--- a/apps/qsol-graphics-codec/Runtime/Dm3dRomImage.cs
+++ b/apps/qsol-graphics-codec/Runtime/Dm3dRomImage.cs
@@ -1,0 +1,290 @@
+using System.Buffers.Binary;
+using System.Security.Cryptography;
+
+namespace QSol.GraphicsCodec.Runtime;
+
+internal enum Dm3dOpcode : byte
+{
+    Nop = 0x00,
+    CfgAxis = 0x01,
+    CfgBits = 0x02,
+    CfgLatent = 0x03,
+    CfgTopK = 0x04,
+    CfgAlphaQ16 = 0x05,
+    CfgMaxIters = 0x06,
+    CfgQBits = 0x07,
+
+    SelfHashCheck = 0x08,
+    ProfileBegin = 0x09,
+    ProfileEnd = 0x0A,
+    MeasureLatency = 0x0B,
+    MeasureMemory = 0x0C,
+    MeasureVerify = 0x0D,
+    ObjectiveScore = 0x0E,
+    SaveCheckpoint = 0x0F,
+
+    HostSearch = 0x10,
+    LoadInput = 0x11,
+    TokenizeHash = 0x12,
+    EncodeInt8 = 0x13,
+    Binarize256 = 0x14,
+    FuseModalities = 0x15,
+
+    Project3D = 0x20,
+    Morton3D20 = 0x21,
+    PrefixMask = 0x22,
+    OctreeLocalize = 0x23,
+    CacheLookup = 0x24,
+    CachePromote = 0x25,
+
+    AnnXnorPopcount = 0x30,
+    AuthorityWeight = 0x31,
+    TopK = 0x32,
+    DecodeClaims = 0x33,
+    GraphValidate = 0x34,
+    EvidenceMask = 0x35,
+    ContradictionCheck = 0x36,
+    VerifyScore = 0x37,
+
+    IfConverged = 0x40,
+    UpdateLatent = 0x41,
+    ContractRadius = 0x42,
+    ResolvePrefix = 0x43,
+    DecTopK = 0x44,
+    Jump = 0x45,
+
+    ParamDecode = 0x50,
+    RenderVector = 0x51,
+    InverseRender = 0x52,
+    VerifyGraphics = 0x53,
+    SpatialErrorField = 0x54,
+    FreezeLowError = 0x55,
+    RefineHighError = 0x56,
+
+    OptBegin = 0x60,
+    TuneAlpha = 0x61,
+    TuneTopK = 0x62,
+    TuneQBits = 0x63,
+    TuneCache = 0x64,
+    TuneTile = 0x65,
+    GuardrailCheck = 0x66,
+    IfBetter = 0x67,
+    CommitConfig = 0x68,
+    RollbackConfig = 0x69,
+    OptEnd = 0x6A,
+
+    EmitOutput = 0x70,
+    Halt = 0xFF
+}
+
+internal readonly record struct Dm3dInstruction(
+    Dm3dOpcode Opcode,
+    byte Flags = 0,
+    byte Destination = 0,
+    byte Source = 0,
+    uint Immediate32 = 0,
+    ulong Immediate64 = 0);
+
+internal static class Dm3dRomImage
+{
+    public const int RomSize = 128 * 1024;
+    public const int HeaderSize = 256;
+    public const int InstructionSize = 16;
+
+    private const ushort VersionMajor = 2;
+    private const ushort VersionMinor = 0;
+
+    public static byte[] Build()
+    {
+        var instructions = BuildProgram();
+        var program = SerializeProgram(instructions);
+        var rom = new byte[RomSize];
+        Array.Fill(rom, (byte)0xFF);
+
+        WriteHeader(rom, program, instructions);
+        program.CopyTo(rom.AsSpan(HeaderSize));
+
+        var trailerHash = SHA256.HashData(rom.AsSpan(0, rom.Length - 32));
+        trailerHash.CopyTo(rom.AsSpan(rom.Length - 32));
+        return rom;
+    }
+
+    public static void Write(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+        File.WriteAllBytes(path, Build());
+    }
+
+    public static string Sha256Hex(byte[] rom)
+    {
+        ArgumentNullException.ThrowIfNull(rom);
+        return Convert.ToHexString(SHA256.HashData(rom)).ToLowerInvariant();
+    }
+
+    private static List<Dm3dInstruction> BuildProgram()
+    {
+        var p = new List<Dm3dInstruction>
+        {
+            new(Dm3dOpcode.CfgAxis, Destination: 0, Immediate64: Dm3dSelfOptimizingRuntime.AxisCells),
+            new(Dm3dOpcode.CfgAxis, Destination: 1, Immediate64: Dm3dSelfOptimizingRuntime.AxisCells),
+            new(Dm3dOpcode.CfgAxis, Destination: 2, Immediate64: Dm3dSelfOptimizingRuntime.AxisCells),
+            new(Dm3dOpcode.CfgBits, Immediate32: Dm3dSelfOptimizingRuntime.BitsPerAxis),
+            new(Dm3dOpcode.CfgLatent, Immediate32: Dm3dSelfOptimizingRuntime.LatentBits),
+            new(Dm3dOpcode.CfgTopK, Immediate32: 4096),
+            new(Dm3dOpcode.CfgAlphaQ16, Immediate32: Q16(0.50)),
+            new(Dm3dOpcode.CfgMaxIters, Immediate32: 8),
+            new(Dm3dOpcode.CfgQBits, Immediate32: 8),
+            new(Dm3dOpcode.SelfHashCheck, Flags: 1),
+            new(Dm3dOpcode.SaveCheckpoint, Flags: 1),
+            new(Dm3dOpcode.ProfileBegin),
+            new(Dm3dOpcode.HostSearch, Flags: 1, Immediate32: 32),
+            new(Dm3dOpcode.LoadInput),
+            new(Dm3dOpcode.TokenizeHash, Immediate32: 65_536),
+            new(Dm3dOpcode.EncodeInt8, Immediate32: 128),
+            new(Dm3dOpcode.Binarize256, Immediate32: 256),
+            new(Dm3dOpcode.FuseModalities, Immediate32: 3),
+            new(Dm3dOpcode.Project3D, Immediate32: 3),
+            new(Dm3dOpcode.Morton3D20, Immediate32: 20),
+            new(Dm3dOpcode.PrefixMask, Immediate32: 16),
+            new(Dm3dOpcode.OctreeLocalize, Immediate32: 4),
+            new(Dm3dOpcode.CacheLookup)
+        };
+
+        var innerLoopPc = p.Count;
+        p.Add(new(Dm3dOpcode.AnnXnorPopcount, Immediate32: 256));
+        p.Add(new(Dm3dOpcode.AuthorityWeight, Immediate32: 8));
+        p.Add(new(Dm3dOpcode.TopK));
+        p.Add(new(Dm3dOpcode.DecodeClaims, Immediate32: 64));
+        p.Add(new(Dm3dOpcode.GraphValidate, Flags: 1));
+        p.Add(new(Dm3dOpcode.EvidenceMask));
+        p.Add(new(Dm3dOpcode.ContradictionCheck, Flags: 1));
+        p.Add(new(Dm3dOpcode.VerifyScore, Immediate32: Q16(0.90)));
+
+        var convergencePc = p.Count;
+        p.Add(new(Dm3dOpcode.IfConverged));
+        p.Add(new(Dm3dOpcode.UpdateLatent, Immediate32: Q16(0.125)));
+        p.Add(new(Dm3dOpcode.ContractRadius, Immediate32: Q16(0.50)));
+        p.Add(new(Dm3dOpcode.ResolvePrefix, Immediate32: 1));
+        p.Add(new(Dm3dOpcode.DecTopK, Immediate32: 3));
+        p.Add(new(Dm3dOpcode.Project3D, Immediate32: 3));
+        p.Add(new(Dm3dOpcode.Morton3D20, Immediate32: 20));
+        p.Add(new(Dm3dOpcode.OctreeLocalize, Immediate32: 1));
+        p.Add(new(Dm3dOpcode.CacheLookup));
+        p.Add(new(Dm3dOpcode.Jump, Immediate32: (uint)innerLoopPc));
+
+        var graphicsPc = p.Count;
+        p[convergencePc] = p[convergencePc] with { Immediate32 = (uint)graphicsPc };
+
+        p.Add(new(Dm3dOpcode.ParamDecode, Immediate32: 256));
+        p.Add(new(Dm3dOpcode.RenderVector, Flags: 1));
+        p.Add(new(Dm3dOpcode.InverseRender));
+        p.Add(new(Dm3dOpcode.VerifyGraphics, Immediate32: Q16(0.95)));
+        p.Add(new(Dm3dOpcode.SpatialErrorField, Immediate32: 32));
+        p.Add(new(Dm3dOpcode.FreezeLowError, Immediate32: Q16(0.02)));
+        p.Add(new(Dm3dOpcode.RefineHighError, Immediate32: Q16(0.10)));
+        p.Add(new(Dm3dOpcode.CachePromote, Immediate32: 16));
+        p.Add(new(Dm3dOpcode.ProfileEnd));
+        p.Add(new(Dm3dOpcode.MeasureLatency));
+        p.Add(new(Dm3dOpcode.MeasureMemory));
+        p.Add(new(Dm3dOpcode.MeasureVerify));
+        p.Add(new(Dm3dOpcode.ObjectiveScore, Immediate32: 0x0001_0001));
+        p.Add(new(Dm3dOpcode.OptBegin));
+        p.Add(new(Dm3dOpcode.TuneAlpha, Immediate32: PackU16(Q16Short(0.35), Q16Short(0.75))));
+        p.Add(new(Dm3dOpcode.TuneTopK, Immediate32: 4096, Immediate64: 8));
+        p.Add(new(Dm3dOpcode.TuneQBits, Immediate32: PackU16(4, 8)));
+        p.Add(new(Dm3dOpcode.TuneCache, Immediate32: 64));
+        p.Add(new(Dm3dOpcode.TuneTile, Immediate32: PackU16(8, 64)));
+        p.Add(new(Dm3dOpcode.GuardrailCheck, Flags: 1, Immediate32: Q16(0.95)));
+
+        var ifBetterPc = p.Count;
+        p.Add(new(Dm3dOpcode.IfBetter));
+        p.Add(new(Dm3dOpcode.RollbackConfig, Flags: 1));
+        var jumpEmitPc = p.Count;
+        p.Add(new(Dm3dOpcode.Jump));
+        var commitPc = p.Count;
+        p.Add(new(Dm3dOpcode.CommitConfig, Flags: 1));
+        p.Add(new(Dm3dOpcode.OptEnd));
+        var emitPc = p.Count;
+        p.Add(new(Dm3dOpcode.EmitOutput, Flags: 1));
+        p.Add(new(Dm3dOpcode.Halt));
+
+        p[ifBetterPc] = p[ifBetterPc] with { Immediate32 = (uint)commitPc };
+        p[jumpEmitPc] = p[jumpEmitPc] with { Immediate32 = (uint)emitPc };
+        return p;
+    }
+
+    private static byte[] SerializeProgram(IReadOnlyList<Dm3dInstruction> instructions)
+    {
+        var program = new byte[instructions.Count * InstructionSize];
+        for (var i = 0; i < instructions.Count; i++)
+        {
+            var offset = i * InstructionSize;
+            var instruction = instructions[i];
+            program[offset] = (byte)instruction.Opcode;
+            program[offset + 1] = instruction.Flags;
+            program[offset + 2] = instruction.Destination;
+            program[offset + 3] = instruction.Source;
+            BinaryPrimitives.WriteUInt32LittleEndian(program.AsSpan(offset + 4, 4), instruction.Immediate32);
+            BinaryPrimitives.WriteUInt64LittleEndian(program.AsSpan(offset + 8, 8), instruction.Immediate64);
+        }
+        return program;
+    }
+
+    private static void WriteHeader(
+        Span<byte> rom,
+        ReadOnlySpan<byte> program,
+        IReadOnlyList<Dm3dInstruction> instructions)
+    {
+        "DM3DSO2\0"u8.CopyTo(rom);
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(8, 2), VersionMajor);
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(10, 2), VersionMinor);
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(12, 2), HeaderSize);
+        BinaryPrimitives.WriteUInt64LittleEndian(rom.Slice(16, 8), Dm3dSelfOptimizingRuntime.AxisCells);
+        rom[24] = Dm3dSelfOptimizingRuntime.BitsPerAxis;
+        rom[25] = Dm3dSelfOptimizingRuntime.LatentBits / 8;
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(26, 2), 8);
+
+        var virtualCells = checked((ulong)Dm3dSelfOptimizingRuntime.AxisCells
+            * (ulong)Dm3dSelfOptimizingRuntime.AxisCells
+            * (ulong)Dm3dSelfOptimizingRuntime.AxisCells);
+        BinaryPrimitives.WriteUInt64LittleEndian(rom.Slice(32, 8), virtualCells);
+        BinaryPrimitives.WriteUInt32LittleEndian(rom.Slice(40, 4), (uint)program.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(rom.Slice(44, 4), (uint)instructions.Count);
+        BinaryPrimitives.WriteUInt32LittleEndian(rom.Slice(48, 4), Crc32(program));
+
+        var programHash = SHA256.HashData(program);
+        programHash.CopyTo(rom.Slice(64, 32));
+
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(104, 2), Q16Short(0.55));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(106, 2), Q16Short(0.20));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(108, 2), Q16Short(0.15));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(110, 2), Q16Short(0.10));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(120, 2), Q16Short(0.95));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(122, 2), Q16Short(0.35));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(124, 2), Q16Short(0.75));
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(126, 2), 4);
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(128, 2), 8);
+        BinaryPrimitives.WriteUInt16LittleEndian(rom.Slice(130, 2), 64);
+    }
+
+    private static uint Q16(double value) => (uint)Math.Round(Math.Clamp(value, 0, 1) * 65_535.0);
+
+    private static ushort Q16Short(double value) => (ushort)Q16(value);
+
+    private static uint PackU16(ushort high, ushort low) => ((uint)high << 16) | low;
+
+    private static uint Crc32(ReadOnlySpan<byte> data)
+    {
+        var crc = 0xFFFF_FFFFu;
+        foreach (var value in data)
+        {
+            crc ^= value;
+            for (var bit = 0; bit < 8; bit++)
+                crc = (crc >> 1) ^ (0xEDB8_8320u & (uint)-(int)(crc & 1));
+        }
+        return ~crc;
+    }
+}

--- a/apps/qsol-graphics-codec/Runtime/Dm3dSelfOptimizingRuntime.cs
+++ b/apps/qsol-graphics-codec/Runtime/Dm3dSelfOptimizingRuntime.cs
@@ -1,0 +1,293 @@
+using System.Numerics;
+
+namespace QSol.GraphicsCodec.Runtime;
+
+internal readonly record struct Dm3dRuntimeConfig(
+    double Alpha,
+    int TopK,
+    int QuantizationBits,
+    int CacheShards,
+    int TileSize);
+
+internal readonly record struct Dm3dMetrics(
+    double Quality,
+    double Latency,
+    double Memory,
+    double EnergyProxy,
+    double Objective);
+
+internal readonly record struct Dm3dInwardStep(
+    int Iteration,
+    double Radius,
+    int TopK,
+    int ResolvedBitsPerAxis,
+    int FreeBitsPerAxis,
+    long CandidateCells);
+
+internal readonly record struct Dm3dEvidence(
+    ulong[] BinaryCode,
+    byte Authority,
+    bool GraphValid,
+    bool ContradictionFree);
+
+internal sealed record Dm3dOptimizationResult(
+    Dm3dRuntimeConfig Baseline,
+    Dm3dRuntimeConfig Selected,
+    Dm3dMetrics BaselineMetrics,
+    Dm3dMetrics SelectedMetrics,
+    IReadOnlyList<(Dm3dRuntimeConfig Config, Dm3dMetrics Metrics, bool Committed)> Trials);
+
+internal static class Dm3dSelfOptimizingRuntime
+{
+    public const int AxisCells = 1_024_000;
+    public const int BitsPerAxis = 20;
+    public const int LatentBits = 256;
+    public const double MinimumVerificationQuality = 0.95;
+
+    public static IReadOnlyList<Dm3dInwardStep> BuildInwardSchedule(
+        Dm3dRuntimeConfig config,
+        int maxIterations = 8)
+    {
+        ValidateConfig(config);
+        if (maxIterations is < 1 or > 64)
+            throw new ArgumentOutOfRangeException(nameof(maxIterations));
+
+        var radius = 16.0;
+        var topK = config.TopK;
+        var resolvedBits = 16;
+        var steps = new List<Dm3dInwardStep>(maxIterations);
+
+        for (var iteration = 0; iteration < maxIterations; iteration++)
+        {
+            var freeBits = Math.Max(0, BitsPerAxis - resolvedBits);
+            var candidateCells = CandidateCells(freeBits);
+            steps.Add(new Dm3dInwardStep(
+                iteration,
+                radius,
+                topK,
+                resolvedBits,
+                freeBits,
+                candidateCells));
+
+            if (topK <= 8 || freeBits == 0)
+                break;
+
+            radius *= config.Alpha;
+            topK = Math.Max(8, topK >> 3);
+            resolvedBits = Math.Min(BitsPerAxis, resolvedBits + 1);
+        }
+
+        return steps;
+    }
+
+    public static ulong Morton3D20(uint x, uint y, uint z)
+    {
+        if (x >= AxisCells || y >= AxisCells || z >= AxisCells)
+            throw new ArgumentOutOfRangeException(nameof(x), "Coordinates must fit the virtual 1,024,000-cell axis.");
+
+        ulong morton = 0;
+        for (var bit = 0; bit < BitsPerAxis; bit++)
+        {
+            morton |= ((ulong)(x >> bit) & 1UL) << (3 * bit);
+            morton |= ((ulong)(y >> bit) & 1UL) << (3 * bit + 1);
+            morton |= ((ulong)(z >> bit) & 1UL) << (3 * bit + 2);
+        }
+
+        return morton;
+    }
+
+    public static int XnorPopCount256(ReadOnlySpan<ulong> left, ReadOnlySpan<ulong> right)
+    {
+        if (left.Length < 4 || right.Length < 4)
+            throw new ArgumentException("A 256-bit code requires four UInt64 words.");
+
+        var matches = 0;
+        for (var i = 0; i < 4; i++)
+            matches += BitOperations.PopCount(~(left[i] ^ right[i]));
+        return matches;
+    }
+
+    public static double VerifyEvidence(
+        ReadOnlySpan<ulong> queryCode,
+        IReadOnlyList<Dm3dEvidence> evidence)
+    {
+        if (queryCode.Length < 4)
+            throw new ArgumentException("A 256-bit query code requires four UInt64 words.", nameof(queryCode));
+        if (evidence.Count == 0)
+            return 0;
+
+        var best = 0.0;
+        foreach (var item in evidence)
+        {
+            if (!item.GraphValid || !item.ContradictionFree)
+                continue;
+            if (item.BinaryCode.Length < 4)
+                throw new InvalidOperationException("Evidence codes must contain four UInt64 words.");
+
+            var semantic = XnorPopCount256(queryCode, item.BinaryCode) / 256.0;
+            var authority = item.Authority / 255.0;
+            best = Math.Max(best, semantic * authority);
+        }
+
+        return best;
+    }
+
+    public static Dm3dOptimizationResult OptimizeRuntime()
+    {
+        var baseline = new Dm3dRuntimeConfig(
+            Alpha: 0.50,
+            TopK: 4096,
+            QuantizationBits: 8,
+            CacheShards: 0,
+            TileSize: 32);
+
+        var candidates = new[]
+        {
+            new Dm3dRuntimeConfig(0.50, 512, 8, 16, 32),
+            new Dm3dRuntimeConfig(0.45, 256, 6, 32, 48),
+            new Dm3dRuntimeConfig(0.40, 128, 6, 48, 48),
+            new Dm3dRuntimeConfig(0.35, 64, 4, 64, 64)
+        };
+
+        var selected = baseline;
+        var selectedMetrics = Measure(baseline);
+        var baselineMetrics = selectedMetrics;
+        var trials = new List<(Dm3dRuntimeConfig Config, Dm3dMetrics Metrics, bool Committed)>();
+
+        foreach (var candidate in candidates)
+        {
+            var metrics = Measure(candidate);
+            var passesGuardrail = metrics.Quality >= MinimumVerificationQuality;
+            var better = passesGuardrail && metrics.Objective > selectedMetrics.Objective;
+            trials.Add((candidate, metrics, better));
+
+            if (!better)
+                continue;
+
+            selected = candidate;
+            selectedMetrics = metrics;
+        }
+
+        return new Dm3dOptimizationResult(
+            baseline,
+            selected,
+            baselineMetrics,
+            selectedMetrics,
+            trials);
+    }
+
+    public static Dm3dMetrics Measure(Dm3dRuntimeConfig config)
+    {
+        ValidateConfig(config);
+
+        var quality = 0.88
+            + 0.025 * (config.QuantizationBits - 4)
+            + 0.000012 * Math.Min(config.TopK, 4096)
+            - Math.Abs(config.Alpha - 0.50) * 0.08
+            - Math.Max(0, config.TileSize - 48) * 0.0008;
+        quality = Math.Clamp(quality, 0.0, 0.999);
+
+        var latency = (config.TopK / 4096.0)
+            * (config.QuantizationBits / 8.0)
+            * (1.0 / (1.0 + config.CacheShards / 24.0))
+            * (32.0 / Math.Max(8, config.TileSize))
+            * (0.65 + config.Alpha);
+
+        var memory = 0.25 * (config.TopK / 4096.0)
+            + 0.45 * (config.QuantizationBits / 8.0)
+            + 0.30 * (config.CacheShards / 64.0);
+
+        var energy = 0.70 * latency + 0.30 * memory;
+        var objective = 0.55 * quality - 0.20 * latency - 0.15 * memory - 0.10 * energy;
+        return new Dm3dMetrics(quality, latency, memory, energy, objective);
+    }
+
+    public static int SelfTest()
+    {
+        var baseline = new Dm3dRuntimeConfig(0.50, 4096, 8, 0, 32);
+        var schedule = BuildInwardSchedule(baseline);
+        var expectedVolumes = new long[] { 4096, 512, 64, 8 };
+
+        if (schedule.Count < expectedVolumes.Length)
+            throw new InvalidOperationException("DM3D inward schedule terminated too early.");
+
+        for (var i = 0; i < expectedVolumes.Length; i++)
+        {
+            if (schedule[i].CandidateCells != expectedVolumes[i])
+                throw new InvalidOperationException(
+                    $"DM3D volume contraction mismatch at t={i}: {schedule[i].CandidateCells} != {expectedVolumes[i]}.");
+        }
+
+        if (Morton3D20(1, 0, 0) != 1 || Morton3D20(0, 1, 0) != 2 || Morton3D20(0, 0, 1) != 4)
+            throw new InvalidOperationException("DM3D Morton XYZ bit interleave invariant failed.");
+
+        var code = new[]
+        {
+            0x0123_4567_89AB_CDEFUL,
+            0xFEDC_BA98_7654_3210UL,
+            0x0F0F_F0F0_AA55_55AAUL,
+            0x1357_9BDF_2468_ACE0UL
+        };
+        var complement = code.Select(static word => ~word).ToArray();
+
+        if (XnorPopCount256(code, code) != 256)
+            throw new InvalidOperationException("DM3D XNOR/POPCOUNT identity score failed.");
+        if (XnorPopCount256(code, complement) != 0)
+            throw new InvalidOperationException("DM3D XNOR/POPCOUNT complement score failed.");
+
+        var evidence = new[]
+        {
+            new Dm3dEvidence(code, 255, GraphValid: true, ContradictionFree: true),
+            new Dm3dEvidence(complement, 255, GraphValid: false, ContradictionFree: false)
+        };
+        if (VerifyEvidence(code, evidence) < 0.999)
+            throw new InvalidOperationException("DM3D verified evidence gate failed.");
+
+        var optimization = OptimizeRuntime();
+        if (optimization.SelectedMetrics.Quality < MinimumVerificationQuality)
+            throw new InvalidOperationException("DM3D optimizer committed a configuration below the verification guardrail.");
+        if (optimization.SelectedMetrics.Objective <= optimization.BaselineMetrics.Objective)
+            throw new InvalidOperationException("DM3D optimizer failed to improve the bounded objective.");
+
+        var romA = Dm3dRomImage.Build();
+        var romB = Dm3dRomImage.Build();
+        if (romA.Length != Dm3dRomImage.RomSize || !romA.AsSpan().SequenceEqual(romB))
+            throw new InvalidOperationException("DM3D ROM generation is not deterministic.");
+
+        Console.WriteLine("DM3D inward evidence/graphics runtime self-test PASS");
+        foreach (var step in schedule)
+        {
+            Console.WriteLine(FormattableString.Invariant(
+                $"t={step.Iteration} radius={step.Radius:G6} topK={step.TopK} resolved={step.ResolvedBitsPerAxis}/axis candidateCells={step.CandidateCells}"));
+        }
+
+        Console.WriteLine(FormattableString.Invariant(
+            $"optimizer baselineObjective={optimization.BaselineMetrics.Objective:G6} selectedObjective={optimization.SelectedMetrics.Objective:G6} selectedQuality={optimization.SelectedMetrics.Quality:G6}"));
+        Console.WriteLine(
+            $"selected alpha={optimization.Selected.Alpha:G3} topK={optimization.Selected.TopK} qbits={optimization.Selected.QuantizationBits} cache={optimization.Selected.CacheShards} tile={optimization.Selected.TileSize}");
+
+        return 0;
+    }
+
+    private static long CandidateCells(int freeBitsPerAxis)
+    {
+        var totalFreeBits = 3 * freeBitsPerAxis;
+        if (totalFreeBits >= 63)
+            throw new InvalidOperationException("Candidate-cell count exceeds Int64 range.");
+        return 1L << totalFreeBits;
+    }
+
+    private static void ValidateConfig(Dm3dRuntimeConfig config)
+    {
+        if (config.Alpha is < 0.35 or > 0.75)
+            throw new ArgumentOutOfRangeException(nameof(config), "Alpha must be in [0.35, 0.75].");
+        if (config.TopK is < 8 or > 4096)
+            throw new ArgumentOutOfRangeException(nameof(config), "TopK must be in [8, 4096].");
+        if (config.QuantizationBits is < 4 or > 8)
+            throw new ArgumentOutOfRangeException(nameof(config), "Quantization bits must be in [4, 8].");
+        if (config.CacheShards is < 0 or > 64)
+            throw new ArgumentOutOfRangeException(nameof(config), "Cache shards must be in [0, 64].");
+        if (config.TileSize is < 8 or > 64)
+            throw new ArgumentOutOfRangeException(nameof(config), "Tile size must be in [8, 64].");
+    }
+}


### PR DESCRIPTION
## Summary

Permeates the inward 3D evidence/graphics architecture into the existing `apps/qsol-graphics-codec` executable rather than creating a parallel runtime.

### Added

- `Runtime/Dm3dSelfOptimizingRuntime.cs`
  - virtual `1,024,000^3` address manifold (20 bits/axis)
  - 60-bit Morton XYZ addressing
  - 256-bit XNOR/POPCOUNT evidence similarity
  - authority + graph + contradiction gates
  - inward prefix refinement (`4096 -> 512 -> 64 -> 8` candidate cells)
  - bounded runtime objective over quality/latency/memory/energy proxy
  - transactional commit/rollback with minimum verification quality `0.95`
  - deterministic runtime self-test

- `Runtime/Dm3dRomImage.cs`
  - deterministic 128 KiB ROM builder
  - fixed-width 16-byte bytecode instructions
  - evidence encode/localize/retrieve/verify opcodes
  - graphics parameter decode/render/inverse-render/spatial-error opcodes
  - profiling and guarded optimizer opcodes
  - CRC32 + SHA-256 integrity metadata
  - immutable executable bytecode; only bounded configuration/cache/latent state is adaptive

- CLI integration
  - `--dm3d-self-test`
  - `--dm3d-rom <path>`
  - regular `--self-test` now also executes DM3D invariants

- README documentation for the inward evidence/graphics loop and ROM generation.

## Core invariant

The extension preserves the existing QSOL codec principle:

> promote a smaller/faster representation only after decoding/verification proves it remains inside the declared quality bound.

The DM3D equivalent is:

```text
evidence -> encode -> 3D locality -> retrieve -> verify
        -> latent correction -> inward contraction -> repeat
        -> parametric render -> inverse render -> spatial error
        -> profile -> guarded config commit/rollback
```

## Important scope constraints

- The `1,024,000^3` lattice is **virtual/procedural**. No dense exabyte-scale buffer is allocated.
- `HOST_SEARCH` is a host integration boundary; the ROM does not treat itself as a web client or source of truth.
- Optimizer latency/memory/energy values in the reference controller are deterministic proxy metrics, not claims of measured CPU/GPU speedup.
- Optimization is bounded configuration search, not arbitrary self-modifying executable code.
- A candidate runtime configuration is rejected if verification quality falls below `0.95`.

## Verification

The DM3D self-test covers:

1. `4096 -> 512 -> 64 -> 8` 3D contraction schedule;
2. Morton XYZ interleave invariants;
3. 256-bit XNOR/POPCOUNT identity/complement behavior;
4. graph/contradiction evidence gating;
5. quality guardrail enforcement;
6. bounded objective improvement;
7. deterministic ROM generation.

No GitHub Actions workflow was triggered by the branch at PR creation time, so this PR is intentionally opened as **draft** pending repository CI/build verification.