### PR TITLE
Add open verified-execution market for Jarvis-X

### DIFF
--- a/docs/OPEN_MARKET_SWARM_MVP.md
+++ b/docs/OPEN_MARKET_SWARM_MVP.md
@@ -1,0 +1,322 @@
+# Jarvis-X Open Source Open Market Swarm MVP
+
+## Status
+
+Integration candidate. This document describes the bounded open-market prototype implemented by `jarvisx.open_market` and `jarvisx.open_market_api`. It does not create a real payment network, public token, securities instrument or hostile-code execution service.
+
+## Objective
+
+The MVP turns the existing Jarvis-X transaction boundary into an open capability market:
+
+```text
+provider registration
+    -> buyer task
+    -> competitive plans/bids
+    -> deterministic award
+    -> SystemRuntime execution
+    -> COMMIT / REJECT / FAIL
+    -> verified execution receipt
+    -> internal accounting settlement
+    -> append-only market ledger
+```
+
+The governing invariant is:
+
+```text
+Plan != Execute != Commit != Settle
+```
+
+A provider can be economically credited only after the selected plan produces a committed Jarvis-X execution receipt.
+
+## 1. Actors
+
+### Buyer
+
+Creates a bounded task with:
+
+- required market capability;
+- maximum accounting price;
+- VM cycle and program-size budgets;
+- candidate-count ceiling;
+- utility weights for quality, cost, latency and risk.
+
+### Provider
+
+Advertises one or more market capabilities such as:
+
+```text
+optimization
+rendering
+simulation
+scheduling
+inspection
+```
+
+The registry is intentionally generic. A provider can later represent a human service, software agent, model endpoint, compute node, enterprise service or machine adapter.
+
+### Jarvis-X market
+
+The market validates participation, selects an admissible plan and delegates execution to the existing `SystemRuntime` / `CodexVM` boundary.
+
+## 2. Task contract
+
+For task `T_j`:
+
+```text
+T_j = (
+  buyer,
+  capability,
+  max_price,
+  resource_budget,
+  granted_capabilities,
+  utility_weights
+)
+```
+
+The current reference implementation requires `vm.execute` and rejects bids whose program exceeds the buyer's declared word budget or whose requested capabilities exceed the buyer's grants.
+
+## 3. Bid contract
+
+Provider `i` submits:
+
+```text
+B_ij = (
+  provider,
+  program,
+  price,
+  quality,
+  latency,
+  risk,
+  required_capabilities
+)
+```
+
+A bid is rejected before award when:
+
+- the provider does not exist;
+- the task is not open;
+- the provider does not advertise the requested capability;
+- price exceeds the buyer ceiling;
+- program length exceeds the task budget;
+- required VM capabilities exceed the buyer's grants.
+
+## 4. Deterministic market clearing
+
+The prototype reuses the canonical deterministic planner:
+
+```text
+J(B_i) = w_q Q_i - w_c C_i - w_l L_i - w_r R_i
+```
+
+Only admissible bids enter the candidate set. The maximum `J` wins. Ties are resolved deterministically by bid id through the existing planner semantics.
+
+This is a reference allocation function, not a claim that a real market should use one universal objective. Production deployments can define task-specific weights or replace the planner behind a compatible admission contract.
+
+## 5. Verified execution
+
+The winning bid is converted into an immutable `ExecutionRequest` and passed into `SystemRuntime`:
+
+```text
+winning program
+    -> capability projection
+    -> isolated CodexVM
+    -> bounded execution
+    -> VM ledger verification
+    -> result hash
+    -> system audit append
+    -> COMMIT / REJECT / FAIL
+```
+
+The market does not directly mutate authoritative VM state.
+
+## 6. Settlement
+
+The MVP uses integer accounting units only.
+
+For a successful committed execution:
+
+```text
+gross_units = winning_bid.price_units
+platform_fee_units = floor(gross_units * fee_bps / 10000)
+provider_units = gross_units - platform_fee_units
+```
+
+For rejected or failed execution:
+
+```text
+gross_units = 0
+platform_fee_units = 0
+provider_units = 0
+```
+
+This is accounting, not money movement. A future payment adapter can map verified settlement receipts to bank transfer, card, stable-value settlement, invoice, ERP payable or another legally appropriate rail without coupling payment authority into the VM kernel.
+
+## 7. Provenance
+
+The open market has its own `OmegaLedger` chain. Events include:
+
+```text
+provider.registered
+task.created
+bid.submitted
+task.awarded
+task.settled
+task.failed
+```
+
+A settlement receipt binds:
+
+- task and bid ids;
+- buyer and provider ids;
+- gross / fee / provider accounting units;
+- execution status;
+- execution request id;
+- authoritative state hash;
+- VM ledger head;
+- system audit head;
+- market ledger head.
+
+The result is a three-level provenance chain:
+
+```text
+CodexVM ledger
+    -> SystemRuntime audit receipt
+    -> OpenMarket settlement ledger
+```
+
+## 8. API
+
+Run the service during development with:
+
+```bash
+uvicorn jarvisx.open_market_api:app --reload
+```
+
+Primary endpoints:
+
+```text
+GET  /healthz
+GET  /v1/capabilities
+POST /v1/providers
+GET  /v1/providers
+POST /v1/tasks
+GET  /v1/tasks/{task_id}
+POST /v1/tasks/{task_id}/bids
+GET  /v1/tasks/{task_id}/bids
+POST /v1/tasks/{task_id}/award
+POST /v1/tasks/{task_id}/execute
+GET  /v1/tasks/{task_id}/settlement
+GET  /v1/market
+GET  /v1/ledger
+```
+
+### Example provider
+
+```json
+{
+  "provider_id": "optimizer-a",
+  "display_name": "Optimizer A",
+  "capabilities": ["optimization"]
+}
+```
+
+### Example task
+
+```json
+{
+  "task_id": "factory-throughput-001",
+  "buyer_id": "factory-a",
+  "capability": "optimization",
+  "max_price_units": 2000,
+  "quality_weight": 100.0,
+  "cost_weight": 0.01,
+  "latency_weight": 1.0,
+  "risk_weight": 10.0
+}
+```
+
+### Example bid
+
+```json
+{
+  "bid_id": "plan-a",
+  "provider_id": "optimizer-a",
+  "source": "SET A 42\nHALT",
+  "price_units": 1200,
+  "quality": 0.98,
+  "latency": 1.0,
+  "risk": 0.05
+}
+```
+
+Execute with:
+
+```text
+POST /v1/tasks/factory-throughput-001/execute
+```
+
+A successful response includes both the computed state and the linked execution / market hashes.
+
+## 9. Direct Python demonstration
+
+```bash
+python examples/open_market_demo.py
+```
+
+The example registers two optimization providers, creates one buyer task, submits two executable plans, awards the deterministic winner, executes through `SystemRuntime`, settles integer units and verifies the market ledger.
+
+## 10. Security boundary
+
+This MVP inherits the canonical Jarvis-X security boundary.
+
+The current cycle sandbox is not hostile-code operating-system isolation. The public API must not be exposed as an unrestricted public bytecode-execution marketplace. Before production use with untrusted providers, add at minimum:
+
+- authenticated identities;
+- tenant and capability isolation;
+- signed provider manifests;
+- process/container isolation;
+- CPU, memory, filesystem and network quotas;
+- secrets isolation;
+- rate limits and abuse controls;
+- persistent transactional market storage;
+- audit export and retention controls;
+- reproducible provider package verification.
+
+## 11. Commercial progression
+
+The intended product progression is:
+
+```text
+open-source Jarvis-X kernel
+    -> hosted verified-execution service
+    -> enterprise private market
+    -> industrial connectors
+    -> third-party capability marketplace
+    -> metered verified executions
+```
+
+The commercial unit can therefore become a Verified Execution (`VX`):
+
+```text
+VX = one authorized request
+     + bounded execution
+     + verification
+     + committed receipt
+```
+
+The present MVP records the prerequisite evidence for that unit but intentionally does not implement billing, invoicing, tax handling, escrow or external settlement.
+
+## 12. Next production gates
+
+Before promotion to a canonical enterprise subsystem:
+
+1. add durable SQL-backed market state and transactional recovery;
+2. bind users/providers to authenticated identities and RBAC;
+3. package provider plans as signed manifests rather than raw public assembly;
+4. execute provider workloads inside hardened process/container isolation;
+5. add task schemas and domain-specific verifiers;
+6. add ERP/MES/PLM/IIoT connector contracts;
+7. add usage metering and invoice/export adapters;
+8. define SLA, dispute, retry and cancellation semantics;
+9. benchmark market throughput and execution latency;
+10. add machine-readable evidence artifacts to CI.

--- a/examples/open_market_demo.py
+++ b/examples/open_market_demo.py
@@ -1,0 +1,78 @@
+from jarvisx.assembler import Assembler
+from jarvisx.open_market import MarketBid, MarketTask, OpenMarketEngine, Provider
+from jarvisx.parser import Parser
+from jarvisx.system_runtime import UtilityWeights
+
+
+def assemble(source: str) -> tuple[int, ...]:
+    return tuple(Assembler().assemble(Parser().parse(source)))
+
+
+def main() -> None:
+    market = OpenMarketEngine(fee_bps=250)
+
+    market.register_provider(
+        Provider(
+            provider_id="alpha-optimizer",
+            display_name="Alpha Optimizer",
+            capabilities=frozenset({"optimization"}),
+        )
+    )
+    market.register_provider(
+        Provider(
+            provider_id="beta-optimizer",
+            display_name="Beta Optimizer",
+            capabilities=frozenset({"optimization"}),
+        )
+    )
+
+    market.create_task(
+        MarketTask(
+            task_id="factory-throughput-001",
+            buyer_id="factory-demo",
+            capability="optimization",
+            max_price_units=2_000,
+            weights=UtilityWeights(quality=100.0, cost=0.01, latency=1.0, risk=10.0),
+        )
+    )
+
+    market.submit_bid(
+        MarketBid(
+            bid_id="alpha-plan",
+            task_id="factory-throughput-001",
+            provider_id="alpha-optimizer",
+            program=assemble("SET A 10\nHALT"),
+            price_units=1_000,
+            quality=0.80,
+            latency=2.0,
+            risk=0.20,
+        )
+    )
+    market.submit_bid(
+        MarketBid(
+            bid_id="beta-plan",
+            task_id="factory-throughput-001",
+            provider_id="beta-optimizer",
+            program=assemble("SET A 42\nHALT"),
+            price_units=1_200,
+            quality=0.98,
+            latency=1.0,
+            risk=0.05,
+        )
+    )
+
+    settlement = market.execute_task("factory-throughput-001")
+
+    print("winner:", settlement.provider_id)
+    print("bid:", settlement.bid_id)
+    print("execution:", settlement.execution_status)
+    print("state:", settlement.state_dict())
+    print("gross units:", settlement.gross_units)
+    print("platform fee:", settlement.platform_fee_units)
+    print("provider units:", settlement.provider_units)
+    print("market ledger head:", settlement.market_ledger_head)
+    print("market valid:", market.verify())
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
 jarvisx-dr-moagi-3d-animation = "jarvisx.dr_moagi_3d_animation_codec:main"
 jarvisx-dr-moagi-codegen = "jarvisx.dr_moagi_codegen_engine:main"
 jarvisx-dr-moagi-resonator = "jarvisx.dr_moagi_monadic_resonator:main"
+jarvisx-open-market = "jarvisx.open_market_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/geometric_intelligence.py
+++ b/src/jarvisx/geometric_intelligence.py
@@ -210,7 +210,7 @@ class GeometricIntelligenceKernel:
 
         next_velocity: list[float] = []
         next_latent: list[float] = []
-        for z, v, target, memory, lap_value in zip(
+        for z, v, target, memory_value, lap_value in zip(
             previous.latent,
             previous.velocity,
             encoded,
@@ -222,7 +222,7 @@ class GeometricIntelligenceKernel:
                 -self.config.damping * v
                 -self.config.restoring_gain * (z - target)
                 +self.config.diffusion_gain * lap_value
-                -self.config.memory_gain * memory
+                -self.config.memory_gain * memory_value
             )
             v_next = _clamp(
                 v + acceleration,
@@ -235,7 +235,7 @@ class GeometricIntelligenceKernel:
 
         reconstruction = decode_field(next_latent)
         residual = tuple(x - xhat for x, xhat in zip(obs, reconstruction, strict=True))
-        memory = tuple(
+        next_memory = tuple(
             self.config.memory_decay * old + (1.0 - self.config.memory_decay) * error
             for old, error in zip(previous.memory, residual, strict=True)
         )
@@ -253,7 +253,7 @@ class GeometricIntelligenceKernel:
         current = GeometricState(
             latent=tuple(next_latent),
             velocity=tuple(next_velocity),
-            memory=memory,
+            memory=next_memory,
             major_phase=major_phase,
             micro_phase=micro_phase,
             step_index=previous.step_index + 1,

--- a/src/jarvisx/open_market.py
+++ b/src/jarvisx/open_market.py
@@ -4,7 +4,7 @@ import math
 import threading
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Iterable
+from typing import Callable, cast
 
 from .ledger import OmegaLedger
 from .system_runtime import (
@@ -498,7 +498,7 @@ class OpenMarketEngine:
             raise UnknownResource(f"bid {bid_id!r} does not exist") from exc
 
     def _log(self, opcode: int, state: dict[str, object]) -> dict[str, object]:
-        return self.ledger.log(state, opcode)
+        return cast(dict[str, object], self.ledger.log(state, opcode))
 
 
 __all__ = [

--- a/src/jarvisx/open_market.py
+++ b/src/jarvisx/open_market.py
@@ -1,0 +1,516 @@
+from __future__ import annotations
+
+import math
+import threading
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Callable, Iterable
+
+from .ledger import OmegaLedger
+from .system_runtime import (
+    CAP_VM_EXECUTE,
+    DeterministicPlanner,
+    ExecutionRequest,
+    ExecutionStatus,
+    PlanCandidate,
+    ResourceBudget,
+    SystemRuntime,
+    UtilityWeights,
+)
+
+MARKET_PROVIDER_OPCODE = 0x2000
+MARKET_TASK_OPCODE = 0x2001
+MARKET_BID_OPCODE = 0x2002
+MARKET_AWARD_OPCODE = 0x2003
+MARKET_SETTLEMENT_OPCODE = 0x2004
+MARKET_FAILURE_OPCODE = 0x2005
+
+
+class MarketError(RuntimeError):
+    """Base class for open-market failures."""
+
+
+class DuplicateResource(MarketError):
+    """Raised when an immutable market identifier is reused."""
+
+
+class UnknownResource(MarketError):
+    """Raised when a provider, task, bid or settlement cannot be found."""
+
+
+class MarketStateError(MarketError):
+    """Raised when an operation is invalid for the current market state."""
+
+
+class TaskStatus(str, Enum):
+    OPEN = "open"
+    AWARDED = "awarded"
+    SETTLED = "settled"
+    FAILED = "failed"
+
+
+class SettlementStatus(str, Enum):
+    SETTLED = "settled"
+    EXECUTION_FAILED = "execution_failed"
+
+
+def _nonempty(name: str, value: str) -> str:
+    normalized = str(value).strip()
+    if not normalized:
+        raise ValueError(f"{name} cannot be empty")
+    return normalized
+
+
+def _finite_nonnegative(name: str, value: float) -> float:
+    numeric = float(value)
+    if not math.isfinite(numeric) or numeric < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return numeric
+
+
+@dataclass(frozen=True)
+class Provider:
+    provider_id: str
+    display_name: str
+    capabilities: frozenset[str]
+    metadata: tuple[tuple[str, str], ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "provider_id", _nonempty("provider_id", self.provider_id))
+        object.__setattr__(self, "display_name", _nonempty("display_name", self.display_name))
+        capabilities = frozenset(_nonempty("capability", value) for value in self.capabilities)
+        if not capabilities:
+            raise ValueError("capabilities cannot be empty")
+        object.__setattr__(self, "capabilities", capabilities)
+        object.__setattr__(
+            self,
+            "metadata",
+            tuple(sorted((_nonempty("metadata key", k), str(v)) for k, v in self.metadata)),
+        )
+
+
+@dataclass
+class MarketTask:
+    task_id: str
+    buyer_id: str
+    capability: str
+    max_price_units: int
+    granted_capabilities: frozenset[str] = field(
+        default_factory=lambda: frozenset({CAP_VM_EXECUTE})
+    )
+    budget: ResourceBudget = field(default_factory=ResourceBudget)
+    weights: UtilityWeights = field(default_factory=UtilityWeights)
+    status: TaskStatus = TaskStatus.OPEN
+    awarded_bid_id: str | None = None
+
+    def __post_init__(self) -> None:
+        self.task_id = _nonempty("task_id", self.task_id)
+        self.buyer_id = _nonempty("buyer_id", self.buyer_id)
+        self.capability = _nonempty("capability", self.capability)
+        if (
+            not isinstance(self.max_price_units, int)
+            or isinstance(self.max_price_units, bool)
+            or self.max_price_units < 1
+        ):
+            raise ValueError("max_price_units must be a positive integer")
+        self.granted_capabilities = frozenset(self.granted_capabilities)
+        if CAP_VM_EXECUTE not in self.granted_capabilities:
+            raise ValueError("tasks must grant vm.execute")
+
+
+@dataclass(frozen=True)
+class MarketBid:
+    bid_id: str
+    task_id: str
+    provider_id: str
+    program: tuple[int, ...]
+    price_units: int
+    quality: float
+    latency: float
+    risk: float
+    required_capabilities: frozenset[str] = field(
+        default_factory=lambda: frozenset({CAP_VM_EXECUTE})
+    )
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "bid_id", _nonempty("bid_id", self.bid_id))
+        object.__setattr__(self, "task_id", _nonempty("task_id", self.task_id))
+        object.__setattr__(self, "provider_id", _nonempty("provider_id", self.provider_id))
+        program = tuple(self.program)
+        if not program:
+            raise ValueError("program cannot be empty")
+        for index, word in enumerate(program):
+            if not isinstance(word, int) or isinstance(word, bool):
+                raise TypeError(f"program word {index} is not an integer")
+            if not 0 <= word <= 0xFFFFFFFFFFFFFFFF:
+                raise ValueError(f"program word {index} is outside unsigned 64-bit range")
+        object.__setattr__(self, "program", program)
+        if (
+            not isinstance(self.price_units, int)
+            or isinstance(self.price_units, bool)
+            or self.price_units < 0
+        ):
+            raise ValueError("price_units must be a non-negative integer")
+        object.__setattr__(self, "quality", _finite_nonnegative("quality", self.quality))
+        object.__setattr__(self, "latency", _finite_nonnegative("latency", self.latency))
+        object.__setattr__(self, "risk", _finite_nonnegative("risk", self.risk))
+        required = frozenset(self.required_capabilities)
+        if CAP_VM_EXECUTE not in required:
+            required = required | {CAP_VM_EXECUTE}
+        object.__setattr__(self, "required_capabilities", required)
+
+
+@dataclass(frozen=True)
+class SettlementReceipt:
+    settlement_id: str
+    task_id: str
+    bid_id: str
+    buyer_id: str
+    provider_id: str
+    status: SettlementStatus
+    gross_units: int
+    platform_fee_units: int
+    provider_units: int
+    execution_status: str
+    execution_request_id: str
+    execution_state: tuple[tuple[str, int], ...]
+    execution_state_hash: str | None
+    vm_ledger_head: str | None
+    system_audit_head: str
+    market_ledger_head: str
+    error_type: str | None = None
+    error_message: str | None = None
+
+    def state_dict(self) -> dict[str, int]:
+        return dict(self.execution_state)
+
+
+class OpenMarketEngine:
+    """Open capability market settled only by verified Jarvis-X execution.
+
+    The engine intentionally does not move external money. ``*_units`` are
+    integer accounting units that can later be mapped to a regulated payment
+    rail by an adapter. A successful market settlement requires a committed
+    ``SystemRuntime`` receipt; failed or rejected execution settles zero units.
+    """
+
+    def __init__(
+        self,
+        *,
+        runtime: SystemRuntime | None = None,
+        fee_bps: int = 250,
+        clock_ns: Callable[[], int] | None = None,
+    ) -> None:
+        if not isinstance(fee_bps, int) or isinstance(fee_bps, bool) or not 0 <= fee_bps <= 10_000:
+            raise ValueError("fee_bps must be an integer between 0 and 10000")
+        self.runtime = runtime or SystemRuntime()
+        self.fee_bps = fee_bps
+        self.ledger = OmegaLedger(clock_ns=clock_ns)
+        self.providers: dict[str, Provider] = {}
+        self.tasks: dict[str, MarketTask] = {}
+        self.bids: dict[str, MarketBid] = {}
+        self.task_bids: dict[str, list[str]] = {}
+        self.settlements: dict[str, SettlementReceipt] = {}
+        self._lock = threading.RLock()
+
+    def register_provider(self, provider: Provider) -> Provider:
+        with self._lock:
+            if provider.provider_id in self.providers:
+                raise DuplicateResource(f"provider {provider.provider_id!r} already exists")
+            self.providers[provider.provider_id] = provider
+            self._log(
+                MARKET_PROVIDER_OPCODE,
+                {
+                    "event": "provider.registered",
+                    "provider_id": provider.provider_id,
+                    "display_name": provider.display_name,
+                    "capabilities": sorted(provider.capabilities),
+                },
+            )
+            return provider
+
+    def create_task(self, task: MarketTask) -> MarketTask:
+        with self._lock:
+            if task.task_id in self.tasks:
+                raise DuplicateResource(f"task {task.task_id!r} already exists")
+            self.tasks[task.task_id] = task
+            self.task_bids[task.task_id] = []
+            self._log(
+                MARKET_TASK_OPCODE,
+                {
+                    "event": "task.created",
+                    "task_id": task.task_id,
+                    "buyer_id": task.buyer_id,
+                    "capability": task.capability,
+                    "max_price_units": task.max_price_units,
+                    "max_cycles": task.budget.max_cycles,
+                    "max_program_words": task.budget.max_program_words,
+                },
+            )
+            return task
+
+    def submit_bid(self, bid: MarketBid) -> MarketBid:
+        with self._lock:
+            if bid.bid_id in self.bids:
+                raise DuplicateResource(f"bid {bid.bid_id!r} already exists")
+            task = self._task(bid.task_id)
+            if task.status is not TaskStatus.OPEN:
+                raise MarketStateError(f"task {task.task_id!r} is not open")
+            provider = self._provider(bid.provider_id)
+            if task.capability not in provider.capabilities:
+                raise MarketStateError(
+                    f"provider {provider.provider_id!r} does not advertise capability {task.capability!r}"
+                )
+            if bid.price_units > task.max_price_units:
+                raise MarketStateError(
+                    f"bid price {bid.price_units} exceeds task maximum {task.max_price_units}"
+                )
+            if len(bid.program) > task.budget.max_program_words:
+                raise MarketStateError(
+                    f"bid program length {len(bid.program)} exceeds task budget "
+                    f"{task.budget.max_program_words}"
+                )
+            if not bid.required_capabilities.issubset(task.granted_capabilities):
+                missing = sorted(bid.required_capabilities - task.granted_capabilities)
+                raise MarketStateError(
+                    "bid requires capabilities not granted by task: " + ", ".join(missing)
+                )
+            self.bids[bid.bid_id] = bid
+            self.task_bids[task.task_id].append(bid.bid_id)
+            self._log(
+                MARKET_BID_OPCODE,
+                {
+                    "event": "bid.submitted",
+                    "bid_id": bid.bid_id,
+                    "task_id": bid.task_id,
+                    "provider_id": bid.provider_id,
+                    "price_units": bid.price_units,
+                    "quality": bid.quality,
+                    "latency": bid.latency,
+                    "risk": bid.risk,
+                    "program_words": len(bid.program),
+                },
+            )
+            return bid
+
+    def award_task(self, task_id: str) -> MarketBid:
+        with self._lock:
+            task = self._task(task_id)
+            if task.status is TaskStatus.SETTLED:
+                return self._bid(task.awarded_bid_id)
+            if task.status is TaskStatus.FAILED:
+                raise MarketStateError(f"task {task.task_id!r} has failed")
+            if task.status is TaskStatus.AWARDED:
+                return self._bid(task.awarded_bid_id)
+            bid_ids = tuple(self.task_bids.get(task.task_id, ()))
+            if not bid_ids:
+                raise MarketStateError(f"task {task.task_id!r} has no bids")
+
+            candidates = tuple(self._plan_candidate(self.bids[bid_id]) for bid_id in bid_ids)
+            planner = DeterministicPlanner(weights=task.weights)
+            selected = planner.select(
+                candidates,
+                granted_capabilities=task.granted_capabilities,
+                budget=task.budget,
+            )
+            winning_bid = self._bid(selected.plan_id)
+            task.awarded_bid_id = winning_bid.bid_id
+            task.status = TaskStatus.AWARDED
+            self._log(
+                MARKET_AWARD_OPCODE,
+                {
+                    "event": "task.awarded",
+                    "task_id": task.task_id,
+                    "bid_id": winning_bid.bid_id,
+                    "provider_id": winning_bid.provider_id,
+                    "price_units": winning_bid.price_units,
+                    "utility": planner.utility(selected),
+                },
+            )
+            return winning_bid
+
+    def execute_task(self, task_id: str) -> SettlementReceipt:
+        with self._lock:
+            existing = self.settlements.get(task_id)
+            if existing is not None:
+                return existing
+            task = self._task(task_id)
+            if task.status is TaskStatus.FAILED:
+                raise MarketStateError(f"task {task.task_id!r} has failed")
+            bid = self.award_task(task.task_id)
+            request_id = f"market:{task.task_id}:{bid.bid_id}"
+            receipt = self.runtime.execute(
+                ExecutionRequest(
+                    request_id=request_id,
+                    program=bid.program,
+                    granted_capabilities=task.granted_capabilities,
+                    required_capabilities=bid.required_capabilities,
+                    budget=task.budget,
+                    plan_id=bid.bid_id,
+                )
+            )
+
+            if receipt.status is ExecutionStatus.COMMITTED and receipt.committed:
+                gross = bid.price_units
+                fee = (gross * self.fee_bps) // 10_000
+                provider_units = gross - fee
+                status = SettlementStatus.SETTLED
+                task.status = TaskStatus.SETTLED
+                opcode = MARKET_SETTLEMENT_OPCODE
+            else:
+                gross = 0
+                fee = 0
+                provider_units = 0
+                status = SettlementStatus.EXECUTION_FAILED
+                task.status = TaskStatus.FAILED
+                opcode = MARKET_FAILURE_OPCODE
+
+            event = self._log(
+                opcode,
+                {
+                    "event": "task.settled" if status is SettlementStatus.SETTLED else "task.failed",
+                    "task_id": task.task_id,
+                    "bid_id": bid.bid_id,
+                    "provider_id": bid.provider_id,
+                    "buyer_id": task.buyer_id,
+                    "gross_units": gross,
+                    "platform_fee_units": fee,
+                    "provider_units": provider_units,
+                    "execution_status": receipt.status.value,
+                    "execution_request_id": receipt.request_id,
+                    "execution_state_hash": receipt.state_hash,
+                    "system_audit_head": receipt.audit_head,
+                    "error_type": receipt.error_type,
+                },
+            )
+            settlement = SettlementReceipt(
+                settlement_id=f"settlement:{task.task_id}",
+                task_id=task.task_id,
+                bid_id=bid.bid_id,
+                buyer_id=task.buyer_id,
+                provider_id=bid.provider_id,
+                status=status,
+                gross_units=gross,
+                platform_fee_units=fee,
+                provider_units=provider_units,
+                execution_status=receipt.status.value,
+                execution_request_id=receipt.request_id,
+                execution_state=receipt.state,
+                execution_state_hash=receipt.state_hash,
+                vm_ledger_head=receipt.vm_ledger_head,
+                system_audit_head=receipt.audit_head,
+                market_ledger_head=str(event["hash"]),
+                error_type=receipt.error_type,
+                error_message=receipt.error_message,
+            )
+            self.settlements[task.task_id] = settlement
+            return settlement
+
+    def bids_for_task(self, task_id: str) -> tuple[MarketBid, ...]:
+        with self._lock:
+            self._task(task_id)
+            return tuple(self.bids[bid_id] for bid_id in self.task_bids.get(task_id, ()))
+
+    def settlement_for_task(self, task_id: str) -> SettlementReceipt | None:
+        with self._lock:
+            self._task(task_id)
+            return self.settlements.get(task_id)
+
+    def snapshot(self) -> dict[str, object]:
+        with self._lock:
+            status_counts = {status.value: 0 for status in TaskStatus}
+            for task in self.tasks.values():
+                status_counts[task.status.value] += 1
+            gross = sum(item.gross_units for item in self.settlements.values())
+            fees = sum(item.platform_fee_units for item in self.settlements.values())
+            return {
+                "providers": len(self.providers),
+                "tasks": len(self.tasks),
+                "bids": len(self.bids),
+                "settlements": len(self.settlements),
+                "task_status": status_counts,
+                "gross_verified_units": gross,
+                "platform_fee_units": fees,
+                "market_ledger_entries": len(self.ledger.chain),
+                "market_ledger_valid": self.ledger.verify(),
+                "runtime_valid": self.runtime.verify(),
+            }
+
+    def verify(self) -> bool:
+        with self._lock:
+            if not self.ledger.verify() or not self.runtime.verify():
+                return False
+            for task_id, settlement in self.settlements.items():
+                task = self.tasks.get(task_id)
+                bid = self.bids.get(settlement.bid_id)
+                if task is None or bid is None or task.awarded_bid_id != bid.bid_id:
+                    return False
+                if settlement.status is SettlementStatus.SETTLED:
+                    if task.status is not TaskStatus.SETTLED:
+                        return False
+                    if settlement.gross_units != bid.price_units:
+                        return False
+                    expected_fee = (bid.price_units * self.fee_bps) // 10_000
+                    if settlement.platform_fee_units != expected_fee:
+                        return False
+                    if settlement.provider_units != bid.price_units - expected_fee:
+                        return False
+                    if settlement.execution_state_hash is None:
+                        return False
+                else:
+                    if task.status is not TaskStatus.FAILED:
+                        return False
+                    if any(
+                        (settlement.gross_units, settlement.platform_fee_units, settlement.provider_units)
+                    ):
+                        return False
+            return True
+
+    def _plan_candidate(self, bid: MarketBid) -> PlanCandidate:
+        return PlanCandidate(
+            plan_id=bid.bid_id,
+            program=bid.program,
+            quality=bid.quality,
+            cost=float(bid.price_units),
+            latency=bid.latency,
+            risk=bid.risk,
+            required_capabilities=bid.required_capabilities,
+        )
+
+    def _provider(self, provider_id: str) -> Provider:
+        try:
+            return self.providers[provider_id]
+        except KeyError as exc:
+            raise UnknownResource(f"provider {provider_id!r} does not exist") from exc
+
+    def _task(self, task_id: str) -> MarketTask:
+        try:
+            return self.tasks[task_id]
+        except KeyError as exc:
+            raise UnknownResource(f"task {task_id!r} does not exist") from exc
+
+    def _bid(self, bid_id: str | None) -> MarketBid:
+        if bid_id is None:
+            raise UnknownResource("bid is not assigned")
+        try:
+            return self.bids[bid_id]
+        except KeyError as exc:
+            raise UnknownResource(f"bid {bid_id!r} does not exist") from exc
+
+    def _log(self, opcode: int, state: dict[str, object]) -> dict[str, object]:
+        return self.ledger.log(state, opcode)
+
+
+__all__ = [
+    "DuplicateResource",
+    "MarketBid",
+    "MarketError",
+    "MarketStateError",
+    "MarketTask",
+    "OpenMarketEngine",
+    "Provider",
+    "SettlementReceipt",
+    "SettlementStatus",
+    "TaskStatus",
+    "UnknownResource",
+]

--- a/src/jarvisx/open_market_api.py
+++ b/src/jarvisx/open_market_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Any
+from typing import Any, cast
 
 from fastapi import FastAPI, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -304,7 +304,7 @@ def get_settlement(task_id: str) -> dict[str, Any]:
 
 @app.get("/v1/market")
 def market_status() -> dict[str, Any]:
-    return market.snapshot()
+    return cast(dict[str, Any], market.snapshot())
 
 
 @app.get("/v1/ledger")

--- a/src/jarvisx/open_market_api.py
+++ b/src/jarvisx/open_market_api.py
@@ -1,0 +1,317 @@
+"""FastAPI surface for the Jarvis-X open verified-execution market."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from .assembler import Assembler
+from .open_market import (
+    DuplicateResource,
+    MarketBid,
+    MarketError,
+    MarketStateError,
+    MarketTask,
+    OpenMarketEngine,
+    Provider,
+    SettlementReceipt,
+    UnknownResource,
+)
+from .parser import Parser
+from .system_runtime import CAP_VM_EXECUTE, ResourceBudget, UtilityWeights
+
+app = FastAPI(
+    title="Jarvis-X Open Market",
+    version="0.1.0",
+    description=(
+        "Open capability market for deterministic Jarvis-X plans. Providers advertise "
+        "capabilities, buyers post bounded tasks, bids compete on quality/cost/latency/risk, "
+        "and accounting settlement occurs only after verified committed execution."
+    ),
+)
+market = OpenMarketEngine()
+
+
+class ProviderCreate(BaseModel):
+    provider_id: str = Field(min_length=1, max_length=128)
+    display_name: str = Field(min_length=1, max_length=200)
+    capabilities: list[str] = Field(min_length=1, max_length=64)
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class TaskCreate(BaseModel):
+    task_id: str = Field(min_length=1, max_length=128)
+    buyer_id: str = Field(min_length=1, max_length=128)
+    capability: str = Field(min_length=1, max_length=128)
+    max_price_units: int = Field(ge=1, le=10**15)
+    max_cycles: int = Field(default=10_000, ge=1, le=1_000_000)
+    max_program_words: int = Field(default=4_096, ge=1, le=100_000)
+    max_candidates: int = Field(default=32, ge=1, le=1_000)
+    quality_weight: float = Field(default=1.0, ge=0.0, le=1_000_000.0)
+    cost_weight: float = Field(default=1.0, ge=0.0, le=1_000_000.0)
+    latency_weight: float = Field(default=1.0, ge=0.0, le=1_000_000.0)
+    risk_weight: float = Field(default=1.0, ge=0.0, le=1_000_000.0)
+
+
+class BidCreate(BaseModel):
+    bid_id: str = Field(min_length=1, max_length=128)
+    provider_id: str = Field(min_length=1, max_length=128)
+    source: str = Field(min_length=1, max_length=262_144)
+    price_units: int = Field(ge=0, le=10**15)
+    quality: float = Field(ge=0.0, le=1_000_000.0)
+    latency: float = Field(ge=0.0, le=1_000_000_000.0)
+    risk: float = Field(ge=0.0, le=1_000_000.0)
+    required_capabilities: list[str] = Field(default_factory=lambda: [CAP_VM_EXECUTE])
+
+
+def _assemble(source: str) -> tuple[int, ...]:
+    return tuple(Assembler().assemble(Parser().parse(source)))
+
+
+def _fail(exc: Exception) -> HTTPException:
+    if isinstance(exc, UnknownResource):
+        return HTTPException(status_code=404, detail=str(exc))
+    if isinstance(exc, DuplicateResource):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, (MarketStateError, MarketError)):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, (TypeError, ValueError)):
+        return HTTPException(status_code=422, detail=str(exc))
+    return HTTPException(status_code=500, detail="internal market failure")
+
+
+def _provider_dict(provider: Provider) -> dict[str, Any]:
+    return {
+        "provider_id": provider.provider_id,
+        "display_name": provider.display_name,
+        "capabilities": sorted(provider.capabilities),
+        "metadata": dict(provider.metadata),
+    }
+
+
+def _task_dict(task: MarketTask) -> dict[str, Any]:
+    return {
+        "task_id": task.task_id,
+        "buyer_id": task.buyer_id,
+        "capability": task.capability,
+        "max_price_units": task.max_price_units,
+        "granted_capabilities": sorted(task.granted_capabilities),
+        "budget": {
+            "max_cycles": task.budget.max_cycles,
+            "max_program_words": task.budget.max_program_words,
+            "max_candidates": task.budget.max_candidates,
+        },
+        "weights": asdict(task.weights),
+        "status": task.status.value,
+        "awarded_bid_id": task.awarded_bid_id,
+    }
+
+
+def _bid_dict(bid: MarketBid, *, include_program: bool = False) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "bid_id": bid.bid_id,
+        "task_id": bid.task_id,
+        "provider_id": bid.provider_id,
+        "price_units": bid.price_units,
+        "quality": bid.quality,
+        "latency": bid.latency,
+        "risk": bid.risk,
+        "required_capabilities": sorted(bid.required_capabilities),
+        "program_words": len(bid.program),
+    }
+    if include_program:
+        result["program"] = list(bid.program)
+    return result
+
+
+def _settlement_dict(settlement: SettlementReceipt) -> dict[str, Any]:
+    return {
+        "settlement_id": settlement.settlement_id,
+        "task_id": settlement.task_id,
+        "bid_id": settlement.bid_id,
+        "buyer_id": settlement.buyer_id,
+        "provider_id": settlement.provider_id,
+        "status": settlement.status.value,
+        "gross_units": settlement.gross_units,
+        "platform_fee_units": settlement.platform_fee_units,
+        "provider_units": settlement.provider_units,
+        "execution_status": settlement.execution_status,
+        "execution_request_id": settlement.execution_request_id,
+        "execution_state": settlement.state_dict(),
+        "execution_state_hash": settlement.execution_state_hash,
+        "vm_ledger_head": settlement.vm_ledger_head,
+        "system_audit_head": settlement.system_audit_head,
+        "market_ledger_head": settlement.market_ledger_head,
+        "error_type": settlement.error_type,
+        "error_message": settlement.error_message,
+    }
+
+
+@app.get("/healthz")
+def healthz() -> dict[str, Any]:
+    snapshot = market.snapshot()
+    return {
+        "status": "ok" if market.verify() else "degraded",
+        "service": "jarvisx-open-market",
+        "version": app.version,
+        **snapshot,
+    }
+
+
+@app.get("/v1/capabilities")
+def capabilities() -> dict[str, Any]:
+    return {
+        "market": {
+            "provider_registry": True,
+            "task_market": True,
+            "competitive_bids": True,
+            "deterministic_award": True,
+            "verified_execution": True,
+            "settlement_mode": "internal integer accounting units only",
+            "external_payment_rail": False,
+        },
+        "runtime": {
+            "engine": "SystemRuntime/CodexVM",
+            "plan_execute_commit_separation": True,
+            "cycle_bounded": True,
+            "audit_linked_receipts": True,
+        },
+        "security_boundary": (
+            "Reference integration only. The current VM cycle sandbox is not hostile-code "
+            "process isolation; do not accept untrusted public bytecode in production."
+        ),
+    }
+
+
+@app.post("/v1/providers")
+def register_provider(request: ProviderCreate) -> dict[str, Any]:
+    try:
+        provider = market.register_provider(
+            Provider(
+                provider_id=request.provider_id,
+                display_name=request.display_name,
+                capabilities=frozenset(request.capabilities),
+                metadata=tuple(request.metadata.items()),
+            )
+        )
+        return _provider_dict(provider)
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.get("/v1/providers")
+def list_providers(limit: int = Query(default=100, ge=1, le=1_000)) -> dict[str, Any]:
+    providers = sorted(market.providers.values(), key=lambda item: item.provider_id)[:limit]
+    return {"providers": [_provider_dict(provider) for provider in providers]}
+
+
+@app.post("/v1/tasks")
+def create_task(request: TaskCreate) -> dict[str, Any]:
+    try:
+        task = market.create_task(
+            MarketTask(
+                task_id=request.task_id,
+                buyer_id=request.buyer_id,
+                capability=request.capability,
+                max_price_units=request.max_price_units,
+                budget=ResourceBudget(
+                    max_cycles=request.max_cycles,
+                    max_program_words=request.max_program_words,
+                    max_candidates=request.max_candidates,
+                ),
+                weights=UtilityWeights(
+                    quality=request.quality_weight,
+                    cost=request.cost_weight,
+                    latency=request.latency_weight,
+                    risk=request.risk_weight,
+                ),
+            )
+        )
+        return _task_dict(task)
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.get("/v1/tasks/{task_id}")
+def get_task(task_id: str) -> dict[str, Any]:
+    try:
+        return _task_dict(market.tasks[task_id])
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=f"task {task_id!r} does not exist") from exc
+
+
+@app.post("/v1/tasks/{task_id}/bids")
+def submit_bid(task_id: str, request: BidCreate) -> dict[str, Any]:
+    try:
+        bid = market.submit_bid(
+            MarketBid(
+                bid_id=request.bid_id,
+                task_id=task_id,
+                provider_id=request.provider_id,
+                program=_assemble(request.source),
+                price_units=request.price_units,
+                quality=request.quality,
+                latency=request.latency,
+                risk=request.risk,
+                required_capabilities=frozenset(request.required_capabilities),
+            )
+        )
+        return _bid_dict(bid)
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.get("/v1/tasks/{task_id}/bids")
+def list_bids(task_id: str) -> dict[str, Any]:
+    try:
+        bids = market.bids_for_task(task_id)
+        return {"bids": [_bid_dict(bid) for bid in bids]}
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.post("/v1/tasks/{task_id}/award")
+def award_task(task_id: str) -> dict[str, Any]:
+    try:
+        return _bid_dict(market.award_task(task_id))
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.post("/v1/tasks/{task_id}/execute")
+def execute_task(task_id: str) -> dict[str, Any]:
+    try:
+        return _settlement_dict(market.execute_task(task_id))
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.get("/v1/tasks/{task_id}/settlement")
+def get_settlement(task_id: str) -> dict[str, Any]:
+    try:
+        settlement = market.settlement_for_task(task_id)
+        if settlement is None:
+            raise HTTPException(status_code=404, detail="task has not settled")
+        return _settlement_dict(settlement)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise _fail(exc) from exc
+
+
+@app.get("/v1/market")
+def market_status() -> dict[str, Any]:
+    return market.snapshot()
+
+
+@app.get("/v1/ledger")
+def market_ledger(limit: int = Query(default=100, ge=1, le=10_000)) -> dict[str, Any]:
+    chain = market.ledger.chain[-limit:]
+    return {
+        "valid": market.ledger.verify(),
+        "entries": chain,
+        "head": chain[-1]["hash"] if chain else None,
+    }

--- a/src/jarvisx/open_market_cli.py
+++ b/src/jarvisx/open_market_cli.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+
+import uvicorn
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run the Jarvis-X open verified-execution market API")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--reload", action="store_true")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    uvicorn.run(
+        "jarvisx.open_market_api:app",
+        host=args.host,
+        port=args.port,
+        reload=args.reload,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_open_market.py
+++ b/tests/test_open_market.py
@@ -1,0 +1,212 @@
+import pytest
+
+from jarvisx.assembler import Assembler
+from jarvisx.open_market import (
+    MarketBid,
+    MarketStateError,
+    MarketTask,
+    OpenMarketEngine,
+    Provider,
+    SettlementStatus,
+    TaskStatus,
+)
+from jarvisx.parser import Parser
+from jarvisx.system_runtime import ResourceBudget, UtilityWeights
+
+
+def assemble(source: str) -> tuple[int, ...]:
+    return tuple(Assembler().assemble(Parser().parse(source)))
+
+
+def provider(provider_id: str, *capabilities: str) -> Provider:
+    return Provider(
+        provider_id=provider_id,
+        display_name=provider_id.title(),
+        capabilities=frozenset(capabilities),
+    )
+
+
+def test_open_market_end_to_end_awards_executes_and_settles_verified_bid() -> None:
+    market = OpenMarketEngine(fee_bps=250, clock_ns=lambda: 1)
+    market.register_provider(provider("alpha", "optimization"))
+    market.register_provider(provider("beta", "optimization"))
+    market.create_task(
+        MarketTask(
+            task_id="task-1",
+            buyer_id="factory-1",
+            capability="optimization",
+            max_price_units=2_000,
+            weights=UtilityWeights(quality=100.0, cost=0.01, latency=1.0, risk=10.0),
+        )
+    )
+    market.submit_bid(
+        MarketBid(
+            bid_id="bid-alpha",
+            task_id="task-1",
+            provider_id="alpha",
+            program=assemble("SET A 10\nHALT"),
+            price_units=1_000,
+            quality=0.80,
+            latency=2.0,
+            risk=0.20,
+        )
+    )
+    market.submit_bid(
+        MarketBid(
+            bid_id="bid-beta",
+            task_id="task-1",
+            provider_id="beta",
+            program=assemble("SET A 42\nHALT"),
+            price_units=1_200,
+            quality=0.98,
+            latency=1.0,
+            risk=0.05,
+        )
+    )
+
+    settlement = market.execute_task("task-1")
+
+    assert settlement.status is SettlementStatus.SETTLED
+    assert settlement.bid_id == "bid-beta"
+    assert settlement.provider_id == "beta"
+    assert settlement.gross_units == 1_200
+    assert settlement.platform_fee_units == 30
+    assert settlement.provider_units == 1_170
+    assert settlement.state_dict()["A"] == 42
+    assert settlement.execution_state_hash is not None
+    assert settlement.vm_ledger_head is not None
+    assert market.tasks["task-1"].status is TaskStatus.SETTLED
+    assert market.snapshot()["gross_verified_units"] == 1_200
+    assert market.verify()
+
+
+def test_provider_must_advertise_requested_capability() -> None:
+    market = OpenMarketEngine(clock_ns=lambda: 1)
+    market.register_provider(provider("render-node", "rendering"))
+    market.create_task(
+        MarketTask(
+            task_id="task-2",
+            buyer_id="factory-1",
+            capability="optimization",
+            max_price_units=500,
+        )
+    )
+
+    with pytest.raises(MarketStateError, match="does not advertise capability"):
+        market.submit_bid(
+            MarketBid(
+                bid_id="wrong-capability",
+                task_id="task-2",
+                provider_id="render-node",
+                program=assemble("HALT"),
+                price_units=10,
+                quality=1.0,
+                latency=1.0,
+                risk=0.0,
+            )
+        )
+
+
+def test_bid_over_buyer_price_ceiling_is_rejected() -> None:
+    market = OpenMarketEngine(clock_ns=lambda: 1)
+    market.register_provider(provider("optimizer", "optimization"))
+    market.create_task(
+        MarketTask(
+            task_id="task-3",
+            buyer_id="factory-1",
+            capability="optimization",
+            max_price_units=100,
+        )
+    )
+
+    with pytest.raises(MarketStateError, match="exceeds task maximum"):
+        market.submit_bid(
+            MarketBid(
+                bid_id="expensive",
+                task_id="task-3",
+                provider_id="optimizer",
+                program=assemble("HALT"),
+                price_units=101,
+                quality=1.0,
+                latency=1.0,
+                risk=0.0,
+            )
+        )
+
+
+def test_failed_execution_settles_zero_and_cannot_pay_provider() -> None:
+    market = OpenMarketEngine(fee_bps=500, clock_ns=lambda: 1)
+    market.register_provider(provider("optimizer", "optimization"))
+    market.create_task(
+        MarketTask(
+            task_id="task-fail",
+            buyer_id="factory-1",
+            capability="optimization",
+            max_price_units=1_000,
+            budget=ResourceBudget(max_cycles=1, max_program_words=32, max_candidates=4),
+        )
+    )
+    market.submit_bid(
+        MarketBid(
+            bid_id="will-fail",
+            task_id="task-fail",
+            provider_id="optimizer",
+            program=assemble("SET A 1\nSET A 2\nHALT"),
+            price_units=500,
+            quality=1.0,
+            latency=1.0,
+            risk=0.0,
+        )
+    )
+
+    settlement = market.execute_task("task-fail")
+
+    assert settlement.status is SettlementStatus.EXECUTION_FAILED
+    assert settlement.gross_units == 0
+    assert settlement.platform_fee_units == 0
+    assert settlement.provider_units == 0
+    assert settlement.execution_state == ()
+    assert market.tasks["task-fail"].status is TaskStatus.FAILED
+    assert market.verify()
+
+
+def test_execute_is_idempotent_after_settlement() -> None:
+    market = OpenMarketEngine(clock_ns=lambda: 1)
+    market.register_provider(provider("optimizer", "optimization"))
+    market.create_task(
+        MarketTask(
+            task_id="task-idempotent",
+            buyer_id="factory-1",
+            capability="optimization",
+            max_price_units=100,
+        )
+    )
+    market.submit_bid(
+        MarketBid(
+            bid_id="bid-idempotent",
+            task_id="task-idempotent",
+            provider_id="optimizer",
+            program=assemble("SET A 9\nHALT"),
+            price_units=100,
+            quality=1.0,
+            latency=1.0,
+            risk=0.0,
+        )
+    )
+
+    first = market.execute_task("task-idempotent")
+    ledger_length = len(market.ledger.chain)
+    second = market.execute_task("task-idempotent")
+
+    assert second == first
+    assert len(market.ledger.chain) == ledger_length
+    assert market.verify()
+
+
+def test_market_ledger_detects_tampering() -> None:
+    market = OpenMarketEngine(clock_ns=lambda: 1)
+    market.register_provider(provider("optimizer", "optimization"))
+
+    assert market.verify()
+    market.ledger.chain[0]["state"]["provider_id"] = "attacker"
+    assert market.verify() is False


### PR DESCRIPTION
## Summary

Implements the first end-to-end **Open Source / Open Market** Jarvis-X MVP around the canonical `SystemRuntime` boundary.

### Flow

`provider registry -> buyer task -> competitive bids -> deterministic award -> governed VM execution -> verified receipt -> internal accounting settlement -> market ledger`

### Added

- `src/jarvisx/open_market.py`
  - provider capability registry
  - bounded buyer tasks
  - executable provider bids
  - deterministic quality/cost/latency/risk award
  - execution through existing `SystemRuntime`
  - settlement only after `COMMITTED` execution
  - zero settlement on rejected/failed execution
  - idempotent task execution
  - hash-chained market provenance
- `src/jarvisx/open_market_api.py`
  - FastAPI provider/task/bid/award/execute/settlement endpoints
  - market health/capability/ledger endpoints
- `src/jarvisx/open_market_cli.py`
  - `jarvisx-open-market` service launcher
- `examples/open_market_demo.py`
  - two-provider end-to-end market example
- `tests/test_open_market.py`
  - award + verified settlement
  - capability mismatch rejection
  - buyer price ceiling
  - zero settlement on failed execution
  - idempotency
  - ledger tamper detection
- `docs/OPEN_MARKET_SWARM_MVP.md`
  - architecture, API, settlement and security boundary

## Invariants

The implementation deliberately preserves:

`Plan != Execute != Commit != Settle`

A provider receives internal accounting credit only after a committed Jarvis-X execution receipt.

## Financial boundary

This PR does **not** implement money movement, tokens, securities, escrow, banking or payment processing. `*_units` are integer accounting units only. A future regulated payment adapter can consume verified settlement receipts without coupling financial authority into the VM kernel.

## Security boundary

This is a reference integration candidate, not a public hostile-code execution service. It inherits the repository's current VM security boundary. Public untrusted providers would require identity, RBAC, signed manifests, hardened process/container isolation, quotas, persistence, and abuse controls before production exposure.

## Next gates

1. durable SQL-backed market state + recovery
2. authenticated provider/buyer identities + RBAC
3. signed provider manifests
4. hardened worker isolation
5. domain-specific task schemas/verifiers
6. ERP/MES/PLM/IIoT adapters
7. usage metering/invoice export
8. SLA/dispute/retry/cancellation semantics
9. benchmark + retained evidence artifacts
