### PR TITLE
Permeate ⟲⊙ reality-constrained recursive reckoning

### DIFF
--- a/docs/reality-constrained-recursive-reckoning.md
+++ b/docs/reality-constrained-recursive-reckoning.md
@@ -1,0 +1,127 @@
+# ⟲⊙ — Reality-Constrained Recursive Reckoning
+
+`⟲⊙` is the executable Jarvis-X contract for coupling recursive internal stabilization to an explicit external observation anchor.
+
+It does **not** define an observation as absolute truth. Observation provenance remains the caller's responsibility. The runtime guarantee is narrower and testable: every admitted recursive transition is evaluated against the declared world anchor, and successful convergence requires both internal coherence and external correspondence.
+
+## Canonical invariant
+
+Let `H_t` be the authoritative sparse runtime state and `X_world` the declared observation field.
+
+```text
+Generate → Contrast → Reckon → Verify → Correct → Recur
+```
+
+The operational fixed-point condition is:
+
+```text
+H* = F_DM(H*; X_world)
+||H* - F_DM(H*; X_world)|| <= epsilon_i
+d(H*, X_world) <= epsilon_e
+```
+
+The first inequality is the internal fixed-point condition. The second is the external correspondence condition. Neither is substituted for the other.
+
+## Commit rule
+
+For a generated candidate `H'_t`, the runtime evaluates external residuals before and after correction:
+
+```text
+e_before    = d(H_t, X_world)
+e_generated = d(H'_t, X_world)
+H''_t       = Correct(H'_t, X_world)
+e_after     = d(H''_t, X_world)
+```
+
+A candidate may commit only when all existing numerical and Theta-policy gates pass **and** correspondence is non-worsening:
+
+```text
+e_after <= e_before
+```
+
+This allows a state to advance toward reality over multiple bounded recursive cycles instead of requiring an exact world match in a single update.
+
+Convergence is stronger than admission:
+
+```text
+internal_converged
+AND external_residual <= epsilon_e
+```
+
+## Permeation stack
+
+The runtime exposes the invariant across the canonical stack:
+
+```text
+Psi → Phi → Lambda^-1 → Omega → Theta → X_world
+```
+
+`Psi..Theta` remain the bounded internal operator. `X_world` is not collapsed into the latent model; it remains an external correspondence constraint. This preserves the model/territory distinction already present in the DM-vOmegaXi+ fixed-point runtime.
+
+## Sparse reference implementation
+
+```python
+from jarvisx.dm_vomegaxi_fixed_point import DMvOmegaXiFixedPointConfig
+from jarvisx.reality_reckoning import (
+    RealityConstrainedDMvOmegaXiEngine,
+    SparseRealityAnchor,
+)
+
+world = {
+    (2, 2, 2): 0.25,
+    (3, 2, 2): 0.25,
+}
+
+initial = {
+    (2, 2, 2): 0.75,
+    (3, 2, 2): 0.75,
+}
+
+anchor = SparseRealityAnchor(
+    world,
+    tolerance=1.0e-4,
+    correction_gain=0.5,
+)
+engine = RealityConstrainedDMvOmegaXiEngine(
+    anchor,
+    DMvOmegaXiFixedPointConfig(fixed_point_tolerance=1.0e-4),
+)
+engine.load(initial)
+reports = engine.run_until_fixed_point()
+
+assert reports[-1].internal_converged
+assert reports[-1].external_correspondence
+assert reports[-1].converged
+```
+
+## Telemetry
+
+Each cycle records:
+
+- internal fixed-point residual;
+- reconstruction, memory and Theta residuals;
+- external residual before generation;
+- external residual after internal generation;
+- external residual after correction;
+- whether reality correction changed the candidate;
+- independent internal/external convergence flags;
+- authoritative state hash and hash-chain journal head.
+
+`status()` additionally exposes:
+
+```text
+glyph: ⟲⊙
+operator: Reality-Constrained Recursive Reckoning
+reckoning_cycle: Generate, Contrast, Reckon, Verify, Correct, Recur
+permeation_stack: Psi, Phi, Lambda^-1, Omega, Theta, X_world
+```
+
+## Scientific boundary
+
+Internal convergence alone remains insufficient:
+
+```text
+H* = F_DM(H*)  does not imply  H* corresponds to reality.
+```
+
+Likewise, a world anchor is only as reliable as its measurement and provenance. `⟲⊙` therefore operationalizes **reality-constrained correction**, not an oracle of truth.

--- a/examples/reality_reckoning_demo.py
+++ b/examples/reality_reckoning_demo.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from jarvisx.dm_vomegaxi_fixed_point import DMvOmegaXiFixedPointConfig
+from jarvisx.reality_reckoning import (
+    RealityConstrainedDMvOmegaXiEngine,
+    SparseRealityAnchor,
+)
+
+
+def main() -> None:
+    world = {
+        (2, 2, 2): 0.25,
+        (3, 2, 2): 0.25,
+    }
+    initial = {
+        (2, 2, 2): 0.75,
+        (3, 2, 2): 0.75,
+    }
+
+    anchor = SparseRealityAnchor(
+        world,
+        tolerance=1.0e-4,
+        correction_gain=0.5,
+    )
+    engine = RealityConstrainedDMvOmegaXiEngine(
+        anchor,
+        DMvOmegaXiFixedPointConfig(
+            fixed_point_tolerance=1.0e-4,
+            max_iterations=64,
+        ),
+    )
+    engine.load(initial)
+
+    for report in engine.run_until_fixed_point():
+        print(
+            f"iter={report.iteration:02d} "
+            f"internal={report.fixed_point_residual:.6g} "
+            f"external={report.external_residual_after:.6g} "
+            f"converged={report.converged}"
+        )
+
+    print(engine.status())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/reality_reckoning.py
+++ b/src/jarvisx/reality_reckoning.py
@@ -1,0 +1,325 @@
+"""Reality-constrained recursive reckoning for the Dr Moagi sparse runtime.
+
+The glyph ``⟲⊙`` is treated here as an executable contract rather than a logo:
+recursive internal stabilization (⟲) may advance only while correspondence to a
+declared external reference (⊙) is non-worsening.  Convergence requires both an
+internal fixed point and an external correspondence threshold.
+
+This module intentionally does not claim that an arbitrary reference field is
+"truth".  The caller owns observation provenance.  The runtime guarantees only
+that the declared anchor participates in every admitted recursive transition.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Mapping
+
+from .dm_vomegaxi_fixed_point import (
+    DMvOmegaXiFixedPointConfig,
+    DMvOmegaXiFixedPointEngine,
+)
+from .dr_moagi_field_runtime import Coordinate, SparseField
+
+
+@dataclass(frozen=True)
+class RealityEvaluation:
+    """Measured correspondence between a candidate field and the world anchor."""
+
+    residual: float
+    evidence_cells: int
+    within_tolerance: bool
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.residual) or self.residual < 0.0:
+            raise ValueError("residual must be finite and non-negative")
+        if isinstance(self.evidence_cells, bool) or not isinstance(self.evidence_cells, int):
+            raise TypeError("evidence_cells must be an integer")
+        if self.evidence_cells < 0:
+            raise ValueError("evidence_cells must be non-negative")
+
+
+class SparseRealityAnchor:
+    """Finite sparse 3D observation anchor with a bounded correction operator.
+
+    ``correction_gain`` controls how strongly one recursive cycle moves a
+    candidate toward the observation.  A gain of 1 applies the full observed
+    correction; smaller gains make correspondence contract over repeated cycles.
+    """
+
+    def __init__(
+        self,
+        world: Mapping[Coordinate, float],
+        *,
+        tolerance: float = 1.0e-6,
+        correction_gain: float = 0.5,
+    ) -> None:
+        tolerance_f = float(tolerance)
+        gain_f = float(correction_gain)
+        if not math.isfinite(tolerance_f) or tolerance_f < 0.0:
+            raise ValueError("tolerance must be finite and non-negative")
+        if not math.isfinite(gain_f) or not 0.0 < gain_f <= 1.0:
+            raise ValueError("correction_gain must be finite and in (0, 1]")
+
+        normalized: SparseField = {}
+        for coordinate, raw in world.items():
+            if (
+                len(coordinate) != 3
+                or any(isinstance(axis, bool) or not isinstance(axis, int) for axis in coordinate)
+            ):
+                raise TypeError("world coordinates must be integer triples")
+            value = float(raw)
+            if not math.isfinite(value):
+                raise ValueError("world values must be finite")
+            normalized[coordinate] = value
+
+        self._world = normalized
+        self.tolerance = tolerance_f
+        self.correction_gain = gain_f
+
+    def snapshot(self) -> SparseField:
+        return dict(self._world)
+
+    def evaluate(self, candidate: Mapping[Coordinate, float]) -> RealityEvaluation:
+        support = set(self._world) | set(candidate)
+        if not support:
+            residual = 0.0
+        else:
+            mse = sum(
+                (
+                    float(candidate.get(coordinate, 0.0))
+                    - float(self._world.get(coordinate, 0.0))
+                )
+                ** 2
+                for coordinate in support
+            ) / len(support)
+            residual = math.sqrt(mse)
+        return RealityEvaluation(
+            residual=residual,
+            evidence_cells=len(support),
+            within_tolerance=residual <= self.tolerance,
+        )
+
+    def correct(self, candidate: Mapping[Coordinate, float]) -> SparseField:
+        """Move the candidate toward the observed field on the union support."""
+
+        gain = self.correction_gain
+        corrected: SparseField = {}
+        for coordinate in sorted(set(self._world) | set(candidate)):
+            value = float(candidate.get(coordinate, 0.0))
+            target = float(self._world.get(coordinate, 0.0))
+            next_value = value + gain * (target - value)
+            if next_value != 0.0:
+                corrected[coordinate] = next_value
+        return corrected
+
+
+@dataclass(frozen=True)
+class RealityFixedPointReport:
+    """One Generate→Contrast→Reckon→Verify→Correct→Recur transaction."""
+
+    iteration: int
+    committed: bool
+    active_cells: int
+    latent_cells: int
+    reconstruction_rms: float
+    memory_rms: float
+    theta_rms: float
+    fixed_point_residual: float
+    semantic_gap: float
+    internal_converged: bool
+    external_residual_before: float
+    external_residual_generated: float
+    external_residual_after: float
+    external_correspondence: bool
+    reality_corrected: bool
+    converged: bool
+    theta_gate_passed: bool
+    rejection_reason: str | None
+    state_hash: str
+    journal_hash: str = ""
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
+    """DM-vOmegaXi+ with the canonical ``⟲⊙`` correspondence invariant.
+
+    A cycle is admitted when numerical/policy constraints pass and the proposed
+    transition does not worsen correspondence to the supplied world anchor.
+    The anchor's correction operator is applied before admission.  Successful
+    convergence requires *both* the inherited internal fixed-point tolerance and
+    the anchor's external correspondence tolerance.
+    """
+
+    GLYPH = "⟲⊙"
+    OPERATOR_NAME = "Reality-Constrained Recursive Reckoning"
+    RECKONING_CYCLE = (
+        "Generate",
+        "Contrast",
+        "Reckon",
+        "Verify",
+        "Correct",
+        "Recur",
+    )
+    PERMEATION_STACK = ("Psi", "Phi", "Lambda^-1", "Omega", "Theta", "X_world")
+
+    def __init__(
+        self,
+        reality_anchor: SparseRealityAnchor,
+        config: DMvOmegaXiFixedPointConfig | None = None,
+        *,
+        theta_gate=None,
+        journal_path: str | Path | None = None,
+    ) -> None:
+        if not isinstance(reality_anchor, SparseRealityAnchor):
+            raise TypeError("reality_anchor must be a SparseRealityAnchor")
+        super().__init__(config, theta_gate=theta_gate, journal_path=journal_path)
+        self.reality_anchor = reality_anchor
+        self.reports: list[RealityFixedPointReport] = []
+
+    def step(self) -> RealityFixedPointReport:
+        self._require_loaded()
+        current = dict(self._state)
+        support = tuple(sorted(current))
+
+        # Generate: execute the inherited bounded sparse internal operator.
+        latent = self.phi(current)
+        bounded_latent = self.lambda_inverse(latent)
+        decoded = self.codec.decode(bounded_latent, support)
+        folded = self.omega_fold(decoded, support)
+        generated = self.theta_project(current, folded)
+
+        # Contrast/Reckon: measure internal and external discrepancy separately.
+        before_eval = self.reality_anchor.evaluate(current)
+        generated_eval = self.reality_anchor.evaluate(generated)
+
+        # Correct: reality participates before any authoritative-state commit.
+        corrected_raw = self.reality_anchor.correct(generated)
+        corrected = self._bound_sparse_field(corrected_raw)
+        corrected_eval = self.reality_anchor.evaluate(corrected)
+
+        # Never accept a correction that is less reality-correspondent than the
+        # internally generated proposal.  This keeps the operator monotone in
+        # the declared external discrepancy even for future anchor variants.
+        if corrected_eval.residual <= generated_eval.residual:
+            candidate = corrected
+            final_eval = corrected_eval
+        else:
+            candidate = generated
+            final_eval = generated_eval
+
+        reconstruction_rms = self._rms(current, decoded)
+        memory_rms = self._rms(candidate, folded)
+        theta_rms = self._rms(candidate, current)
+        representation_rms = self._rms(candidate, decoded)
+        residual = max(theta_rms, memory_rms, representation_rms)
+        semantic_gap = max(self.config.semantic_floor, reconstruction_rms)
+        internal_converged = residual <= self.config.fixed_point_tolerance
+        nonworsening_external = final_eval.residual <= before_eval.residual + 1.0e-15
+
+        rejection_reason: str | None = None
+        theta_gate_passed = True
+        if len(candidate) > self.config.max_active_cells:
+            rejection_reason = "active-cell budget exceeded"
+        elif not self._finite(candidate):
+            rejection_reason = "non-finite candidate state"
+        elif self.theta_gate is not None:
+            theta_gate_passed = bool(self.theta_gate(candidate))
+            if not theta_gate_passed:
+                rejection_reason = "Theta policy gate rejected candidate"
+        if rejection_reason is None and not nonworsening_external:
+            rejection_reason = "reality correspondence worsened"
+
+        committed = rejection_reason is None
+        if committed:
+            self._state = candidate
+            self._memory = folded
+            self._iteration += 1
+
+        external_correspondence = bool(committed and final_eval.within_tolerance)
+        converged = bool(committed and internal_converged and external_correspondence)
+        authoritative = self._state if committed else current
+        provisional = RealityFixedPointReport(
+            iteration=self._iteration,
+            committed=committed,
+            active_cells=len(authoritative),
+            latent_cells=bounded_latent.latent_cells,
+            reconstruction_rms=reconstruction_rms,
+            memory_rms=memory_rms,
+            theta_rms=theta_rms,
+            fixed_point_residual=residual,
+            semantic_gap=semantic_gap,
+            internal_converged=internal_converged,
+            external_residual_before=before_eval.residual,
+            external_residual_generated=generated_eval.residual,
+            external_residual_after=final_eval.residual,
+            external_correspondence=external_correspondence,
+            reality_corrected=candidate != generated,
+            converged=converged,
+            theta_gate_passed=theta_gate_passed,
+            rejection_reason=rejection_reason,
+            state_hash=self._state_hash(authoritative),
+        )
+        record = provisional.as_dict()
+        record.pop("journal_hash", None)
+        record["glyph"] = self.GLYPH
+        record["operator"] = self.OPERATOR_NAME
+        digest = self.journal.append(record)
+        report = replace(provisional, journal_hash=digest)
+        self.reports.append(report)
+        return report
+
+    def run_until_fixed_point(
+        self,
+        max_iterations: int | None = None,
+    ) -> tuple[RealityFixedPointReport, ...]:
+        self._require_loaded()
+        limit = self.config.max_iterations if max_iterations is None else max_iterations
+        if isinstance(limit, bool) or not isinstance(limit, int) or limit <= 0:
+            raise ValueError("max_iterations must be a positive integer")
+        for _ in range(limit):
+            report = self.step()
+            if report.converged or not report.committed:
+                break
+        return tuple(self.reports)
+
+    def status(self) -> dict[str, object]:
+        status = super().status()
+        latest = self.reports[-1] if self.reports else None
+        status.update(
+            {
+                "glyph": self.GLYPH,
+                "operator": self.OPERATOR_NAME,
+                "reckoning_cycle": list(self.RECKONING_CYCLE),
+                "permeation_stack": list(self.PERMEATION_STACK),
+                "reality_fixed_point_equation": (
+                    "H* = F_DM(H*; X_world), "
+                    "||H* - F_DM(H*; X_world)|| <= epsilon_i, "
+                    "d(H*, X_world) <= epsilon_e"
+                ),
+                "external_tolerance": self.reality_anchor.tolerance,
+                "external_residual": latest.external_residual_after if latest else None,
+                "external_correspondence": latest.external_correspondence if latest else False,
+                "internal_converged": latest.internal_converged if latest else False,
+                "converged": latest.converged if latest else False,
+            }
+        )
+        return status
+
+    def _bound_sparse_field(self, field: Mapping[Coordinate, float]) -> SparseField:
+        """Project reality correction back into the runtime's admissible domain."""
+
+        eps = self.config.policy.prune_epsilon
+        result: SparseField = {}
+        for coordinate in sorted(field):
+            value = max(
+                self.config.value_min,
+                min(self.config.value_max, float(field[coordinate])),
+            )
+            if abs(value) > eps:
+                result[coordinate] = value
+        return result

--- a/src/jarvisx/reality_reckoning.py
+++ b/src/jarvisx/reality_reckoning.py
@@ -2,24 +2,26 @@
 
 The glyph ``⟲⊙`` is treated here as an executable contract rather than a logo:
 recursive internal stabilization (⟲) may advance only while correspondence to a
-declared external reference (⊙) is non-worsening.  Convergence requires both an
+declared external reference (⊙) is non-worsening. Convergence requires both an
 internal fixed point and an external correspondence threshold.
 
 This module intentionally does not claim that an arbitrary reference field is
-"truth".  The caller owns observation provenance.  The runtime guarantees only
+"truth". The caller owns observation provenance. The runtime guarantees only
 that the declared anchor participates in every admitted recursive transition.
 """
 
 from __future__ import annotations
 
 import math
-from dataclasses import asdict, dataclass, replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Mapping
 
 from .dm_vomegaxi_fixed_point import (
     DMvOmegaXiFixedPointConfig,
     DMvOmegaXiFixedPointEngine,
+    FixedPointReport,
+    ThetaGate,
 )
 from .dr_moagi_field_runtime import Coordinate, SparseField
 
@@ -45,7 +47,7 @@ class SparseRealityAnchor:
     """Finite sparse 3D observation anchor with a bounded correction operator.
 
     ``correction_gain`` controls how strongly one recursive cycle moves a
-    candidate toward the observation.  A gain of 1 applies the full observed
+    candidate toward the observation. A gain of 1 applies the full observed
     correction; smaller gains make correspondence contract over repeated cycles.
     """
 
@@ -117,32 +119,15 @@ class SparseRealityAnchor:
 
 
 @dataclass(frozen=True)
-class RealityFixedPointReport:
+class RealityFixedPointReport(FixedPointReport):
     """One Generate→Contrast→Reckon→Verify→Correct→Recur transaction."""
 
-    iteration: int
-    committed: bool
-    active_cells: int
-    latent_cells: int
-    reconstruction_rms: float
-    memory_rms: float
-    theta_rms: float
-    fixed_point_residual: float
-    semantic_gap: float
-    internal_converged: bool
-    external_residual_before: float
-    external_residual_generated: float
-    external_residual_after: float
-    external_correspondence: bool
-    reality_corrected: bool
-    converged: bool
-    theta_gate_passed: bool
-    rejection_reason: str | None
-    state_hash: str
-    journal_hash: str = ""
-
-    def as_dict(self) -> dict[str, object]:
-        return asdict(self)
+    internal_converged: bool = False
+    external_residual_before: float = 0.0
+    external_residual_generated: float = 0.0
+    external_residual_after: float = 0.0
+    external_correspondence: bool = False
+    reality_corrected: bool = False
 
 
 class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
@@ -150,8 +135,8 @@ class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
 
     A cycle is admitted when numerical/policy constraints pass and the proposed
     transition does not worsen correspondence to the supplied world anchor.
-    The anchor's correction operator is applied before admission.  Successful
-    convergence requires *both* the inherited internal fixed-point tolerance and
+    The anchor's correction operator is applied before admission. Successful
+    convergence requires both the inherited internal fixed-point tolerance and
     the anchor's external correspondence tolerance.
     """
 
@@ -172,14 +157,14 @@ class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
         reality_anchor: SparseRealityAnchor,
         config: DMvOmegaXiFixedPointConfig | None = None,
         *,
-        theta_gate=None,
+        theta_gate: ThetaGate | None = None,
         journal_path: str | Path | None = None,
     ) -> None:
         if not isinstance(reality_anchor, SparseRealityAnchor):
             raise TypeError("reality_anchor must be a SparseRealityAnchor")
         super().__init__(config, theta_gate=theta_gate, journal_path=journal_path)
         self.reality_anchor = reality_anchor
-        self.reports: list[RealityFixedPointReport] = []
+        self.reports.clear()
 
     def step(self) -> RealityFixedPointReport:
         self._require_loaded()
@@ -203,8 +188,8 @@ class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
         corrected_eval = self.reality_anchor.evaluate(corrected)
 
         # Never accept a correction that is less reality-correspondent than the
-        # internally generated proposal.  This keeps the operator monotone in
-        # the declared external discrepancy even for future anchor variants.
+        # internally generated proposal. This keeps the operator monotone in the
+        # declared external discrepancy even for future anchor variants.
         if corrected_eval.residual <= generated_eval.residual:
             candidate = corrected
             final_eval = corrected_eval
@@ -253,16 +238,16 @@ class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
             theta_rms=theta_rms,
             fixed_point_residual=residual,
             semantic_gap=semantic_gap,
+            converged=converged,
+            theta_gate_passed=theta_gate_passed,
+            rejection_reason=rejection_reason,
+            state_hash=self._state_hash(authoritative),
             internal_converged=internal_converged,
             external_residual_before=before_eval.residual,
             external_residual_generated=generated_eval.residual,
             external_residual_after=final_eval.residual,
             external_correspondence=external_correspondence,
             reality_corrected=candidate != generated,
-            converged=converged,
-            theta_gate_passed=theta_gate_passed,
-            rejection_reason=rejection_reason,
-            state_hash=self._state_hash(authoritative),
         )
         record = provisional.as_dict()
         record.pop("journal_hash", None)
@@ -285,11 +270,14 @@ class RealityConstrainedDMvOmegaXiEngine(DMvOmegaXiFixedPointEngine):
             report = self.step()
             if report.converged or not report.committed:
                 break
-        return tuple(self.reports)
+        return tuple(
+            report for report in self.reports if isinstance(report, RealityFixedPointReport)
+        )
 
     def status(self) -> dict[str, object]:
         status = super().status()
-        latest = self.reports[-1] if self.reports else None
+        latest_base = self.reports[-1] if self.reports else None
+        latest = latest_base if isinstance(latest_base, RealityFixedPointReport) else None
         status.update(
             {
                 "glyph": self.GLYPH,

--- a/tests/test_reality_reckoning.py
+++ b/tests/test_reality_reckoning.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.dm_vomegaxi_fixed_point import DMvOmegaXiFixedPointConfig
+from jarvisx.dr_moagi_autoexec import AutoExecPolicy
+from jarvisx.reality_reckoning import (
+    RealityConstrainedDMvOmegaXiEngine,
+    SparseRealityAnchor,
+)
+
+
+def _config(**overrides):
+    values = dict(
+        side=16,
+        max_active_cells=64,
+        value_min=-2.0,
+        value_max=2.0,
+        policy=AutoExecPolicy(block_size=2, quantization=0.01, prune_epsilon=0.0),
+        latent_bound=1.0,
+        omega_memory=0.5,
+        theta_gain=0.5,
+        theta_max_delta=0.25,
+        fixed_point_tolerance=1.0e-6,
+        semantic_floor=1.0e-12,
+        max_iterations=128,
+    )
+    values.update(overrides)
+    return DMvOmegaXiFixedPointConfig(**values)
+
+
+def test_glyph_converges_only_when_internal_and_external_conditions_hold():
+    field = {(2, 2, 2): 0.75, (3, 2, 2): 0.75}
+    anchor = SparseRealityAnchor(field, tolerance=1.0e-12, correction_gain=0.5)
+    engine = RealityConstrainedDMvOmegaXiEngine(anchor, _config())
+    engine.load(field)
+
+    report = engine.step()
+
+    assert report.committed
+    assert report.internal_converged
+    assert report.external_correspondence
+    assert report.converged
+    assert report.external_residual_after == pytest.approx(0.0)
+    assert not report.reality_corrected
+    assert engine.status()["glyph"] == "⟲⊙"
+
+
+def test_internal_fixed_point_alone_is_not_reported_as_converged():
+    initial = {(2, 2, 2): 0.75, (3, 2, 2): 0.75}
+    world = {(2, 2, 2): 0.25, (3, 2, 2): 0.25}
+    anchor = SparseRealityAnchor(world, tolerance=1.0e-4, correction_gain=0.5)
+    engine = RealityConstrainedDMvOmegaXiEngine(anchor, _config(fixed_point_tolerance=1.0e-4))
+    engine.load(initial)
+
+    first = engine.step()
+
+    assert first.committed
+    assert first.reality_corrected
+    assert first.external_residual_after < first.external_residual_before
+    assert not first.converged
+
+    reports = engine.run_until_fixed_point()
+    assert reports[-1].converged
+    assert reports[-1].internal_converged
+    assert reports[-1].external_correspondence
+    assert reports[-1].external_residual_after <= anchor.tolerance
+
+
+def test_reality_correction_can_add_observed_support():
+    initial = {(2, 2, 2): 0.5}
+    world = {(2, 2, 2): 0.5, (4, 4, 4): 1.0}
+    anchor = SparseRealityAnchor(world, tolerance=1.0e-4, correction_gain=1.0)
+    engine = RealityConstrainedDMvOmegaXiEngine(anchor, _config())
+    engine.load(initial)
+
+    report = engine.step()
+
+    assert report.committed
+    assert (4, 4, 4) in engine.snapshot()
+    assert engine.snapshot()[(4, 4, 4)] == pytest.approx(1.0)
+    assert report.external_residual_after < report.external_residual_before
+
+
+def test_theta_gate_still_has_authority_over_reality_corrected_candidate():
+    initial = {(2, 2, 2): 1.0}
+    anchor = SparseRealityAnchor({(2, 2, 2): 0.0}, correction_gain=0.5)
+    engine = RealityConstrainedDMvOmegaXiEngine(
+        anchor,
+        _config(),
+        theta_gate=lambda _: False,
+    )
+    engine.load(initial)
+
+    report = engine.step()
+
+    assert not report.committed
+    assert not report.theta_gate_passed
+    assert report.rejection_reason == "Theta policy gate rejected candidate"
+    assert engine.snapshot() == initial
+    assert engine.journal.verify()
+
+
+def test_anchor_validation_rejects_nonfinite_world_values():
+    with pytest.raises(ValueError, match="world values must be finite"):
+        SparseRealityAnchor({(0, 0, 0): float("nan")})
+
+
+def test_status_exposes_permeation_contract():
+    field = {(1, 1, 1): 0.5}
+    engine = RealityConstrainedDMvOmegaXiEngine(
+        SparseRealityAnchor(field, tolerance=1.0e-8),
+        _config(),
+    )
+    engine.load(field)
+    engine.step()
+
+    status = engine.status()
+
+    assert status["operator"] == "Reality-Constrained Recursive Reckoning"
+    assert status["reckoning_cycle"] == [
+        "Generate",
+        "Contrast",
+        "Reckon",
+        "Verify",
+        "Correct",
+        "Recur",
+    ]
+    assert status["permeation_stack"] == [
+        "Psi",
+        "Phi",
+        "Lambda^-1",
+        "Omega",
+        "Theta",
+        "X_world",
+    ]
+    assert status["external_correspondence"]


### PR DESCRIPTION
## Summary

Operationalizes the canonical `⟲⊙` glyph as an executable **Reality-Constrained Recursive Reckoning** layer over the existing DM-vOmegaXi+ sparse fixed-point runtime.

## Invariant

The runtime now has a reference implementation for:

`Generate → Contrast → Reckon → Verify → Correct → Recur`

with dual convergence:

- internal coherence: fixed-point residual `<= epsilon_i`
- external correspondence: distance to the declared `X_world` anchor `<= epsilon_e`

An internally converged state is therefore not reported as fully converged unless external correspondence also holds.

## Operational behavior

- preserves the existing DM-vOmegaXi+ fixed-point engine unchanged;
- adds `SparseRealityAnchor` with explicit observation tolerance and bounded correction gain;
- applies reality correction before authoritative-state commit;
- admits recursive progress only when external residual is non-worsening;
- keeps Theta policy authority and numerical/sparse-state constraints intact;
- journals internal and external residuals together with the `⟲⊙` operator identity;
- exposes the permeation stack `Psi → Phi → Lambda^-1 → Omega → Theta → X_world`;
- adds a runnable example and tests for dual convergence, observed-support injection, policy rejection, validation, and telemetry.

## Scientific boundary

This does not treat the anchor as an oracle of truth. Observation provenance is caller-owned. The executable guarantee is that the declared external anchor participates in every admitted recursive transition and that internal convergence is not conflated with external correctness.

## Files

- `src/jarvisx/reality_reckoning.py`
- `tests/test_reality_reckoning.py`
- `docs/reality-constrained-recursive-reckoning.md`
- `examples/reality_reckoning_demo.py`
