### PR TITLE
feat: permeate 1000x1000 multiparallel 3D Dr Moagi runtime

### DIFF
--- a/docs/DR_MOAGI_1000X1000_MULTIPARALLEL_3D.md
+++ b/docs/DR_MOAGI_1000X1000_MULTIPARALLEL_3D.md
@@ -1,0 +1,353 @@
+# Dr Moagi 1000x1000 Multiparallel 3D Runtime
+
+## Status
+
+Operational sparse reference implementation.
+
+This module turns the 1000x1000 multiparallel inward-loop design into an executable,
+bounded runtime without pretending that one million full neural networks are physically
+allocated. The default topology exposes **1,000,000 logical AE/AD loop coordinates** and
+uses recursive encode/decode depth as the third geometric axis. Only active loop/depth
+cells are materialized.
+
+Implementation:
+
+- `src/jarvisx/dr_moagi_multiparallel.py`
+- CLI: `src/jarvisx/dr_moagi_multiparallel_cli.py`
+- tests: `tests/test_dr_moagi_multiparallel.py`
+
+## 1. Topology
+
+The logical loop plane is
+
+\[
+\Lambda_{xy}=\{(i,j)\mid 0\le i,j<1000\},
+\qquad |\Lambda_{xy}|=10^6.
+\]
+
+Recursive inward/outward depth is
+
+\[
+k\in\{0,\ldots,K\}.
+\]
+
+The full logical volume is therefore
+
+\[
+\Lambda_{3D}=\Lambda_{xy}\times\{0,\ldots,K\}.
+\]
+
+For the default `depth=8`, the runtime exposes 9,000,000 logical volume cells but does
+not allocate them densely.
+
+Each active loop contains a fixed-width vector
+
+\[
+Z_{ij,k}\in\mathbb R^C,
+\]
+
+where channel semantics are external to the core runtime. A multimodal projection layer
+may map image, audio, text, video, geometry and code/control state into those channels.
+
+## 2. One closed cycle
+
+```text
+sparse multimodal surface
+        |
+        v
+X/Y neighbor halo
+        |
+        v
+kinetic permeation
+        |
+        v
+inward shared encode
+        |
+        v
+local deepest cores
+        |
+        v
+global core mean / coupling
+        |
+        v
+outward shared decode
+        |
+        v
+reconstruction + error
+        |
+        v
+memory update
+        |
+        v
+verification gate
+   |             |
+ commit       rollback
+   |
+   +------------- loop
+```
+
+The runtime is transactional: the evolved candidate does not become authoritative until
+its reconstruction error is within the configured budget and an optional external
+validator accepts it.
+
+## 3. Kinetics on the 1000x1000 plane
+
+For an active loop coordinate `(i,j)`, the four-neighbor discrete Laplacian is
+
+\[
+\Delta_\Lambda Z_{ij}
+=\sum_{(p,q)\in\mathcal N_{ij}} Z_{pq}
+-|\mathcal N_{ij}|Z_{ij}.
+\]
+
+Velocity and surface state evolve as
+
+\[
+V_{ij,t+1}
+=\mu V_{ij,t}
++\nu\Delta_\Lambda Z_{ij,t}
++\gamma M_{ij,t},
+\]
+
+\[
+Z_{ij,t+1}=Z_{ij,t}+\Delta t\,V_{ij,t+1}.
+\]
+
+The current deterministic reference implementation uses:
+
+- `damping = mu`
+- `diffusion = nu`
+- `memory_gain = gamma`
+- `dt = delta t`
+
+An optional one-cell halo allows active information to permeate into neighboring logical
+loops without ever scanning the full million-cell plane.
+
+## 4. Inward fold is the Z axis
+
+At each active `(i,j)`, the shared encoder recursively contracts the vector:
+
+\[
+Z_{ij,k+1}=Q_q(s Z_{ij,k}),
+\qquad 0<s\le1,
+\]
+
+where `s = encode_scale` and `Q_q` is deterministic quantization.
+
+The deepest local state is
+
+\[
+\Omega_{ij}=Z_{ij,K}.
+\]
+
+The implementation stores only
+
+\[
+(i,j,k)\mapsto Z_{ij,k}
+\]
+
+for active loops, so an active set of `A` loops materializes at most approximately
+
+\[
+A(K+1)
+\]
+
+volume entries before pruning.
+
+## 5. Global inward fold
+
+The global self-core is the mean of active deepest states:
+
+\[
+\Omega^*=\frac{1}{A}\sum_{(i,j)\in\mathcal A}\Omega_{ij}.
+\]
+
+Before outward reconstruction, each local core is coupled to the global core:
+
+\[
+\tilde\Omega_{ij}
+=(1-g)\Omega_{ij}+g\Omega^*,
+\]
+
+where `g = global_coupling`.
+
+This makes the million-loop lattice a coupled system rather than a collection of
+independent codecs.
+
+## 6. Outward decode
+
+The decoder reverses the shared inward scale:
+
+\[
+\hat Z_{ij,k-1}=s^{-1}\hat Z_{ij,k}.
+\]
+
+After `K` outward steps:
+
+\[
+\hat X_{ij}=D^{\uparrow}(\tilde\Omega_{ij}).
+\]
+
+Reconstruction error is measured as
+
+\[
+E_{ij}=X_{ij}-\hat X_{ij}
+\]
+
+and
+
+\[
+L_{recon}=\frac{1}{AC}\sum_{ijc}E_{ijc}^2.
+\]
+
+The candidate is rejected if
+
+\[
+L_{recon}>L_{max}.
+\]
+
+## 7. Error memory
+
+Committed reconstruction error is accumulated as
+
+\[
+M_{ij,t+1}
+=\rho M_{ij,t}
++(1-\rho)E_{ij,t}.
+\]
+
+That memory participates in subsequent kinetic updates, creating a bounded recursive
+feedback loop rather than discarding reconstruction discrepancy after every pass.
+
+## 8. Sparse resource contract
+
+The distinction between logical and physical state is explicit.
+
+Default topology:
+
+```text
+logical loops          = 1000 * 1000 = 1,000,000
+logical depth planes   = depth + 1
+logical volume cells   = 1,000,000 * (depth + 1)
+physical allocation    = active sparse dictionaries only
+```
+
+For example, with two active loops and `depth=4`, load-time volume allocation is only
+
+\[
+2(4+1)=10
+\]
+
+stored `(x,y,z)` entries, not five million.
+
+This preserves Jarvis-X's existing invariant that virtual extent must not be confused
+with physical allocation.
+
+## 9. Multimodal channel contract
+
+The reference runtime is modality-agnostic. A caller can project source modalities into
+a shared vector such as
+
+```text
+[image, audio, text, video/motion, geometry, code/control]
+```
+
+or a larger learned feature vector up to `max_channels`.
+
+The kinetic/fold machinery operates on the shared vector without hard-coding modality
+semantics, keeping ingestion and generation adapters replaceable.
+
+## 10. Run
+
+After installation:
+
+```bash
+jarvisx-dr-moagi-multiparallel --cycles 4 --depth 8 --pretty
+```
+
+The built-in demo uses a sparse six-channel multimodal field around the center of the
+1000x1000 lattice.
+
+Direct Python use:
+
+```python
+from jarvisx.dr_moagi_multiparallel import (
+    DrMoagiMultiparallel3D,
+    MultiparallelConfig,
+)
+
+engine = DrMoagiMultiparallel3D(
+    MultiparallelConfig(side=1000, depth=8, max_active_loops=100_000)
+)
+engine.load(
+    {
+        (500, 500): (1.0, 0.2, 0.4, 0.3, 0.8, 0.1),
+        (501, 500): (0.7, 0.1, 0.35, 0.45, 0.55, 0.2),
+    }
+)
+reports = engine.run(4)
+print(engine.status())
+```
+
+## 11. JSON input
+
+```json
+{
+  "loops": [
+    {"x": 500, "y": 500, "values": [1.0, 0.2, 0.4, 0.3, 0.8, 0.1]},
+    {"x": 501, "y": 500, "values": [0.7, 0.1, 0.35, 0.45, 0.55, 0.2]}
+  ]
+}
+```
+
+Run:
+
+```bash
+jarvisx-dr-moagi-multiparallel --input field.json --cycles 8 --pretty
+```
+
+## 12. What this implementation does and does not claim
+
+It **does** implement:
+
+- one million logical loop addresses;
+- recursive 3D inward/outward state;
+- sparse support and halo expansion;
+- deterministic neighbor kinetics;
+- a shared AE/AD codec contract;
+- global core coupling;
+- reconstruction/error telemetry;
+- error memory;
+- verification-gated commit/rollback;
+- a CLI and tests.
+
+It does **not** claim that CPython executes one million loops physically in parallel.
+The reference backend is deterministic sparse CPU code. The state representation and
+operator boundaries are intentionally suitable for later vectorized CUDA/Triton/torch
+or other accelerator backends, where active tiles can be dispatched in parallel while
+preserving the same transactional contract.
+
+## 13. Closed operator
+
+The executable cycle is summarized by
+
+\[
+\boxed{
+S_{t+1}
+=\mathcal G\circ\mathcal M\circ\mathcal C\circ\mathcal D^{\uparrow}
+\circ\mathcal F_G\circ\mathcal E^{\downarrow}\circ\mathcal K(S_t)
+}
+\]
+
+where:
+
+- `K` = X/Y kinetic permeation;
+- `E down` = recursive inward encoding;
+- `F_G` = global-core fold/coupling;
+- `D up` = outward decoding;
+- `C` = reconstruction comparison;
+- `M` = error-memory update;
+- `G` = verification gate and atomic commit/rollback.
+
+This is the operational meaning of **permeating the 1000x1000 multiparallel design into
+Jarvis-X** while retaining bounded sparse execution and auditable state transitions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ jarvisx-deep-distiller = "jarvisx.dr_moagi_deep_distiller_cli:main"
 jarvisx-dr-moagi-3d-animation = "jarvisx.dr_moagi_3d_animation_codec:main"
 jarvisx-dr-moagi-codegen = "jarvisx.dr_moagi_codegen_engine:main"
 jarvisx-dr-moagi-resonator = "jarvisx.dr_moagi_monadic_resonator:main"
+jarvisx-dr-moagi-multiparallel = "jarvisx.dr_moagi_multiparallel_cli:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/dr_moagi_multiparallel.py
+++ b/src/jarvisx/dr_moagi_multiparallel.py
@@ -1,0 +1,522 @@
+"""Sparse 1000x1000 multiparallel inward/outward 3D Dr Moagi runtime.
+
+The runtime models one million *logical* auto-encoding/decoding loops arranged on
+an X/Y lattice.  Recursive encode/decode depth is the third spatial axis.  Only
+active loop/depth cells are materialized, so the reference implementation never
+allocates a dense 1000x1000xK tensor.
+
+One transaction performs:
+
+    surface -> kinetic permeation -> inward fold -> global core -> outward fold
+            -> reconstruction/error -> memory update -> commit/rollback
+
+The implementation is deterministic and CPU-oriented.  The state layout is
+chosen so the same equations can be tensorized on GPU/TPU backends later.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from typing import Callable, Mapping, Sequence
+
+LoopCoordinate = tuple[int, int]
+VolumeCoordinate = tuple[int, int, int]
+Vector = tuple[float, ...]
+SparseLoopField = dict[LoopCoordinate, Vector]
+SparseVolume3D = dict[VolumeCoordinate, Vector]
+Validator = Callable[[Mapping[LoopCoordinate, Vector], "MultiparallelStepMetrics"], bool]
+
+
+@dataclass(frozen=True)
+class MultiparallelConfig:
+    """Numerical, topology and resource contract for the sparse logical lattice."""
+
+    side: int = 1000
+    depth: int = 8
+    max_active_loops: int = 100_000
+    max_channels: int = 64
+    dt: float = 0.05
+    damping: float = 0.90
+    diffusion: float = 0.08
+    memory_gain: float = 0.10
+    memory_decay: float = 0.90
+    encode_scale: float = 0.5
+    quantization: float = 1.0e-6
+    global_coupling: float = 0.05
+    prune_epsilon: float = 1.0e-12
+    expand_halo: bool = True
+    max_reconstruction_mse: float = 0.25
+
+    def __post_init__(self) -> None:
+        if isinstance(self.side, bool) or not isinstance(self.side, int) or self.side <= 0:
+            raise ValueError("side must be a positive integer")
+        if isinstance(self.depth, bool) or not isinstance(self.depth, int) or self.depth <= 0:
+            raise ValueError("depth must be a positive integer")
+        if (
+            isinstance(self.max_active_loops, bool)
+            or not isinstance(self.max_active_loops, int)
+            or self.max_active_loops <= 0
+        ):
+            raise ValueError("max_active_loops must be a positive integer")
+        if (
+            isinstance(self.max_channels, bool)
+            or not isinstance(self.max_channels, int)
+            or self.max_channels <= 0
+        ):
+            raise ValueError("max_channels must be a positive integer")
+
+        for name in (
+            "dt",
+            "damping",
+            "diffusion",
+            "memory_gain",
+            "memory_decay",
+            "encode_scale",
+            "quantization",
+            "global_coupling",
+            "prune_epsilon",
+            "max_reconstruction_mse",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be numeric")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+
+        if self.dt <= 0.0:
+            raise ValueError("dt must be positive")
+        if not 0.0 <= self.damping <= 1.0:
+            raise ValueError("damping must be in [0, 1]")
+        if self.diffusion < 0.0 or self.memory_gain < 0.0:
+            raise ValueError("diffusion and memory_gain must be non-negative")
+        if not 0.0 <= self.memory_decay <= 1.0:
+            raise ValueError("memory_decay must be in [0, 1]")
+        if not 0.0 < self.encode_scale <= 1.0:
+            raise ValueError("encode_scale must be in (0, 1]")
+        if self.quantization <= 0.0:
+            raise ValueError("quantization must be positive")
+        if not 0.0 <= self.global_coupling <= 1.0:
+            raise ValueError("global_coupling must be in [0, 1]")
+        if self.prune_epsilon < 0.0:
+            raise ValueError("prune_epsilon must be non-negative")
+        if self.max_reconstruction_mse < 0.0:
+            raise ValueError("max_reconstruction_mse must be non-negative")
+
+    @property
+    def logical_loop_count(self) -> int:
+        return self.side * self.side
+
+    @property
+    def logical_volume_cell_count(self) -> int:
+        return self.logical_loop_count * (self.depth + 1)
+
+
+@dataclass(frozen=True)
+class MultiparallelStepMetrics:
+    cycle: int
+    support_loops: int
+    active_loops_before: int
+    active_loops_after: int
+    allocated_volume_cells: int
+    channel_count: int
+    reconstruction_mse: float
+    max_abs_error: float
+    kinetic_energy: float
+    global_core: Vector
+    committed: bool
+    rejection_reason: str | None = None
+
+
+class DrMoagiMultiparallel3D:
+    """Sparse reference runtime for 1000x1000 logical AE/AD loops.
+
+    X/Y identify a logical loop.  Encode/decode depth is Z.  Each loop carries a
+    fixed-width multimodal vector; channel semantics are intentionally external
+    (for example image/audio/text/video/geometry/code projections may all feed
+    the same vector contract).
+    """
+
+    _NEIGHBOURS: tuple[LoopCoordinate, ...] = (
+        (-1, 0),
+        (1, 0),
+        (0, -1),
+        (0, 1),
+    )
+
+    def __init__(self, config: MultiparallelConfig | None = None) -> None:
+        self.config = config or MultiparallelConfig()
+        self._surface: SparseLoopField = {}
+        self._velocity: SparseLoopField = {}
+        self._memory: SparseLoopField = {}
+        self._error: SparseLoopField = {}
+        self._volume: SparseVolume3D = {}
+        self._global_core: Vector = ()
+        self._channels = 0
+        self._cycle = 0
+
+    @property
+    def cycle(self) -> int:
+        return self._cycle
+
+    @property
+    def logical_loop_count(self) -> int:
+        return self.config.logical_loop_count
+
+    @property
+    def logical_volume_cell_count(self) -> int:
+        return self.config.logical_volume_cell_count
+
+    @property
+    def active_loop_count(self) -> int:
+        return len(self._surface)
+
+    @property
+    def allocated_volume_cell_count(self) -> int:
+        return len(self._volume)
+
+    @property
+    def channel_count(self) -> int:
+        return self._channels
+
+    @property
+    def global_core(self) -> Vector:
+        return self._global_core
+
+    def snapshot_surface(self) -> SparseLoopField:
+        return dict(self._surface)
+
+    def snapshot_volume(self) -> SparseVolume3D:
+        return dict(self._volume)
+
+    def snapshot_error(self) -> SparseLoopField:
+        return dict(self._error)
+
+    def load(self, field: Mapping[LoopCoordinate, Sequence[float]]) -> SparseLoopField:
+        parsed: SparseLoopField = {}
+        channels: int | None = None
+        for raw_coordinate, raw_vector in field.items():
+            coordinate = self._validate_coordinate(raw_coordinate)
+            vector = self._validate_vector(raw_vector)
+            if channels is None:
+                channels = len(vector)
+            elif len(vector) != channels:
+                raise ValueError("all loop vectors must have the same channel count")
+            if self._active(vector):
+                parsed[coordinate] = vector
+            if len(parsed) > self.config.max_active_loops:
+                raise RuntimeError("active-loop budget exceeded during load")
+
+        self._surface = parsed
+        self._channels = channels or 0
+        zero = self._zero()
+        self._velocity = {coordinate: zero for coordinate in parsed}
+        self._memory = {coordinate: zero for coordinate in parsed}
+        self._error = {coordinate: zero for coordinate in parsed}
+        self._volume, self._global_core = self._fold_volume(parsed)
+        self._cycle = 0
+        return self.snapshot_surface()
+
+    def run(
+        self,
+        cycles: int,
+        *,
+        validator: Validator | None = None,
+    ) -> tuple[MultiparallelStepMetrics, ...]:
+        if isinstance(cycles, bool) or not isinstance(cycles, int) or cycles <= 0:
+            raise ValueError("cycles must be a positive integer")
+        return tuple(self.step(validator=validator) for _ in range(cycles))
+
+    def step(self, validator: Validator | None = None) -> MultiparallelStepMetrics:
+        self._require_loaded()
+        snapshot = dict(self._surface)
+        support = self._support(snapshot)
+        cycle = self._cycle + 1
+
+        candidate: SparseLoopField = {}
+        candidate_velocity: SparseLoopField = {}
+        zero = self._zero()
+        kinetic_energy = 0.0
+
+        for coordinate in support:
+            current = snapshot.get(coordinate, zero)
+            laplacian = self._laplacian(snapshot, coordinate)
+            memory = self._memory.get(coordinate, zero)
+            previous_velocity = self._velocity.get(coordinate, zero)
+            force = self._add(
+                self._scale(laplacian, self.config.diffusion),
+                self._scale(memory, self.config.memory_gain),
+            )
+            velocity = self._add(
+                self._scale(previous_velocity, self.config.damping),
+                force,
+            )
+            value = self._add(current, self._scale(velocity, self.config.dt))
+            if self._active(value):
+                candidate[coordinate] = value
+                candidate_velocity[coordinate] = velocity
+                kinetic_energy += 0.5 * self._dot(velocity, velocity)
+
+        if len(candidate) > self.config.max_active_loops:
+            self._cycle = cycle
+            return self._metrics(
+                cycle=cycle,
+                support=support,
+                before=snapshot,
+                after=candidate,
+                volume={},
+                global_core=(),
+                reconstruction={},
+                kinetic_energy=kinetic_energy,
+                committed=False,
+                rejection_reason="active-loop budget exceeded",
+            )
+
+        volume, global_core = self._fold_volume(candidate)
+        reconstruction = self._unfold_volume(volume, global_core, tuple(candidate))
+        provisional = self._metrics(
+            cycle=cycle,
+            support=support,
+            before=snapshot,
+            after=candidate,
+            volume=volume,
+            global_core=global_core,
+            reconstruction=reconstruction,
+            kinetic_energy=kinetic_energy,
+            committed=False,
+        )
+
+        if provisional.reconstruction_mse > self.config.max_reconstruction_mse:
+            self._cycle = cycle
+            return replace(
+                provisional, rejection_reason="reconstruction error budget exceeded"
+            )
+        if validator is not None and not bool(validator(candidate, provisional)):
+            self._cycle = cycle
+            return replace(provisional, rejection_reason="validator rejected candidate")
+
+        error = {
+            coordinate: self._sub(candidate[coordinate], reconstruction[coordinate])
+            for coordinate in candidate
+        }
+        new_memory: SparseLoopField = {}
+        for coordinate, value in candidate.items():
+            old = self._memory.get(coordinate, zero)
+            err = error[coordinate]
+            memory = self._add(
+                self._scale(old, self.config.memory_decay),
+                self._scale(err, 1.0 - self.config.memory_decay),
+            )
+            if self._active(memory):
+                new_memory[coordinate] = memory
+
+        self._surface = candidate
+        self._velocity = candidate_velocity
+        self._memory = new_memory
+        self._error = error
+        self._volume = volume
+        self._global_core = global_core
+        self._cycle = cycle
+
+        return self._metrics(
+            cycle=cycle,
+            support=support,
+            before=snapshot,
+            after=candidate,
+            volume=volume,
+            global_core=global_core,
+            reconstruction=reconstruction,
+            kinetic_energy=kinetic_energy,
+            committed=True,
+        )
+
+    def reconstruct(self) -> SparseLoopField:
+        self._require_loaded()
+        if not self._surface:
+            return {}
+        if not self._volume:
+            self._volume, self._global_core = self._fold_volume(self._surface)
+        return self._unfold_volume(self._volume, self._global_core, tuple(self._surface))
+
+    def status(self) -> dict[str, object]:
+        return {
+            "cycle": self._cycle,
+            "side": self.config.side,
+            "depth": self.config.depth,
+            "logical_loops": self.logical_loop_count,
+            "logical_volume_cells": self.logical_volume_cell_count,
+            "active_loops": self.active_loop_count,
+            "allocated_volume_cells": self.allocated_volume_cell_count,
+            "channels": self.channel_count,
+            "global_core": self.global_core,
+            "sparsity": 1.0 - self.active_loop_count / self.logical_loop_count,
+        }
+
+    def _fold_volume(self, surface: Mapping[LoopCoordinate, Vector]) -> tuple[SparseVolume3D, Vector]:
+        volume: SparseVolume3D = {}
+        deepest: list[Vector] = []
+        for coordinate in sorted(surface, key=self._linear_address):
+            value = tuple(surface[coordinate])
+            volume[(coordinate[0], coordinate[1], 0)] = value
+            z = value
+            for depth in range(1, self.config.depth + 1):
+                z = self._encode(z)
+                volume[(coordinate[0], coordinate[1], depth)] = z
+            deepest.append(z)
+        core = self._mean(deepest) if deepest else self._zero()
+        return volume, core
+
+    def _unfold_volume(
+        self,
+        volume: Mapping[VolumeCoordinate, Vector],
+        global_core: Vector,
+        support: Sequence[LoopCoordinate],
+    ) -> SparseLoopField:
+        output: SparseLoopField = {}
+        coupling = self.config.global_coupling
+        for i, j in support:
+            z = volume[(i, j, self.config.depth)]
+            if global_core:
+                z = self._add(self._scale(z, 1.0 - coupling), self._scale(global_core, coupling))
+            for _ in range(self.config.depth):
+                z = self._decode(z)
+            output[(i, j)] = z
+        return output
+
+    def _encode(self, vector: Vector) -> Vector:
+        scaled = self._scale(vector, self.config.encode_scale)
+        q = self.config.quantization
+        return tuple(round(value / q) * q for value in scaled)
+
+    def _decode(self, vector: Vector) -> Vector:
+        return self._scale(vector, 1.0 / self.config.encode_scale)
+
+    def _support(self, field: Mapping[LoopCoordinate, Vector]) -> tuple[LoopCoordinate, ...]:
+        support = set(field)
+        if self.config.expand_halo:
+            for coordinate in tuple(support):
+                support.update(self._iter_neighbours(coordinate))
+        if len(support) > self.config.max_active_loops:
+            raise RuntimeError("support-closure budget exceeded")
+        return tuple(sorted(support, key=self._linear_address))
+
+    def _laplacian(self, field: Mapping[LoopCoordinate, Vector], coordinate: LoopCoordinate) -> Vector:
+        center = field.get(coordinate, self._zero())
+        neighbours = tuple(self._iter_neighbours(coordinate))
+        if not neighbours:
+            return self._zero()
+        total = self._zero()
+        for neighbour in neighbours:
+            total = self._add(total, field.get(neighbour, self._zero()))
+        return self._sub(total, self._scale(center, float(len(neighbours))))
+
+    def _iter_neighbours(self, coordinate: LoopCoordinate):
+        i, j = coordinate
+        for di, dj in self._NEIGHBOURS:
+            neighbour = (i + di, j + dj)
+            if 0 <= neighbour[0] < self.config.side and 0 <= neighbour[1] < self.config.side:
+                yield neighbour
+
+    def _metrics(
+        self,
+        *,
+        cycle: int,
+        support: Sequence[LoopCoordinate],
+        before: Mapping[LoopCoordinate, Vector],
+        after: Mapping[LoopCoordinate, Vector],
+        volume: Mapping[VolumeCoordinate, Vector],
+        global_core: Vector,
+        reconstruction: Mapping[LoopCoordinate, Vector],
+        kinetic_energy: float,
+        committed: bool,
+        rejection_reason: str | None = None,
+    ) -> MultiparallelStepMetrics:
+        squared_error = 0.0
+        max_abs_error = 0.0
+        samples = 0
+        for coordinate, value in after.items():
+            reconstructed = reconstruction.get(coordinate, self._zero())
+            for actual, predicted in zip(value, reconstructed):
+                error = actual - predicted
+                squared_error += error * error
+                max_abs_error = max(max_abs_error, abs(error))
+                samples += 1
+        mse = squared_error / samples if samples else 0.0
+        return MultiparallelStepMetrics(
+            cycle=cycle,
+            support_loops=len(support),
+            active_loops_before=len(before),
+            active_loops_after=len(after),
+            allocated_volume_cells=len(volume),
+            channel_count=self._channels,
+            reconstruction_mse=mse,
+            max_abs_error=max_abs_error,
+            kinetic_energy=kinetic_energy,
+            global_core=global_core,
+            committed=committed,
+            rejection_reason=rejection_reason,
+        )
+
+    def _validate_coordinate(self, coordinate: object) -> LoopCoordinate:
+        if not isinstance(coordinate, (tuple, list)) or len(coordinate) != 2:
+            raise TypeError("loop coordinate must contain exactly two integer axes")
+        i, j = coordinate
+        if isinstance(i, bool) or not isinstance(i, int):
+            raise TypeError("loop coordinate axes must be integers")
+        if isinstance(j, bool) or not isinstance(j, int):
+            raise TypeError("loop coordinate axes must be integers")
+        if not 0 <= i < self.config.side or not 0 <= j < self.config.side:
+            raise ValueError("loop coordinate outside logical 1000x1000 lattice")
+        return i, j
+
+    def _validate_vector(self, vector: object) -> Vector:
+        if isinstance(vector, (str, bytes)) or not isinstance(vector, Sequence):
+            raise TypeError("loop value must be a finite numeric sequence")
+        if not 1 <= len(vector) <= self.config.max_channels:
+            raise ValueError("loop vector channel count outside configured bounds")
+        values: list[float] = []
+        for raw in vector:
+            if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+                raise TypeError("loop channels must be numeric")
+            value = float(raw)
+            if not math.isfinite(value):
+                raise ValueError("loop channels must be finite")
+            values.append(value)
+        return tuple(values)
+
+    def _require_loaded(self) -> None:
+        if self._channels == 0:
+            raise RuntimeError("load a non-empty field before executing the runtime")
+
+    def _zero(self) -> Vector:
+        return (0.0,) * self._channels
+
+    def _active(self, vector: Vector) -> bool:
+        return any(abs(value) > self.config.prune_epsilon for value in vector)
+
+    def _linear_address(self, coordinate: LoopCoordinate) -> int:
+        return coordinate[0] * self.config.side + coordinate[1]
+
+    @staticmethod
+    def _add(left: Vector, right: Vector) -> Vector:
+        return tuple(a + b for a, b in zip(left, right))
+
+    @staticmethod
+    def _sub(left: Vector, right: Vector) -> Vector:
+        return tuple(a - b for a, b in zip(left, right))
+
+    @staticmethod
+    def _scale(vector: Vector, scalar: float) -> Vector:
+        return tuple(scalar * value for value in vector)
+
+    @staticmethod
+    def _dot(left: Vector, right: Vector) -> float:
+        return sum(a * b for a, b in zip(left, right))
+
+    def _mean(self, vectors: Sequence[Vector]) -> Vector:
+        if not vectors:
+            return self._zero()
+        total = self._zero()
+        for vector in vectors:
+            total = self._add(total, vector)
+        return self._scale(total, 1.0 / len(vectors))

--- a/src/jarvisx/dr_moagi_multiparallel_cli.py
+++ b/src/jarvisx/dr_moagi_multiparallel_cli.py
@@ -1,0 +1,110 @@
+"""CLI for the sparse 1000x1000 multiparallel Dr Moagi 3D runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Sequence
+
+from .dr_moagi_multiparallel import DrMoagiMultiparallel3D, MultiparallelConfig
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="jarvisx-dr-moagi-multiparallel",
+        description=(
+            "Run the sparse 1000x1000 logical AE/AD lattice with inward depth, "
+            "kinetic permeation, global core coupling and transactional verification."
+        ),
+    )
+    parser.add_argument("--input", type=Path, help="JSON loop-field input")
+    parser.add_argument("--side", type=int, default=1000)
+    parser.add_argument("--depth", type=int, default=8)
+    parser.add_argument("--cycles", type=int, default=4)
+    parser.add_argument("--max-active-loops", type=int, default=100_000)
+    parser.add_argument("--diffusion", type=float, default=0.08)
+    parser.add_argument("--global-coupling", type=float, default=0.05)
+    parser.add_argument("--quantization", type=float, default=1.0e-6)
+    parser.add_argument("--prune-epsilon", type=float, default=1.0e-12)
+    parser.add_argument("--max-reconstruction-mse", type=float, default=0.25)
+    parser.add_argument("--no-halo", action="store_true")
+    parser.add_argument("--pretty", action="store_true")
+    return parser
+
+
+def _demo_field(side: int) -> dict[tuple[int, int], tuple[float, ...]]:
+    center = side // 2
+    vectors = {
+        (0, 0): (1.0, 0.20, 0.40, 0.30, 0.80, 0.10),
+        (1, 0): (0.70, 0.10, 0.35, 0.45, 0.55, 0.20),
+        (-1, 0): (0.60, 0.15, 0.20, 0.25, 0.50, 0.15),
+        (0, 1): (0.50, 0.30, 0.30, 0.50, 0.40, 0.25),
+        (0, -1): (0.55, 0.25, 0.25, 0.40, 0.45, 0.30),
+    }
+    return {
+        (center + di, center + dj): value
+        for (di, dj), value in vectors.items()
+        if 0 <= center + di < side and 0 <= center + dj < side
+    }
+
+
+def _load_json(path: Path) -> dict[tuple[int, int], tuple[float, ...]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    records = payload.get("loops") if isinstance(payload, dict) else payload
+    if not isinstance(records, list):
+        raise ValueError("input JSON must be a list or an object containing a 'loops' list")
+
+    field: dict[tuple[int, int], tuple[float, ...]] = {}
+    for index, item in enumerate(records):
+        if not isinstance(item, dict):
+            raise ValueError(f"loops[{index}] must be an object")
+        try:
+            coordinate = int(item["x"]), int(item["y"])
+            raw_values = item["values"]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"loops[{index}] must contain integer x/y and values") from exc
+        if not isinstance(raw_values, list) or not raw_values:
+            raise ValueError(f"loops[{index}].values must be a non-empty numeric list")
+        try:
+            vector = tuple(float(value) for value in raw_values)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"loops[{index}].values must be numeric") from exc
+        field[coordinate] = vector
+    return field
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    config = MultiparallelConfig(
+        side=args.side,
+        depth=args.depth,
+        max_active_loops=args.max_active_loops,
+        diffusion=args.diffusion,
+        global_coupling=args.global_coupling,
+        quantization=args.quantization,
+        prune_epsilon=args.prune_epsilon,
+        expand_halo=not args.no_halo,
+        max_reconstruction_mse=args.max_reconstruction_mse,
+    )
+    engine = DrMoagiMultiparallel3D(config)
+    source = _load_json(args.input) if args.input else _demo_field(args.side)
+    engine.load(source)
+    reports = engine.run(args.cycles)
+
+    result = {
+        "engine": "Dr Moagi 1000x1000 Multiparallel 3D",
+        "equation": (
+            "surface -> kinetic permeation -> inward fold -> global core -> "
+            "outward fold -> reconstruction/error -> memory -> commit"
+        ),
+        "reports": [asdict(report) for report in reports],
+        "status": engine.status(),
+    }
+    print(json.dumps(result, indent=2 if args.pretty else None, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dr_moagi_multiparallel.py
+++ b/tests/test_dr_moagi_multiparallel.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dr_moagi_multiparallel import DrMoagiMultiparallel3D, MultiparallelConfig
+
+
+def test_default_topology_is_one_million_logical_loops_without_dense_allocation():
+    engine = DrMoagiMultiparallel3D()
+    status = engine.status()
+
+    assert status["logical_loops"] == 1_000_000
+    assert status["logical_volume_cells"] == 9_000_000
+    assert status["active_loops"] == 0
+    assert status["allocated_volume_cells"] == 0
+
+
+def test_sparse_inward_fold_materializes_only_active_depth_cells():
+    config = MultiparallelConfig(depth=4, expand_halo=False, global_coupling=0.0)
+    engine = DrMoagiMultiparallel3D(config)
+    engine.load({(10, 20): (1.0, 0.5), (999, 999): (0.25, -0.5)})
+
+    assert engine.active_loop_count == 2
+    assert engine.allocated_volume_cell_count == 2 * (config.depth + 1)
+
+    reconstruction = engine.reconstruct()
+    assert reconstruction[(10, 20)] == pytest.approx((1.0, 0.5), abs=1e-4)
+    assert reconstruction[(999, 999)] == pytest.approx((0.25, -0.5), abs=1e-4)
+
+
+def test_kinetic_permeation_activates_neighbor_halo_and_commits():
+    config = MultiparallelConfig(
+        depth=3,
+        max_active_loops=32,
+        diffusion=0.1,
+        global_coupling=0.0,
+        expand_halo=True,
+    )
+    engine = DrMoagiMultiparallel3D(config)
+    engine.load({(500, 500): (1.0, 0.0)})
+
+    report = engine.step()
+    surface = engine.snapshot_surface()
+
+    assert report.committed
+    assert report.support_loops == 5
+    assert engine.active_loop_count == 5
+    assert surface[(499, 500)][0] > 0.0
+    assert surface[(501, 500)][0] > 0.0
+    assert surface[(500, 499)][0] > 0.0
+    assert surface[(500, 501)][0] > 0.0
+
+
+def test_global_core_couples_local_cores_without_dense_materialization():
+    config = MultiparallelConfig(
+        depth=2,
+        expand_halo=False,
+        global_coupling=0.25,
+        max_reconstruction_mse=1.0,
+    )
+    engine = DrMoagiMultiparallel3D(config)
+    engine.load({(0, 0): (1.0,), (999, 999): (-1.0,)})
+
+    report = engine.step()
+
+    assert report.committed
+    assert report.global_core == pytest.approx((0.0,), abs=1e-6)
+    assert report.allocated_volume_cells == 6
+    assert report.reconstruction_mse > 0.0
+
+
+def test_reconstruction_budget_rejects_and_rolls_back_surface():
+    config = MultiparallelConfig(
+        depth=2,
+        diffusion=0.0,
+        memory_gain=0.0,
+        expand_halo=False,
+        global_coupling=0.5,
+        max_reconstruction_mse=0.0,
+    )
+    engine = DrMoagiMultiparallel3D(config)
+    engine.load({(1, 1): (1.0,), (2, 2): (0.5,)})
+    before = engine.snapshot_surface()
+
+    report = engine.step()
+
+    assert not report.committed
+    assert report.rejection_reason == "reconstruction error budget exceeded"
+    assert engine.snapshot_surface() == before
+
+
+def test_input_contract_rejects_bad_coordinates_and_mixed_channel_widths():
+    engine = DrMoagiMultiparallel3D()
+
+    with pytest.raises(ValueError, match="outside logical"):
+        engine.load({(1000, 0): (1.0,)})
+    with pytest.raises(ValueError, match="same channel count"):
+        engine.load({(0, 0): (1.0,), (1, 1): (1.0, 2.0)})


### PR DESCRIPTION
## Summary

Operationalizes the 1000x1000 multiparallel inward/outward Dr Moagi design as a bounded sparse runtime.

### Adds

- **1,000,000 logical AE/AD loop addresses** on a 1000x1000 X/Y lattice.
- Recursive encode/decode **depth as the third geometric axis**.
- Sparse materialization only for active `(x, y, depth)` cells; no dense million-loop network allocation.
- Four-neighbor kinetic permeation with velocity, damping, diffusion, memory feedback and optional halo expansion.
- Shared inward encoder / outward decoder with deterministic quantization.
- Global deepest-core fold and configurable local/global coupling.
- Reconstruction MSE/error telemetry and error-memory feedback.
- Verification-gated transactional commit/rollback.
- Modality-agnostic fixed-width channel vectors suitable for image/audio/text/video/geometry/code projections.
- CLI: `jarvisx-dr-moagi-multiparallel`.
- Operational mathematics and resource-contract documentation.

## Core operator

`surface -> kinetic permeation -> inward fold -> global core -> outward fold -> reconstruction/error -> memory -> commit/rollback`

## Resource invariant

The runtime explicitly distinguishes **logical extent** from **physical allocation**. With `side=1000, depth=8`, it exposes 1,000,000 logical loops / 9,000,000 logical volume cells, while only sparse active loop/depth states are stored.

## Verification performed before push

Focused local test suite: **6 passed**

Covers:

1. one-million logical topology without dense allocation;
2. sparse inward-depth materialization;
3. kinetic neighbor-halo permeation;
4. global-core coupling;
5. reconstruction-budget rollback;
6. coordinate/channel input contracts.

## Scope boundary

This is a deterministic sparse CPU reference runtime. It does **not** claim CPython physically executes one million independent networks in parallel. The state/operator boundaries are designed so a future Torch/Triton/CUDA backend can tile and vectorize active regions without changing the transactional contract.