### PR TITLE
feat: recursive compile–interpret acceleration contract

### DIFF
--- a/cpp_runtime/include/jarvisx/compile_interpret_accelerator.hpp
+++ b/cpp_runtime/include/jarvisx/compile_interpret_accelerator.hpp
@@ -1,0 +1,238 @@
+#pragma once
+
+#include "jarvisx/recursive_cube_interpreter.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace jarvisx::cube::acceleration {
+
+// A septillion is 10^24. Therefore septillion^septillion is
+// (10^24)^(10^24) = 10^(24 * 10^24).  The target is kept in log10 space;
+// the runtime never attempts to materialize this astronomically large scalar.
+constexpr long double kSeptillion = 1.0e24L;
+constexpr long double kSeptillionSquaredExponentLog10 = 24.0L * kSeptillion;
+
+struct AccelerationTarget {
+    long double log10_speedup{kSeptillionSquaredExponentLog10};
+
+    void validate() const {
+        if (!std::isfinite(log10_speedup) || log10_speedup < 0.0L) {
+            throw std::invalid_argument("acceleration target must be finite and non-negative in log10 space");
+        }
+    }
+};
+
+struct AccelerationFactors {
+    long double parallel{1.0L};
+    long double sparse{1.0L};
+    long double memoization{1.0L};
+    long double fusion{1.0L};
+    long double vectorization{1.0L};
+    long double pipeline{1.0L};
+    long double cache{1.0L};
+    long double speculative{1.0L};
+
+    void validate() const {
+        const long double factors[] = {
+            parallel, sparse, memoization, fusion,
+            vectorization, pipeline, cache, speculative,
+        };
+        for (const long double value : factors) {
+            if (!std::isfinite(value) || value < 1.0L) {
+                throw std::invalid_argument("measured acceleration factors must be finite and >= 1");
+            }
+        }
+    }
+
+    long double log10_product() const {
+        validate();
+        return std::log10(parallel) + std::log10(sparse) +
+               std::log10(memoization) + std::log10(fusion) +
+               std::log10(vectorization) + std::log10(pipeline) +
+               std::log10(cache) + std::log10(speculative);
+    }
+};
+
+struct RecursiveFoldProfile {
+    // rho_l is the fraction of work retained after fold l; 0 < rho_l <= 1.
+    std::vector<long double> retention;
+
+    long double log10_speedup() const {
+        long double result = 0.0L;
+        for (const long double rho : retention) {
+            if (!std::isfinite(rho) || rho <= 0.0L || rho > 1.0L) {
+                throw std::invalid_argument("recursive fold retention must lie in (0,1]");
+            }
+            result -= std::log10(rho);
+        }
+        return result;
+    }
+
+    long double retained_work_fraction() const {
+        long double result = 1.0L;
+        for (const long double rho : retention) {
+            if (!std::isfinite(rho) || rho <= 0.0L || rho > 1.0L) {
+                throw std::invalid_argument("recursive fold retention must lie in (0,1]");
+            }
+            result *= rho;
+        }
+        return result;
+    }
+};
+
+struct CompileInterpretTiming {
+    long double compile_ns{0.0L};
+    long double interpret_ns{0.0L};
+    long double commit_ns{0.0L};
+
+    void validate() const {
+        if (!std::isfinite(compile_ns) || !std::isfinite(interpret_ns) ||
+            !std::isfinite(commit_ns) || compile_ns < 0.0L || interpret_ns < 0.0L ||
+            commit_ns < 0.0L) {
+            throw std::invalid_argument("compile/interpret timing must be finite and non-negative");
+        }
+    }
+
+    // Sequential baseline: compile then interpret then commit.
+    long double sequential_ns() const {
+        validate();
+        return compile_ns + interpret_ns + commit_ns;
+    }
+
+    // Ideal fused schedule: compilation/preparation overlaps interpretation;
+    // commit remains a serialized correctness boundary.
+    long double fused_ns() const {
+        validate();
+        return std::max(compile_ns, interpret_ns) + commit_ns;
+    }
+
+    long double ideal_fusion_speedup() const {
+        const long double fused = fused_ns();
+        if (fused <= 0.0L) return 1.0L;
+        return std::max(1.0L, sequential_ns() / fused);
+    }
+};
+
+struct AccelerationContract {
+    AccelerationTarget target{};
+    AccelerationFactors measured_factors{};
+    RecursiveFoldProfile fold{};
+    CompileInterpretTiming fusion_timing{};
+
+    void validate() const {
+        target.validate();
+        measured_factors.validate();
+        (void)fold.log10_speedup();
+        fusion_timing.validate();
+    }
+
+    long double modeled_log10_speedup() const {
+        validate();
+        const long double fusion_gain = std::log10(fusion_timing.ideal_fusion_speedup());
+        return measured_factors.log10_product() + fold.log10_speedup() + fusion_gain;
+    }
+
+    long double target_gap_log10() const {
+        return target.log10_speedup - modeled_log10_speedup();
+    }
+
+    // Map an unbounded acceleration score into a bounded kinetic controller.
+    // This is deliberately not used as a physical clock multiplier.
+    long double bounded_kinetic_gain() const {
+        const long double score = std::max(0.0L, modeled_log10_speedup());
+        return std::tanh(std::log1p(score));
+    }
+};
+
+struct HarmonicCompileInterpretPhase {
+    long double phase{0.0L};
+
+    // Compile and interpret are quadrature components of one bounded phase.
+    // The phase scheduler remains numerically stable regardless of target size.
+    void advance(long double base_omega, long double dt, const AccelerationContract& contract) {
+        if (!std::isfinite(base_omega) || !std::isfinite(dt) || base_omega < 0.0L || dt < 0.0L) {
+            throw std::invalid_argument("harmonic scheduler requires finite non-negative omega and dt");
+        }
+        const long double gain = 1.0L + contract.bounded_kinetic_gain();
+        phase = std::fmod(phase + base_omega * gain * dt, 2.0L * 3.1415926535897932384626433832795L);
+    }
+
+    long double compile_component(long double radius = 1.0L) const { return radius * std::cos(phase); }
+    long double interpret_component(long double radius = 1.0L) const { return radius * std::sin(phase); }
+};
+
+struct AcceleratorReport {
+    CubeRunMetrics cube{};
+    std::uint64_t elapsed_ns{};
+    std::uint64_t maximum_tile_pass_budget{};
+    long double convergence_work_reduction{1.0L};
+    long double modeled_log10_speedup{};
+    long double target_log10_speedup{};
+    long double target_gap_log10{};
+    long double bounded_kinetic_gain{};
+};
+
+class ParallelCompileInterpretAccelerator {
+public:
+    explicit ParallelCompileInterpretAccelerator(RecursiveCubeInterpreter& interpreter,
+                                                  CubeInterpreterConfig config = {})
+        : interpreter_(interpreter), config_(config) {
+        config_.validate();
+    }
+
+    AcceleratorReport run(const std::vector<std::uint8_t>& execution_buffer,
+                          const AccelerationContract& contract = {}) {
+        contract.validate();
+
+        // Parse once here to calculate the constitutional work budget. The
+        // interpreter re-validates the same buffer before execution, preserving
+        // its existing transaction boundary.
+        const auto commands = parse_execution_buffer(execution_buffer, config_);
+        std::uint64_t pass_budget = 0ULL;
+        for (const auto& command : commands) {
+            if (command.opcode == CubeOpcode::EncodeRefine) {
+                const std::uint64_t tiles = static_cast<std::uint64_t>(command.tile_count);
+                const std::uint64_t passes = static_cast<std::uint64_t>(command.max_passes);
+                if (passes != 0ULL && tiles > std::numeric_limits<std::uint64_t>::max() / passes) {
+                    throw std::overflow_error("compile-interpret acceleration pass budget overflow");
+                }
+                pass_budget += tiles * passes;
+            } else if (command.opcode == CubeOpcode::Decode) {
+                pass_budget += static_cast<std::uint64_t>(command.tile_count);
+            }
+        }
+
+        const auto start = std::chrono::steady_clock::now();
+        CubeRunMetrics metrics = interpreter_.run(execution_buffer);
+        const auto stop = std::chrono::steady_clock::now();
+        const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(stop - start).count();
+
+        const std::uint64_t actual_ops = std::max<std::uint64_t>(1ULL, metrics.total_passes +
+            (metrics.commands_executed > 0ULL ? metrics.decoded_output_bytes / kCubeTileBytes : 0ULL));
+        const long double convergence = pass_budget == 0ULL ? 1.0L :
+            std::max(1.0L, static_cast<long double>(pass_budget) / static_cast<long double>(actual_ops));
+
+        AcceleratorReport report;
+        report.cube = std::move(metrics);
+        report.elapsed_ns = elapsed < 0 ? 0ULL : static_cast<std::uint64_t>(elapsed);
+        report.maximum_tile_pass_budget = pass_budget;
+        report.convergence_work_reduction = convergence;
+        report.modeled_log10_speedup = contract.modeled_log10_speedup() + std::log10(convergence);
+        report.target_log10_speedup = contract.target.log10_speedup;
+        report.target_gap_log10 = report.target_log10_speedup - report.modeled_log10_speedup;
+        report.bounded_kinetic_gain = contract.bounded_kinetic_gain();
+        return report;
+    }
+
+private:
+    RecursiveCubeInterpreter& interpreter_;
+    CubeInterpreterConfig config_;
+};
+
+} // namespace jarvisx::cube::acceleration

--- a/cpp_runtime/src/compile_interpret_accelerator_main.cpp
+++ b/cpp_runtime/src/compile_interpret_accelerator_main.cpp
@@ -1,0 +1,125 @@
+#include "jarvisx/compile_interpret_accelerator.hpp"
+
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::filesystem::path state_dir{"jarvisx-compile-interpret-acceleration-state"};
+    std::uint32_t tiles{32U};
+    std::uint8_t levels{2U};
+    bool quiet{};
+};
+
+std::uint32_t parse_u32(const std::string& text, const char* name) {
+    std::size_t used = 0U;
+    const unsigned long value = std::stoul(text, &used, 10);
+    if (used != text.size() || value > 0xffffffffUL) {
+        throw std::invalid_argument(std::string("invalid ") + name);
+    }
+    return static_cast<std::uint32_t>(value);
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--state-dir") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --state-dir");
+            options.state_dir = argv[++i];
+        } else if (arg == "--tiles") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --tiles");
+            options.tiles = parse_u32(argv[++i], "tile count");
+        } else if (arg == "--levels") {
+            if (i + 1 >= argc) throw std::invalid_argument("missing value after --levels");
+            const std::uint32_t value = parse_u32(argv[++i], "level count");
+            if (value > 255U) throw std::invalid_argument("level count exceeds uint8");
+            options.levels = static_cast<std::uint8_t>(value);
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            std::cout << "Usage: DrMoagi-Compile-Interpret-Accelerator "
+                         "[--tiles N] [--levels N] [--state-dir PATH] [--quiet]\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + arg);
+        }
+    }
+    if (options.tiles == 0U || options.levels == 0U || options.levels > 8U) {
+        throw std::invalid_argument("tiles must be positive and levels must be in [1,8]");
+    }
+    return options;
+}
+
+std::uint8_t source_byte(std::uint64_t index) noexcept {
+    return static_cast<std::uint8_t>((index * 37ULL + (index >> 3U) + (index >> 11U)) & 0xffULL);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        std::filesystem::remove_all(options.state_dir);
+
+        jarvisx::intelligence3d::VirtualVolume3D volume({
+            jarvisx::world::kVmadCoordExtent,
+            32U,
+            8ULL * 1024ULL * 1024ULL,
+            options.state_dir / "pages",
+        });
+
+        const auto plan = jarvisx::cube::make_demo_plan(options.tiles, options.levels);
+        const std::uint64_t source_bytes =
+            static_cast<std::uint64_t>(options.tiles) * jarvisx::cube::kCubeTileBytes;
+
+        for (std::uint64_t i = 0ULL; i < source_bytes; ++i) {
+            const auto address = jarvisx::world::vmad_advance_linear(plan.source, i);
+            volume.write(address.coord(), source_byte(i));
+        }
+
+        jarvisx::cube::RecursiveCubeInterpreter interpreter(volume);
+        jarvisx::cube::acceleration::ParallelCompileInterpretAccelerator accelerator(interpreter);
+
+        jarvisx::cube::acceleration::AccelerationContract contract;
+        contract.fold.retention.assign(static_cast<std::size_t>(options.levels), 1.0L / 32.0L);
+
+        const auto report = accelerator.run(plan.execution_buffer, contract);
+        volume.flush();
+
+        jarvisx::cube::acceleration::HarmonicCompileInterpretPhase phase;
+        phase.advance(1.0L, 1.0L, contract);
+
+        if (!options.quiet) {
+            std::cout << std::setprecision(12)
+                      << "DM-vOmegaXi+ parallel compile-interpret acceleration contract\n"
+                      << "target_definition=(10^24)^(10^24)\n"
+                      << "target_log10_speedup=" << report.target_log10_speedup << '\n'
+                      << "modeled_log10_speedup=" << report.modeled_log10_speedup << '\n'
+                      << "target_gap_log10=" << report.target_gap_log10 << '\n'
+                      << "elapsed_ns=" << report.elapsed_ns << '\n'
+                      << "maximum_tile_pass_budget=" << report.maximum_tile_pass_budget << '\n'
+                      << "actual_passes=" << report.cube.total_passes << '\n'
+                      << "convergence_work_reduction=" << report.convergence_work_reduction << '\n'
+                      << "bounded_kinetic_gain=" << report.bounded_kinetic_gain << '\n'
+                      << "compile_phase_component=" << phase.compile_component() << '\n'
+                      << "interpret_phase_component=" << phase.interpret_component() << '\n'
+                      << "commands_executed=" << report.cube.commands_executed << '\n'
+                      << "tiles_processed=" << report.cube.tiles_processed << '\n'
+                      << "claim_boundary=hyper_exponential_target_is_symbolic_log_space_only;"
+                         "reported_runtime_and_work_reduction_are_empirical_for_this_run\n";
+        }
+
+        std::filesystem::remove_all(options.state_dir);
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "DrMoagi Compile-Interpret Accelerator failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/compile_interpret_accelerator_tests.cpp
+++ b/cpp_runtime/tests/compile_interpret_accelerator_tests.cpp
@@ -1,0 +1,107 @@
+#include "jarvisx/compile_interpret_accelerator.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <stdexcept>
+
+namespace accel = jarvisx::cube::acceleration;
+
+namespace {
+
+bool close(long double a, long double b, long double eps = 1.0e-12L) {
+    return std::abs(a - b) <= eps * std::max(1.0L, std::max(std::abs(a), std::abs(b)));
+}
+
+void target_is_septillion_to_septillion_in_log_space() {
+    const accel::AccelerationTarget target{};
+    assert(std::isfinite(target.log10_speedup));
+    assert(close(target.log10_speedup, 24.0L * 1.0e24L, 1.0e-18L));
+}
+
+void factor_product_is_logarithmically_composable() {
+    accel::AccelerationFactors f;
+    f.parallel = 8.0L;
+    f.sparse = 4.0L;
+    f.vectorization = 2.0L;
+    assert(close(f.log10_product(), std::log10(64.0L)));
+}
+
+void recursive_fold_reduces_work_multiplicatively() {
+    accel::RecursiveFoldProfile fold;
+    fold.retention = {0.5L, 0.25L};
+    assert(close(fold.retained_work_fraction(), 0.125L));
+    assert(close(fold.log10_speedup(), std::log10(8.0L)));
+}
+
+void invalid_fold_is_rejected() {
+    accel::RecursiveFoldProfile fold;
+    fold.retention = {1.0L, 0.0L};
+    bool threw = false;
+    try {
+        (void)fold.log10_speedup();
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+}
+
+void compile_interpret_fusion_preserves_serial_commit_boundary() {
+    accel::CompileInterpretTiming timing;
+    timing.compile_ns = 10.0L;
+    timing.interpret_ns = 20.0L;
+    timing.commit_ns = 2.0L;
+    assert(close(timing.sequential_ns(), 32.0L));
+    assert(close(timing.fused_ns(), 22.0L));
+    assert(close(timing.ideal_fusion_speedup(), 32.0L / 22.0L));
+}
+
+void kinetic_gain_is_bounded() {
+    accel::AccelerationContract contract;
+    contract.measured_factors.parallel = 64.0L;
+    contract.fold.retention = {0.5L, 0.5L, 0.5L};
+    const long double gain = contract.bounded_kinetic_gain();
+    assert(gain >= 0.0L);
+    assert(gain < 1.0L);
+}
+
+void harmonic_scheduler_stays_finite() {
+    accel::AccelerationContract contract;
+    contract.measured_factors.parallel = 8.0L;
+    contract.measured_factors.sparse = 16.0L;
+    accel::HarmonicCompileInterpretPhase phase;
+    for (int i = 0; i < 10000; ++i) phase.advance(2.0L, 0.001L, contract);
+    assert(std::isfinite(phase.phase));
+    assert(phase.phase >= 0.0L);
+    assert(phase.phase < 2.0L * 3.1415926535897932384626433832795L);
+    const long double c = phase.compile_component();
+    const long double s = phase.interpret_component();
+    assert(close(c*c + s*s, 1.0L, 1.0e-10L));
+}
+
+void target_gap_never_materializes_hyper_exponential_number() {
+    accel::AccelerationContract contract;
+    contract.measured_factors.parallel = 128.0L;
+    contract.measured_factors.sparse = 32.0L;
+    contract.fold.retention = {0.25L, 0.25L};
+    const long double modeled = contract.modeled_log10_speedup();
+    const long double gap = contract.target_gap_log10();
+    assert(std::isfinite(modeled));
+    assert(std::isfinite(gap));
+    assert(gap > 1.0e24L);
+}
+
+} // namespace
+
+int main() {
+    target_is_septillion_to_septillion_in_log_space();
+    factor_product_is_logarithmically_composable();
+    recursive_fold_reduces_work_multiplicatively();
+    invalid_fold_is_rejected();
+    compile_interpret_fusion_preserves_serial_commit_boundary();
+    kinetic_gain_is_bounded();
+    harmonic_scheduler_stays_finite();
+    target_gap_never_materializes_hyper_exponential_number();
+    std::cout << "compile-interpret accelerator regressions passed\n";
+    return 0;
+}

--- a/cpp_runtime/world_engine.cmake
+++ b/cpp_runtime/world_engine.cmake
@@ -47,3 +47,30 @@ jarvisx_harden(jarvisx-recursive-cube-tests)
 
 add_test(NAME recursive-cube-regressions COMMAND jarvisx-recursive-cube-tests)
 set_tests_properties(recursive-cube-regressions PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-compile-interpret-accelerator
+    src/compile_interpret_accelerator_main.cpp
+)
+set_target_properties(jarvisx-compile-interpret-accelerator PROPERTIES
+    OUTPUT_NAME "DrMoagi-Compile-Interpret-Accelerator")
+jarvisx_include_runtime(jarvisx-compile-interpret-accelerator)
+jarvisx_harden(jarvisx-compile-interpret-accelerator)
+
+add_test(
+    NAME compile-interpret-accelerator-runtime-smoke
+    COMMAND jarvisx-compile-interpret-accelerator
+        --tiles 4
+        --levels 1
+        --state-dir ${CMAKE_CURRENT_BINARY_DIR}/compile-interpret-accelerator-smoke
+        --quiet
+)
+set_tests_properties(compile-interpret-accelerator-runtime-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-compile-interpret-accelerator-tests
+    tests/compile_interpret_accelerator_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-compile-interpret-accelerator-tests)
+jarvisx_harden(jarvisx-compile-interpret-accelerator-tests)
+
+add_test(NAME compile-interpret-accelerator-regressions COMMAND jarvisx-compile-interpret-accelerator-tests)
+set_tests_properties(compile-interpret-accelerator-regressions PROPERTIES TIMEOUT 120)

--- a/docs/COMPILE_INTERPRET_ACCELERATION_CONTRACT.md
+++ b/docs/COMPILE_INTERPRET_ACCELERATION_CONTRACT.md
@@ -1,0 +1,204 @@
+# Recursive Compile–Interpret Acceleration Contract
+
+## Status
+
+Experimental runtime contract for the Jarvis X recursive cube interpreter.
+
+The purpose of this subsystem is to translate the **septillion^septillion acceleration target** into a numerically safe engineering objective without claiming an unmeasured wall-clock speedup.
+
+## 1. Target normalization
+
+A septillion is `10^24`. Therefore:
+
+```text
+septillion^septillion
+= (10^24)^(10^24)
+= 10^(24 * 10^24)
+```
+
+The runtime stores only the base-10 logarithm:
+
+```text
+A_target = log10(S_target) = 24 * 10^24
+```
+
+It never materializes `S_target` as a scalar. This avoids overflow and makes the target a constitutional optimization horizon rather than a fabricated benchmark result.
+
+The expression `10^(24^(10^24))` is a different, much larger power tower and is not mathematically equal to septillion^septillion.
+
+## 2. Base compile–interpret operator
+
+Let
+
+```text
+F_Moagi(x,t) = C_theta(x,t) + I_phi(x,t)
+```
+
+where `C` is compilation/preparation and `I` is interpretation/execution.
+
+Runtime acceleration is not represented by exponentiating `F`. Operator powers change the transformation; they do not by themselves shorten execution time. Instead, effective acceleration is decomposed into independently auditable factors:
+
+```text
+S_eff = S_parallel
+      * S_sparse
+      * S_memoization
+      * S_fusion
+      * S_vectorization
+      * S_pipeline
+      * S_cache
+      * S_speculative
+      * S_fold
+      * S_convergence
+```
+
+To prevent overflow, composition is performed in log space:
+
+```text
+A_eff = log10(S_eff) = sum_i log10(S_i)
+```
+
+and progress toward the constitutional target is
+
+```text
+Delta_A = A_target - A_eff.
+```
+
+Only benchmarked factors should be populated as measured factors.
+
+## 3. Recursive inward folding
+
+For recursive layer `l`, define the retained work fraction
+
+```text
+W_(l+1) = rho_l W_l,    0 < rho_l <= 1.
+```
+
+After `L` folds:
+
+```text
+W_L = W_0 product_l rho_l
+```
+
+and the ideal structural work reduction is
+
+```text
+S_fold = W_0/W_L = 1/(product_l rho_l).
+```
+
+The existing recursive cube demo reduces the tile population by approximately 32:1 between abstraction levels, so the executable uses `rho = 1/32` as a structural fold model. This is a work-model term, not a direct wall-clock claim.
+
+## 4. Compile–interpret fusion
+
+Sequential execution has the critical path
+
+```text
+T_seq = T_compile + T_interpret + T_commit.
+```
+
+If independent compile/preparation work is overlapped with interpretation, the ideal fused critical path is
+
+```text
+T_fused = max(T_compile, T_interpret) + T_commit.
+```
+
+Therefore
+
+```text
+S_fusion = T_seq/T_fused.
+```
+
+The commit remains serialized because it is a correctness boundary. The accelerator does not weaken validation, digest checking, VMAD span checking, acceptance gates, commit, or rollback semantics.
+
+## 5. Convergence acceleration
+
+For an encode/refine command with `N` tiles and at most `P` refinement passes, the maximum work budget is
+
+```text
+B = N * P.
+```
+
+If convergence and rejection gates execute only `A` tile passes, then
+
+```text
+S_convergence = B/max(A,1).
+```
+
+This term is measured directly from the recursive interpreter metrics.
+
+## 6. Bounded kinetic control
+
+Astronomical acceleration targets must never be inserted directly into a numerical integrator. Instead, the log-space score is passed through a bounded map:
+
+```text
+G = tanh(log(1 + max(A_eff,0)))
+```
+
+so
+
+```text
+0 <= G < 1.
+```
+
+This keeps recursive control finite even if the symbolic target is arbitrarily large.
+
+## 7. Harmonic compile–interpret synchronization
+
+Compilation and interpretation are modeled as quadrature components of one phase state:
+
+```text
+C(t) = R cos(phi_t)
+I(t) = R sin(phi_t)
+```
+
+with
+
+```text
+phi_(t+1) = wrap_2pi(phi_t + omega * (1 + G) * dt).
+```
+
+This preserves
+
+```text
+C(t)^2 + I(t)^2 = R^2
+```
+
+without attempting to run an oscillator at an unrepresentable septillion^septillion physical frequency.
+
+## 8. Claim boundary
+
+The subsystem distinguishes three quantities:
+
+1. **Constitutional target** — the symbolic septillion^septillion horizon, represented only in log space.
+2. **Modeled work reduction** — structural folding and supplied benchmark factors.
+3. **Empirical execution measurements** — elapsed nanoseconds, actual passes, accepted/rejected passes, convergence, and processed tiles from a concrete run.
+
+The first must never be reported as the third.
+
+## 9. Runtime files
+
+- `cpp_runtime/include/jarvisx/compile_interpret_accelerator.hpp`
+- `cpp_runtime/src/compile_interpret_accelerator_main.cpp`
+- `cpp_runtime/tests/compile_interpret_accelerator_tests.cpp`
+
+The executable is built as:
+
+```text
+DrMoagi-Compile-Interpret-Accelerator
+```
+
+and participates in CTest through both a smoke test and mathematical regression tests.
+
+## 10. Next performance layer
+
+The contract intentionally separates mathematics from implementation. The next real acceleration work should be benchmark-driven:
+
+- persistent active-tile queues instead of dense discovery;
+- concurrent preparation of independent commands/tiles;
+- SIMD/SWAR kernels for tile transforms;
+- memoized latent tiles keyed by content digest and parameter version;
+- fused encode/delta/validate passes to reduce memory traffic;
+- GPU-resident sparse tile execution where transfer amortization is favorable;
+- speculative execution only behind the existing validate/commit gate;
+- per-factor benchmark instrumentation so every `S_i` can be reproduced.
+
+This turns the extreme target into an optimization direction while preserving numerical stability and empirical accountability.


### PR DESCRIPTION
## Summary

Permeates the recursive cube runtime with a numerically safe compile–interpret acceleration contract.

### What this adds
- Represents the `septillion^septillion` target correctly as `(10^24)^(10^24) = 10^(24 * 10^24)` in **log10 space** only.
- Replaces operator exponentiation as a speed claim with auditable multiplicative acceleration factors: parallelism, sparsity, memoization, fusion, vectorization, pipelining, cache reuse, speculation, recursive folding, and measured convergence work reduction.
- Models recursive work as `W_(l+1) = rho_l W_l` and computes `S_fold = 1 / product(rho_l)`.
- Models ideal compile/interpret overlap as `T_fused = max(T_compile, T_interpret) + T_commit`, preserving the serialized transactional commit boundary.
- Adds a bounded kinetic gain and phase-locked compile/interpret quadrature scheduler without astronomical physical-frequency multiplication.
- Wraps the existing `RecursiveCubeInterpreter` and reports empirical elapsed time, tile/pass budget, actual passes, convergence work reduction, modeled log-speedup, and target gap.
- Adds a standalone `DrMoagi-Compile-Interpret-Accelerator` executable, smoke test, mathematical regression tests, and specification document.

## Claim boundary

This PR **does not claim a septillion^septillion measured wall-clock speedup**. The hyper-exponential quantity is a constitutional optimization target. Concrete speedups remain empirical and must be populated from reproducible benchmarks.

## Files
- `cpp_runtime/include/jarvisx/compile_interpret_accelerator.hpp`
- `cpp_runtime/src/compile_interpret_accelerator_main.cpp`
- `cpp_runtime/tests/compile_interpret_accelerator_tests.cpp`
- `cpp_runtime/world_engine.cmake`
- `docs/COMPILE_INTERPRET_ACCELERATION_CONTRACT.md`
