### PR TITLE
feat(runtime): permeate unified JARVIS-X coordination state

### DIFF
--- a/.github/workflows/dr-moagi-ide.yml
+++ b/.github/workflows/dr-moagi-ide.yml
@@ -6,15 +6,23 @@ on:
     paths:
       - "src/jarvisx/dr_moagi_ide.py"
       - "src/jarvisx/dr_moagi_ide_api.py"
+      - "src/jarvisx/unified_runtime.py"
+      - "src/jarvisx/unified_runtime_api.py"
       - "apps/dr-moagi-ide/**"
       - "tests/test_dr_moagi_ide.py"
+      - "tests/test_unified_runtime.py"
+      - "docs/JARVIS_X_UNIFIED_RUNTIME.md"
       - ".github/workflows/dr-moagi-ide.yml"
   pull_request:
     paths:
       - "src/jarvisx/dr_moagi_ide.py"
       - "src/jarvisx/dr_moagi_ide_api.py"
+      - "src/jarvisx/unified_runtime.py"
+      - "src/jarvisx/unified_runtime_api.py"
       - "apps/dr-moagi-ide/**"
       - "tests/test_dr_moagi_ide.py"
+      - "tests/test_unified_runtime.py"
+      - "docs/JARVIS_X_UNIFIED_RUNTIME.md"
       - ".github/workflows/dr-moagi-ide.yml"
   workflow_dispatch:
 
@@ -31,12 +39,14 @@ jobs:
           python-version: "3.12"
           cache: pip
       - run: python -m pip install -e ".[test]"
-      - run: pytest -q tests/test_dr_moagi_ide.py
+      - run: pytest -q tests/test_dr_moagi_ide.py tests/test_unified_runtime.py
       - name: Import API
         env:
           JARVISX_IDE_DB: ${{ runner.temp }}/ide.sqlite3
           JARVISX_STATE_DIR: ${{ runner.temp }}/dr-moagi-os
-        run: python -c "from jarvisx.dr_moagi_ide_api import app; assert app.title == 'Dr Moagi ANN IDE'"
+        run: |
+          python -c "from jarvisx.dr_moagi_ide_api import app; assert app.title == 'Dr Moagi ANN IDE'"
+          python -c "from jarvisx.unified_runtime_api import app; assert app.title == 'JARVIS-X Unified Runtime'"
 
   container:
     runs-on: ubuntu-latest
@@ -50,6 +60,8 @@ jobs:
           for i in {1..30}; do
             if curl --fail --silent http://127.0.0.1:8000/healthz >/tmp/health.json; then
               cat /tmp/health.json
+              curl --fail --silent http://127.0.0.1:8000/runtime/healthz >/tmp/runtime-health.json
+              cat /tmp/runtime-health.json
               exit 0
             fi
             sleep 1

--- a/docs/JARVIS_X_UNIFIED_RUNTIME.md
+++ b/docs/JARVIS_X_UNIFIED_RUNTIME.md
@@ -1,0 +1,249 @@
+# JARVIS-X Unified Runtime Permeation
+
+## Status
+
+Bounded coordination layer for the existing Dr Moagi ANN IDE.
+
+This module does **not** replace the canonical Jarvis-X VM, the inward ANN implementations,
+the policy/admission layer, or evidence from the external world. It makes the shared
+runtime state explicit so those surfaces can exchange measured state rather than decorative
+telemetry.
+
+## Unified state
+
+The committed state is
+
+```text
+S_t = (
+  Psi_t,
+  Phi_t,
+  Lambda_t,
+  Omega_t,
+  Theta_t,
+  Z_t,
+  Xhat_t,
+  e_t,
+  telemetry_t
+)
+```
+
+with
+
+```text
+S_(t+1) = M(S_t, X_t)
+```
+
+and fixed-point intent
+
+```text
+S* = M(S*, X).
+```
+
+The executable reference is `jarvisx.unified_runtime.UnifiedRuntime`.
+
+## Operators
+
+### Psi
+
+For bounded observation `x_i` and previous residual memory `omega_i`,
+
+```text
+Psi_i = tanh(x_i + g_omega * omega_i)
+```
+
+where `g_omega = psi_memory_gain`.
+
+`Psi` is an internal coordination state, not a claim that the runtime has measured or
+reconstructed the physical world.
+
+### Phi
+
+For at least two state elements,
+
+```text
+Phi_i = 0.5 Psi_i + 0.25 Psi_(i-1) + 0.25 Psi_(i+1)
+```
+
+using wraparound indexing. A one-element state uses `Phi = Psi`.
+
+This gives the coordination layer a deterministic local manifold operator without a dense
+3D allocation.
+
+### Lambda
+
+```text
+Lambda_i = tanh(Phi_i + Theta_t Psi_i)
+```
+
+`Lambda` here is transform state, not an authorization decision. Canonical policy and
+admissibility remain in the existing Jarvis-X transaction/policy machinery.
+
+### Auto-encode / auto-decode
+
+The reference codec uses deterministic block means:
+
+```text
+Z_j = mean(Lambda[j*b : (j+1)*b])
+Xhat = D(Z)
+e = Lambda - Xhat
+L_recon = mean(e^2)
+```
+
+Re-encoding the decoded state gives
+
+```text
+L_cycle = MSE(Z, E(D(Z))).
+```
+
+For this exact block codec, `L_cycle = 0` up to floating-point arithmetic. This is an
+algebraic cycle-consistency check, not a learned-compression claim.
+
+### Omega
+
+Residual memory closes the inward loop:
+
+```text
+Omega_(t+1) = rho Omega_t + (1-rho) e_t
+```
+
+The next `Psi` reads this residual through `psi_memory_gain`.
+
+### Theta
+
+The controller state is bounded:
+
+```text
+Theta_(t+1) = clip(
+    Theta_t + eta (L_recon - epsilon),
+    -Theta_max,
+    +Theta_max
+)
+```
+
+It does not rewrite source code, alter policy, or grant execution authority.
+
+## Measured H_MMM
+
+Earlier browser prototypes used decorative sinusoidal HUD values. The unified runtime
+instead reports
+
+```text
+H_MMM =
+    L_recon
+    + 0.25 L_cycle
+    + 0.10 Delta_state
+    + L_resource
+```
+
+with
+
+```text
+Delta_state = RMS(Psi_t - Psi_(t-1))
+L_resource  = resource_weight * dimensions / max_dimensions.
+```
+
+Lower values indicate a smaller internal reconstruction/state-change objective. `H_MMM`
+is a runtime diagnostic, not a physical Hamiltonian or universal-intelligence score.
+
+## Verification and stability
+
+A state is `verified` only when all committed numeric values are finite.
+
+A state is `stable` only when
+
+```text
+verified
+and L_recon <= stability_epsilon
+and Delta_state <= stability_epsilon.
+```
+
+Every committed state receives a deterministic SHA-256 digest over numeric state, metrics,
+cycle count, and verification flags. The hash supports replay/audit identity; it does not
+establish semantic correctness or external-world truth.
+
+## Relationship to the merged contour operator
+
+`DMvOmegaXiContourOperator` remains a measurable inner kernel that may produce a bounded
+`Delta Psi` before a unified runtime tick:
+
+```text
+(Phi, grad Lambda, Omega, Xi+, DM)
+        -> contour operator
+        -> Delta Psi
+        -> bounded candidate/observation
+        -> UnifiedRuntime.step(...)
+```
+
+This preserves the contour law as an explicit mathematical kernel without letting it bypass
+validation or become an implicit source of truth.
+
+## IDE integration
+
+The repository already exposes:
+
+```text
+Dr Moagi ANN IDE
+  |- transactional CodexVM
+  |- deterministic bounded refactorer
+  |- Inward4D ANN
+  |- SQLite project persistence
+  |- telemetry journal / WebSocket
+  `- Dr Moagi 3D OS mount
+```
+
+The unified runtime is mounted as an additional coordination plane at `/runtime` through
+`jarvisx.unified_runtime_api`.
+
+Typical flow:
+
+```text
+POST   /runtime/v1/sessions
+POST   /runtime/v1/sessions/{id}/tick
+GET    /runtime/v1/sessions/{id}
+POST   /runtime/v1/sessions/{id}/reset
+DELETE /runtime/v1/sessions/{id}
+```
+
+Long-term, Chat, Editor, VM, ANN, and 3D visualization should read the same committed state
+envelope rather than maintain unrelated synthetic metrics.
+
+## Security and authority boundaries
+
+The coordination layer:
+
+- exposes no `eval`, `exec`, shell, GPIO, or host-process execution;
+- contains no provider API secret and makes no remote LLM call;
+- does not allocate symbolic virtual 3D spaces densely;
+- does not treat internal reconstruction error as evidence about the external world;
+- does not replace transaction, policy, rollback, or verification boundaries;
+- uses bounded dimensions, bounded value magnitude, finite checks, deterministic hashing,
+  and a bounded session count.
+
+## Reference use
+
+```python
+from jarvisx.unified_runtime import UnifiedRuntime
+
+runtime = UnifiedRuntime()
+state = runtime.step([0.2, -0.4, 0.8, 0.1])
+
+print(state.h_mmm)
+print(state.state_hash)
+```
+
+The next call re-enters through `Omega` and `Theta`:
+
+```text
+X_t
+ -> Psi
+ -> Phi
+ -> Lambda
+ -> E
+ -> Z
+ -> D
+ -> Xhat
+ -> e
+ -> Omega_(t+1)
+ -> Theta_(t+1)
+ -> next Psi
+```

--- a/src/jarvisx/dr_moagi_ide_api.py
+++ b/src/jarvisx/dr_moagi_ide_api.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from .dr_moagi_ide import ANNRegistry, EventJournal, ProjectStore, execute_program, refactor_program
 from .dr_moagi_os_api import app as os_control_plane
+from .unified_runtime_api import app as unified_runtime_plane
 
 ROOT = Path(__file__).resolve().parents[2]
 STATIC_DIR = Path(os.getenv("JARVISX_IDE_STATIC_DIR", str(ROOT / "apps/dr-moagi-ide/static")))
@@ -24,6 +25,7 @@ projects, events, ann = ProjectStore(DB_PATH), EventJournal(500), ANNRegistry(16
 if STATIC_DIR.is_dir():
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 app.mount("/os", os_control_plane)
+app.mount("/runtime", unified_runtime_plane)
 
 class VMRunRequest(BaseModel):
     source: str = Field(min_length=1, max_length=262_144)
@@ -71,11 +73,11 @@ def index() -> Response:
 
 @app.get("/healthz")
 def healthz() -> dict[str, Any]:
-    return {"status":"ok","service":"dr-moagi-ann-ide","version":app.version,"time":time.time(),"static_bundle":STATIC_DIR.is_dir(),"telemetry_sequence":events.sequence,"os_control_plane":"/os"}
+    return {"status":"ok","service":"dr-moagi-ann-ide","version":app.version,"time":time.time(),"static_bundle":STATIC_DIR.is_dir(),"telemetry_sequence":events.sequence,"os_control_plane":"/os","unified_runtime_plane":"/runtime"}
 
 @app.get("/v1/capabilities")
 def capabilities() -> dict[str, Any]:
-    return {"vm":{"engine":"CodexVM","opcodes":["SET","ADD","SUB","HALT"],"transactional":True,"cycle_bounded":True,"arbitrary_shell":False},"refactorer":{"deterministic":True,"unsafe_mutation":False},"ann":{"engine":"Inward4DANN","side_range":[3,10],"max_epochs_per_request":50,"max_sessions":16},"persistence":{"engine":"sqlite","projects":True},"telemetry":{"http":"/v1/telemetry","websocket":"/ws/telemetry"},"dr_moagi_os":{"mounted":True,"base_path":"/os"}}
+    return {"vm":{"engine":"CodexVM","opcodes":["SET","ADD","SUB","HALT"],"transactional":True,"cycle_bounded":True,"arbitrary_shell":False},"refactorer":{"deterministic":True,"unsafe_mutation":False},"ann":{"engine":"Inward4DANN","side_range":[3,10],"max_epochs_per_request":50,"max_sessions":16},"persistence":{"engine":"sqlite","projects":True},"telemetry":{"http":"/v1/telemetry","websocket":"/ws/telemetry"},"dr_moagi_os":{"mounted":True,"base_path":"/os"},"unified_runtime":{"mounted":True,"base_path":"/runtime","contract":"S[t+1] = M(S[t], X[t])"}}
 
 @app.post("/v1/vm/run")
 def vm_run(req: VMRunRequest) -> dict[str, Any]:

--- a/src/jarvisx/unified_runtime.py
+++ b/src/jarvisx/unified_runtime.py
@@ -1,0 +1,406 @@
+"""Bounded shared-state coordination runtime for JARVIS-X.
+
+This module unifies the symbolic Psi-Phi-Lambda-Omega-Theta vocabulary with an
+explicit, measurable state transition. It is intentionally dependency-free and
+does not replace the canonical CodexVM, ANN implementations, policy engine, or
+external-world verification. Instead it provides a deterministic coordination
+state that those surfaces can observe and drive.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import struct
+import threading
+import uuid
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+Vector = tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class UnifiedRuntimeConfig:
+    """Numerical and resource bounds for one shared-state runtime."""
+
+    latent_block_size: int = 2
+    omega_retention: float = 0.85
+    psi_memory_gain: float = 0.25
+    theta_gain: float = 0.05
+    theta_limit: float = 1.0
+    stability_epsilon: float = 1.0e-6
+    max_dimensions: int = 256
+    value_limit: float = 1.0e6
+    resource_weight: float = 1.0e-3
+
+    def __post_init__(self) -> None:
+        if isinstance(self.latent_block_size, bool) or not isinstance(
+            self.latent_block_size, int
+        ):
+            raise TypeError("latent_block_size must be an integer")
+        if self.latent_block_size < 1:
+            raise ValueError("latent_block_size must be at least 1")
+        if isinstance(self.max_dimensions, bool) or not isinstance(self.max_dimensions, int):
+            raise TypeError("max_dimensions must be an integer")
+        if not 1 <= self.max_dimensions <= 4096:
+            raise ValueError("max_dimensions must be in [1, 4096]")
+
+        bounded_unit = {
+            "omega_retention": self.omega_retention,
+            "psi_memory_gain": self.psi_memory_gain,
+        }
+        for name, value in bounded_unit.items():
+            _finite_number(name, value)
+            if not 0.0 <= float(value) <= 1.0:
+                raise ValueError(f"{name} must be in [0, 1]")
+
+        positive = {
+            "theta_gain": self.theta_gain,
+            "theta_limit": self.theta_limit,
+            "stability_epsilon": self.stability_epsilon,
+            "value_limit": self.value_limit,
+            "resource_weight": self.resource_weight,
+        }
+        for name, value in positive.items():
+            _finite_number(name, value)
+            if float(value) <= 0.0:
+                raise ValueError(f"{name} must be strictly positive")
+
+
+@dataclass(frozen=True)
+class UnifiedRuntimeState:
+    """One committed Psi-Phi-Lambda-Omega-Theta state."""
+
+    cycle: int
+    psi: Vector
+    phi: Vector
+    lambda_state: Vector
+    omega: Vector
+    theta: float
+    latent: Vector
+    reconstruction: Vector
+    error: Vector
+    reconstruction_mse: float
+    latent_cycle_mse: float
+    state_delta: float
+    h_mmm: float
+    verified: bool
+    stable: bool
+    state_hash: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "cycle": self.cycle,
+            "psi": list(self.psi),
+            "phi": list(self.phi),
+            "lambda": list(self.lambda_state),
+            "omega": list(self.omega),
+            "theta": self.theta,
+            "latent": list(self.latent),
+            "reconstruction": list(self.reconstruction),
+            "error": list(self.error),
+            "metrics": {
+                "reconstruction_mse": self.reconstruction_mse,
+                "latent_cycle_mse": self.latent_cycle_mse,
+                "state_delta": self.state_delta,
+                "h_mmm": self.h_mmm,
+            },
+            "verified": self.verified,
+            "stable": self.stable,
+            "state_hash": self.state_hash,
+        }
+
+
+def _finite_number(name: str, value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"{name} must be numeric")
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError(f"{name} must be finite")
+    return number
+
+
+def _validate_values(values: Sequence[float], config: UnifiedRuntimeConfig) -> Vector:
+    if not values:
+        raise ValueError("values must not be empty")
+    if len(values) > config.max_dimensions:
+        raise ValueError(f"values exceed max_dimensions={config.max_dimensions}")
+
+    cleaned: list[float] = []
+    for index, value in enumerate(values):
+        number = _finite_number(f"values[{index}]", value)
+        if abs(number) > config.value_limit:
+            raise ValueError(
+                f"values[{index}] exceeds configured magnitude limit {config.value_limit}"
+            )
+        cleaned.append(number)
+    return tuple(cleaned)
+
+
+def _mse(left: Sequence[float], right: Sequence[float]) -> float:
+    if len(left) != len(right):
+        raise ValueError("MSE vectors must have equal length")
+    if not left:
+        return 0.0
+    return sum((float(a) - float(b)) ** 2 for a, b in zip(left, right)) / len(left)
+
+
+def _rms_delta(left: Sequence[float], right: Sequence[float]) -> float:
+    return math.sqrt(_mse(left, right))
+
+
+def _encode_blocks(values: Vector, block_size: int) -> Vector:
+    latent: list[float] = []
+    for start in range(0, len(values), block_size):
+        block = values[start : start + block_size]
+        latent.append(sum(block) / len(block))
+    return tuple(latent)
+
+
+def _decode_blocks(latent: Vector, length: int, block_size: int) -> Vector:
+    decoded: list[float] = []
+    for value in latent:
+        decoded.extend([value] * min(block_size, length - len(decoded)))
+        if len(decoded) >= length:
+            break
+    return tuple(decoded)
+
+
+def _state_hash(
+    *,
+    cycle: int,
+    vectors: Sequence[Vector],
+    scalars: Sequence[float],
+    verified: bool,
+    stable: bool,
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(struct.pack(">Q", cycle))
+    for vector in vectors:
+        digest.update(struct.pack(">I", len(vector)))
+        for value in vector:
+            digest.update(struct.pack(">d", float(value)))
+    for value in scalars:
+        digest.update(struct.pack(">d", float(value)))
+    digest.update(bytes((int(verified), int(stable))))
+    return digest.hexdigest()
+
+
+class UnifiedRuntime:
+    """Deterministic inward coordination loop over a bounded numeric observation."""
+
+    def __init__(self, config: UnifiedRuntimeConfig | None = None) -> None:
+        self.config = config or UnifiedRuntimeConfig()
+        self._state: UnifiedRuntimeState | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def state(self) -> UnifiedRuntimeState | None:
+        with self._lock:
+            return self._state
+
+    def reset(self) -> None:
+        with self._lock:
+            self._state = None
+
+    def step(self, values: Sequence[float]) -> UnifiedRuntimeState:
+        observation = _validate_values(values, self.config)
+        with self._lock:
+            previous = self._state
+            if previous is not None and len(previous.psi) != len(observation):
+                raise ValueError("observation dimensionality cannot change within a runtime")
+
+            n = len(observation)
+            previous_omega = previous.omega if previous is not None else (0.0,) * n
+            previous_theta = previous.theta if previous is not None else 0.0
+            previous_psi = previous.psi if previous is not None else (0.0,) * n
+
+            psi = tuple(
+                math.tanh(value + self.config.psi_memory_gain * memory)
+                for value, memory in zip(observation, previous_omega)
+            )
+
+            if n == 1:
+                phi = psi
+            else:
+                phi = tuple(
+                    0.5 * psi[index]
+                    + 0.25 * psi[(index - 1) % n]
+                    + 0.25 * psi[(index + 1) % n]
+                    for index in range(n)
+                )
+
+            lambda_state = tuple(
+                math.tanh(structured + previous_theta * state)
+                for structured, state in zip(phi, psi)
+            )
+            latent = _encode_blocks(lambda_state, self.config.latent_block_size)
+            reconstruction = _decode_blocks(
+                latent, len(lambda_state), self.config.latent_block_size
+            )
+            error = tuple(
+                state - decoded for state, decoded in zip(lambda_state, reconstruction)
+            )
+
+            reconstruction_mse = _mse(lambda_state, reconstruction)
+            cycle_latent = _encode_blocks(reconstruction, self.config.latent_block_size)
+            latent_cycle_mse = _mse(latent, cycle_latent)
+            state_delta = _rms_delta(psi, previous_psi)
+
+            omega = tuple(
+                self.config.omega_retention * memory
+                + (1.0 - self.config.omega_retention) * residual
+                for memory, residual in zip(previous_omega, error)
+            )
+
+            theta_drive = reconstruction_mse - self.config.stability_epsilon
+            theta = max(
+                -self.config.theta_limit,
+                min(
+                    self.config.theta_limit,
+                    previous_theta + self.config.theta_gain * theta_drive,
+                ),
+            )
+
+            resource_penalty = self.config.resource_weight * n / self.config.max_dimensions
+            h_mmm = (
+                reconstruction_mse
+                + 0.25 * latent_cycle_mse
+                + 0.10 * state_delta
+                + resource_penalty
+            )
+
+            vectors = (
+                psi,
+                phi,
+                lambda_state,
+                omega,
+                latent,
+                reconstruction,
+                error,
+            )
+            scalars = (
+                theta,
+                reconstruction_mse,
+                latent_cycle_mse,
+                state_delta,
+                h_mmm,
+            )
+            verified = all(
+                math.isfinite(value) for vector in vectors for value in vector
+            ) and all(math.isfinite(value) for value in scalars)
+            stable = (
+                verified
+                and reconstruction_mse <= self.config.stability_epsilon
+                and state_delta <= self.config.stability_epsilon
+            )
+            cycle = 1 if previous is None else previous.cycle + 1
+            digest = _state_hash(
+                cycle=cycle,
+                vectors=vectors,
+                scalars=scalars,
+                verified=verified,
+                stable=stable,
+            )
+            committed = UnifiedRuntimeState(
+                cycle=cycle,
+                psi=psi,
+                phi=phi,
+                lambda_state=lambda_state,
+                omega=omega,
+                theta=theta,
+                latent=latent,
+                reconstruction=reconstruction,
+                error=error,
+                reconstruction_mse=reconstruction_mse,
+                latent_cycle_mse=latent_cycle_mse,
+                state_delta=state_delta,
+                h_mmm=h_mmm,
+                verified=verified,
+                stable=stable,
+                state_hash=digest,
+            )
+            self._state = committed
+            return committed
+
+
+class UnifiedRuntimeRegistry:
+    """Bounded in-process registry for browser/API runtime sessions."""
+
+    def __init__(self, max_sessions: int = 16) -> None:
+        if isinstance(max_sessions, bool) or not isinstance(max_sessions, int):
+            raise TypeError("max_sessions must be an integer")
+        if not 1 <= max_sessions <= 256:
+            raise ValueError("max_sessions must be in [1, 256]")
+        self.max_sessions = max_sessions
+        self._sessions: dict[str, UnifiedRuntime] = {}
+        self._order: list[str] = []
+        self._lock = threading.RLock()
+
+    def create(self, config: UnifiedRuntimeConfig | None = None) -> dict[str, Any]:
+        identifier = uuid.uuid4().hex
+        runtime = UnifiedRuntime(config)
+        with self._lock:
+            if len(self._sessions) >= self.max_sessions:
+                oldest = self._order.pop(0)
+                self._sessions.pop(oldest, None)
+            self._sessions[identifier] = runtime
+            self._order.append(identifier)
+        return {
+            "session_id": identifier,
+            "config": _config_dict(runtime.config),
+            "state": None,
+        }
+
+    def _get(self, session_id: str) -> UnifiedRuntime:
+        with self._lock:
+            runtime = self._sessions.get(session_id)
+        if runtime is None:
+            raise KeyError(session_id)
+        return runtime
+
+    def step(self, session_id: str, values: Sequence[float]) -> dict[str, Any]:
+        runtime = self._get(session_id)
+        state = runtime.step(values)
+        return {
+            "session_id": session_id,
+            "config": _config_dict(runtime.config),
+            "state": state.to_dict(),
+        }
+
+    def status(self, session_id: str) -> dict[str, Any]:
+        runtime = self._get(session_id)
+        state = runtime.state
+        return {
+            "session_id": session_id,
+            "config": _config_dict(runtime.config),
+            "state": None if state is None else state.to_dict(),
+        }
+
+    def reset(self, session_id: str) -> dict[str, Any]:
+        runtime = self._get(session_id)
+        runtime.reset()
+        return self.status(session_id)
+
+    def delete(self, session_id: str) -> bool:
+        with self._lock:
+            existed = session_id in self._sessions
+            self._sessions.pop(session_id, None)
+            if session_id in self._order:
+                self._order.remove(session_id)
+            return existed
+
+
+def _config_dict(config: UnifiedRuntimeConfig) -> dict[str, Any]:
+    return {
+        "latent_block_size": config.latent_block_size,
+        "omega_retention": config.omega_retention,
+        "psi_memory_gain": config.psi_memory_gain,
+        "theta_gain": config.theta_gain,
+        "theta_limit": config.theta_limit,
+        "stability_epsilon": config.stability_epsilon,
+        "max_dimensions": config.max_dimensions,
+        "value_limit": config.value_limit,
+        "resource_weight": config.resource_weight,
+    }

--- a/src/jarvisx/unified_runtime_api.py
+++ b/src/jarvisx/unified_runtime_api.py
@@ -1,0 +1,140 @@
+"""FastAPI control plane for the bounded JARVIS-X unified runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from .unified_runtime import UnifiedRuntimeConfig, UnifiedRuntimeRegistry
+
+app = FastAPI(
+    title="JARVIS-X Unified Runtime",
+    version="1.0.0",
+    description=(
+        "Bounded shared Psi-Phi-Lambda-Omega-Theta coordination state for the "
+        "Dr Moagi ANN IDE."
+    ),
+)
+registry = UnifiedRuntimeRegistry(max_sessions=16)
+
+
+class RuntimeCreateRequest(BaseModel):
+    latent_block_size: int = Field(2, ge=1, le=32)
+    omega_retention: float = Field(0.85, ge=0.0, le=1.0)
+    psi_memory_gain: float = Field(0.25, ge=0.0, le=1.0)
+    theta_gain: float = Field(0.05, gt=0.0, le=1.0)
+    theta_limit: float = Field(1.0, gt=0.0, le=16.0)
+    stability_epsilon: float = Field(1.0e-6, gt=0.0, le=1.0)
+    max_dimensions: int = Field(256, ge=1, le=4096)
+    value_limit: float = Field(1.0e6, gt=0.0, le=1.0e12)
+    resource_weight: float = Field(1.0e-3, gt=0.0, le=1.0)
+
+    def config(self) -> UnifiedRuntimeConfig:
+        return UnifiedRuntimeConfig(
+            latent_block_size=self.latent_block_size,
+            omega_retention=self.omega_retention,
+            psi_memory_gain=self.psi_memory_gain,
+            theta_gain=self.theta_gain,
+            theta_limit=self.theta_limit,
+            stability_epsilon=self.stability_epsilon,
+            max_dimensions=self.max_dimensions,
+            value_limit=self.value_limit,
+            resource_weight=self.resource_weight,
+        )
+
+
+class RuntimeTickRequest(BaseModel):
+    values: list[float] = Field(min_length=1, max_length=4096)
+
+
+def fail(exc: Exception) -> HTTPException:
+    if isinstance(exc, KeyError):
+        return HTTPException(404, "runtime session not found")
+    if isinstance(exc, (TypeError, ValueError)):
+        return HTTPException(422, str(exc))
+    return HTTPException(409, str(exc))
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "service": "jarvis-x-unified-runtime",
+        "version": app.version,
+        "contract": "S[t+1] = M(S[t], X[t])",
+        "authoritative_execution": False,
+    }
+
+
+@app.get("/v1/capabilities")
+def capabilities() -> dict[str, Any]:
+    return {
+        "state": [
+            "psi",
+            "phi",
+            "lambda",
+            "omega",
+            "theta",
+            "latent",
+            "reconstruction",
+            "error",
+        ],
+        "metrics": [
+            "reconstruction_mse",
+            "latent_cycle_mse",
+            "state_delta",
+            "h_mmm",
+        ],
+        "invariants": {
+            "bounded_dimensions": True,
+            "finite_values": True,
+            "deterministic": True,
+            "state_hashed": True,
+            "arbitrary_code_execution": False,
+        },
+        "role": (
+            "coordination telemetry above canonical CodexVM/ANN/policy components; "
+            "not a replacement authority"
+        ),
+    }
+
+
+@app.post("/v1/sessions")
+def create_session(req: RuntimeCreateRequest) -> dict[str, Any]:
+    try:
+        return registry.create(req.config())
+    except Exception as exc:
+        raise fail(exc) from exc
+
+
+@app.get("/v1/sessions/{session_id}")
+def session_status(session_id: str) -> dict[str, Any]:
+    try:
+        return registry.status(session_id)
+    except Exception as exc:
+        raise fail(exc) from exc
+
+
+@app.post("/v1/sessions/{session_id}/tick")
+def tick(session_id: str, req: RuntimeTickRequest) -> dict[str, Any]:
+    try:
+        return registry.step(session_id, req.values)
+    except Exception as exc:
+        raise fail(exc) from exc
+
+
+@app.post("/v1/sessions/{session_id}/reset")
+def reset(session_id: str) -> dict[str, Any]:
+    try:
+        return registry.reset(session_id)
+    except Exception as exc:
+        raise fail(exc) from exc
+
+
+@app.delete("/v1/sessions/{session_id}")
+def delete_session(session_id: str) -> dict[str, Any]:
+    if not registry.delete(session_id):
+        raise HTTPException(404, "runtime session not found")
+    return {"deleted": True, "session_id": session_id}

--- a/tests/test_unified_runtime.py
+++ b/tests/test_unified_runtime.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.unified_runtime import UnifiedRuntime, UnifiedRuntimeConfig, UnifiedRuntimeRegistry
+
+
+def test_unified_runtime_is_deterministic_for_same_history() -> None:
+    config = UnifiedRuntimeConfig(max_dimensions=16)
+    left = UnifiedRuntime(config)
+    right = UnifiedRuntime(config)
+    history = ([0.2, -0.4, 0.8, 0.1], [0.2, -0.4, 0.8, 0.1])
+
+    left_states = [left.step(values) for values in history]
+    right_states = [right.step(values) for values in history]
+
+    assert [state.state_hash for state in left_states] == [
+        state.state_hash for state in right_states
+    ]
+    assert left_states[-1].h_mmm == pytest.approx(right_states[-1].h_mmm)
+
+
+def test_unified_runtime_closes_encode_decode_cycle() -> None:
+    runtime = UnifiedRuntime(UnifiedRuntimeConfig(latent_block_size=2, max_dimensions=8))
+    state = runtime.step([0.5, -0.25, 0.75, -0.5])
+
+    assert len(state.psi) == 4
+    assert len(state.latent) == 2
+    assert len(state.reconstruction) == 4
+    assert state.latent_cycle_mse == pytest.approx(0.0)
+    assert state.reconstruction_mse >= 0.0
+    assert state.verified
+    assert len(state.state_hash) == 64
+
+
+def test_omega_memory_feeds_next_psi_state() -> None:
+    config = UnifiedRuntimeConfig(
+        latent_block_size=2,
+        omega_retention=0.0,
+        psi_memory_gain=1.0,
+        max_dimensions=8,
+    )
+    runtime = UnifiedRuntime(config)
+    first = runtime.step([1.0, -0.5, 0.2, 0.9])
+    second = runtime.step([1.0, -0.5, 0.2, 0.9])
+
+    assert any(abs(value) > 0.0 for value in first.omega)
+    assert second.psi != first.psi
+    assert second.cycle == 2
+
+
+def test_runtime_rejects_dimension_change_and_nonfinite_values() -> None:
+    runtime = UnifiedRuntime(UnifiedRuntimeConfig(max_dimensions=4))
+    runtime.step([0.0, 1.0])
+
+    with pytest.raises(ValueError, match="dimensionality"):
+        runtime.step([0.0, 1.0, 2.0])
+
+    fresh = UnifiedRuntime(UnifiedRuntimeConfig(max_dimensions=4))
+    with pytest.raises(ValueError, match="finite"):
+        fresh.step([math.inf])
+
+
+def test_registry_is_bounded_and_resettable() -> None:
+    registry = UnifiedRuntimeRegistry(max_sessions=1)
+    first = registry.create()
+    second = registry.create()
+
+    with pytest.raises(KeyError):
+        registry.status(first["session_id"])
+
+    stepped = registry.step(second["session_id"], [0.1, 0.2])
+    assert stepped["state"]["cycle"] == 1
+    reset = registry.reset(second["session_id"])
+    assert reset["state"] is None
+    assert registry.delete(second["session_id"])


### PR DESCRIPTION
## Summary

Permeates the consolidated JARVIS-X / DM-vΩΞ⁺ architecture into the existing Dr Moagi ANN IDE as a **single bounded coordination state**, without replacing the canonical CodexVM, ANN, policy, transaction, rollback, or external-evidence boundaries.

The new shared recurrence is:

```text
X_t
 -> Psi
 -> Phi
 -> Lambda
 -> E
 -> Z
 -> D
 -> Xhat
 -> e
 -> Omega_(t+1)
 -> Theta_(t+1)
 -> next Psi
```

with

```text
S_(t+1) = M(S_t, X_t)
```

and fixed-point intent `S* = M(S*, X)`.

## Added

- `src/jarvisx/unified_runtime.py`
  - bounded `Psi/Phi/Lambda/Omega/Theta` state;
  - deterministic block AE/AD cycle;
  - residual-memory inward re-entry;
  - bounded Theta adaptation;
  - measured reconstruction, latent-cycle, state-delta and `H_MMM` telemetry;
  - finite-value and dimensionality guards;
  - deterministic SHA-256 state identity;
  - bounded runtime-session registry.

- `src/jarvisx/unified_runtime_api.py`
  - session create/status/tick/reset/delete endpoints;
  - explicit capability and health contracts;
  - no arbitrary code execution or provider API secret.

- `docs/JARVIS_X_UNIFIED_RUNTIME.md`
  - executable equations, operator semantics, stability criteria, contour-kernel relationship, IDE integration, and authority boundaries.

- `tests/test_unified_runtime.py`
  - deterministic replay;
  - exact latent-cycle closure;
  - Omega re-entry into the next Psi state;
  - finite/dimensional guards;
  - bounded registry eviction/reset.

## IDE integration

`dr_moagi_ide_api` now mounts the coordination plane at:

```text
/runtime
```

and reports it through `/healthz` and `/v1/capabilities`.

The existing VM, refactorer, ANN, persistence, telemetry and 3D OS surfaces remain authoritative in their current domains; this PR adds a shared state envelope above them rather than creating a parallel execution authority.

## H_MMM correction

The runtime replaces decorative sinusoidal "Hamiltonian" telemetry with a measurable diagnostic:

```text
H_MMM = L_recon + 0.25 L_cycle + 0.10 Delta_state + L_resource
```

`H_MMM` is explicitly documented as an internal runtime objective, not a physical Hamiltonian or universal-intelligence score.

## Contour operator relationship

The already-merged `DMvOmegaXiContourOperator` remains an inner mathematical kernel capable of producing bounded `Delta Psi` before a unified runtime tick. This PR does not duplicate or supersede PR #227.

## Validation performed before publication

Focused local validation of the new dependency-free core:

```text
5 passed in 0.05s
```

covering deterministic state hashes, cycle closure, inward memory feedback, validation guards, and session bounds.

The Dr Moagi IDE workflow is extended to run both existing IDE tests and the unified runtime tests, import both API surfaces, build the production container, and smoke-test `/runtime/healthz`.

## Scope boundary

This is a coordination/runtime-state permeation. It does **not** claim semantic truth, external-world verification, unrestricted self-modification, arbitrary shell execution, dense virtual-3D allocation, learned lossless compression, or autonomous hardware authority.

Opened as a **draft** so GitHub CI remains the merge gate.