### PR TITLE
feat: operationalise full 3D multimodal recursive loop

### DIFF
--- a/docs/DM_VOMEGAXI_MULTIMODAL_3D_LOOP.md
+++ b/docs/DM_VOMEGAXI_MULTIMODAL_3D_LOOP.md
@@ -1,0 +1,153 @@
+# DM-vOmegaXi+ Full 3D Multimodal Processing and Generation Loop
+
+## Status
+
+Bounded executable reference architecture. The implementation performs real
+3D encode/decode, temporal latent recurrence, cross-modal fusion, generated
+3D output, self-observation, cycle-error measurement, and transactional model
+updates. The `10^24` rate is a **virtual state-accounting coordinate**, not a
+claim of measured physical CPU/GPU throughput.
+
+## Operational closure
+
+For modality \(m\in\{visual,audio,text,video,generic\}\):
+
+\[
+X_t^{(m)} \xrightarrow{A_m} V_t^{(m)}
+\xrightarrow{E_{\theta_m}} Z_t^{(m)}.
+\]
+
+Temporal memory is an exponentially weighted latent history:
+
+\[
+\bar Z_t^{(m)} =
+\frac{\sum_{k=0}^{K-1}\rho^k Z_{t-k}^{(m)}}
+     {\sum_{k=0}^{K-1}\rho^k}.
+\]
+
+Reconstruction error controls cross-modal routing:
+
+\[
+e_m = \|V_t^{(m)} - D_{\phi_m}(\bar Z_t^{(m)})\|_2^2,
+\qquad
+\alpha_m =
+\frac{(\varepsilon+e_m)^{-1}}
+     {\sum_j(\varepsilon+e_j)^{-1}}.
+\]
+
+The shared 3D field is
+
+\[
+Z_t^{\mathrm{fused}} = \sum_m \alpha_m\bar Z_t^{(m)}.
+\]
+
+The septillion coordinate is derived from elapsed monotonic nanoseconds:
+
+\[
+N_v(t)=\left\lfloor\frac{t_{ns}\,10^{24}}{10^9}\right\rfloor,
+\qquad I_t=N_v(t)\bmod10^{24}.
+\]
+
+`I_t` is deinterleaved in base ten into a bijective
+\(10^8\times10^8\times10^8=10^{24}\) lattice. The normalized coordinate
+perturbs the fused latent field by a bounded sinusoidal term; it does not
+materialize a dense `10^24 x 10^24 x 10^24` volume.
+
+Generation for modality `m` uses
+
+\[
+\tilde Z_t^{(m)}=(1-\mu)\bar Z_t^{(m)}+\mu Z_t^{\mathrm{fused}},
+\qquad
+\hat V_t^{(m)}=D_{\phi_m}(\tilde Z_t^{(m)}).
+\]
+
+The generated state is fed inward again:
+
+\[
+Z_{self,t}^{(m)}=E_{\theta_m}(\hat V_t^{(m)}),
+\qquad
+L_{cycle}^{(m)}=\|Z_{self,t}^{(m)}-\tilde Z_t^{(m)}\|_2^2.
+\]
+
+The executable loop is therefore:
+
+```text
+payload/file/text
+      |
+      v
+modality adapters
+      |
+      v
+3D volumes X[m]
+      |
+      v
+3D encoder E[m] -----> temporal Omega history
+      |                         |
+      +-------------------------+
+      |
+      v
+error-aware cross-modal fusion
+      |
+      +<---- 10^24-state/s virtual coordinate accounting
+      |
+      v
+fused 3D latent field
+      |
+      v
+modality-conditioned 3D decoders/generators
+      |
+      +----> generated-visual.raw
+      +----> generated-audio.raw
+      +----> generated-text.raw
+      +----> generated-video.raw
+      +----> generated-generic.raw
+      |
+      v
+self-observation re-encode
+      |
+      v
+reconstruction + cycle reckoning
+      |
+      v
+transactional parameter update
+      |
+      +------------------------------> recur
+```
+
+## Physical claim boundary
+
+The built-in adapters are codec-agnostic byte-to-volume transforms. A PNG,
+JPEG, WAV, MP4 or other compressed container can be supplied as bytes, but the
+reference engine does not claim to parse that container into semantic pixels,
+audio samples or frames. Production codec adapters should decode the media
+first, then pass normalized tensors/payloads into this loop.
+
+Likewise, `10^24 states/s` denotes the virtual coordinate velocity. Physical
+execution is represented by actual loop cycles/probes and must be benchmarked
+separately.
+
+## CLI
+
+```bash
+jarvisx-dr-moagi-multimodal3d \
+  --cycles 6 \
+  --edge 8 \
+  --input visual=frame.rgb \
+  --input audio=audio.pcm \
+  --input video=clip.raw \
+  --text "Jarvis X echo through" \
+  --out ./multimodal-out
+```
+
+For reproducible tests, bypass wall-clock sampling with an explicit virtual
+stride:
+
+```bash
+jarvisx-dr-moagi-multimodal3d \
+  --cycles 4 \
+  --deterministic-stride 100000000000000000000 \
+  --out ./deterministic-out
+```
+
+The output directory contains raw generated payloads, `metrics.json`, and an
+OBJ representation of the fused 3D latent field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ jarvisx-dr-moagi-3d-animation = "jarvisx.dr_moagi_3d_animation_codec:main"
 jarvisx-dr-moagi-codegen = "jarvisx.dr_moagi_codegen_engine:main"
 jarvisx-dr-moagi-resonator = "jarvisx.dr_moagi_monadic_resonator:main"
 jarvisx-dr-moagi-multiparallel = "jarvisx.dr_moagi_multiparallel_cli:main"
+jarvisx-dr-moagi-multimodal3d = "jarvisx.dr_moagi_multimodal_loop:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/jarvisx/dr_moagi_multimodal_loop.py
+++ b/src/jarvisx/dr_moagi_multimodal_loop.py
@@ -1,0 +1,256 @@
+"""DM-vOmegaXi+ bounded 3D multimodal autoencoding/generation reference loop.
+
+`10**24 states/s` is virtual clock accounting, not measured hardware throughput.
+Media adapters are codec-agnostic byte-to-volume projections; semantic codecs belong upstream.
+"""
+from __future__ import annotations
+
+import argparse, json, math, random, time
+from collections import deque
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Optional, Sequence
+
+OPS_PER_SECOND = 10**24
+VIRTUAL_STATES = 10**24
+
+
+class Modality(str, Enum):
+    VISUAL="visual"; AUDIO="audio"; TEXT="text"; VIDEO="video"; GENERIC="generic"
+
+MODALITIES=tuple(Modality)
+
+
+@dataclass
+class Volume3D:
+    edge:int
+    values:list[float]
+    def __post_init__(self):
+        if self.edge<2 or len(self.values)!=self.edge**3: raise ValueError("invalid 3D volume")
+        if not all(math.isfinite(v) for v in self.values): raise ValueError("non-finite 3D volume")
+    def copy(self): return Volume3D(self.edge,self.values.copy())
+    def _same(self,o):
+        if self.edge!=o.edge: raise ValueError("3D shape mismatch")
+    def mse(self,o):
+        self._same(o); return sum((a-b)**2 for a,b in zip(self.values,o.values))/len(self.values)
+    def energy(self): return sum(v*v for v in self.values)/len(self.values)
+    def blend(self,o,a):
+        self._same(o); a=max(0.0,min(1.0,float(a)))
+        return Volume3D(self.edge,[(1-a)*x+a*y for x,y in zip(self.values,o.values)])
+
+
+class Payload3DAdapter:
+    PHASE={Modality.VISUAL:.17,Modality.AUDIO:.31,Modality.TEXT:.47,Modality.VIDEO:.63,Modality.GENERIC:.79}
+    @classmethod
+    def ingest(cls,payload:bytes,modality:Modality,edge:int):
+        if edge<4 or edge%2: raise ValueError("edge must be even and >=4")
+        payload=payload or b"\0"; n=edge**3; p=len(payload); out=[]; phase=cls.PHASE[modality]
+        for i in range(n):
+            b0=payload[(131*i+17)%p]; b1=payload[(197*i+43)%p]
+            x=i%edge; y=(i//edge)%edge; z=i//(edge*edge)
+            v=((.72*b0+.28*b1)/255.0)*2-1
+            v+=.08*math.sin(phase+.37*x+.23*y+.19*z)
+            if modality is Modality.AUDIO: v+=.07*math.sin(.83*x+.41*z)
+            elif modality is Modality.TEXT: v+=.05*(1 if b0&(1<<(i%7)) else -1)
+            elif modality is Modality.VIDEO: v+=.06*math.sin(.29*(x+y)+.71*z)
+            elif modality is Modality.VISUAL: v+=.05*math.cos(.53*x-.47*y)
+            out.append(math.tanh(v))
+        return Volume3D(edge,out)
+    @staticmethod
+    def emit(volume:Volume3D,length:int):
+        length=max(1,length); n=len(volume.values); out=bytearray(length)
+        for i in range(length):
+            v=max(-1.0,min(1.0,volume.values[min(n-1,i*n//length)]))
+            out[i]=max(0,min(255,round((v+1)*127.5)))
+        return bytes(out)
+
+
+class Autoencoder3D:
+    """Shared-weight 2x2x2 contraction/expansion neural codec with transactional updates."""
+    PARAMS=("eg","eb","dg","db")
+    def __init__(self,edge:int,seed:int):
+        if edge<4 or edge%2: raise ValueError("edge must be even and >=4")
+        self.edge=edge; self.le=edge//2; r=random.Random(seed)
+        self.eg=.92+.16*r.random(); self.eb=(r.random()-.5)*.04
+        self.dg=.92+.16*r.random(); self.db=(r.random()-.5)*.04
+        self.accepted=0; self.rejected=0
+    @staticmethod
+    def idx(e,x,y,z): return (z*e+y)*e+x
+    def encode(self,v:Volume3D):
+        if v.edge!=self.edge: raise ValueError("encoder edge mismatch")
+        o=[0.0]*(self.le**3)
+        for z in range(self.le):
+          for y in range(self.le):
+            for x in range(self.le):
+              s=0.0
+              for dz in (0,1):
+               for dy in (0,1):
+                for dx in (0,1): s+=v.values[self.idx(self.edge,2*x+dx,2*y+dy,2*z+dz)]
+              o[self.idx(self.le,x,y,z)]=math.tanh(self.eg*s/8+self.eb)
+        return Volume3D(self.le,o)
+    def decode(self,zv:Volume3D):
+        if zv.edge!=self.le: raise ValueError("decoder edge mismatch")
+        o=[0.0]*(self.edge**3)
+        for z in range(self.le):
+          for y in range(self.le):
+            for x in range(self.le):
+              q=zv.values[self.idx(self.le,x,y,z)]; base=math.tanh(self.dg*q+self.db)
+              for dz in (0,1):
+               for dy in (0,1):
+                for dx in (0,1):
+                 detail=.025*((dx+2*dy+3*dz)-3.0)
+                 o[self.idx(self.edge,2*x+dx,2*y+dy,2*z+dz)]=math.tanh(base+detail*q)
+        return Volume3D(self.edge,o)
+    def loss(self,v): return v.mse(self.decode(self.encode(v)))
+    def train_transactional(self,v,lr=.08,h=.002):
+        base=self.loss(v); old={p:getattr(self,p) for p in self.PARAMS}; g={}
+        for p in self.PARAMS:
+            x=getattr(self,p); setattr(self,p,x+h); a=self.loss(v); setattr(self,p,x-h); b=self.loss(v); setattr(self,p,x)
+            g[p]=(a-b)/(2*h)
+        for p in self.PARAMS: setattr(self,p,max(-3,min(3,old[p]-lr*max(-4,min(4,g[p])))))
+        if math.isfinite(self.loss(v)) and self.loss(v)<=base+1e-12: self.accepted+=1; return True
+        for p,x in old.items(): setattr(self,p,x)
+        self.rejected+=1; return False
+
+
+class SeptillionAddressSpace:
+    TOTAL=10**24; AXIS=10**8
+    @classmethod
+    def address(cls,index:int):
+        n=int(index)%cls.TOTAL; a=[0,0,0]; place=[1,1,1]
+        for level in range(24):
+            axis=level%3; a[axis]+=(n%10)*place[axis]; place[axis]*=10; n//=10
+        return tuple(a)
+    @classmethod
+    def normalized(cls,index:int):
+        d=float(cls.AXIS-1); return tuple(2*v/d-1 for v in cls.address(index))
+
+
+class VirtualSeptillionClock:
+    def __init__(self,ops_per_second:int=OPS_PER_SECOND,now_ns:Callable[[],int]=time.monotonic_ns):
+        if ops_per_second<=0: raise ValueError("ops_per_second must be positive")
+        self.rate=int(ops_per_second); self.now_ns=now_ns; self.started=int(now_ns()); self.probes=0
+    def virtual_ops(self): return max(0,int(self.now_ns())-self.started)*self.rate//10**9
+    def sample(self):
+        n=self.virtual_ops(); self.probes+=1; return n,SeptillionAddressSpace.address(n)
+
+
+@dataclass
+class ModalityMetrics:
+    reconstruction_mse:float; cycle_mse:float; latent_energy:float; fusion_weight:float
+    accepted_updates:int; rejected_updates:int
+
+@dataclass
+class LoopMetrics:
+    cycle:int; virtual_ops:int; virtual_index:int; virtual_address:tuple[int,int,int]
+    aggregate_reconstruction_mse:float; aggregate_cycle_mse:float; fixed_point_delta:float
+    converged:bool; physical_probes:int; modalities:dict[str,ModalityMetrics]
+
+
+class DrMoagiMultimodal3DLoop:
+    def __init__(self,edge=8,temporal_depth=4,temporal_decay=.72,cross_modal_mix=.35,
+                 coordinate_gain=.035,convergence_eps=1e-5,convergence_streak=3,
+                 seed=0x4A415256495358,clock:Optional[VirtualSeptillionClock]=None):
+        if edge<4 or edge%2: raise ValueError("edge must be even and >=4")
+        if not 1<=temporal_depth<=64 or not 0<=temporal_decay<1 or not 0<=cross_modal_mix<=1: raise ValueError("invalid loop configuration")
+        self.edge=edge; self.depth=temporal_depth; self.decay=temporal_decay; self.mix=cross_modal_mix
+        self.coordinate_gain=coordinate_gain; self.eps=convergence_eps; self.streak_needed=convergence_streak
+        self.clock=clock or VirtualSeptillionClock(); self.cycle=0; self.streak=0; self.prev=None
+        self.models={m:Autoencoder3D(edge,seed^(0x9E3779B97F4A7C15*(i+1))) for i,m in enumerate(MODALITIES)}
+        self.inputs={}; self.lengths={}; self.history={m:deque(maxlen=temporal_depth) for m in MODALITIES}
+        self.generated={}; self.fused=None; self.last_metrics=None
+    def set_payload(self,modality:Modality|str,payload:bytes|str):
+        m=modality if isinstance(modality,Modality) else Modality(modality); raw=payload.encode() if isinstance(payload,str) else bytes(payload)
+        self.inputs[m]=Payload3DAdapter.ingest(raw,m,self.edge); self.lengths[m]=max(1,len(raw)); self.history[m].clear()
+    def ensure_inputs(self):
+        for m in MODALITIES:
+            if m not in self.inputs: self.set_payload(m,f"DM-vOMEGA-XI+::{m.value}::3D recursive field")
+    def temporal(self,m):
+        h=self.history[m]; weights=[self.decay**i for i in range(len(h))]; total=sum(weights); o=[0.0]*len(h[0].values)
+        for w,v in zip(weights,h):
+            for i,x in enumerate(v.values): o[i]+=w*x/total
+        return Volume3D(h[0].edge,o)
+    @staticmethod
+    def fuse(vols,weights):
+        first=next(iter(vols.values())); out=[0.0]*len(first.values)
+        for m,v in vols.items():
+            first._same(v)
+            for i,x in enumerate(v.values): out[i]+=weights[m]*x
+        return Volume3D(first.edge,out)
+    def condition(self,zv,index):
+        cx,cy,cz=SeptillionAddressSpace.normalized(index); out=zv.copy(); e=zv.edge
+        for i,v in enumerate(out.values):
+            x=i%e; y=(i//e)%e; z=i//(e*e); phase=cx*(x+1)/e+cy*(y+1)/e+cz*(z+1)/e
+            out.values[i]=math.tanh(v+self.coordinate_gain*math.sin(math.pi*phase))
+        return out
+    @staticmethod
+    def signature(vols):
+        out=[]
+        for m in MODALITIES:
+            v=vols[m].values; step=max(1,len(v)//16); out.extend(v[::step][:16])
+        return out
+    def step(self,virtual_ops:Optional[int]=None):
+        self.ensure_inputs()
+        if virtual_ops is None: virtual_ops,address=self.clock.sample()
+        else: virtual_ops=int(virtual_ops); address=SeptillionAddressSpace.address(virtual_ops); self.clock.probes+=1
+        index=virtual_ops%VIRTUAL_STATES
+        for m in MODALITIES: self.models[m].train_transactional(self.inputs[m])
+        temporal={}; losses={}
+        for m in MODALITIES:
+            model=self.models[m]; self.history[m].appendleft(model.encode(self.inputs[m])); temporal[m]=self.temporal(m)
+            losses[m]=self.inputs[m].mse(model.decode(temporal[m]))
+        raw={m:1/(1e-6+losses[m]) for m in MODALITIES}; s=sum(raw.values()); weights={m:raw[m]/s for m in MODALITIES}
+        self.fused=self.condition(self.fuse(temporal,weights),index)
+        generated={}; mm={}; rs=cs=0.0
+        for m in MODALITIES:
+            model=self.models[m]; latent=temporal[m].blend(self.fused,self.mix); out=model.decode(latent); generated[m]=out
+            cyc=latent.mse(model.encode(out)); rs+=losses[m]; cs+=cyc
+            mm[m.value]=ModalityMetrics(losses[m],cyc,latent.energy(),weights[m],model.accepted,model.rejected)
+        self.generated=generated; sig=self.signature(generated)
+        delta=math.inf if self.prev is None else math.sqrt(sum((a-b)**2 for a,b in zip(sig,self.prev))/len(sig)); self.prev=sig
+        self.streak=self.streak+1 if math.isfinite(delta) and delta<self.eps else 0; self.cycle+=1
+        self.last_metrics=LoopMetrics(self.cycle,virtual_ops,index,address,rs/len(MODALITIES),cs/len(MODALITIES),delta,self.streak>=self.streak_needed,self.clock.probes,mm)
+        return self.last_metrics
+    def run(self,cycles:int,deterministic_virtual_stride:Optional[int]=None):
+        if cycles<1: raise ValueError("cycles must be >=1")
+        last=None
+        for i in range(cycles): last=self.step(None if deterministic_virtual_stride is None else i*int(deterministic_virtual_stride))
+        return last
+    def generated_payload(self,modality:Modality|str):
+        m=modality if isinstance(modality,Modality) else Modality(modality)
+        if m not in self.generated: raise RuntimeError("run before generation")
+        return Payload3DAdapter.emit(self.generated[m],self.lengths.get(m,self.edge**3))
+    def export(self,directory:str|Path):
+        if self.last_metrics is None or self.fused is None: raise RuntimeError("run before export")
+        p=Path(directory); p.mkdir(parents=True,exist_ok=True)
+        for m in MODALITIES: (p/f"generated-{m.value}.raw").write_bytes(self.generated_payload(m))
+        (p/"metrics.json").write_text(json.dumps(asdict(self.last_metrics),indent=2,sort_keys=True)+"\n")
+        lines=["# Jarvis-X fused 3D latent field"]; e=self.fused.edge
+        for i,v in enumerate(self.fused.values): lines.append(f"v {i%e} {(i//e)%e} {i//(e*e)} {0.5+0.5*max(-1,min(1,v)):.6f}")
+        (p/"fused-latent.obj").write_text("\n".join(lines)+"\n")
+
+
+def parser():
+    p=argparse.ArgumentParser(description="DM-vOmegaXi+ full 3D multimodal recursive loop")
+    p.add_argument("--cycles",type=int,default=4); p.add_argument("--edge",type=int,default=8); p.add_argument("--temporal-depth",type=int,default=4)
+    p.add_argument("--mix",type=float,default=.35); p.add_argument("--input",action="append",default=[],metavar="MODALITY=PATH")
+    p.add_argument("--text"); p.add_argument("--out",default="./dm-multimodal3d-out"); p.add_argument("--deterministic-stride",type=int); p.add_argument("--quiet",action="store_true")
+    return p
+
+
+def main(argv:Optional[Sequence[str]]=None):
+    a=parser().parse_args(argv); engine=DrMoagiMultimodal3DLoop(a.edge,a.temporal_depth,cross_modal_mix=a.mix)
+    try:
+        for spec in a.input:
+            name,path=spec.split("=",1); engine.set_payload(Modality(name.lower()),Path(path).read_bytes())
+        if a.text is not None: engine.set_payload(Modality.TEXT,a.text)
+        m=engine.run(a.cycles,a.deterministic_stride); engine.export(a.out)
+    except (OSError,ValueError,RuntimeError) as exc: raise SystemExit(f"error: {exc}") from exc
+    if not a.quiet:
+        d="inf" if not math.isfinite(m.fixed_point_delta) else f"{m.fixed_point_delta:.6g}"
+        print(f"cycle={m.cycle} virtual={m.virtual_ops} index={m.virtual_index} address={m.virtual_address} recon={m.aggregate_reconstruction_mse:.6g} cycle_mse={m.aggregate_cycle_mse:.6g} delta={d} converged={m.converged} probes={m.physical_probes}")
+        print(f"output={Path(a.out).resolve()}"); print("virtual-rate=1e24 states/s accounting only; physical work is the measured loop/probe count")
+    return 0
+
+if __name__=="__main__": raise SystemExit(main())

--- a/tests/test_dr_moagi_multimodal_loop.py
+++ b/tests/test_dr_moagi_multimodal_loop.py
@@ -1,0 +1,59 @@
+import math
+
+from jarvisx.dr_moagi_multimodal_loop import (
+    Autoencoder3D,
+    DrMoagiMultimodal3DLoop,
+    Modality,
+    Payload3DAdapter,
+    SeptillionAddressSpace,
+    VirtualSeptillionClock,
+)
+
+
+def test_septillion_address_deinterleaves_24_digits_into_3d():
+    assert SeptillionAddressSpace.address(0) == (0, 0, 0)
+    assert SeptillionAddressSpace.address(1) == (1, 0, 0)
+    assert SeptillionAddressSpace.address(10) == (0, 1, 0)
+    assert SeptillionAddressSpace.address(100) == (0, 0, 1)
+    x, y, z = SeptillionAddressSpace.address(10**24 - 1)
+    assert (x, y, z) == (99_999_999, 99_999_999, 99_999_999)
+
+
+def test_virtual_clock_uses_integer_nanosecond_accounting():
+    ticks = iter((1_000_000_000, 1_000_000_123))
+    clock = VirtualSeptillionClock(now_ns=lambda: next(ticks))
+    assert clock.virtual_ops() == 123 * 10**15
+
+
+def test_transactional_autoencoder_never_commits_a_worse_step():
+    volume = Payload3DAdapter.ingest(b"3D transactional test", Modality.TEXT, 8)
+    model = Autoencoder3D(8, seed=7)
+    before = model.loss(volume)
+    model.train_transactional(volume)
+    after = model.loss(volume)
+    assert math.isfinite(after)
+    assert after <= before + 1.0e-12
+
+
+def test_full_loop_generates_every_modality(tmp_path):
+    engine = DrMoagiMultimodal3DLoop(edge=8, temporal_depth=3, seed=11)
+    engine.set_payload(Modality.TEXT, "Jarvis X multimodal loop")
+    engine.set_payload(Modality.AUDIO, bytes(range(64)))
+    metrics = engine.run(cycles=2, deterministic_virtual_stride=10**20)
+
+    assert metrics.cycle == 2
+    assert metrics.virtual_ops == 10**20
+    assert metrics.virtual_index == 10**20
+    assert math.isfinite(metrics.aggregate_reconstruction_mse)
+    assert math.isfinite(metrics.aggregate_cycle_mse)
+    assert set(metrics.modalities) == {m.value for m in Modality}
+    assert abs(sum(m.fusion_weight for m in metrics.modalities.values()) - 1.0) < 1.0e-6
+
+    for modality in Modality:
+        payload = engine.generated_payload(modality)
+        assert payload
+
+    engine.export(tmp_path)
+    assert (tmp_path / "metrics.json").is_file()
+    assert (tmp_path / "fused-latent.obj").is_file()
+    assert (tmp_path / "generated-text.raw").is_file()


### PR DESCRIPTION
## Summary

Operationalises the DM-vOmegaXi+ inward loop as a bounded end-to-end 3D multimodal processing and generation reference runtime.

### Pipeline

`payload/file/text -> modality 3D field -> per-modality 3D encoder -> temporal latent memory -> error-aware cross-modal fusion -> 10^24-state virtual-coordinate conditioning -> modality 3D decoder/generator -> self-observation re-encode -> reconstruction/cycle reckoning -> transactional update -> recur`

### Included

- `src/jarvisx/dr_moagi_multimodal_loop.py`
  - visual/audio/text/video/generic byte-to-volume adapters
  - bounded trainable 3D autoencoder/decoder per modality
  - temporal Omega-style latent recurrence
  - reconstruction-error weighted cross-modal fusion
  - bijective `10^24 -> 10^8 x 10^8 x 10^8` virtual address mapping
  - monotonic-nanosecond virtual clock accounting at `10^24 states/s`
  - coordinate-conditioned fused latent dynamics
  - per-modality generation
  - self-observation re-encoding and cycle MSE
  - transactional non-worsening model updates
  - fixed-point delta/streak metrics
  - raw generated payload export, metrics JSON, and fused latent OBJ
- `tests/test_dr_moagi_multimodal_loop.py`
- `docs/DM_VOMEGAXI_MULTIMODAL_3D_LOOP.md`
- CLI: `jarvisx-dr-moagi-multimodal3d`

## Claim boundary

`10^24 states/s` is explicitly virtual state accounting, not measured CPU/GPU throughput. The built-in media adapters operate on bytes; they do not claim semantic PNG/JPEG/WAV/MP4 decoding. Production codecs can be placed upstream without changing the recurrent core.

## Local validation

Targeted tests executed against the branch implementation:

```text
4 passed
```

Validated:
- septillion address deinterleaving
- integer nanosecond virtual accounting
- transactional autoencoder non-regression
- two-cycle full multimodal generation/export smoke path
