### PR TITLE
ADR-014: DM operator transfer functional

### DIFF
--- a/docs/DM_OPERATOR_TRANSFER_FUNCTIONAL.md
+++ b/docs/DM_OPERATOR_TRANSFER_FUNCTIONAL.md
@@ -1,0 +1,239 @@
+# DM Operator Transfer Functional
+
+## Status
+
+Reference specification for ADR-014. This is a Layer-5 research contract and does not redefine the canonical Jarvis-X bytecode VM.
+
+## 1. Governing expression
+
+The supplied expression is normalized to:
+
+```text
+D_M(Psi)
+  = nu
+    Omega^(Xi+)
+    (Lambda ⊗ Theta)^dagger
+    K_Phi(Psi)
+```
+
+with `K_Phi(Psi) = Psi star Phi`.
+
+A dimensionally clean operator-power form is:
+
+```text
+D_M(Psi)
+  = nu
+    (Omega / Omega0)^xi
+    (Lambda ⊗ Theta)^dagger
+    K_Phi(Psi).
+```
+
+## 2. State field
+
+Let
+
+```text
+Psi : Omega_3 x R -> R^d
+```
+
+with `Omega_3` a bounded 3D lattice or continuous domain. In the discrete reference runtime:
+
+```text
+Psi[i,j,k]
+```
+
+is a scalar field sample.
+
+## 3. Local geometric transform
+
+For a finite 3D kernel `Phi[a,b,c]`:
+
+```text
+Y[i,j,k]
+  = sum_{a,b,c} Phi[a,b,c]
+                  Psi[i+a,j+b,k+c].
+```
+
+The reference runtime uses deterministic zero boundary conditions.
+
+## 4. Constraint normalization
+
+The rigorous full-space form is:
+
+```text
+Z = (Lambda ⊗ Theta)^dagger Y.
+```
+
+The dependency-free executable reference uses a scalar jointly-diagonal mode:
+
+```text
+C = lambda_gain * theta_gain
+Z = Y / C.
+```
+
+The implementation rejects `|C| <= epsilon`.
+
+## 5. Recursive operator power
+
+Define the dimensionless memory ratio
+
+```text
+r_omega = omega / omega0.
+```
+
+Then
+
+```text
+G_omega = r_omega^xi.
+```
+
+The reference requires `r_omega > 0` for arbitrary real `xi`.
+
+## 6. Output and recurrence
+
+```text
+D_M = nu * G_omega * Z
+Psi_next = Psi + dt * D_M.
+```
+
+The complete local recurrence is therefore:
+
+```text
+Psi
+ -> K_Phi
+ -> constraint normalization
+ -> recursive memory gain
+ -> kinetic gain
+ -> Euler state update
+ -> Psi_next.
+```
+
+## 7. Transfer function
+
+For translation-invariant diagonal modes:
+
+```text
+D_hat(k) = H(k) Psi_hat(k)
+```
+
+with
+
+```text
+H(k)
+ = nu * G_omega(k) * Phi_hat(k)
+   / (lambda(k) * theta(k)).
+```
+
+The magnitude
+
+```text
+|H(k)|
+```
+
+is the modal operator gain.
+
+## 8. Discrete-loop stability
+
+Because the reference recurrence is
+
+```text
+Psi_next = (I + dt A) Psi,
+```
+
+where
+
+```text
+A = nu * G_omega * C^dagger * K_Phi,
+```
+
+a mode with eigenvalue `a_k` advances with multiplier
+
+```text
+m_k = 1 + dt * a_k.
+```
+
+A sufficient per-mode discrete stability condition is
+
+```text
+|m_k| < 1.
+```
+
+For the scalar upper-bound estimate used by the reference runtime:
+
+```text
+|a_k| <= |nu| * |G_omega| * ||Phi||_1 / |C|.
+```
+
+This upper bound is conservative and does not prove stability when it exceeds one.
+
+## 9. Fixed point
+
+A fixed point satisfies
+
+```text
+Psi* = F(Psi*).
+```
+
+For the linear homogeneous reference recurrence this becomes
+
+```text
+A Psi* = 0.
+```
+
+Thus non-zero fixed points lie in the null space of the transfer operator. A contraction claim requires an explicit Jacobian/spectral bound; naming the operator “recursive” does not imply convergence.
+
+## 10. Sensitivity
+
+In one scalar mode:
+
+```text
+D = nu * (omega/omega0)^xi * Y / (lambda * theta).
+```
+
+Therefore:
+
+```text
+d ln|D| / d ln|nu|     = 1
+d ln|D| / d ln|omega|  = xi
+d ln|D| / d ln|lambda| = -1
+d ln|D| / d ln|theta|  = -1
+d ln|D| / d xi         = ln(omega/omega0).
+```
+
+These elasticities are directly testable.
+
+## 11. Relationship to ADR-013
+
+ADR-013 defines the broader state:
+
+```text
+S_t = (X_t, Z_t, V_t, Phi_t, Omega_t, Theta).
+```
+
+ADR-014 supplies one admissible Layer-5 transformation law for a field component within that architecture. It does not replace ADR-013 kinetic state, transactional validation, memory/reasoning timing separation or hardware-latency caveats.
+
+## 12. Operational interpretation
+
+```text
+STATE FIELD
+ -> LOCAL 3D CORRELATION
+ -> CONSTRAINT NORMALIZATION
+ -> RECURSIVE MEMORY POWER
+ -> KINETIC GAIN
+ -> STATE INCREMENT
+ -> VERIFY
+ -> COMMIT / ROLLBACK
+ -> RE-ENTER.
+```
+
+The essential mathematical identity is:
+
+```text
+A
+ = nu
+   (Omega/Omega0)^xi
+   (Lambda ⊗ Theta)^dagger
+   K_Phi,
+
+D_M = A Psi.
+```

--- a/docs/adr/0014-dm-operator-transfer-functional.md
+++ b/docs/adr/0014-dm-operator-transfer-functional.md
@@ -1,0 +1,101 @@
+# ADR-014: Adopt a bounded DM operator transfer functional
+
+**Status:** Proposed  
+**Date:** 2026-09-06  
+**Extends:** ADR-013
+
+## Context
+
+A compact governing expression has been supplied for the research layer:
+
+```text
+D_M = nu * Omega^(Xi+) [ (Psi * Phi) / (Lambda ⊗ Theta) ]
+```
+
+The notation is ambiguous unless the algebraic domains are declared. In particular, division by a tensor/operator is not a primitive operation. This ADR fixes the executable interpretation while preserving the canonical Jarvis-X VM boundary.
+
+## Decision
+
+Interpret the expression as the composite operator
+
+```text
+D_M(Psi) = nu * Omega^(Xi+) * (Lambda ⊗ Theta)^dagger * K_Phi(Psi)
+```
+
+where:
+
+- `K_Phi(Psi) = Psi star Phi` is a bounded 3D convolution/correlation operator;
+- `(Lambda ⊗ Theta)^dagger` is an inverse or Moore-Penrose pseudoinverse action on the declared constraint space;
+- `Omega^(Xi+)` is an operator power, defined spectrally when applicable;
+- `nu` is a scalar gain;
+- all shapes, units, boundary conditions and numerical tolerances must be explicit.
+
+For the dependency-free reference implementation, use the diagonal/scalar specialization:
+
+```text
+C = lambda_gain * theta_gain
+memory_gain = (omega / omega0)^xi
+D_M = nu * memory_gain * K_Phi(Psi) / C
+Psi_next = Psi + dt * D_M
+```
+
+This specialization is exact for jointly diagonal modes and is intentionally not presented as a general dense pseudoinverse engine.
+
+## Frequency-domain form
+
+For a diagonalizable translation-invariant mode `k`:
+
+```text
+D_hat(k) = H(k) Psi_hat(k)
+
+H(k) = nu * Omega(k)^(Xi+) * Phi_hat(k)
+       / (Lambda(k) * Theta(k))
+```
+
+The loop is contractive only when the selected discrete-time update satisfies its declared stability guard. The continuous operator itself is not automatically stable.
+
+## Invariants
+
+1. The denominator is never implemented as syntactic tensor division.
+2. Constraint magnitudes must remain finite and bounded away from zero.
+3. Fractional operator powers require a dimensionless ratio `Omega/Omega0` or an explicitly dimensionless operator.
+4. `Psi`, `K_Phi(Psi)`, and `D_M` must have compatible declared field shapes.
+5. Boundary behavior for the 3D stencil must be deterministic.
+6. The reference implementation must expose spectral/mode gain estimates separately from empirical runtime measurements.
+7. No sub-nanosecond or hardware performance claim follows from this mathematics.
+8. The operator remains a Layer-5 candidate transform and cannot bypass snapshot/verify/commit semantics from the canonical kinetic runtime.
+
+## Reference recurrence
+
+```text
+Y_t       = K_Phi(Psi_t)
+Z_t       = C^dagger Y_t
+Z_plus_t  = Omega^(Xi+) Z_t
+D_M,t     = nu Z_plus_t
+Psi_t+1   = Psi_t + dt D_M,t
+```
+
+For repeated inward application:
+
+```text
+Psi_(n+1) = F(Psi_n)
+```
+
+and a linearized fixed point is locally contractive when
+
+```text
+rho(J_F(Psi*)) < 1.
+```
+
+## Consequences
+
+The archive expression becomes falsifiable: every symbol maps to an executable operator, every denominator has a defined inverse semantics, every recursive gain is dimensionally normalized, and stability can be checked mode-by-mode. The canonical bytecode VM remains unchanged.
+
+## Promotion criteria
+
+ADR-014 may be promoted only after the repository contains:
+
+- an executable reference implementation;
+- deterministic tests for convolution, denominator guards, dimensionless operator power, recurrence determinism and fixed-point/stability estimates;
+- documentation separating mathematical gain from measured implementation throughput;
+- CI evidence for the declared test surface.

--- a/src/jarvisx/dm_operator_transfer.py
+++ b/src/jarvisx/dm_operator_transfer.py
@@ -1,0 +1,205 @@
+"""Bounded reference implementation for ADR-014.
+
+The module implements the jointly-diagonal/scalar specialization of
+
+    D_M = nu * (Omega/Omega0)^xi
+          * (Lambda tensor Theta)^dagger
+          * K_Phi(Psi)
+
+on a scalar 3D field.  It is intentionally dependency-free and does not claim
+to implement a general dense Moore-Penrose pseudoinverse or measured hardware
+latency.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+Field3D = tuple[tuple[tuple[float, ...], ...], ...]
+Kernel3D = tuple[tuple[tuple[float, ...], ...], ...]
+
+
+def _shape3(value: Sequence[Sequence[Sequence[float]]], name: str) -> tuple[int, int, int]:
+    if not value:
+        raise ValueError(f"{name} must be non-empty")
+    nx = len(value)
+    ny = len(value[0])
+    if ny == 0:
+        raise ValueError(f"{name} must be non-empty")
+    nz = len(value[0][0])
+    if nz == 0:
+        raise ValueError(f"{name} must be non-empty")
+    for plane in value:
+        if len(plane) != ny:
+            raise ValueError(f"{name} must be rectangular")
+        for row in plane:
+            if len(row) != nz:
+                raise ValueError(f"{name} must be rectangular")
+            for sample in row:
+                if not math.isfinite(float(sample)):
+                    raise ValueError(f"{name} values must be finite")
+    return nx, ny, nz
+
+
+def as_field3d(value: Sequence[Sequence[Sequence[float]]]) -> Field3D:
+    _shape3(value, "field")
+    return tuple(tuple(tuple(float(v) for v in row) for row in plane) for plane in value)
+
+
+def as_kernel3d(value: Sequence[Sequence[Sequence[float]]]) -> Kernel3D:
+    shape = _shape3(value, "kernel")
+    if any(size % 2 == 0 for size in shape):
+        raise ValueError("kernel dimensions must be odd")
+    return tuple(tuple(tuple(float(v) for v in row) for row in plane) for plane in value)
+
+
+@dataclass(frozen=True)
+class DMOperatorConfig:
+    """Numerical contract for the scalar jointly-diagonal ADR-014 reference."""
+
+    nu: float = -0.1
+    omega: float = 1.0
+    omega0: float = 1.0
+    xi: float = 1.0
+    lambda_gain: float = 1.0
+    theta_gain: float = 1.0
+    dt: float = 0.1
+    epsilon: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        for name in ("nu", "omega", "omega0", "xi", "lambda_gain", "theta_gain", "dt", "epsilon"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if self.omega <= 0.0 or self.omega0 <= 0.0:
+            raise ValueError("omega and omega0 must be positive for arbitrary real xi")
+        if self.dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if self.epsilon <= 0.0:
+            raise ValueError("epsilon must be positive")
+        if abs(self.constraint_gain) <= self.epsilon:
+            raise ValueError("lambda_gain * theta_gain is too close to zero")
+
+    @property
+    def constraint_gain(self) -> float:
+        return self.lambda_gain * self.theta_gain
+
+    @property
+    def memory_gain(self) -> float:
+        return (self.omega / self.omega0) ** self.xi
+
+    @property
+    def scalar_gain(self) -> float:
+        return self.nu * self.memory_gain / self.constraint_gain
+
+
+def convolve3d_zero(field: Field3D, kernel: Kernel3D) -> Field3D:
+    """Return deterministic zero-padded 3D correlation with an odd kernel."""
+
+    nx, ny, nz = _shape3(field, "field")
+    kx, ky, kz = _shape3(kernel, "kernel")
+    if any(size % 2 == 0 for size in (kx, ky, kz)):
+        raise ValueError("kernel dimensions must be odd")
+    cx, cy, cz = kx // 2, ky // 2, kz // 2
+    output: list[list[list[float]]] = []
+    for i in range(nx):
+        plane: list[list[float]] = []
+        for j in range(ny):
+            row: list[float] = []
+            for k in range(nz):
+                total = 0.0
+                for a in range(kx):
+                    ii = i + a - cx
+                    if not 0 <= ii < nx:
+                        continue
+                    for b in range(ky):
+                        jj = j + b - cy
+                        if not 0 <= jj < ny:
+                            continue
+                        for c in range(kz):
+                            kk = k + c - cz
+                            if 0 <= kk < nz:
+                                total += kernel[a][b][c] * field[ii][jj][kk]
+                row.append(total)
+            plane.append(row)
+        output.append(plane)
+    return as_field3d(output)
+
+
+def scale_field(field: Field3D, gain: float) -> Field3D:
+    if not math.isfinite(gain):
+        raise ValueError("gain must be finite")
+    return tuple(
+        tuple(tuple(gain * sample for sample in row) for row in plane)
+        for plane in field
+    )
+
+
+def add_fields(left: Field3D, right: Field3D, right_gain: float = 1.0) -> Field3D:
+    if _shape3(left, "left") != _shape3(right, "right"):
+        raise ValueError("field shapes must match")
+    if not math.isfinite(right_gain):
+        raise ValueError("right_gain must be finite")
+    return tuple(
+        tuple(
+            tuple(a + right_gain * b for a, b in zip(lrow, rrow))
+            for lrow, rrow in zip(lplane, rplane)
+        )
+        for lplane, rplane in zip(left, right)
+    )
+
+
+def dm_operator(field: Field3D, kernel: Kernel3D, config: DMOperatorConfig) -> Field3D:
+    """Evaluate D_M for the scalar jointly-diagonal specialization."""
+
+    transformed = convolve3d_zero(field, kernel)
+    return scale_field(transformed, config.scalar_gain)
+
+
+def step(field: Field3D, kernel: Kernel3D, config: DMOperatorConfig) -> Field3D:
+    """Advance Psi_next = Psi + dt * D_M(Psi)."""
+
+    derivative = dm_operator(field, kernel, config)
+    return add_fields(field, derivative, config.dt)
+
+
+def kernel_l1_norm(kernel: Kernel3D) -> float:
+    _shape3(kernel, "kernel")
+    return sum(abs(value) for plane in kernel for row in plane for value in row)
+
+
+def operator_gain_bound(kernel: Kernel3D, config: DMOperatorConfig) -> float:
+    """Conservative infinity-norm bound for |A| in D_M = A Psi."""
+
+    return abs(config.scalar_gain) * kernel_l1_norm(kernel)
+
+
+def uniform_mode_eigenvalue(kernel: Kernel3D, config: DMOperatorConfig) -> float:
+    """Periodic/interior uniform-mode eigenvalue of the continuous operator."""
+
+    kernel_sum = sum(value for plane in kernel for row in plane for value in row)
+    return config.scalar_gain * kernel_sum
+
+
+def uniform_mode_multiplier(kernel: Kernel3D, config: DMOperatorConfig) -> float:
+    """Euler multiplier 1 + dt*a for the uniform translation-invariant mode."""
+
+    return 1.0 + config.dt * uniform_mode_eigenvalue(kernel, config)
+
+
+def uniform_mode_is_contracting(kernel: Kernel3D, config: DMOperatorConfig) -> bool:
+    return abs(uniform_mode_multiplier(kernel, config)) < 1.0
+
+
+def elasticity_summary(config: DMOperatorConfig) -> dict[str, float]:
+    """Return scalar-mode logarithmic sensitivities from ADR-014."""
+
+    return {
+        "nu": 1.0,
+        "omega": config.xi,
+        "lambda_gain": -1.0,
+        "theta_gain": -1.0,
+        "xi": math.log(config.omega / config.omega0),
+    }

--- a/tests/test_dm_operator_transfer.py
+++ b/tests/test_dm_operator_transfer.py
@@ -1,0 +1,93 @@
+import math
+
+import pytest
+
+from jarvisx.dm_operator_transfer import (
+    DMOperatorConfig,
+    as_field3d,
+    as_kernel3d,
+    convolve3d_zero,
+    dm_operator,
+    elasticity_summary,
+    operator_gain_bound,
+    step,
+    uniform_mode_is_contracting,
+    uniform_mode_multiplier,
+)
+
+
+def singleton(value: float):
+    return as_field3d([[[value]]])
+
+
+def identity_kernel():
+    return as_kernel3d([[[1.0]]])
+
+
+def test_identity_kernel_preserves_field_before_gain():
+    field = as_field3d([[[1.0, 2.0], [3.0, 4.0]]])
+    assert convolve3d_zero(field, identity_kernel()) == field
+
+
+def test_operator_matches_scalar_closed_form():
+    config = DMOperatorConfig(
+        nu=2.0,
+        omega=4.0,
+        omega0=2.0,
+        xi=2.0,
+        lambda_gain=2.0,
+        theta_gain=4.0,
+        dt=0.25,
+    )
+    # memory=(4/2)^2=4, constraint=8, scalar gain=2*4/8=1
+    assert config.memory_gain == pytest.approx(4.0)
+    assert config.scalar_gain == pytest.approx(1.0)
+    assert dm_operator(singleton(3.0), identity_kernel(), config) == singleton(3.0)
+    assert step(singleton(3.0), identity_kernel(), config) == singleton(3.75)
+
+
+def test_near_singular_constraint_is_rejected():
+    with pytest.raises(ValueError, match="too close to zero"):
+        DMOperatorConfig(lambda_gain=0.0, theta_gain=1.0)
+
+
+def test_fractional_power_uses_dimensionless_positive_ratio():
+    config = DMOperatorConfig(omega=9.0, omega0=4.0, xi=0.5)
+    assert config.memory_gain == pytest.approx(1.5)
+    with pytest.raises(ValueError, match="positive"):
+        DMOperatorConfig(omega=0.0)
+
+
+def test_operator_is_deterministic():
+    field = as_field3d([[[1.0, -2.0]], [[3.0, 4.0]]])
+    kernel = identity_kernel()
+    config = DMOperatorConfig(nu=-0.25, dt=0.5)
+    assert step(field, kernel, config) == step(field, kernel, config)
+
+
+def test_gain_bound_for_identity_kernel():
+    config = DMOperatorConfig(nu=-0.25, omega=2.0, omega0=1.0, xi=1.0)
+    assert operator_gain_bound(identity_kernel(), config) == pytest.approx(0.5)
+
+
+def test_uniform_mode_contracts_for_negative_identity_feedback():
+    config = DMOperatorConfig(nu=-0.5, dt=1.0)
+    multiplier = uniform_mode_multiplier(identity_kernel(), config)
+    assert multiplier == pytest.approx(0.5)
+    assert uniform_mode_is_contracting(identity_kernel(), config)
+
+
+def test_uniform_mode_rejects_false_contraction_claim():
+    config = DMOperatorConfig(nu=0.5, dt=1.0)
+    assert uniform_mode_multiplier(identity_kernel(), config) == pytest.approx(1.5)
+    assert not uniform_mode_is_contracting(identity_kernel(), config)
+
+
+def test_elasticities_match_closed_form():
+    config = DMOperatorConfig(omega=4.0, omega0=2.0, xi=3.0)
+    summary = elasticity_summary(config)
+    assert summary["nu"] == 1.0
+    assert summary["omega"] == 3.0
+    assert summary["lambda_gain"] == -1.0
+    assert summary["theta_gain"] == -1.0
+    assert summary["xi"] == pytest.approx(math.log(2.0))


### PR DESCRIPTION
## Summary

Permeates the uploaded webarchive's governing expression into Jarvis-X as a bounded, executable Layer-5 mathematical contract.

### Governing operator

`D_M = nu * Omega^(Xi+) [ (Psi star Phi) / (Lambda tensor Theta) ]`

is normalized to the rigorous form:

`D_M(Psi) = nu * (Omega/Omega0)^xi * (Lambda tensor Theta)^dagger * K_Phi(Psi)`

where tensor "division" is explicitly an inverse/pseudoinverse action and fractional operator power is dimensionally normalized.

### Adds
- `docs/adr/0014-dm-operator-transfer-functional.md`
- `docs/DM_OPERATOR_TRANSFER_FUNCTIONAL.md`
- `src/jarvisx/dm_operator_transfer.py`
- `tests/test_dm_operator_transfer.py`

### Executable reference

The dependency-free runtime implements the jointly-diagonal/scalar specialization with deterministic zero-boundary 3D correlation, constraint normalization, recursive memory gain, Euler recurrence, conservative operator-gain bounds, uniform-mode stability checks, and logarithmic sensitivity coefficients.

### Verification surface

Tests cover identity correlation, scalar closed-form equivalence, singular-constraint rejection, dimensionless fractional powers, deterministic recurrence, gain bounds, contraction/non-contraction cases, and analytic elasticities.

This PR does not claim a general dense pseudoinverse implementation, universal convergence, or hardware latency/throughput from the mathematics alone.