### PR TITLE
Permeate DM-vOmegaXi+ contour operator into runtime

### DIFF
--- a/docs/dm-vomegaxi-contour-operator.md
+++ b/docs/dm-vomegaxi-contour-operator.md
@@ -1,0 +1,230 @@
+# DM-vOmegaXi+ Contour Operator
+
+## Status
+
+Executable mathematical kernel for the archived operator
+
+```text
+Psi = integral_Theta [ (Phi tensor grad(Lambda)) / Omega^Xi+ ]
+                     * exp(DM - v*Omega*Xi+) dv
+```
+
+This document makes the implicit types, numerical assumptions, and integration semantics explicit. It is designed to feed the existing bounded `Psi -> Phi -> Lambda^-1 -> Omega -> Theta` fixed-point runtime; it does not replace that runtime or relax its transactional invariants.
+
+## Typed state
+
+Let
+
+```text
+Phi(v)         in R^m
+grad Lambda(v) in R^d
+Omega(v)       > 0
+Xi+(v)         > 0
+DM(v)          in R
+```
+
+Then
+
+```text
+Phi tensor grad(Lambda) in R^(m x d)
+Psi                      in R^(m x d)
+```
+
+Componentwise,
+
+```text
+Psi_ij = integral Phi_i(v) * d_j Lambda(v)
+                  * Omega(v)^(-Xi+(v))
+                  * exp(DM(v) - v*Omega(v)*Xi+(v)) dv
+```
+
+All quantities appearing inside exponentials are normalized dimensionless runtime values.
+
+## Local recurrence
+
+Define the scalar weight
+
+```text
+W(v) = Omega(v)^(-Xi+(v)) * exp(DM(v) - v*Omega(v)*Xi+(v))
+```
+
+and the local tensor coupling
+
+```text
+C(v) = Phi(v) tensor grad(Lambda(v)).
+```
+
+Then
+
+```text
+dPsi/dv = W(v) * C(v)
+```
+
+and the discrete runtime recurrence is
+
+```text
+Psi[k+1] = Psi[k] + dv * W(v_k) * C(v_k).
+```
+
+The implementation is `DMvOmegaXiContourOperator.step`.
+
+## Closed form for constant fields
+
+For constant `Phi`, `grad(Lambda)`, `Omega`, `Xi+`, and `DM` over `v in [0,L]`,
+
+```text
+Psi = (Phi tensor grad(Lambda))
+      * exp(DM)
+      * (1 - exp(-L*Omega*Xi+))
+      / (Xi+ * Omega^(Xi+ + 1)).
+```
+
+This is implemented exactly by `constant_causal_closed_form` using `expm1` for improved small-argument precision.
+
+For the concrete arithmetic example
+
+```text
+Phi         = [2, -1]
+grad Lambda = [3, 4]
+Omega       = 2
+Xi+         = 1
+DM          = 0.5
+L           = 1
+```
+
+we obtain
+
+```text
+Phi tensor grad(Lambda)
+= [[ 6,  8],
+   [-3, -4]]
+```
+
+and
+
+```text
+Psi ~= [[ 2.1384,  2.8512],
+        [-1.0692, -1.4256]].
+```
+
+The test suite locks this result.
+
+## Sensitivity structure
+
+For the causal gate,
+
+```text
+log W = DM - Xi+*log(Omega) - v*Omega*Xi+.
+```
+
+Therefore
+
+```text
+d(log W)/dDM       = 1
+d(log W)/dv        = -Omega*Xi+
+d(log W)/dOmega    = -Xi+/Omega - v*Xi+
+d(log W)/dXi+      = -log(Omega) - v*Omega.
+```
+
+These derivatives are exposed by `causal_sensitivities` and are suitable for diagnostics, controller tuning, or gradient-based parameter updates.
+
+## Causal versus genuinely closed contours
+
+The archived formula combines a closed-contour symbol with the non-periodic factor
+
+```text
+exp(-v*Omega*Xi+).
+```
+
+If `v=0` and `v=L` denote the same point on a closed loop, this factor generally has different endpoint values. The implementation therefore makes the choice explicit.
+
+### Causal mode
+
+`gate_mode="causal"` preserves the archived attenuation law exactly:
+
+```text
+G(v) = exp(DM - v*Omega*Xi+).
+```
+
+Use this for a forward path, time-like coordinate, or dissipative runtime interval.
+
+### Periodic mode
+
+`gate_mode="periodic"` uses
+
+```text
+G(v) = exp(DM - Omega*Xi+*(1-cos(theta)))
+theta = 2*pi*v/period.
+```
+
+Then
+
+```text
+G(v + period) = G(v),
+```
+
+so the weighting is consistent on a true closed contour.
+
+## Numerical safeguards
+
+The executable contract enforces:
+
+1. `Omega > 0` to avoid the power-law singularity.
+2. `Xi+ > 0` for the intended positive selectivity/attenuation regime.
+3. finite vector and scalar inputs.
+4. finite positive integration step `dv`.
+5. bounded logarithmic exponent before `exp` to prevent floating-point overflow.
+6. invariant tensor shape across a discrete integration pass.
+
+No large dense 3D allocation is implied by this operator.
+
+## Relationship to the fixed-point engine
+
+The contour kernel computes a measurable state increment. A higher-level inward loop may consume that increment before passing the candidate state through the existing encoder/decoder, recurrent memory fold, and bounded `Theta` projection.
+
+Schematically:
+
+```text
+(Phi_t, grad Lambda_t, Omega_t, Xi+_t, DM_t)
+    -> contour operator
+    -> Delta Psi_t
+    -> Psi_candidate
+    -> Phi encode
+    -> Lambda^-1 latent projection
+    -> decode
+    -> Omega recurrent fold
+    -> Theta bounded projection
+    -> H_(t+1)
+```
+
+The higher-level fixed point remains
+
+```text
+H* = F_DM(H*)
+```
+
+with measured convergence and a strictly positive semantic uncertainty floor. The contour equation is therefore an executable inner kernel, not a substitute for validation, observation, or external-world evidence.
+
+## Reference API
+
+```python
+from jarvisx.dm_vomegaxi_contour_operator import (
+    ContourSample,
+    DMvOmegaXiContourOperator,
+)
+
+op = DMvOmegaXiContourOperator()
+psi = ()
+psi = op.step(
+    psi,
+    ContourSample(
+        v=0.0,
+        phi=(2.0, -1.0),
+        grad_lambda=(3.0, 4.0),
+        omega=2.0,
+        xi_plus=1.0,
+        dm=0.5,
+    ),
+    dv=0.01,
+)
+```

--- a/src/jarvisx/dm_vomegaxi_contour_operator.py
+++ b/src/jarvisx/dm_vomegaxi_contour_operator.py
@@ -1,0 +1,259 @@
+"""Numerically bounded reference kernel for the DM-vOmegaXi+ contour operator.
+
+The symbolic law is
+
+    Psi = integral_Theta [ (Phi tensor grad(Lambda)) / Omega**Xi+ ]
+                         * exp(DM - v * Omega * Xi+) dv
+
+This module makes the implicit types explicit and provides two execution modes:
+
+* ``causal`` evaluates the archived exponential attenuation literally over an
+  interval.  This is the natural interpretation for a forward runtime path.
+* ``periodic`` replaces the non-periodic attenuation term with the periodic
+  gate ``exp(DM - Omega*Xi+*(1-cos(theta)))`` so that a true closed contour has
+  matching values at its endpoints.
+
+All quantities in an exponential are treated as dimensionless normalized
+runtime values.  The operator is an internal mathematical kernel; it does not
+assert correspondence between an internal state and external reality.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+Vector = tuple[float, ...]
+Matrix = tuple[tuple[float, ...], ...]
+GateMode = Literal["causal", "periodic"]
+
+
+@dataclass(frozen=True)
+class ContourOperatorConfig:
+    """Numerical contract for the contour operator."""
+
+    gate_mode: GateMode = "causal"
+    omega_epsilon: float = 1.0e-12
+    exponent_limit: float = 700.0
+    period: float = 2.0 * math.pi
+
+    def __post_init__(self) -> None:
+        if self.gate_mode not in ("causal", "periodic"):
+            raise ValueError("gate_mode must be 'causal' or 'periodic'")
+        for name in ("omega_epsilon", "exponent_limit", "period"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+            if float(value) <= 0.0:
+                raise ValueError(f"{name} must be strictly positive")
+
+
+@dataclass(frozen=True)
+class ContourSample:
+    """One typed sample of the DM-vOmegaXi+ integrand."""
+
+    v: float
+    phi: Vector
+    grad_lambda: Vector
+    omega: float
+    xi_plus: float
+    dm: float
+
+    def __post_init__(self) -> None:
+        scalars = {
+            "v": self.v,
+            "omega": self.omega,
+            "xi_plus": self.xi_plus,
+            "dm": self.dm,
+        }
+        for name, value in scalars.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if self.omega <= 0.0:
+            raise ValueError("omega must be strictly positive")
+        if self.xi_plus <= 0.0:
+            raise ValueError("xi_plus must be strictly positive")
+        if not self.phi:
+            raise ValueError("phi must not be empty")
+        if not self.grad_lambda:
+            raise ValueError("grad_lambda must not be empty")
+        _validate_vector("phi", self.phi)
+        _validate_vector("grad_lambda", self.grad_lambda)
+
+
+@dataclass(frozen=True)
+class WeightSensitivities:
+    """Analytic derivatives of log(weight) in causal mode."""
+
+    d_log_weight_d_dm: float
+    d_log_weight_d_v: float
+    d_log_weight_d_omega: float
+    d_log_weight_d_xi_plus: float
+
+
+class DMvOmegaXiContourOperator:
+    """Executable tensor-integral kernel for the archived DM-vOmegaXi+ law."""
+
+    LAW_ID = "DM-vOmegaXi+-contour"
+
+    def __init__(self, config: ContourOperatorConfig | None = None) -> None:
+        self.config = config or ContourOperatorConfig()
+
+    @staticmethod
+    def outer(phi: Sequence[float], grad_lambda: Sequence[float]) -> Matrix:
+        """Return Phi tensor grad(Lambda)."""
+        if not phi or not grad_lambda:
+            raise ValueError("outer-product vectors must not be empty")
+        _validate_vector("phi", phi)
+        _validate_vector("grad_lambda", grad_lambda)
+        return tuple(
+            tuple(float(phi_i) * float(grad_j) for grad_j in grad_lambda)
+            for phi_i in phi
+        )
+
+    def log_weight(self, sample: ContourSample) -> float:
+        """Return log(Omega^-Xi+ * gate) before exponent clipping."""
+        omega = max(float(sample.omega), self.config.omega_epsilon)
+        xi = float(sample.xi_plus)
+        if self.config.gate_mode == "causal":
+            gate_exponent = float(sample.dm) - float(sample.v) * omega * xi
+        else:
+            theta = 2.0 * math.pi * float(sample.v) / self.config.period
+            gate_exponent = float(sample.dm) - omega * xi * (1.0 - math.cos(theta))
+        return gate_exponent - xi * math.log(omega)
+
+    def weight(self, sample: ContourSample) -> float:
+        """Return the bounded scalar weight multiplying the tensor product."""
+        log_weight = self.log_weight(sample)
+        limit = self.config.exponent_limit
+        return math.exp(max(-limit, min(limit, log_weight)))
+
+    def local_derivative(self, sample: ContourSample) -> Matrix:
+        """Evaluate dPsi/dv at one sample."""
+        tensor = self.outer(sample.phi, sample.grad_lambda)
+        scalar = self.weight(sample)
+        return _scale_matrix(tensor, scalar)
+
+    def step(self, psi: Matrix, sample: ContourSample, dv: float) -> Matrix:
+        """Apply Psi[k+1] = Psi[k] + dv * integrand(sample)."""
+        _validate_step(dv)
+        derivative = self.local_derivative(sample)
+        if not psi:
+            psi = _zero_matrix(len(sample.phi), len(sample.grad_lambda))
+        _validate_same_shape(psi, derivative)
+        return _add_matrix(psi, _scale_matrix(derivative, float(dv)))
+
+    def integrate(self, samples: Sequence[ContourSample], dv: float) -> Matrix:
+        """Uniform left-Riemann accumulation over typed samples."""
+        if not samples:
+            raise ValueError("samples must not be empty")
+        _validate_step(dv)
+        rows = len(samples[0].phi)
+        cols = len(samples[0].grad_lambda)
+        psi = _zero_matrix(rows, cols)
+        for sample in samples:
+            if len(sample.phi) != rows or len(sample.grad_lambda) != cols:
+                raise ValueError("all samples must have the same tensor shape")
+            psi = self.step(psi, sample, dv)
+        return psi
+
+    def causal_sensitivities(self, sample: ContourSample) -> WeightSensitivities:
+        """Return analytic sensitivities of log(weight) for the archived gate."""
+        if self.config.gate_mode != "causal":
+            raise RuntimeError("causal sensitivities require gate_mode='causal'")
+        omega = max(float(sample.omega), self.config.omega_epsilon)
+        xi = float(sample.xi_plus)
+        v = float(sample.v)
+        return WeightSensitivities(
+            d_log_weight_d_dm=1.0,
+            d_log_weight_d_v=-omega * xi,
+            d_log_weight_d_omega=-(xi / omega) - v * xi,
+            d_log_weight_d_xi_plus=-math.log(omega) - v * omega,
+        )
+
+    @staticmethod
+    def constant_causal_closed_form(
+        *,
+        phi: Sequence[float],
+        grad_lambda: Sequence[float],
+        omega: float,
+        xi_plus: float,
+        dm: float,
+        length: float,
+    ) -> Matrix:
+        """Exact integral for constant fields over v in [0, length].
+
+        Psi = (Phi tensor grad(Lambda))
+              * exp(DM) * (1-exp(-length*Omega*Xi+))
+              / (Xi+ * Omega**(Xi+ + 1)).
+        """
+        for name, value in {
+            "omega": omega,
+            "xi_plus": xi_plus,
+            "dm": dm,
+            "length": length,
+        }.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if omega <= 0.0:
+            raise ValueError("omega must be strictly positive")
+        if xi_plus <= 0.0:
+            raise ValueError("xi_plus must be strictly positive")
+        if length < 0.0:
+            raise ValueError("length must be non-negative")
+
+        tensor = DMvOmegaXiContourOperator.outer(phi, grad_lambda)
+        decay = -math.expm1(-float(length) * float(omega) * float(xi_plus))
+        scale = (
+            math.exp(float(dm))
+            * decay
+            / (float(xi_plus) * float(omega) ** (float(xi_plus) + 1.0))
+        )
+        return _scale_matrix(tensor, scale)
+
+
+def _validate_vector(name: str, vector: Sequence[float]) -> None:
+    for value in vector:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} entries must be numeric")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} entries must be finite")
+
+
+def _validate_step(dv: float) -> None:
+    if isinstance(dv, bool) or not isinstance(dv, (int, float)):
+        raise TypeError("dv must be numeric")
+    if not math.isfinite(float(dv)):
+        raise ValueError("dv must be finite")
+    if float(dv) <= 0.0:
+        raise ValueError("dv must be strictly positive")
+
+
+def _zero_matrix(rows: int, cols: int) -> Matrix:
+    return tuple(tuple(0.0 for _ in range(cols)) for _ in range(rows))
+
+
+def _scale_matrix(matrix: Matrix, scalar: float) -> Matrix:
+    return tuple(tuple(float(value) * scalar for value in row) for row in matrix)
+
+
+def _add_matrix(left: Matrix, right: Matrix) -> Matrix:
+    _validate_same_shape(left, right)
+    return tuple(
+        tuple(left[i][j] + right[i][j] for j in range(len(left[i])))
+        for i in range(len(left))
+    )
+
+
+def _validate_same_shape(left: Matrix, right: Matrix) -> None:
+    if len(left) != len(right):
+        raise ValueError("matrix row counts must match")
+    if any(len(left_row) != len(right_row) for left_row, right_row in zip(left, right)):
+        raise ValueError("matrix column counts must match")

--- a/tests/test_dm_vomegaxi_contour_operator.py
+++ b/tests/test_dm_vomegaxi_contour_operator.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.dm_vomegaxi_contour_operator import (
+    ContourOperatorConfig,
+    ContourSample,
+    DMvOmegaXiContourOperator,
+)
+
+
+def test_outer_product_is_typed_tensor_coupling():
+    tensor = DMvOmegaXiContourOperator.outer((2.0, -1.0), (3.0, 4.0))
+
+    assert tensor == ((6.0, 8.0), (-3.0, -4.0))
+
+
+def test_constant_closed_form_matches_documented_arithmetic_example():
+    psi = DMvOmegaXiContourOperator.constant_causal_closed_form(
+        phi=(2.0, -1.0),
+        grad_lambda=(3.0, 4.0),
+        omega=2.0,
+        xi_plus=1.0,
+        dm=0.5,
+        length=1.0,
+    )
+
+    assert psi[0][0] == pytest.approx(2.13839, rel=1.0e-5)
+    assert psi[0][1] == pytest.approx(2.85119, rel=1.0e-5)
+    assert psi[1][0] == pytest.approx(-1.06919, rel=1.0e-5)
+    assert psi[1][1] == pytest.approx(-1.42559, rel=1.0e-5)
+
+
+def test_discrete_recurrence_converges_to_constant_closed_form():
+    operator = DMvOmegaXiContourOperator()
+    n = 20_000
+    dv = 1.0 / n
+    samples = tuple(
+        ContourSample(
+            v=k * dv,
+            phi=(2.0, -1.0),
+            grad_lambda=(3.0, 4.0),
+            omega=2.0,
+            xi_plus=1.0,
+            dm=0.5,
+        )
+        for k in range(n)
+    )
+
+    numerical = operator.integrate(samples, dv)
+    exact = operator.constant_causal_closed_form(
+        phi=(2.0, -1.0),
+        grad_lambda=(3.0, 4.0),
+        omega=2.0,
+        xi_plus=1.0,
+        dm=0.5,
+        length=1.0,
+    )
+
+    for numerical_row, exact_row in zip(numerical, exact):
+        for numerical_value, exact_value in zip(numerical_row, exact_row):
+            assert numerical_value == pytest.approx(exact_value, rel=1.5e-4)
+
+
+def test_zero_gradient_produces_zero_local_update():
+    operator = DMvOmegaXiContourOperator()
+    sample = ContourSample(
+        v=0.5,
+        phi=(7.0, -3.0),
+        grad_lambda=(0.0, 0.0, 0.0),
+        omega=1.5,
+        xi_plus=2.0,
+        dm=1.0,
+    )
+
+    assert operator.local_derivative(sample) == (
+        (0.0, 0.0, 0.0),
+        (0.0, 0.0, 0.0),
+    )
+
+
+def test_periodic_gate_matches_at_closed_contour_endpoints():
+    operator = DMvOmegaXiContourOperator(
+        ContourOperatorConfig(gate_mode="periodic", period=2.0 * math.pi)
+    )
+    start = ContourSample(
+        v=0.0,
+        phi=(1.0,),
+        grad_lambda=(1.0,),
+        omega=2.0,
+        xi_plus=1.5,
+        dm=0.25,
+    )
+    end = ContourSample(
+        v=2.0 * math.pi,
+        phi=(1.0,),
+        grad_lambda=(1.0,),
+        omega=2.0,
+        xi_plus=1.5,
+        dm=0.25,
+    )
+
+    assert operator.weight(start) == pytest.approx(operator.weight(end), rel=1.0e-14)
+
+
+def test_causal_gate_is_not_periodic_and_decays_for_positive_omega_xi():
+    operator = DMvOmegaXiContourOperator(ContourOperatorConfig(gate_mode="causal"))
+    start = ContourSample(0.0, (1.0,), (1.0,), 2.0, 1.5, 0.25)
+    later = ContourSample(1.0, (1.0,), (1.0,), 2.0, 1.5, 0.25)
+
+    assert operator.weight(later) < operator.weight(start)
+
+
+def test_causal_sensitivities_match_closed_form_derivatives():
+    operator = DMvOmegaXiContourOperator()
+    sample = ContourSample(
+        v=0.5,
+        phi=(1.0,),
+        grad_lambda=(1.0,),
+        omega=2.0,
+        xi_plus=3.0,
+        dm=0.25,
+    )
+
+    sensitivity = operator.causal_sensitivities(sample)
+
+    assert sensitivity.d_log_weight_d_dm == pytest.approx(1.0)
+    assert sensitivity.d_log_weight_d_v == pytest.approx(-6.0)
+    assert sensitivity.d_log_weight_d_omega == pytest.approx(-3.0)
+    assert sensitivity.d_log_weight_d_xi_plus == pytest.approx(-math.log(2.0) - 1.0)
+
+
+def test_operator_rejects_singular_or_non_positive_control_values():
+    with pytest.raises(ValueError, match="omega must be strictly positive"):
+        ContourSample(0.0, (1.0,), (1.0,), 0.0, 1.0, 0.0)
+
+    with pytest.raises(ValueError, match="xi_plus must be strictly positive"):
+        ContourSample(0.0, (1.0,), (1.0,), 1.0, 0.0, 0.0)
+
+
+def test_exponent_limit_prevents_overflow():
+    operator = DMvOmegaXiContourOperator(ContourOperatorConfig(exponent_limit=100.0))
+    sample = ContourSample(
+        v=0.0,
+        phi=(1.0,),
+        grad_lambda=(1.0,),
+        omega=1.0,
+        xi_plus=1.0,
+        dm=1.0e9,
+    )
+
+    assert math.isfinite(operator.weight(sample))
+    assert operator.weight(sample) == pytest.approx(math.exp(100.0))


### PR DESCRIPTION
## Summary

Permeates the archived DM-vOmegaXi+ contour equation into Jarvis-X as an executable, bounded mathematical kernel.

### Added
- `src/jarvisx/dm_vomegaxi_contour_operator.py`
  - typed `Phi ⊗ grad(Lambda)` tensor coupling
  - power-law `Omega^-Xi+` normalization
  - literal causal gate `exp(DM - v*Omega*Xi+)`
  - periodic closed-contour gate for endpoint-consistent toroidal execution
  - discrete recurrence `Psi[k+1] = Psi[k] + dv * integrand`
  - exact constant-field closed form
  - analytic causal log-weight sensitivities
  - finite-domain validation and exponent clamping
- `tests/test_dm_vomegaxi_contour_operator.py`
  - locks the arithmetic example
  - verifies discrete-to-closed-form convergence
  - verifies zero-gradient behavior
  - verifies periodic endpoint identity and causal decay
  - verifies sensitivities and numerical guards
- `docs/dm-vomegaxi-contour-operator.md`
  - formal types, equations, dimensional assumptions, causal/periodic distinction, and fixed-point integration semantics

## Architectural boundary

This does **not** replace the existing bounded `Psi -> Phi -> Lambda^-1 -> Omega -> Theta` fixed-point engine. It adds the uploaded contour law as a measurable inner kernel that can produce `Delta Psi` before the existing transactional encode/decode/memory/Theta loop.

The fixed-point contract remains `H* = F_DM(H*)`, with measured convergence and a positive semantic uncertainty floor.