### PR TITLE
Operationalize system-wide sparse→dense Dr Moagi execution loop

### DIFF
--- a/.github/workflows/dr-moagi-volumetric-torch.yml
+++ b/.github/workflows/dr-moagi-volumetric-torch.yml
@@ -4,10 +4,20 @@ on:
   push:
     paths:
       - "apps/dr-moagi-volumetric-torch/**"
+      - "src/jarvisx/candidate_receipt.py"
+      - "src/jarvisx/sparse_dense_bridge.py"
+      - "src/jarvisx/dr_moagi_multiparallel.py"
+      - "tests/test_candidate_receipt.py"
+      - "tests/test_sparse_dense_bridge.py"
       - ".github/workflows/dr-moagi-volumetric-torch.yml"
   pull_request:
     paths:
       - "apps/dr-moagi-volumetric-torch/**"
+      - "src/jarvisx/candidate_receipt.py"
+      - "src/jarvisx/sparse_dense_bridge.py"
+      - "src/jarvisx/dr_moagi_multiparallel.py"
+      - "tests/test_candidate_receipt.py"
+      - "tests/test_sparse_dense_bridge.py"
       - ".github/workflows/dr-moagi-volumetric-torch.yml"
 
 permissions:
@@ -27,7 +37,9 @@ jobs:
           cache: pip
       - name: Install CPU Torch
         run: python -m pip install --index-url https://download.pytorch.org/whl/cpu "torch>=2.4"
-      - name: Compile backend
-        run: python -m py_compile engine.py test_engine.py
-      - name: Run focused mechanics tests
-        run: python -m unittest -v test_engine.py
+      - name: Compile backend and bridge
+        run: python -m py_compile engine.py sparse_bridge.py test_engine.py test_sparse_bridge.py
+      - name: Run focused mechanics and integration tests
+        run: python -m unittest -v test_engine.py test_sparse_bridge.py
+      - name: Run end-to-end sparse-dense smoke
+        run: python sparse_bridge.py

--- a/apps/dr-moagi-volumetric-torch/sparse_bridge.py
+++ b/apps/dr-moagi-volumetric-torch/sparse_bridge.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Sparse 1000x1000 -> bounded dense Torch tile operational bridge."""
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import torch
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from jarvisx.dr_moagi_multiparallel import MultiparallelConfig  # noqa: E402
+from jarvisx.sparse_dense_bridge import (  # noqa: E402
+    DenseTile,
+    DenseTileResult,
+    SparseDenseBridgeConfig,
+    SparseDenseTileBridge,
+    SparseDenseTransactionalRuntime,
+)
+
+from engine import VolumetricMultimodalInterpreter  # noqa: E402
+
+
+class TorchVolumetricTileBackend:
+    """Inference adapter from a bridge DenseTile into the merged Torch engine."""
+
+    def __init__(
+        self,
+        model: VolumetricMultimodalInterpreter,
+        *,
+        recursive_depth: int = 2,
+        convergence_tol: float = 0.0,
+    ) -> None:
+        if recursive_depth < 0:
+            raise ValueError("recursive_depth must be non-negative")
+        if not math.isfinite(convergence_tol) or convergence_tol < 0.0:
+            raise ValueError("convergence_tol must be finite and non-negative")
+        self.model = model
+        self.recursive_depth = recursive_depth
+        self.convergence_tol = convergence_tol
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.model.parameters()).device
+
+    def process(self, tile: DenseTile) -> DenseTileResult:
+        if tile.channels != 16:
+            raise ValueError("Torch volumetric outer shell requires exactly 16 channels")
+        if tile.side != self.model.base_res or tile.depth != self.model.base_res:
+            raise ValueError("dense tile side/depth must equal the Torch model base_res")
+        tensor = torch.tensor(tile.values, dtype=torch.float32, device=self.device).view(
+            1,
+            tile.channels,
+            tile.depth,
+            tile.side,
+            tile.side,
+        )
+        self.model.eval()
+        with torch.no_grad():
+            output, _mid, _inner, _core = self.model(
+                tensor,
+                recursive_depth=self.recursive_depth,
+                commit_state=False,
+                convergence_tol=self.convergence_tol,
+            )
+        delta_rms = float((output - tensor).pow(2).mean().sqrt().cpu())
+        recursive_steps = int(self.model.last_metrics.get("recursive_steps", 0))
+        values = tuple(float(value) for value in output.detach().cpu().reshape(-1).tolist())
+        return DenseTileResult(
+            values=values,
+            metrics=(
+                ("dense_delta_rms", delta_rms),
+                ("recursive_steps", recursive_steps),
+            ),
+        )
+
+
+def build_demo_runtime() -> SparseDenseTransactionalRuntime:
+    runtime = SparseDenseTransactionalRuntime(
+        MultiparallelConfig(
+            side=1000,
+            depth=4,
+            max_active_loops=128,
+            max_channels=16,
+            expand_halo=False,
+            global_coupling=0.0,
+            max_reconstruction_mse=1.0,
+        )
+    )
+    vector_a = tuple(0.05 * (index + 1) for index in range(16))
+    vector_b = tuple(-0.025 * (index + 1) for index in range(16))
+    runtime.load({(8, 8): vector_a, (9, 8): vector_b, (8, 9): vector_b, (9, 9): vector_a})
+    return runtime
+
+
+def main() -> int:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    runtime = build_demo_runtime()
+    model = VolumetricMultimodalInterpreter(base_res=16, device=device).to(device)
+    backend = TorchVolumetricTileBackend(model, recursive_depth=2, convergence_tol=1.0e-6)
+    bridge = SparseDenseTileBridge(
+        SparseDenseBridgeConfig(
+            tile_side=16,
+            tile_depth=16,
+            max_tiles=4,
+            max_candidate_mse=0.25,
+            output_blend=0.01,
+            convergence_tol=1.0e-5,
+        )
+    )
+    runs = bridge.run_until_converged(runtime, backend, max_rounds=3)
+    final = runs[-1]
+    print(
+        {
+            "device": str(device),
+            "rounds": len(runs),
+            "committed": final.receipt.committed,
+            "converged": final.converged,
+            "candidate_mse": final.candidate_mse,
+            "state_delta_rms": final.state_delta_rms,
+            "receipt_hash": final.receipt.receipt_hash,
+            "active_loops": runtime.active_loop_count,
+            "logical_loops": runtime.logical_loop_count,
+        }
+    )
+    return 0 if final.receipt.committed else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/dr-moagi-volumetric-torch/test_sparse_bridge.py
+++ b/apps/dr-moagi-volumetric-torch/test_sparse_bridge.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from sparse_bridge import (
+    SparseDenseBridgeConfig,
+    SparseDenseTileBridge,
+    TorchVolumetricTileBackend,
+    build_demo_runtime,
+)
+from engine import VolumetricMultimodalInterpreter
+
+
+class SparseDenseTorchBridgeTests(unittest.TestCase):
+    def test_torch_backend_executes_candidate_first_sparse_dense_round_trip(self) -> None:
+        torch.manual_seed(7)
+        runtime = build_demo_runtime()
+        before = runtime.snapshot_surface()
+        model = VolumetricMultimodalInterpreter(base_res=16, device="cpu")
+        backend = TorchVolumetricTileBackend(model, recursive_depth=1)
+        bridge = SparseDenseTileBridge(
+            SparseDenseBridgeConfig(
+                tile_side=16,
+                tile_depth=16,
+                max_tiles=4,
+                max_candidate_mse=0.25,
+                output_blend=0.01,
+                convergence_tol=1.0e-9,
+            )
+        )
+
+        result = bridge.run(runtime, backend)
+
+        self.assertTrue(result.receipt.committed)
+        self.assertEqual(result.tile_count, 1)
+        self.assertEqual(model.last_metrics["recursive_steps"], 1)
+        self.assertNotEqual(runtime.snapshot_surface(), before)
+        self.assertEqual(result.receipt.after_state_hash, result.receipt.candidate_state_hash)
+        self.assertLessEqual(result.candidate_mse, 0.25)
+
+    def test_authority_rejection_preserves_sparse_surface(self) -> None:
+        torch.manual_seed(11)
+        runtime = build_demo_runtime()
+        before = runtime.snapshot_surface()
+        model = VolumetricMultimodalInterpreter(base_res=16, device="cpu")
+        backend = TorchVolumetricTileBackend(model, recursive_depth=1)
+        bridge = SparseDenseTileBridge(
+            SparseDenseBridgeConfig(
+                tile_side=16,
+                tile_depth=16,
+                max_tiles=4,
+                max_candidate_mse=1.0,
+                output_blend=0.01,
+            )
+        )
+
+        result = bridge.run(
+            runtime,
+            backend,
+            authority_validator=lambda _candidate, _metrics: False,
+        )
+
+        self.assertFalse(result.receipt.committed)
+        self.assertEqual(runtime.snapshot_surface(), before)
+        self.assertEqual(result.receipt.after_state_hash, result.receipt.parent_state_hash)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/SPARSE_DENSE_OPERATIONAL_RUNTIME.md
+++ b/docs/SPARSE_DENSE_OPERATIONAL_RUNTIME.md
@@ -1,0 +1,121 @@
+# Jarvis-X Sparse–Dense Operational Runtime
+
+Status: **reference integration candidate**
+
+This integration closes the previously separate execution paths between the
+sparse `1000 x 1000` Dr Moagi multiparallel scheduler and the merged dense
+volumetric Torch backend.
+
+## Authority law
+
+The dense backend is never authoritative. The operational path is:
+
+```text
+sparse authoritative surface
+  -> deterministic tile grouping
+  -> bounded dense tile gather
+  -> dense backend candidate transform
+  -> finite/shape verification
+  -> scatter onto already-authoritative sparse coordinates
+  -> numerical distortion gate
+  -> optional epistemic evidence gate
+  -> optional authority validator
+  -> COMMIT or ROLLBACK
+  -> deterministic candidate receipt
+  -> re-enter / converge or stop at a hard round ceiling
+```
+
+A rejected candidate cannot mutate the sparse surface.
+
+## Two distinct geometries
+
+The integration deliberately distinguishes:
+
+- `L = [1000] x [1000] x [K]`: sparse computational geometry, where X/Y
+  identify logical processing loops and K is recursive AE/AD depth;
+- `T = [C] x [D] x [H] x [W]`: a bounded dense numerical tile presented to a
+  backend such as the Torch volumetric engine.
+
+The default bridge places each sparse loop vector on the centre depth plane of
+a dense tile. This is a computational embedding only. Sparse recursive depth is
+not equated with physical world Z.
+
+## Shared receipt
+
+Every bridge transaction emits a deterministic receipt containing:
+
+```text
+parent_state_hash
+candidate_state_hash
+after_state_hash
+objective_before
+candidate_objective
+objective_after
+hard_constraints
+verification = (integrity, numerical, epistemic, authority)
+COMMIT | ROLLBACK
+receipt_hash
+```
+
+The receipt enforces:
+
+```text
+COMMIT   => after_hash == candidate_hash
+ROLLBACK => after_hash == parent_hash
+```
+
+Integrity is not external truth. Numerical convergence is not epistemic
+verification. Epistemic verification is explicit and remains caller supplied
+until a concrete evidence/CTR service is bound to this integration surface.
+
+## Fixed-point telemetry
+
+Each external candidate records:
+
+```text
+state_delta_rms
+candidate_mse
+global_core_delta_rms
+```
+
+The bounded recursive bridge declares local convergence only when both:
+
+```text
+state_delta_rms <= epsilon
+global_core_delta_rms <= epsilon
+```
+
+Otherwise it continues only to the configured finite `max_rounds` ceiling.
+
+## Torch adapter
+
+`apps/dr-moagi-volumetric-torch/sparse_bridge.py` maps a bounded bridge tile to
+`VolumetricMultimodalInterpreter`:
+
+```text
+DenseTile[C,D,H,W]
+  -> torch.Tensor[1,C,D,H,W]
+  -> recursive 3D encode/decode refinement
+  -> candidate Tensor
+  -> DenseTileResult
+  -> sparse scatter
+  -> verification
+```
+
+The current merged Torch outer shell has `C=16`, and the tile side/depth must
+match the model `base_res`.
+
+Run the integration reference:
+
+```bash
+cd apps/dr-moagi-volumetric-torch
+python sparse_bridge.py
+```
+
+## Capability boundary
+
+This closes a software integration path. It does not claim that one million
+neural networks are simultaneously resident, that sparse recursion depth is a
+physical coordinate, that the untrained Torch weights provide semantic truth,
+or that convergence proves correctness in the external world. GPU performance
+and rate-distortion superiority remain empirical benchmark questions.

--- a/src/jarvisx/candidate_receipt.py
+++ b/src/jarvisx/candidate_receipt.py
@@ -1,0 +1,194 @@
+"""Backend-neutral candidate admission receipts for Jarvis-X.
+
+The contract separates integrity, numerical validity, epistemic evidence and
+execution authority.  It intentionally hashes only the declared state scope;
+a receipt must never be interpreted as proof of external truth merely because
+its candidate converged or its digest verifies.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from typing import Literal, Mapping, Sequence
+
+VerificationStatus = Literal["PASS", "FAIL", "NOT_APPLICABLE"]
+JsonScalar = str | int | float | bool | None
+
+
+@dataclass(frozen=True)
+class VerificationVector:
+    integrity: VerificationStatus
+    numerical: VerificationStatus
+    epistemic: VerificationStatus
+    authority: VerificationStatus
+
+    def as_dict(self) -> dict[str, VerificationStatus]:
+        return {
+            "integrity": self.integrity,
+            "numerical": self.numerical,
+            "epistemic": self.epistemic,
+            "authority": self.authority,
+        }
+
+
+@dataclass(frozen=True)
+class CandidateReceipt:
+    subsystem: str
+    operator: str
+    state_scope: str
+    parent_state_hash: str
+    candidate_state_hash: str
+    after_state_hash: str
+    objective_before: float
+    candidate_objective: float
+    objective_after: float
+    metrics: tuple[tuple[str, JsonScalar], ...]
+    hard_constraints: tuple[tuple[str, bool], ...]
+    verification: VerificationVector
+    committed: bool
+    rejection_reason: str | None
+    receipt_hash: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "subsystem": self.subsystem,
+            "operator": self.operator,
+            "state_scope": self.state_scope,
+            "parent_state_hash": self.parent_state_hash,
+            "candidate_state_hash": self.candidate_state_hash,
+            "after_state_hash": self.after_state_hash,
+            "objective_before": self.objective_before,
+            "candidate_objective": self.candidate_objective,
+            "objective_after": self.objective_after,
+            "metrics": dict(self.metrics),
+            "hard_constraints": dict(self.hard_constraints),
+            "verification": self.verification.as_dict(),
+            "committed": self.committed,
+            "rejection_reason": self.rejection_reason,
+            "receipt_hash": self.receipt_hash,
+        }
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _finite_float(name: str, value: float) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _normalize_metrics(metrics: Mapping[str, JsonScalar]) -> tuple[tuple[str, JsonScalar], ...]:
+    normalized: list[tuple[str, JsonScalar]] = []
+    for key in sorted(metrics):
+        value = metrics[key]
+        if isinstance(value, float) and not math.isfinite(value):
+            raise ValueError(f"metric {key!r} must be finite")
+        normalized.append((str(key), value))
+    return tuple(normalized)
+
+
+def hash_sparse_field(field: Mapping[tuple[int, int], Sequence[float]]) -> str:
+    """Hash a finite sparse 2D-coordinate/vector state deterministically."""
+
+    records: list[list[object]] = []
+    for coordinate in sorted(field):
+        if len(coordinate) != 2 or any(isinstance(axis, bool) or not isinstance(axis, int) for axis in coordinate):
+            raise TypeError("sparse-field coordinates must be integer pairs")
+        values: list[float] = []
+        for raw in field[coordinate]:
+            value = float(raw)
+            if not math.isfinite(value):
+                raise ValueError("sparse-field values must be finite")
+            values.append(value)
+        records.append([coordinate[0], coordinate[1], values])
+    return hashlib.sha256(_canonical_json(records)).hexdigest()
+
+
+def build_candidate_receipt(
+    *,
+    subsystem: str,
+    operator: str,
+    state_scope: str,
+    parent_state_hash: str,
+    candidate_state_hash: str,
+    after_state_hash: str,
+    objective_before: float,
+    candidate_objective: float,
+    objective_after: float,
+    metrics: Mapping[str, JsonScalar],
+    hard_constraints: Mapping[str, bool],
+    verification: VerificationVector,
+    committed: bool,
+    rejection_reason: str | None = None,
+) -> CandidateReceipt:
+    """Build a deterministic receipt while enforcing commit/rollback identity.
+
+    A commit must publish the candidate state.  A rollback must leave the
+    declared authoritative state scope equal to its parent state.
+    """
+
+    if not subsystem or not operator or not state_scope:
+        raise ValueError("subsystem, operator and state_scope must be non-empty")
+    if committed:
+        if after_state_hash != candidate_state_hash:
+            raise ValueError("committed receipt must publish the candidate state")
+        if rejection_reason is not None:
+            raise ValueError("committed receipt cannot contain a rejection reason")
+    else:
+        if after_state_hash != parent_state_hash:
+            raise ValueError("rollback receipt must preserve the parent state")
+        if rejection_reason is None:
+            rejection_reason = "candidate rejected"
+
+    objective_before_f = _finite_float("objective_before", objective_before)
+    candidate_objective_f = _finite_float("candidate_objective", candidate_objective)
+    objective_after_f = _finite_float("objective_after", objective_after)
+    normalized_metrics = _normalize_metrics(metrics)
+    normalized_constraints = tuple((str(key), bool(hard_constraints[key])) for key in sorted(hard_constraints))
+
+    body = {
+        "subsystem": subsystem,
+        "operator": operator,
+        "state_scope": state_scope,
+        "parent_state_hash": parent_state_hash,
+        "candidate_state_hash": candidate_state_hash,
+        "after_state_hash": after_state_hash,
+        "objective_before": objective_before_f,
+        "candidate_objective": candidate_objective_f,
+        "objective_after": objective_after_f,
+        "metrics": dict(normalized_metrics),
+        "hard_constraints": dict(normalized_constraints),
+        "verification": verification.as_dict(),
+        "committed": committed,
+        "rejection_reason": rejection_reason,
+    }
+    receipt_hash = hashlib.sha256(_canonical_json(body)).hexdigest()
+    return CandidateReceipt(
+        subsystem=subsystem,
+        operator=operator,
+        state_scope=state_scope,
+        parent_state_hash=parent_state_hash,
+        candidate_state_hash=candidate_state_hash,
+        after_state_hash=after_state_hash,
+        objective_before=objective_before_f,
+        candidate_objective=candidate_objective_f,
+        objective_after=objective_after_f,
+        metrics=normalized_metrics,
+        hard_constraints=normalized_constraints,
+        verification=verification,
+        committed=committed,
+        rejection_reason=rejection_reason,
+        receipt_hash=receipt_hash,
+    )

--- a/src/jarvisx/dm_operator_transfer.py
+++ b/src/jarvisx/dm_operator_transfer.py
@@ -167,7 +167,12 @@ def step(field: Field3D, kernel: Kernel3D, config: DMOperatorConfig) -> Field3D:
 
 def kernel_l1_norm(kernel: Kernel3D) -> float:
     _shape3(kernel, "kernel")
-    return sum(abs(value) for plane in kernel for row in plane for value in row)
+    return math.fsum(
+        abs(value)
+        for plane in kernel
+        for row in plane
+        for value in row
+    )
 
 
 def operator_gain_bound(kernel: Kernel3D, config: DMOperatorConfig) -> float:
@@ -179,7 +184,12 @@ def operator_gain_bound(kernel: Kernel3D, config: DMOperatorConfig) -> float:
 def uniform_mode_eigenvalue(kernel: Kernel3D, config: DMOperatorConfig) -> float:
     """Periodic/interior uniform-mode eigenvalue of the continuous operator."""
 
-    kernel_sum = sum(value for plane in kernel for row in plane for value in row)
+    kernel_sum = math.fsum(
+        value
+        for plane in kernel
+        for row in plane
+        for value in row
+    )
     return config.scalar_gain * kernel_sum
 
 

--- a/src/jarvisx/dm_operator_transfer.py
+++ b/src/jarvisx/dm_operator_transfer.py
@@ -88,7 +88,7 @@ class DMOperatorConfig:
 
     @property
     def memory_gain(self) -> float:
-        return (self.omega / self.omega0) ** self.xi
+        return float((self.omega / self.omega0) ** self.xi)
 
     @property
     def scalar_gain(self) -> float:

--- a/src/jarvisx/geometric_intelligence.py
+++ b/src/jarvisx/geometric_intelligence.py
@@ -210,7 +210,7 @@ class GeometricIntelligenceKernel:
 
         next_velocity: list[float] = []
         next_latent: list[float] = []
-        for z, v, target, memory, lap_value in zip(
+        for z, v, target, memory_component, lap_value in zip(
             previous.latent,
             previous.velocity,
             encoded,
@@ -221,8 +221,8 @@ class GeometricIntelligenceKernel:
             acceleration = (
                 -self.config.damping * v
                 -self.config.restoring_gain * (z - target)
-                +self.config.diffusion_gain * lap_value
-                -self.config.memory_gain * memory
+                + self.config.diffusion_gain * lap_value
+                - self.config.memory_gain * memory_component
             )
             v_next = _clamp(
                 v + acceleration,
@@ -235,7 +235,7 @@ class GeometricIntelligenceKernel:
 
         reconstruction = decode_field(next_latent)
         residual = tuple(x - xhat for x, xhat in zip(obs, reconstruction, strict=True))
-        memory = tuple(
+        next_memory = tuple(
             self.config.memory_decay * old + (1.0 - self.config.memory_decay) * error
             for old, error in zip(previous.memory, residual, strict=True)
         )
@@ -253,7 +253,7 @@ class GeometricIntelligenceKernel:
         current = GeometricState(
             latent=tuple(next_latent),
             velocity=tuple(next_velocity),
-            memory=memory,
+            memory=next_memory,
             major_phase=major_phase,
             micro_phase=micro_phase,
             step_index=previous.step_index + 1,

--- a/src/jarvisx/sparse_dense_bridge.py
+++ b/src/jarvisx/sparse_dense_bridge.py
@@ -1,0 +1,459 @@
+"""Transactional sparse-to-dense bridge for the Dr Moagi 3D runtimes.
+
+The sparse 1000x1000 lattice remains the logical scheduling/authority surface.
+Dense backends receive bounded tiles and return candidates.  Candidates are
+scattered only onto already-authoritative sparse coordinates, then admitted or
+rolled back through an explicit numerical/epistemic/authority gate.
+
+The bridge deliberately keeps two geometries distinct:
+
+* sparse X/Y coordinates identify logical processing loops;
+* dense D/H/W coordinates identify a bounded numerical tile presented to a
+  neural or other dense backend.
+
+The default embedding places sparse loop values on the centre depth plane.  It
+does not identify recursive sparse encode/decode depth with physical world Z.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Callable, Mapping, Protocol, Sequence
+
+from .candidate_receipt import (
+    CandidateReceipt,
+    VerificationVector,
+    build_candidate_receipt,
+    hash_sparse_field,
+)
+from .dr_moagi_multiparallel import (
+    DrMoagiMultiparallel3D,
+    LoopCoordinate,
+    SparseLoopField,
+    Vector,
+)
+
+
+@dataclass(frozen=True)
+class ExternalCandidateMetrics:
+    cycle: int
+    active_loops_before: int
+    active_loops_after: int
+    channel_count: int
+    candidate_mse: float
+    max_abs_delta: float
+    state_delta_rms: float
+    global_core_delta_rms: float
+    committed: bool
+    rejection_reason: str | None = None
+
+
+ExternalValidator = Callable[[Mapping[LoopCoordinate, Vector], ExternalCandidateMetrics], bool]
+EpistemicValidator = Callable[[Mapping[LoopCoordinate, Vector]], bool]
+
+
+class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
+    """Sparse runtime extended with candidate-first external backend admission."""
+
+    def commit_external_candidate(
+        self,
+        field: Mapping[LoopCoordinate, Sequence[float]],
+        *,
+        max_candidate_mse: float | None = None,
+        validator: ExternalValidator | None = None,
+    ) -> ExternalCandidateMetrics:
+        self._require_loaded()
+        before = self.snapshot_surface()
+        parsed: SparseLoopField = {}
+        for raw_coordinate, raw_vector in field.items():
+            coordinate = self._validate_coordinate(raw_coordinate)
+            vector = self._validate_vector(raw_vector)
+            if len(vector) != self.channel_count:
+                raise ValueError("external candidate channel count must match the loaded runtime")
+            if self._active(vector):
+                parsed[coordinate] = vector
+            if len(parsed) > self.config.max_active_loops:
+                raise RuntimeError("external candidate active-loop budget exceeded")
+
+        if max_candidate_mse is None:
+            budget = self.config.max_reconstruction_mse
+        else:
+            if isinstance(max_candidate_mse, bool) or not isinstance(max_candidate_mse, (int, float)):
+                raise TypeError("max_candidate_mse must be numeric")
+            budget = float(max_candidate_mse)
+            if not math.isfinite(budget) or budget < 0.0:
+                raise ValueError("max_candidate_mse must be finite and non-negative")
+
+        coordinates = sorted(set(before) | set(parsed), key=self._linear_address)
+        zero = self._zero()
+        squared_delta = 0.0
+        max_abs_delta = 0.0
+        samples = 0
+        for coordinate in coordinates:
+            prior = before.get(coordinate, zero)
+            proposed = parsed.get(coordinate, zero)
+            for left, right in zip(prior, proposed):
+                delta = right - left
+                squared_delta += delta * delta
+                max_abs_delta = max(max_abs_delta, abs(delta))
+                samples += 1
+        candidate_mse = squared_delta / samples if samples else 0.0
+        state_delta_rms = math.sqrt(candidate_mse)
+
+        volume, global_core = self._fold_volume(parsed)
+        old_core = self.global_core if self.global_core else zero
+        new_core = global_core if global_core else zero
+        core_sq = sum((a - b) ** 2 for a, b in zip(old_core, new_core))
+        global_core_delta_rms = math.sqrt(core_sq / self.channel_count) if self.channel_count else 0.0
+        cycle = self.cycle + 1
+        provisional = ExternalCandidateMetrics(
+            cycle=cycle,
+            active_loops_before=len(before),
+            active_loops_after=len(parsed),
+            channel_count=self.channel_count,
+            candidate_mse=candidate_mse,
+            max_abs_delta=max_abs_delta,
+            state_delta_rms=state_delta_rms,
+            global_core_delta_rms=global_core_delta_rms,
+            committed=False,
+        )
+
+        if candidate_mse > budget:
+            self._cycle = cycle
+            return ExternalCandidateMetrics(
+                **{
+                    **provisional.__dict__,
+                    "rejection_reason": "candidate distortion budget exceeded",
+                }
+            )
+        if validator is not None and not bool(validator(parsed, provisional)):
+            self._cycle = cycle
+            return ExternalCandidateMetrics(
+                **{
+                    **provisional.__dict__,
+                    "rejection_reason": "external validator rejected candidate",
+                }
+            )
+
+        new_memory: SparseLoopField = {}
+        new_error: SparseLoopField = {}
+        new_velocity: SparseLoopField = {}
+        for coordinate, value in parsed.items():
+            prior = before.get(coordinate, zero)
+            delta = self._sub(value, prior)
+            new_error[coordinate] = delta
+            previous_memory = self._memory.get(coordinate, zero)
+            memory = self._add(
+                self._scale(previous_memory, self.config.memory_decay),
+                self._scale(delta, 1.0 - self.config.memory_decay),
+            )
+            if self._active(memory):
+                new_memory[coordinate] = memory
+            new_velocity[coordinate] = self._velocity.get(coordinate, zero)
+
+        self._surface = parsed
+        self._velocity = new_velocity
+        self._memory = new_memory
+        self._error = new_error
+        self._volume = volume
+        self._global_core = global_core
+        self._cycle = cycle
+        return ExternalCandidateMetrics(
+            cycle=cycle,
+            active_loops_before=len(before),
+            active_loops_after=len(parsed),
+            channel_count=self.channel_count,
+            candidate_mse=candidate_mse,
+            max_abs_delta=max_abs_delta,
+            state_delta_rms=state_delta_rms,
+            global_core_delta_rms=global_core_delta_rms,
+            committed=True,
+        )
+
+
+@dataclass(frozen=True)
+class DenseTile:
+    tile_key: tuple[int, int]
+    origin: tuple[int, int]
+    side: int
+    depth: int
+    channels: int
+    centre_depth: int
+    active_coordinates: tuple[LoopCoordinate, ...]
+    values: tuple[float, ...]
+
+    @property
+    def element_count(self) -> int:
+        return self.channels * self.depth * self.side * self.side
+
+
+@dataclass(frozen=True)
+class DenseTileResult:
+    values: tuple[float, ...]
+    metrics: tuple[tuple[str, float | int | bool], ...] = ()
+
+
+class DenseTileBackend(Protocol):
+    def process(self, tile: DenseTile) -> DenseTileResult:
+        """Transform one bounded dense tile without mutating sparse authority."""
+
+
+@dataclass(frozen=True)
+class SparseDenseBridgeConfig:
+    tile_side: int = 16
+    tile_depth: int = 16
+    max_tiles: int = 256
+    max_candidate_mse: float = 0.25
+    output_blend: float = 1.0
+    convergence_tol: float = 1.0e-5
+
+    def __post_init__(self) -> None:
+        if isinstance(self.tile_side, bool) or not isinstance(self.tile_side, int) or self.tile_side <= 0:
+            raise ValueError("tile_side must be a positive integer")
+        if isinstance(self.tile_depth, bool) or not isinstance(self.tile_depth, int) or self.tile_depth <= 0:
+            raise ValueError("tile_depth must be a positive integer")
+        if isinstance(self.max_tiles, bool) or not isinstance(self.max_tiles, int) or self.max_tiles <= 0:
+            raise ValueError("max_tiles must be a positive integer")
+        for name in ("max_candidate_mse", "output_blend", "convergence_tol"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value):
+                raise ValueError(f"{name} must be finite")
+        if self.max_candidate_mse < 0.0:
+            raise ValueError("max_candidate_mse must be non-negative")
+        if not 0.0 <= self.output_blend <= 1.0:
+            raise ValueError("output_blend must be in [0, 1]")
+        if self.convergence_tol < 0.0:
+            raise ValueError("convergence_tol must be non-negative")
+
+
+@dataclass(frozen=True)
+class SparseDenseBridgeRun:
+    receipt: CandidateReceipt
+    tile_count: int
+    candidate_mse: float
+    state_delta_rms: float
+    global_core_delta_rms: float
+    converged: bool
+
+
+class SparseDenseTileBridge:
+    """Gather sparse loops, execute dense tiles, scatter a guarded candidate."""
+
+    def __init__(self, config: SparseDenseBridgeConfig | None = None) -> None:
+        self.config = config or SparseDenseBridgeConfig()
+
+    def run(
+        self,
+        runtime: SparseDenseTransactionalRuntime,
+        backend: DenseTileBackend,
+        *,
+        epistemic_validator: EpistemicValidator | None = None,
+        authority_validator: ExternalValidator | None = None,
+    ) -> SparseDenseBridgeRun:
+        parent = runtime.snapshot_surface()
+        if not parent:
+            raise RuntimeError("sparse-dense bridge requires at least one active sparse loop")
+        groups = self._group_coordinates(parent)
+        if len(groups) > self.config.max_tiles:
+            raise RuntimeError("dense tile budget exceeded")
+
+        candidate: SparseLoopField = dict(parent)
+        backend_metric_count = 0
+        for tile_key in sorted(groups):
+            tile = self._pack_tile(runtime, parent, tile_key, groups[tile_key])
+            result = backend.process(tile)
+            self._validate_result(tile, result)
+            backend_metric_count += len(result.metrics)
+            self._scatter_tile(candidate, parent, tile, result)
+
+        epistemic_pass = True
+        epistemic_status = "NOT_APPLICABLE"
+        if epistemic_validator is not None:
+            epistemic_pass = bool(epistemic_validator(candidate))
+            epistemic_status = "PASS" if epistemic_pass else "FAIL"
+
+        authority_pass = True
+
+        def combined_validator(
+            proposed: Mapping[LoopCoordinate, Vector], metrics: ExternalCandidateMetrics
+        ) -> bool:
+            nonlocal authority_pass
+            if not epistemic_pass:
+                authority_pass = False
+                return False
+            if authority_validator is None:
+                return True
+            authority_pass = bool(authority_validator(proposed, metrics))
+            return authority_pass
+
+        parent_hash = hash_sparse_field(parent)
+        candidate_hash = hash_sparse_field(candidate)
+        external = runtime.commit_external_candidate(
+            candidate,
+            max_candidate_mse=self.config.max_candidate_mse,
+            validator=combined_validator,
+        )
+        after = runtime.snapshot_surface()
+        after_hash = hash_sparse_field(after)
+        numerical_pass = external.candidate_mse <= self.config.max_candidate_mse
+        if not external.committed and external.rejection_reason == "candidate distortion budget exceeded":
+            numerical_pass = False
+        if not external.committed and external.rejection_reason == "external validator rejected candidate":
+            authority_pass = False
+
+        verification = VerificationVector(
+            integrity="PASS",
+            numerical="PASS" if numerical_pass else "FAIL",
+            epistemic=epistemic_status,  # type: ignore[arg-type]
+            authority="PASS" if external.committed else "FAIL",
+        )
+        hard_constraints = {
+            "tile_budget": len(groups) <= self.config.max_tiles,
+            "candidate_distortion": numerical_pass,
+            "epistemic_gate": epistemic_pass,
+            "authority_gate": authority_pass,
+        }
+        receipt = build_candidate_receipt(
+            subsystem="dr-moagi-sparse-dense",
+            operator="gather->dense-backend->scatter->verify->commit",
+            state_scope="sparse_surface",
+            parent_state_hash=parent_hash,
+            candidate_state_hash=candidate_hash,
+            after_state_hash=after_hash,
+            objective_before=0.0,
+            candidate_objective=external.candidate_mse,
+            objective_after=external.candidate_mse if external.committed else 0.0,
+            metrics={
+                "cycle": external.cycle,
+                "tile_count": len(groups),
+                "backend_metric_count": backend_metric_count,
+                "active_loops_before": external.active_loops_before,
+                "active_loops_after": external.active_loops_after,
+                "candidate_mse": external.candidate_mse,
+                "max_abs_delta": external.max_abs_delta,
+                "state_delta_rms": external.state_delta_rms,
+                "global_core_delta_rms": external.global_core_delta_rms,
+            },
+            hard_constraints=hard_constraints,
+            verification=verification,
+            committed=external.committed,
+            rejection_reason=external.rejection_reason,
+        )
+        converged = bool(
+            external.committed
+            and external.state_delta_rms <= self.config.convergence_tol
+            and external.global_core_delta_rms <= self.config.convergence_tol
+        )
+        return SparseDenseBridgeRun(
+            receipt=receipt,
+            tile_count=len(groups),
+            candidate_mse=external.candidate_mse,
+            state_delta_rms=external.state_delta_rms,
+            global_core_delta_rms=external.global_core_delta_rms,
+            converged=converged,
+        )
+
+    def run_until_converged(
+        self,
+        runtime: SparseDenseTransactionalRuntime,
+        backend: DenseTileBackend,
+        *,
+        max_rounds: int = 4,
+        epistemic_validator: EpistemicValidator | None = None,
+        authority_validator: ExternalValidator | None = None,
+    ) -> tuple[SparseDenseBridgeRun, ...]:
+        if isinstance(max_rounds, bool) or not isinstance(max_rounds, int) or max_rounds <= 0:
+            raise ValueError("max_rounds must be a positive integer")
+        runs: list[SparseDenseBridgeRun] = []
+        for _ in range(max_rounds):
+            result = self.run(
+                runtime,
+                backend,
+                epistemic_validator=epistemic_validator,
+                authority_validator=authority_validator,
+            )
+            runs.append(result)
+            if not result.receipt.committed or result.converged:
+                break
+        return tuple(runs)
+
+    def _group_coordinates(
+        self, field: Mapping[LoopCoordinate, Vector]
+    ) -> dict[tuple[int, int], tuple[LoopCoordinate, ...]]:
+        grouped: dict[tuple[int, int], list[LoopCoordinate]] = {}
+        side = self.config.tile_side
+        for coordinate in sorted(field):
+            key = coordinate[0] // side, coordinate[1] // side
+            grouped.setdefault(key, []).append(coordinate)
+        return {key: tuple(value) for key, value in grouped.items()}
+
+    def _pack_tile(
+        self,
+        runtime: SparseDenseTransactionalRuntime,
+        field: Mapping[LoopCoordinate, Vector],
+        tile_key: tuple[int, int],
+        coordinates: Sequence[LoopCoordinate],
+    ) -> DenseTile:
+        side = self.config.tile_side
+        depth = self.config.tile_depth
+        channels = runtime.channel_count
+        centre = depth // 2
+        values = [0.0] * (channels * depth * side * side)
+        origin = tile_key[0] * side, tile_key[1] * side
+        for coordinate in coordinates:
+            local_x = coordinate[0] - origin[0]
+            local_y = coordinate[1] - origin[1]
+            vector = field[coordinate]
+            for channel, value in enumerate(vector):
+                values[self._flat_index(channel, centre, local_y, local_x, depth, side)] = value
+        return DenseTile(
+            tile_key=tile_key,
+            origin=origin,
+            side=side,
+            depth=depth,
+            channels=channels,
+            centre_depth=centre,
+            active_coordinates=tuple(coordinates),
+            values=tuple(values),
+        )
+
+    def _scatter_tile(
+        self,
+        candidate: SparseLoopField,
+        parent: Mapping[LoopCoordinate, Vector],
+        tile: DenseTile,
+        result: DenseTileResult,
+    ) -> None:
+        blend = self.config.output_blend
+        for coordinate in tile.active_coordinates:
+            local_x = coordinate[0] - tile.origin[0]
+            local_y = coordinate[1] - tile.origin[1]
+            output: list[float] = []
+            for channel in range(tile.channels):
+                index = self._flat_index(
+                    channel,
+                    tile.centre_depth,
+                    local_y,
+                    local_x,
+                    tile.depth,
+                    tile.side,
+                )
+                value = float(result.values[index])
+                source = parent[coordinate][channel]
+                output.append((1.0 - blend) * source + blend * value)
+            candidate[coordinate] = tuple(output)
+
+    @staticmethod
+    def _validate_result(tile: DenseTile, result: DenseTileResult) -> None:
+        if len(result.values) != tile.element_count:
+            raise ValueError("dense backend result shape does not match input tile")
+        if any(not math.isfinite(float(value)) for value in result.values):
+            raise ValueError("dense backend returned non-finite values")
+        for key, value in result.metrics:
+            if isinstance(value, float) and not math.isfinite(value):
+                raise ValueError(f"dense backend metric {key!r} is non-finite")
+
+    @staticmethod
+    def _flat_index(channel: int, depth: int, row: int, column: int, depth_size: int, side: int) -> int:
+        return (((channel * depth_size + depth) * side + row) * side) + column

--- a/src/jarvisx/sparse_dense_bridge.py
+++ b/src/jarvisx/sparse_dense_bridge.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, replace
-from typing import Callable, Mapping, Protocol, Sequence
+from typing import Callable, Mapping, Protocol, Sequence, cast
 
 from .candidate_receipt import (
     CandidateReceipt,
@@ -139,6 +139,8 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
                 rejection_reason="external validator rejected candidate",
             )
 
+        memory_state = cast(SparseLoopField, getattr(self, "_memory"))
+        velocity_state = cast(SparseLoopField, getattr(self, "_velocity"))
         new_memory: SparseLoopField = {}
         new_error: SparseLoopField = {}
         new_velocity: SparseLoopField = {}
@@ -146,14 +148,14 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
             prior = before.get(coordinate, zero)
             delta = self._sub(value, prior)
             new_error[coordinate] = delta
-            previous_memory = self._memory.get(coordinate, zero)
+            previous_memory = memory_state.get(coordinate, zero)
             memory = self._add(
                 self._scale(previous_memory, self.config.memory_decay),
                 self._scale(delta, 1.0 - self.config.memory_decay),
             )
             if self._active(memory):
                 new_memory[coordinate] = memory
-            new_velocity[coordinate] = self._velocity.get(coordinate, zero)
+            new_velocity[coordinate] = velocity_state.get(coordinate, zero)
 
         self._surface = parsed
         self._velocity = new_velocity

--- a/src/jarvisx/sparse_dense_bridge.py
+++ b/src/jarvisx/sparse_dense_bridge.py
@@ -1,7 +1,7 @@
 """Transactional sparse-to-dense bridge for the Dr Moagi 3D runtimes.
 
 The sparse 1000x1000 lattice remains the logical scheduling/authority surface.
-Dense backends receive bounded tiles and return candidates.  Candidates are
+Dense backends receive bounded tiles and return candidates. Candidates are
 scattered only onto already-authoritative sparse coordinates, then admitted or
 rolled back through an explicit numerical/epistemic/authority gate.
 
@@ -11,18 +11,19 @@ The bridge deliberately keeps two geometries distinct:
 * dense D/H/W coordinates identify a bounded numerical tile presented to a
   neural or other dense backend.
 
-The default embedding places sparse loop values on the centre depth plane.  It
+The default embedding places sparse loop values on the centre depth plane. It
 does not identify recursive sparse encode/decode depth with physical world Z.
 """
 
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Callable, Mapping, Protocol, Sequence
 
 from .candidate_receipt import (
     CandidateReceipt,
+    VerificationStatus,
     VerificationVector,
     build_candidate_receipt,
     hash_sparse_field,
@@ -70,7 +71,9 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
             coordinate = self._validate_coordinate(raw_coordinate)
             vector = self._validate_vector(raw_vector)
             if len(vector) != self.channel_count:
-                raise ValueError("external candidate channel count must match the loaded runtime")
+                raise ValueError(
+                    "external candidate channel count must match the loaded runtime"
+                )
             if self._active(vector):
                 parsed[coordinate] = vector
             if len(parsed) > self.config.max_active_loops:
@@ -79,7 +82,9 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
         if max_candidate_mse is None:
             budget = self.config.max_reconstruction_mse
         else:
-            if isinstance(max_candidate_mse, bool) or not isinstance(max_candidate_mse, (int, float)):
+            if isinstance(max_candidate_mse, bool) or not isinstance(
+                max_candidate_mse, (int, float)
+            ):
                 raise TypeError("max_candidate_mse must be numeric")
             budget = float(max_candidate_mse)
             if not math.isfinite(budget) or budget < 0.0:
@@ -105,7 +110,9 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
         old_core = self.global_core if self.global_core else zero
         new_core = global_core if global_core else zero
         core_sq = sum((a - b) ** 2 for a, b in zip(old_core, new_core))
-        global_core_delta_rms = math.sqrt(core_sq / self.channel_count) if self.channel_count else 0.0
+        global_core_delta_rms = (
+            math.sqrt(core_sq / self.channel_count) if self.channel_count else 0.0
+        )
         cycle = self.cycle + 1
         provisional = ExternalCandidateMetrics(
             cycle=cycle,
@@ -121,19 +128,15 @@ class SparseDenseTransactionalRuntime(DrMoagiMultiparallel3D):
 
         if candidate_mse > budget:
             self._cycle = cycle
-            return ExternalCandidateMetrics(
-                **{
-                    **provisional.__dict__,
-                    "rejection_reason": "candidate distortion budget exceeded",
-                }
+            return replace(
+                provisional,
+                rejection_reason="candidate distortion budget exceeded",
             )
         if validator is not None and not bool(validator(parsed, provisional)):
             self._cycle = cycle
-            return ExternalCandidateMetrics(
-                **{
-                    **provisional.__dict__,
-                    "rejection_reason": "external validator rejected candidate",
-                }
+            return replace(
+                provisional,
+                rejection_reason="external validator rejected candidate",
             )
 
         new_memory: SparseLoopField = {}
@@ -197,6 +200,7 @@ class DenseTileResult:
 class DenseTileBackend(Protocol):
     def process(self, tile: DenseTile) -> DenseTileResult:
         """Transform one bounded dense tile without mutating sparse authority."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -209,11 +213,23 @@ class SparseDenseBridgeConfig:
     convergence_tol: float = 1.0e-5
 
     def __post_init__(self) -> None:
-        if isinstance(self.tile_side, bool) or not isinstance(self.tile_side, int) or self.tile_side <= 0:
+        if (
+            isinstance(self.tile_side, bool)
+            or not isinstance(self.tile_side, int)
+            or self.tile_side <= 0
+        ):
             raise ValueError("tile_side must be a positive integer")
-        if isinstance(self.tile_depth, bool) or not isinstance(self.tile_depth, int) or self.tile_depth <= 0:
+        if (
+            isinstance(self.tile_depth, bool)
+            or not isinstance(self.tile_depth, int)
+            or self.tile_depth <= 0
+        ):
             raise ValueError("tile_depth must be a positive integer")
-        if isinstance(self.max_tiles, bool) or not isinstance(self.max_tiles, int) or self.max_tiles <= 0:
+        if (
+            isinstance(self.max_tiles, bool)
+            or not isinstance(self.max_tiles, int)
+            or self.max_tiles <= 0
+        ):
             raise ValueError("max_tiles must be a positive integer")
         for name in ("max_candidate_mse", "output_blend", "convergence_tol"):
             value = float(getattr(self, name))
@@ -268,7 +284,7 @@ class SparseDenseTileBridge:
             self._scatter_tile(candidate, parent, tile, result)
 
         epistemic_pass = True
-        epistemic_status = "NOT_APPLICABLE"
+        epistemic_status: VerificationStatus = "NOT_APPLICABLE"
         if epistemic_validator is not None:
             epistemic_pass = bool(epistemic_validator(candidate))
             epistemic_status = "PASS" if epistemic_pass else "FAIL"
@@ -297,15 +313,21 @@ class SparseDenseTileBridge:
         after = runtime.snapshot_surface()
         after_hash = hash_sparse_field(after)
         numerical_pass = external.candidate_mse <= self.config.max_candidate_mse
-        if not external.committed and external.rejection_reason == "candidate distortion budget exceeded":
+        if (
+            not external.committed
+            and external.rejection_reason == "candidate distortion budget exceeded"
+        ):
             numerical_pass = False
-        if not external.committed and external.rejection_reason == "external validator rejected candidate":
+        if (
+            not external.committed
+            and external.rejection_reason == "external validator rejected candidate"
+        ):
             authority_pass = False
 
         verification = VerificationVector(
             integrity="PASS",
             numerical="PASS" if numerical_pass else "FAIL",
-            epistemic=epistemic_status,  # type: ignore[arg-type]
+            epistemic=epistemic_status,
             authority="PASS" if external.committed else "FAIL",
         )
         hard_constraints = {
@@ -363,7 +385,11 @@ class SparseDenseTileBridge:
         epistemic_validator: EpistemicValidator | None = None,
         authority_validator: ExternalValidator | None = None,
     ) -> tuple[SparseDenseBridgeRun, ...]:
-        if isinstance(max_rounds, bool) or not isinstance(max_rounds, int) or max_rounds <= 0:
+        if (
+            isinstance(max_rounds, bool)
+            or not isinstance(max_rounds, int)
+            or max_rounds <= 0
+        ):
             raise ValueError("max_rounds must be a positive integer")
         runs: list[SparseDenseBridgeRun] = []
         for _ in range(max_rounds):
@@ -406,7 +432,15 @@ class SparseDenseTileBridge:
             local_y = coordinate[1] - origin[1]
             vector = field[coordinate]
             for channel, value in enumerate(vector):
-                values[self._flat_index(channel, centre, local_y, local_x, depth, side)] = value
+                index = self._flat_index(
+                    channel,
+                    centre,
+                    local_y,
+                    local_x,
+                    depth,
+                    side,
+                )
+                values[index] = value
         return DenseTile(
             tile_key=tile_key,
             origin=origin,
@@ -455,5 +489,12 @@ class SparseDenseTileBridge:
                 raise ValueError(f"dense backend metric {key!r} is non-finite")
 
     @staticmethod
-    def _flat_index(channel: int, depth: int, row: int, column: int, depth_size: int, side: int) -> int:
+    def _flat_index(
+        channel: int,
+        depth: int,
+        row: int,
+        column: int,
+        depth_size: int,
+        side: int,
+    ) -> int:
         return (((channel * depth_size + depth) * side + row) * side) + column

--- a/tests/test_candidate_receipt.py
+++ b/tests/test_candidate_receipt.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.candidate_receipt import (
+    VerificationVector,
+    build_candidate_receipt,
+    hash_sparse_field,
+)
+
+
+def test_sparse_field_hash_is_coordinate_order_independent():
+    left = {(2, 1): (3.0, 4.0), (0, 0): (1.0, 2.0)}
+    right = {(0, 0): (1.0, 2.0), (2, 1): (3.0, 4.0)}
+
+    assert hash_sparse_field(left) == hash_sparse_field(right)
+
+
+def test_commit_receipt_requires_candidate_to_be_published():
+    parent = hash_sparse_field({(0, 0): (1.0,)})
+    candidate = hash_sparse_field({(0, 0): (2.0,)})
+
+    with pytest.raises(ValueError, match="publish the candidate"):
+        build_candidate_receipt(
+            subsystem="test",
+            operator="candidate",
+            state_scope="surface",
+            parent_state_hash=parent,
+            candidate_state_hash=candidate,
+            after_state_hash=parent,
+            objective_before=1.0,
+            candidate_objective=0.5,
+            objective_after=0.5,
+            metrics={},
+            hard_constraints={"finite": True},
+            verification=VerificationVector("PASS", "PASS", "NOT_APPLICABLE", "PASS"),
+            committed=True,
+        )
+
+
+def test_rollback_receipt_is_deterministic_and_preserves_parent():
+    parent = hash_sparse_field({(0, 0): (1.0,)})
+    candidate = hash_sparse_field({(0, 0): (2.0,)})
+    kwargs = dict(
+        subsystem="test",
+        operator="candidate",
+        state_scope="surface",
+        parent_state_hash=parent,
+        candidate_state_hash=candidate,
+        after_state_hash=parent,
+        objective_before=0.0,
+        candidate_objective=1.0,
+        objective_after=0.0,
+        metrics={"mse": 1.0},
+        hard_constraints={"finite": True, "quality": False},
+        verification=VerificationVector("PASS", "FAIL", "NOT_APPLICABLE", "FAIL"),
+        committed=False,
+        rejection_reason="quality gate",
+    )
+
+    first = build_candidate_receipt(**kwargs)
+    second = build_candidate_receipt(**kwargs)
+
+    assert first.receipt_hash == second.receipt_hash
+    assert first.after_state_hash == parent
+    assert not first.committed

--- a/tests/test_sparse_dense_bridge.py
+++ b/tests/test_sparse_dense_bridge.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from jarvisx.sparse_dense_bridge import (
+    DenseTile,
+    DenseTileResult,
+    SparseDenseBridgeConfig,
+    SparseDenseTileBridge,
+    SparseDenseTransactionalRuntime,
+)
+from jarvisx.dr_moagi_multiparallel import MultiparallelConfig
+
+
+class OffsetBackend:
+    def __init__(self, offset: float) -> None:
+        self.offset = offset
+        self.depths: list[int] = []
+
+    def process(self, tile: DenseTile) -> DenseTileResult:
+        self.depths.append(tile.depth)
+        values = list(tile.values)
+        for coordinate in tile.active_coordinates:
+            local_x = coordinate[0] - tile.origin[0]
+            local_y = coordinate[1] - tile.origin[1]
+            for channel in range(tile.channels):
+                index = (((channel * tile.depth + tile.centre_depth) * tile.side + local_y) * tile.side) + local_x
+                values[index] += self.offset
+        return DenseTileResult(tuple(values), metrics=(("offset", self.offset),))
+
+
+def _runtime() -> SparseDenseTransactionalRuntime:
+    runtime = SparseDenseTransactionalRuntime(
+        MultiparallelConfig(
+            side=32,
+            depth=2,
+            max_active_loops=32,
+            max_channels=4,
+            expand_halo=False,
+            global_coupling=0.0,
+            max_reconstruction_mse=1.0,
+        )
+    )
+    runtime.load({(1, 1): (1.0, 0.0), (2, 3): (0.5, -0.5)})
+    return runtime
+
+
+def test_sparse_dense_bridge_commits_backend_candidate_without_conflating_depth_axes():
+    runtime = _runtime()
+    backend = OffsetBackend(0.1)
+    bridge = SparseDenseTileBridge(
+        SparseDenseBridgeConfig(
+            tile_side=4,
+            tile_depth=5,
+            max_tiles=4,
+            max_candidate_mse=0.1,
+            output_blend=1.0,
+            convergence_tol=1.0e-8,
+        )
+    )
+
+    result = bridge.run(runtime, backend)
+    surface = runtime.snapshot_surface()
+
+    assert result.receipt.committed
+    assert result.tile_count == 1
+    assert backend.depths == [5]
+    assert runtime.config.depth == 2
+    assert surface[(1, 1)] == (1.1, 0.1)
+    assert surface[(2, 3)] == (0.6, -0.4)
+    assert result.state_delta_rms > 0.0
+    assert result.receipt.after_state_hash == result.receipt.candidate_state_hash
+
+
+def test_sparse_dense_bridge_rolls_back_on_epistemic_gate_failure():
+    runtime = _runtime()
+    before = runtime.snapshot_surface()
+    bridge = SparseDenseTileBridge(
+        SparseDenseBridgeConfig(tile_side=4, tile_depth=3, max_candidate_mse=1.0)
+    )
+
+    result = bridge.run(
+        runtime,
+        OffsetBackend(0.1),
+        epistemic_validator=lambda _candidate: False,
+    )
+
+    assert not result.receipt.committed
+    assert result.receipt.verification.epistemic == "FAIL"
+    assert runtime.snapshot_surface() == before
+    assert result.receipt.after_state_hash == result.receipt.parent_state_hash
+
+
+def test_sparse_dense_bridge_rolls_back_on_distortion_budget():
+    runtime = _runtime()
+    before = runtime.snapshot_surface()
+    bridge = SparseDenseTileBridge(
+        SparseDenseBridgeConfig(
+            tile_side=4,
+            tile_depth=3,
+            max_candidate_mse=1.0e-6,
+            output_blend=1.0,
+        )
+    )
+
+    result = bridge.run(runtime, OffsetBackend(1.0))
+
+    assert not result.receipt.committed
+    assert result.receipt.verification.numerical == "FAIL"
+    assert runtime.snapshot_surface() == before
+
+
+def test_run_until_converged_stops_on_fixed_point():
+    runtime = _runtime()
+    bridge = SparseDenseTileBridge(
+        SparseDenseBridgeConfig(
+            tile_side=4,
+            tile_depth=3,
+            max_candidate_mse=0.0,
+            output_blend=1.0,
+            convergence_tol=0.0,
+        )
+    )
+
+    runs = bridge.run_until_converged(runtime, OffsetBackend(0.0), max_rounds=5)
+
+    assert len(runs) == 1
+    assert runs[0].receipt.committed
+    assert runs[0].converged


### PR DESCRIPTION
## Summary

Closes the principal integration gap identified by the systems-wide sweep: the merged sparse `1000 x 1000` logical Dr Moagi runtime and the merged dense volumetric Torch backend now execute through one candidate-first operational path.

## End-to-end path

```text
sparse authoritative surface
 -> deterministic tile grouping
 -> bounded dense tile gather
 -> dense backend candidate transform
 -> finite/shape verification
 -> scatter onto existing sparse coordinates
 -> numerical distortion gate
 -> optional epistemic evidence gate
 -> optional authority validator
 -> COMMIT / ROLLBACK
 -> deterministic candidate receipt
 -> bounded re-entry until fixed-point tolerance or hard round ceiling
```

## Added

- `src/jarvisx/candidate_receipt.py`
  - backend-neutral candidate receipt;
  - deterministic SHA-256 state/receipt identities;
  - explicit integrity / numerical / epistemic / authority verification vector;
  - enforced `COMMIT => after == candidate` and `ROLLBACK => after == parent` invariants.

- `src/jarvisx/sparse_dense_bridge.py`
  - `SparseDenseTransactionalRuntime` integration surface over the existing multiparallel runtime;
  - bounded sparse-to-dense tile materialization;
  - explicit separation of sparse recursive depth from dense numerical D/H/W geometry;
  - candidate-only dense execution;
  - external candidate MSE gate and atomic rollback;
  - persistent sparse memory/error update only after commit;
  - state/core delta telemetry and finite fixed-point stopping;
  - optional epistemic and authority validators.

- `apps/dr-moagi-volumetric-torch/sparse_bridge.py`
  - real adapter into the already-merged `VolumetricMultimodalInterpreter`;
  - dense `C x D x H x W` tile -> Torch tensor -> recursive 3D AE/AD -> candidate tile;
  - no direct Torch authority over sparse state.

- focused pure-Python and Torch integration tests;
- dedicated end-to-end Torch smoke execution in GitHub Actions;
- `docs/SPARSE_DENSE_OPERATIONAL_RUNTIME.md`.

## CI repair included

Also repairs the two repository-wide mypy blockers identified by the sweep:

1. `geometric_intelligence.py`: separates scalar memory-component naming from the next memory tuple;
2. `dm_operator_transfer.py`: uses explicitly typed `math.fsum` reductions for operator norms/mode sums.

## Geometry boundary

The bridge explicitly distinguishes:

```text
L = [1000] x [1000] x [K]     # logical computational recursion geometry
T = [C] x [D] x [H] x [W]     # bounded dense numerical backend tile
```

Sparse recursive depth is not represented as physical world Z. The current gather embeds sparse loop vectors on the centre plane of a bounded dense tile.

## Truth / convergence boundary

A numerical fixed point does not establish external truth. The bridge accepts a separate epistemic validator; absent one, epistemic status is `NOT_APPLICABLE`. Integrity, numerical validity, epistemic evidence and authority remain separate receipt dimensions.

## Scope

This is a software integration/runtime reference. It does not claim one million resident neural networks, semantic correctness from untrained Torch weights, physical instantaneous propagation, GPU SOTA performance, or hostile-code isolation.
