### PR TITLE
feat: operationalize the Moagi-3D recursive ANN engine

### DIFF
--- a/cpp_runtime/include/jarvisx/moagi3d_engine.hpp
+++ b/cpp_runtime/include/jarvisx/moagi3d_engine.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+#include "jarvisx/autoencoder3d.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace jarvisx {
+
+struct Moagi3DConfig {
+    std::size_t input_edge{8U};
+    std::size_t channels{3U};
+    std::size_t latent_channels{4U};
+    std::size_t max_iterations{32U};
+    float epsilon{1.0e-5F};
+    float feedback_gain{0.5F};
+    float softmax_temperature{8.0F};
+    std::uint64_t seed{0x4D4F4147493344ULL};
+    bool quantized_latent{false};
+
+    void validate() const {
+        if (input_edge < 4U || input_edge > 64U || input_edge % 2U != 0U) {
+            throw std::invalid_argument("Moagi-3D input edge must be even and in [4, 64]");
+        }
+        if (channels < 1U || channels > 32U) {
+            throw std::invalid_argument("Moagi-3D channel count must be in [1, 32]");
+        }
+        if (latent_channels < 1U || latent_channels > 32U) {
+            throw std::invalid_argument("Moagi-3D latent channels must be in [1, 32]");
+        }
+        if (max_iterations < 1U || max_iterations > 100000U) {
+            throw std::invalid_argument("Moagi-3D max iterations must be in [1, 100000]");
+        }
+        if (!std::isfinite(epsilon) || epsilon <= 0.0F) {
+            throw std::invalid_argument("Moagi-3D epsilon must be finite and positive");
+        }
+        if (!std::isfinite(feedback_gain) || feedback_gain <= 0.0F ||
+            feedback_gain > 1.0F) {
+            throw std::invalid_argument("Moagi-3D feedback gain must be in (0, 1]");
+        }
+        if (!std::isfinite(softmax_temperature) || softmax_temperature <= 0.0F ||
+            softmax_temperature > 1000.0F) {
+            throw std::invalid_argument("Moagi-3D softmax temperature must be in (0, 1000]");
+        }
+    }
+};
+
+struct Moagi3DIterationTelemetry {
+    std::size_t iteration{};
+    float delta_l2{};
+    float anchor_l2{};
+    std::vector<float> channel_mse;
+    std::vector<float> fusion_weights;
+};
+
+struct Moagi3DResult {
+    Tensor4D output;
+    std::size_t iterations{};
+    bool converged{};
+    float final_delta_l2{};
+    float final_anchor_l2{};
+    std::vector<float> fusion_weights;
+    std::vector<Moagi3DIterationTelemetry> history;
+};
+
+class Moagi3DEngine {
+public:
+    explicit Moagi3DEngine(Moagi3DConfig config)
+        : config_(config) {
+        config_.validate();
+        channels_.reserve(config_.channels);
+        constexpr std::uint64_t kSeedStride = 0x9E3779B97F4A7C15ULL;
+        for (std::size_t channel = 0U; channel < config_.channels; ++channel) {
+            const std::uint64_t channel_seed = config_.seed +
+                kSeedStride * static_cast<std::uint64_t>(channel + 1U);
+            channels_.emplace_back(Autoencoder3DConfig{
+                config_.input_edge,
+                config_.latent_channels,
+                0.03F,
+                1.0e-4F,
+                1.0F,
+                channel_seed
+            });
+        }
+    }
+
+    const Moagi3DConfig& config() const noexcept { return config_; }
+    std::size_t channel_count() const noexcept { return channels_.size(); }
+
+    Moagi3DResult run(const Tensor4D& input) const {
+        validate_input(input);
+        ensure_finite(input, "input");
+
+        const Tensor4D anchor = input;
+        Tensor4D current = input;
+        std::vector<Moagi3DIterationTelemetry> history;
+        history.reserve(config_.max_iterations);
+        std::vector<float> final_weights(config_.channels,
+                                         1.0F / static_cast<float>(config_.channels));
+        float final_delta = std::numeric_limits<float>::infinity();
+        float final_anchor = 0.0F;
+
+        for (std::size_t iteration = 1U; iteration <= config_.max_iterations;
+             ++iteration) {
+            std::vector<Tensor4D> reconstructions;
+            reconstructions.reserve(config_.channels);
+            std::vector<float> channel_mse;
+            channel_mse.reserve(config_.channels);
+
+            for (const Autoencoder3D& channel : channels_) {
+                const Tensor4D latent = channel.encode(current, config_.quantized_latent);
+                const Tensor4D reconstruction = channel.decode(latent);
+                ensure_finite(latent, "latent");
+                ensure_finite(reconstruction, "channel reconstruction");
+                channel_mse.push_back(mean_squared_error(current, reconstruction));
+                reconstructions.push_back(reconstruction);
+            }
+
+            final_weights = attention_weights(channel_mse);
+            const Tensor4D fused = fuse(reconstructions, final_weights, current.shape());
+            Tensor4D next(current.shape());
+            for (std::size_t index = 0U; index < current.size(); ++index) {
+                next.values()[index] =
+                    (1.0F - config_.feedback_gain) * current.values()[index] +
+                    config_.feedback_gain * fused.values()[index];
+            }
+            ensure_finite(next, "recursive state");
+
+            final_delta = l2_distance(current, next);
+            final_anchor = l2_distance(anchor, next);
+            history.push_back(Moagi3DIterationTelemetry{
+                iteration,
+                final_delta,
+                final_anchor,
+                channel_mse,
+                final_weights
+            });
+
+            current = next;
+            if (final_delta <= config_.epsilon) {
+                return Moagi3DResult{
+                    current,
+                    iteration,
+                    true,
+                    final_delta,
+                    final_anchor,
+                    final_weights,
+                    history
+                };
+            }
+        }
+
+        return Moagi3DResult{
+            current,
+            config_.max_iterations,
+            false,
+            final_delta,
+            final_anchor,
+            final_weights,
+            history
+        };
+    }
+
+    static float l2_distance(const Tensor4D& lhs, const Tensor4D& rhs) {
+        if (lhs.shape().channels != rhs.shape().channels ||
+            lhs.shape().depth != rhs.shape().depth ||
+            lhs.shape().height != rhs.shape().height ||
+            lhs.shape().width != rhs.shape().width) {
+            throw std::invalid_argument("L2 distance requires identical tensor shapes");
+        }
+        double sum = 0.0;
+        for (std::size_t index = 0U; index < lhs.size(); ++index) {
+            const double difference = static_cast<double>(lhs.values()[index]) -
+                                      static_cast<double>(rhs.values()[index]);
+            sum += difference * difference;
+        }
+        return static_cast<float>(std::sqrt(sum));
+    }
+
+private:
+    Moagi3DConfig config_;
+    std::vector<Autoencoder3D> channels_;
+
+    void validate_input(const Tensor4D& input) const {
+        const TensorShape4D& shape = input.shape();
+        if (shape.channels != 1U || shape.depth != config_.input_edge ||
+            shape.height != config_.input_edge || shape.width != config_.input_edge) {
+            throw std::invalid_argument(
+                "Moagi-3D input must have shape [1, edge, edge, edge]");
+        }
+    }
+
+    static void ensure_finite(const Tensor4D& tensor, const char* stage) {
+        for (const float value : tensor.values()) {
+            if (!std::isfinite(value)) {
+                throw std::runtime_error(std::string("non-finite value at Moagi-3D ") + stage);
+            }
+        }
+    }
+
+    static float mean_squared_error(const Tensor4D& target,
+                                    const Tensor4D& predicted) {
+        if (target.size() != predicted.size()) {
+            throw std::invalid_argument("MSE requires tensors with equal element counts");
+        }
+        double sum = 0.0;
+        for (std::size_t index = 0U; index < target.size(); ++index) {
+            const double error = static_cast<double>(predicted.values()[index]) -
+                                 static_cast<double>(target.values()[index]);
+            sum += error * error;
+        }
+        return static_cast<float>(sum / static_cast<double>(target.size()));
+    }
+
+    std::vector<float> attention_weights(const std::vector<float>& mse) const {
+        if (mse.size() != config_.channels) {
+            throw std::logic_error("Moagi-3D channel metric count mismatch");
+        }
+
+        std::vector<double> logits(mse.size(), 0.0);
+        double maximum = -std::numeric_limits<double>::infinity();
+        for (std::size_t index = 0U; index < mse.size(); ++index) {
+            logits[index] = -static_cast<double>(config_.softmax_temperature) *
+                            static_cast<double>(mse[index]);
+            maximum = std::max(maximum, logits[index]);
+        }
+
+        double denominator = 0.0;
+        for (double& logit : logits) {
+            logit = std::exp(logit - maximum);
+            denominator += logit;
+        }
+        if (!std::isfinite(denominator) || denominator <= 0.0) {
+            throw std::runtime_error("Moagi-3D fusion softmax became invalid");
+        }
+
+        std::vector<float> weights(logits.size(), 0.0F);
+        for (std::size_t index = 0U; index < logits.size(); ++index) {
+            weights[index] = static_cast<float>(logits[index] / denominator);
+        }
+        return weights;
+    }
+
+    static Tensor4D fuse(const std::vector<Tensor4D>& reconstructions,
+                         const std::vector<float>& weights,
+                         TensorShape4D shape) {
+        if (reconstructions.empty() || reconstructions.size() != weights.size()) {
+            throw std::invalid_argument("Moagi-3D fusion requires one weight per channel");
+        }
+
+        Tensor4D fused(shape);
+        for (std::size_t channel = 0U; channel < reconstructions.size(); ++channel) {
+            if (reconstructions[channel].size() != fused.size()) {
+                throw std::invalid_argument("Moagi-3D channel reconstruction shape mismatch");
+            }
+            for (std::size_t index = 0U; index < fused.size(); ++index) {
+                fused.values()[index] += weights[channel] *
+                                         reconstructions[channel].values()[index];
+            }
+        }
+        return fused;
+    }
+};
+
+} // namespace jarvisx

--- a/cpp_runtime/moagi3d_engine.cmake
+++ b/cpp_runtime/moagi3d_engine.cmake
@@ -1,0 +1,28 @@
+add_executable(jarvisx-moagi3d-engine
+    src/moagi3d_engine_main.cpp
+)
+set_target_properties(jarvisx-moagi3d-engine PROPERTIES OUTPUT_NAME "DrMoagi-3D-Engine")
+jarvisx_include_runtime(jarvisx-moagi3d-engine)
+jarvisx_harden(jarvisx-moagi3d-engine)
+
+add_test(
+    NAME moagi3d-engine-smoke
+    COMMAND jarvisx-moagi3d-engine
+        --edge 8
+        --channels 3
+        --latent-channels 3
+        --max-iterations 4
+        --epsilon 0.00001
+        --pattern sphere
+        --quiet
+)
+set_tests_properties(moagi3d-engine-smoke PROPERTIES TIMEOUT 120)
+
+add_executable(jarvisx-moagi3d-engine-tests
+    tests/moagi3d_engine_tests.cpp
+)
+jarvisx_include_runtime(jarvisx-moagi3d-engine-tests)
+jarvisx_harden(jarvisx-moagi3d-engine-tests)
+
+add_test(NAME moagi3d-engine-regressions COMMAND jarvisx-moagi3d-engine-tests)
+set_tests_properties(moagi3d-engine-regressions PROPERTIES TIMEOUT 120)

--- a/cpp_runtime/src/moagi3d_engine_main.cpp
+++ b/cpp_runtime/src/moagi3d_engine_main.cpp
@@ -1,0 +1,160 @@
+#include "jarvisx/moagi3d_engine.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <string>
+
+namespace {
+
+struct Options {
+    std::size_t edge{8U};
+    std::size_t channels{3U};
+    std::size_t latent_channels{4U};
+    std::size_t max_iterations{32U};
+    float epsilon{1.0e-5F};
+    float feedback_gain{0.5F};
+    float temperature{8.0F};
+    std::uint64_t seed{0x4D4F4147493344ULL};
+    std::string pattern{"sphere"};
+    bool quantized{};
+    bool quiet{};
+};
+
+std::uint64_t parse_u64(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const std::uint64_t parsed = std::stoull(value, &consumed, 10);
+    if (consumed != value.size()) {
+        throw std::invalid_argument("invalid integer after " + flag);
+    }
+    return parsed;
+}
+
+float parse_float(const std::string& value, const std::string& flag) {
+    std::size_t consumed = 0U;
+    const float parsed = std::stof(value, &consumed);
+    if (consumed != value.size() || !std::isfinite(parsed)) {
+        throw std::invalid_argument("invalid floating-point value after " + flag);
+    }
+    return parsed;
+}
+
+Options parse_options(int argc, char** argv) {
+    Options options;
+    auto value = [&](int& index, const std::string& flag) -> std::string {
+        if (index + 1 >= argc) {
+            throw std::invalid_argument("missing value after " + flag);
+        }
+        ++index;
+        return argv[index];
+    };
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--edge") {
+            options.edge = static_cast<std::size_t>(parse_u64(value(index, argument), argument));
+        } else if (argument == "--channels") {
+            options.channels = static_cast<std::size_t>(parse_u64(value(index, argument), argument));
+        } else if (argument == "--latent-channels") {
+            options.latent_channels = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--max-iterations") {
+            options.max_iterations = static_cast<std::size_t>(
+                parse_u64(value(index, argument), argument));
+        } else if (argument == "--epsilon") {
+            options.epsilon = parse_float(value(index, argument), argument);
+        } else if (argument == "--feedback-gain") {
+            options.feedback_gain = parse_float(value(index, argument), argument);
+        } else if (argument == "--temperature") {
+            options.temperature = parse_float(value(index, argument), argument);
+        } else if (argument == "--seed") {
+            options.seed = parse_u64(value(index, argument), argument);
+        } else if (argument == "--pattern") {
+            options.pattern = value(index, argument);
+        } else if (argument == "--quantized") {
+            options.quantized = true;
+        } else if (argument == "--quiet") {
+            options.quiet = true;
+        } else if (argument == "--help" || argument == "-h") {
+            std::cout
+                << "Usage: DrMoagi-3D-Engine [options]\n"
+                << "  --edge N              even 3D input edge in [4,64]\n"
+                << "  --channels K          parallel Moagi manifold channels in [1,32]\n"
+                << "  --latent-channels N   latent channels per encoder/decoder\n"
+                << "  --max-iterations N    RAC hard iteration ceiling\n"
+                << "  --epsilon X           RAC absolute L2 convergence threshold\n"
+                << "  --feedback-gain X     recursive under-relaxation gain in (0,1]\n"
+                << "  --temperature X       FRM softmax temperature\n"
+                << "  --seed N              deterministic channel seed base\n"
+                << "  --pattern NAME        sphere|shell|checker|wave|noise\n"
+                << "  --quantized           use Q3 latent reconstruction\n"
+                << "  --quiet               suppress telemetry\n";
+            std::exit(0);
+        } else {
+            throw std::invalid_argument("unknown option: " + argument);
+        }
+    }
+    return options;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    try {
+        const Options options = parse_options(argc, argv);
+        const jarvisx::Moagi3DConfig config{
+            options.edge,
+            options.channels,
+            options.latent_channels,
+            options.max_iterations,
+            options.epsilon,
+            options.feedback_gain,
+            options.temperature,
+            options.seed,
+            options.quantized
+        };
+
+        const jarvisx::Tensor4D input = jarvisx::make_volume(
+            options.edge, options.pattern, options.seed);
+        const jarvisx::Moagi3DEngine engine(config);
+        const jarvisx::Moagi3DResult result = engine.run(input);
+
+        if (!options.quiet) {
+            std::cout << std::setprecision(8)
+                      << "engine=Moagi-3D"
+                      << " channels=" << engine.channel_count()
+                      << " iterations=" << result.iterations
+                      << " converged=" << (result.converged ? "true" : "false")
+                      << " final_delta_l2=" << result.final_delta_l2
+                      << " anchor_l2=" << result.final_anchor_l2
+                      << " termination="
+                      << (result.converged ? "epsilon" : "max_iterations")
+                      << '\n';
+
+            for (const auto& step : result.history) {
+                std::cout << "iteration=" << step.iteration
+                          << " delta_l2=" << step.delta_l2
+                          << " anchor_l2=" << step.anchor_l2
+                          << " alpha=[";
+                for (std::size_t index = 0U; index < step.fusion_weights.size(); ++index) {
+                    if (index != 0U) std::cout << ',';
+                    std::cout << step.fusion_weights[index];
+                }
+                std::cout << "] mse=[";
+                for (std::size_t index = 0U; index < step.channel_mse.size(); ++index) {
+                    if (index != 0U) std::cout << ',';
+                    std::cout << step.channel_mse[index];
+                }
+                std::cout << "]\n";
+            }
+        }
+
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Moagi-3D engine failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/tests/moagi3d_engine_tests.cpp
+++ b/cpp_runtime/tests/moagi3d_engine_tests.cpp
@@ -1,0 +1,122 @@
+#include "jarvisx/moagi3d_engine.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <stdexcept>
+
+namespace {
+
+void require(bool condition, const char* message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+jarvisx::Moagi3DConfig base_config() {
+    return jarvisx::Moagi3DConfig{
+        8U,
+        3U,
+        3U,
+        8U,
+        1.0e-5F,
+        0.5F,
+        8.0F,
+        42U,
+        false
+    };
+}
+
+void deterministic_replay() {
+    const auto config = base_config();
+    const auto input = jarvisx::make_volume(8U, "sphere", 42U);
+    const jarvisx::Moagi3DEngine first(config);
+    const jarvisx::Moagi3DEngine second(config);
+    const auto a = first.run(input);
+    const auto b = second.run(input);
+
+    require(a.output.values() == b.output.values(),
+            "same Moagi-3D config must replay exactly");
+    require(a.iterations == b.iterations,
+            "same Moagi-3D config must use the same iteration count");
+    require(a.fusion_weights == b.fusion_weights,
+            "same Moagi-3D config must reproduce fusion weights");
+}
+
+void zero_is_fixed_point() {
+    auto config = base_config();
+    config.max_iterations = 4U;
+    const jarvisx::Tensor4D zero({1U, 8U, 8U, 8U}, 0.0F);
+    const jarvisx::Moagi3DEngine engine(config);
+    const auto result = engine.run(zero);
+
+    require(result.converged, "zero volume must be a fixed point");
+    require(result.iterations == 1U,
+            "RAC must halt immediately when the first update is stationary");
+    require(result.final_delta_l2 <= config.epsilon,
+            "fixed point delta must satisfy epsilon threshold");
+}
+
+void fusion_weights_are_probabilities() {
+    const auto config = base_config();
+    const auto input = jarvisx::make_volume(8U, "wave", 7U);
+    const jarvisx::Moagi3DEngine engine(config);
+    const auto result = engine.run(input);
+
+    require(result.fusion_weights.size() == config.channels,
+            "FRM must emit one alpha weight per channel");
+    const float sum = std::accumulate(result.fusion_weights.begin(),
+                                      result.fusion_weights.end(), 0.0F);
+    require(std::fabs(sum - 1.0F) < 1.0e-5F,
+            "FRM softmax weights must sum to one");
+    for (const float weight : result.fusion_weights) {
+        require(std::isfinite(weight) && weight >= 0.0F && weight <= 1.0F,
+                "FRM softmax weights must be finite probabilities");
+    }
+}
+
+void rac_enforces_hard_iteration_bound() {
+    auto config = base_config();
+    config.max_iterations = 3U;
+    config.epsilon = 1.0e-12F;
+    const auto input = jarvisx::make_volume(8U, "checker", 9U);
+    const jarvisx::Moagi3DEngine engine(config);
+    const auto result = engine.run(input);
+
+    require(result.iterations <= config.max_iterations,
+            "RAC must never exceed the configured iteration ceiling");
+    require(result.history.size() == result.iterations,
+            "RAC telemetry must contain exactly one record per executed iteration");
+    require(std::isfinite(result.final_delta_l2),
+            "RAC final delta must remain finite");
+    require(std::isfinite(result.final_anchor_l2),
+            "anchor-drift telemetry must remain finite");
+}
+
+void invalid_configuration_fails_closed() {
+    auto config = base_config();
+    config.channels = 0U;
+    bool rejected = false;
+    try {
+        const jarvisx::Moagi3DEngine engine(config);
+        (void)engine;
+    } catch (const std::invalid_argument&) {
+        rejected = true;
+    }
+    require(rejected, "invalid Moagi-3D configuration must fail closed");
+}
+
+} // namespace
+
+int main() {
+    try {
+        deterministic_replay();
+        zero_is_fixed_point();
+        fusion_weights_are_probabilities();
+        rac_enforces_hard_iteration_bound();
+        invalid_configuration_fails_closed();
+        std::cout << "Moagi-3D engine tests passed\n";
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Moagi-3D engine test failure: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/cpp_runtime/world_engine.cmake
+++ b/cpp_runtime/world_engine.cmake
@@ -74,3 +74,6 @@ jarvisx_harden(jarvisx-compile-interpret-accelerator-tests)
 
 add_test(NAME compile-interpret-accelerator-regressions COMMAND jarvisx-compile-interpret-accelerator-tests)
 set_tests_properties(compile-interpret-accelerator-regressions PROPERTIES TIMEOUT 120)
+
+# Additional bounded Dr Moagi runtime modules.
+include(${CMAKE_CURRENT_SOURCE_DIR}/moagi3d_engine.cmake)

--- a/docs/adr/0003-moagi-3d-engine.md
+++ b/docs/adr/0003-moagi-3d-engine.md
@@ -1,0 +1,54 @@
+# ADR-003: Adopt the Moagi-3D recursive multi-channel attractor engine
+
+**Status:** Accepted  
+**Date:** 2026-09-07
+
+## Context
+
+ADR-002 established the Dr Moagi 3D adaptive codec-runtime as a bounded research architecture. The next layer formalizes the user-facing four-subsystem blueprint as an executable orchestration runtime: Volumetric Ingestion Fabric (VIF), K-channel Moagi Manifold, Fusion & Routing Matrix (FRM), and Recursive Attractor Controller (RAC).
+
+The design must preserve the repository's existing distinction between mathematical architecture and measured hardware capability. It must also remain bounded, observable and deterministic in its portable reference implementation.
+
+## Decision
+
+Jarvis-X adopts the Moagi-3D Engine with transition
+
+```text
+Z_k^(n) = E_k(P^(n))
+R_k^(n) = D_k(Z_k^(n))
+alpha^(n) = softmax(-tau * MSE(P^(n), R_k^(n)))
+F^(n) = sum_k alpha_k^(n) R_k^(n)
+P^(n+1) = (1-g)P^(n) + gF^(n)
+```
+
+and RAC condition
+
+```text
+Delta_n = ||P^(n+1) - P^(n)||_2
+halt if Delta_n <= epsilon OR n == N_max.
+```
+
+The implementation keeps `P^(0)` immutable as an anchor and emits `||P^(n)-P^(0)||_2` as drift telemetry.
+
+K denotes the number of parallel channels; it is not the per-channel latent dimensionality. Each channel uses a distinct deterministic encoder/decoder instance. Independent seeds create distinct kernels, but strict orthogonality is a separate training/verification requirement and must not be inferred from seed diversity.
+
+## Required invariants
+
+1. deterministic replay for fixed configuration, seeds and input;
+2. finite-state checks at input, latent, reconstruction and recursive-state boundaries;
+3. normalized non-negative FRM weights;
+4. hard `N_max` resource bound in addition to epsilon convergence;
+5. immutable source anchor for generational-drift measurement;
+6. explicit convergence versus budget-exhaustion telemetry;
+7. no claim that the portable C++ runtime is itself HBM/tensor-core/crossbar silicon;
+8. no claim that a self-consistent attractor is automatically physical ground truth.
+
+## Consequences
+
+The Moagi-3D blueprint now has an executable reference layer that reuses the existing 3D autoencoder substrate and can be compiled, smoke-tested and regressed in CI. Future GPU/FPGA/ASIC implementations can preserve the same operator while replacing the portable VIF/FRM/RAC realization with physical accelerators.
+
+The bounded feedback gain `g` is an under-relaxation control. It improves operational stability but does not by itself prove global contraction; formal contraction claims require a bound such as `rho(J_T(P*)) < 1` or an equivalent Lipschitz certificate.
+
+## Reference
+
+`docs/research/MOAGI_3D_ENGINE.md`

--- a/docs/research/MOAGI_3D_ENGINE.md
+++ b/docs/research/MOAGI_3D_ENGINE.md
@@ -1,0 +1,109 @@
+# 3D Dr Moagi Autoencoding & Decoding ANN Engine
+
+## Status
+
+Operational C++17 research runtime for the canonical Moagi-3D architecture.
+
+The implementation emulates the hardware/software contract in portable C++; it does **not** claim that the present host CPU physically implements the future HBM/SRAM/tensor-core/crossbar silicon datapath.
+
+## Closed operator
+
+For input state `P^(n)` and K independent encoder/decoder channels,
+
+```text
+Z_k^(n) = E_k(P^(n))
+R_k^(n) = D_k(Z_k^(n))
+alpha^(n) = softmax(-tau * MSE(P^(n), R_k^(n)))
+F^(n) = sum_k alpha_k^(n) R_k^(n)
+P^(n+1) = (1-g) P^(n) + g F^(n)
+```
+
+where `g in (0,1]` is the recursive feedback gain and `tau > 0` is the FRM softmax temperature.
+
+The Recursive Attractor Controller evaluates
+
+```text
+Delta_n = ||P^(n+1) - P^(n)||_2
+```
+
+and terminates on
+
+```text
+Delta_n <= epsilon
+```
+
+or on the hard safety bound
+
+```text
+n == N_max.
+```
+
+The practical fixed point is therefore
+
+```text
+P* ~= T(P*)
+```
+
+with `T` equal to the encode/decode/fuse/feedback operator above.
+
+## Subsystem mapping
+
+| Blueprint subsystem | Portable runtime realization |
+| --- | --- |
+| VIF — Volumetric Ingestion Fabric | `Tensor4D` input validation and contiguous voxel storage |
+| K-channel Moagi Manifold | K deterministic `Autoencoder3D` instances with distinct seeds |
+| FRM — Fusion & Routing Matrix | numerically stable softmax over per-channel reconstruction MSE, followed by weighted voxel fusion |
+| RAC — Recursive Attractor Controller | L2 delta, immutable-anchor drift telemetry, epsilon halt, finite-state checks, and hard iteration ceiling |
+
+The current K channels are independent deterministic feature transforms. Distinct seeds provide kernel diversity, but **strict latent orthogonality is not asserted by seed diversity alone**. A future training path should enforce the architectural orthogonality contract explicitly, for example with
+
+```text
+L_orth = sum_(i != j) |<Z_i,Z_j>|^2 / (||Z_i||^2 ||Z_j||^2 + delta).
+```
+
+## Runtime invariants
+
+1. Same configuration, seed and input produce deterministic output.
+2. Every FRM alpha is finite and non-negative.
+3. `sum(alpha_k) = 1` up to floating-point tolerance.
+4. Non-finite input, latent, reconstruction or recursive state fails closed.
+5. RAC never executes more than `N_max` iterations.
+6. The immutable input anchor is retained for drift measurement.
+7. `epsilon` convergence and `N_max` exhaustion are reported as distinct termination modes.
+8. K (parallel channels) is distinct from `latent_channels` (per-channel latent width).
+
+## Build
+
+```bash
+cmake -S . -B build
+cmake --build build --target jarvisx-moagi3d-engine jarvisx-moagi3d-engine-tests
+ctest --test-dir build -R moagi3d-engine --output-on-failure
+```
+
+The executable is emitted as:
+
+```text
+DrMoagi-3D-Engine
+```
+
+Example:
+
+```bash
+./build/cpp_runtime/DrMoagi-3D-Engine \
+  --edge 8 \
+  --channels 3 \
+  --latent-channels 4 \
+  --max-iterations 32 \
+  --epsilon 0.00001 \
+  --feedback-gain 0.5 \
+  --temperature 8 \
+  --pattern sphere
+```
+
+The CLI emits per-iteration RAC/FRM telemetry including `delta_l2`, `anchor_l2`, channel MSE values, fusion weights, convergence state and termination cause.
+
+## Hardware correspondence
+
+A silicon realization may map the same operator onto tiled HBM/SRAM transport, parallel tensor-core clusters, a hardware softmax/crossbar FRM and a dedicated convergence state machine. The portable runtime is the executable architectural reference against which such an implementation can be tested.
+
+The phrase “Platonic ideal” remains a design metaphor. Mathematically, `P*` is a fixed point/self-consistent attractor of the learned operator. External measurements, task losses or proof gates are required before treating that attractor as ground truth.

--- a/docs/research/MOAGI_3D_ENGINE.md
+++ b/docs/research/MOAGI_3D_ENGINE.md
@@ -75,9 +75,9 @@ L_orth = sum_(i != j) |<Z_i,Z_j>|^2 / (||Z_i||^2 ||Z_j||^2 + delta).
 ## Build
 
 ```bash
-cmake -S . -B build
-cmake --build build --target jarvisx-moagi3d-engine jarvisx-moagi3d-engine-tests
-ctest --test-dir build -R moagi3d-engine --output-on-failure
+cmake -S cpp_runtime -B build/cpp-runtime -DCMAKE_BUILD_TYPE=Release
+cmake --build build/cpp-runtime --target jarvisx-moagi3d-engine jarvisx-moagi3d-engine-tests
+ctest --test-dir build/cpp-runtime -R moagi3d-engine --output-on-failure
 ```
 
 The executable is emitted as:
@@ -89,7 +89,7 @@ DrMoagi-3D-Engine
 Example:
 
 ```bash
-./build/cpp_runtime/DrMoagi-3D-Engine \
+./build/cpp-runtime/DrMoagi-3D-Engine \
   --edge 8 \
   --channels 3 \
   --latent-channels 4 \


### PR DESCRIPTION
## Summary

Permeates the locked **3D Dr Moagi Autoencoding & Decoding ANN Engine** architecture into the existing Jarvis-X C++ runtime.

### Runtime
- adds `Moagi3DEngine`, a bounded K-channel recursive 3D autoencoding/decoding operator;
- reuses the existing deterministic `Autoencoder3D` as each independent `E_k/D_k` channel;
- implements FRM fusion as numerically stable softmax over per-channel reconstruction MSE;
- implements RAC convergence as absolute L2 state delta with epsilon halt plus a hard `N_max` safety ceiling;
- keeps the source tensor immutable as an anchor and emits anchor-drift telemetry;
- rejects invalid configuration and non-finite state fail-closed;
- distinguishes channel count `K` from per-channel latent dimensionality.

### CLI / build
- adds `DrMoagi-3D-Engine`;
- adds CTest smoke and regression targets;
- wires the engine into the existing C++ runtime build.

### Architecture
- adds ADR-003 accepting the VIF / K-channel Manifold / FRM / RAC orchestration layer;
- adds the executable mathematical contract in `docs/research/MOAGI_3D_ENGINE.md`;
- explicitly preserves the distinction between a fixed-point attractor and ground truth;
- explicitly does not infer strict latent orthogonality from independent seeds alone.

## Core operator

```text
Z_k^(n) = E_k(P^(n))
R_k^(n) = D_k(Z_k^(n))
alpha^(n) = softmax(-tau * MSE(P^(n), R_k^(n)))
F^(n) = sum_k alpha_k^(n) R_k^(n)
P^(n+1) = (1-g)P^(n) + gF^(n)
Delta_n = ||P^(n+1) - P^(n)||_2
```

RAC terminates when `Delta_n <= epsilon` or when `n == N_max`.

## Validation

The PR touches `cpp_runtime/**`, so the existing C++ matrix should build and execute the full CTest suite on GCC, Clang with sanitizers, and MSVC.
