### PR TITLE
Implement normalized recursive Dr Moagi Q16 cube codec

### DIFF
--- a/.github/workflows/dr-moagi-q16-codec.yml
+++ b/.github/workflows/dr-moagi-q16-codec.yml
@@ -1,0 +1,48 @@
+name: Dr Moagi Q16 codec
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/jarvisx/dr_moagi_q16_field.py"
+      - "tests/test_dr_moagi_q16*.py"
+      - "examples/dr_moagi_q16_cube.py"
+      - ".github/workflows/dr-moagi-q16-codec.yml"
+  pull_request:
+    paths:
+      - "src/jarvisx/dr_moagi_q16_field.py"
+      - "tests/test_dr_moagi_q16*.py"
+      - "examples/dr_moagi_q16_cube.py"
+      - ".github/workflows/dr-moagi-q16-codec.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.13"]
+    env:
+      PYTHONPATH: src
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install pytest
+      - name: Run arithmetic, topology and transaction tests
+        run: python -m pytest -q -o addopts='' tests/test_dr_moagi_q16_field.py tests/test_dr_moagi_q16_codec.py
+      - name: Run recursive cube example
+        run: |
+          python examples/dr_moagi_q16_cube.py --steps 3 > /tmp/q16-cube.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          result = json.loads(Path('/tmp/q16-cube.json').read_text())
+          assert result['ledger_valid']
+          assert result['layout']['logical_cells'] == 10**18
+          assert len(result['cycles']) == 3
+          print([(c['tick'], c['processed_cells'], c['squared_error_raw']) for c in result['cycles']])
+          PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The project follows semantic versioning where practical during alpha development
 
 ### Added
 
+- normalized, bounded recursive Q16.16 codec over sparse 3D neighborhoods, with five-category SHA3 receipts and an executable `10^18`-address cube example;
 - verifiable JSON-native Omega ledger entries;
 - atomic persistent-ledger writes;
 - deterministic clock injection for replay fixtures;
@@ -53,6 +54,7 @@ The project follows semantic versioning where practical during alpha development
 
 ### Fixed
 
+- Q16.16 negative-product rounding, missing optional `/64` encoder normalization, premature codec accumulation saturation, omitted sparse stencil halos, mutable receipt aliases and partial field commits on ledger failure;
 - raw `bytes` objects in ledger entries were not JSON serializable;
 - pytest used the invalid coverage reporter `term-local`;
 - tests could create or mutate an `omega_ledger.json` file in the working directory;

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ Experimental engines remain in draft pull requests until their tests, interfaces
 
 ## Quick start
 
+### Run the normalized Dr Moagi Q16.16 cube
+
+```bash
+PYTHONPATH=src python examples/dr_moagi_q16_cube.py --side 1000000 --steps 3
+```
+
+This bounded sparse reference executes the `Psi -> Phi -> Lambda -> Theta`
+codec and feeds decoded cells into the next cycle, with exact error metrics
+and SHA3 receipts. The `10^18`-cell cube is a logical address space; the JSON
+reports actual processed cells. See the [arithmetic and provenance contract](docs/DR_MOAGI_Q16_FIELD_SUBSTRATE.md).
+
 ### Install the Python package for development
 
 ```bash

--- a/docs/DR_MOAGI_Q16_FIELD_SUBSTRATE.md
+++ b/docs/DR_MOAGI_Q16_FIELD_SUBSTRATE.md
@@ -12,6 +12,13 @@ The volumetric state is represented by signed 32-bit Q16.16 integers:
 
 The runtime stores the raw integer `q`; conversion to a real value is `q / 2^16`.
 
+This is a saturating signed integer representation, not the modular ring
+`Z_32` (32 elements) or wraparound arithmetic modulo `2^32`. A cube with
+`side = 1_000_000` has `10^18` cells. One dense Q16.16 scalar field alone
+requires `4 * 10^18` bytes = **4 decimal exabytes**, before memory, gradients,
+weights, decoder output or indexing. This runtime materializes sparse active
+coordinates and bounded stencil neighborhoods.
+
 ## 2. Saturating arithmetic
 
 For raw signed 32-bit values `a`, `b`:
@@ -26,6 +33,9 @@ a\otimes b = \operatorname{sat}_{32}\!\left((a\cdot b)\gg16\right).
 \]
 
 The 16-bit rescale is required for Q16.16 × Q16.16 multiplication.
+Signed right shifts round toward negative infinity. In particular,
+`q_mul(-1, 1) == -1` in raw units. Float ingestion rounds to nearest with ties
+to even before saturation. Left shifts saturate, including large shift counts.
 
 ## 3. Discrete codec bus
 
@@ -36,7 +46,7 @@ G_k = V_k\wedge\Psi_k,
 \]
 
 \[
-C = \operatorname{sat}_{32}\left(\sum_k G_k\otimes W_k^\Phi\right),
+C = \operatorname{sat}_{32}\left(\left(\sum_k G_k\otimes W_k^\Phi\right)\gg s\right),
 \]
 
 \[
@@ -44,7 +54,7 @@ A = \Pi_{[0,2^{31}-1]}(C),
 \]
 
 \[
-H_t = \operatorname{SHA3}_{256}(H_{t-1}\Vert\operatorname{serialize}(A,t,\mathbf r)),
+H_t = \operatorname{SHA3}_{256}(H_{t-1}\Vert\operatorname{serialize}(\mathrm{receipt}_t)),
 \]
 
 \[
@@ -64,6 +74,77 @@ V_{out}=\Pi_{[0,2^{16}-1]}(D).
 \]
 
 The final `2^16-1` bound is preserved exactly as a **raw integer output ceiling** because that is how the supplied equation states it.
+It represents `[0, 65535/65536]`, not real-valued `[0, 65535]` in Q16.16.
+
+`step_codec` defaults to `s = 6`, preserving the submitted `>> 6` operation.
+This divides the encoder sum by 64; it averages 64 unit-weight taps. The
+single-cell `encode_decode_cell` retains `s = 0` by default for existing
+callers; pass `encoder_shift=6` to select the normalized law there.
+
+Each Q16 product is saturated individually. The sum of these terms is widened,
+then shifted and saturated once. Encoder and decoder each allow at most 4096
+taps, so products and accumulators fit signed 64-bit intermediates. This is
+different from saturating after every addition or summing Q32.32 products
+before requantization. A native backend must preserve this order exactly.
+
+`binary_intent_mask(True)` produces `0xFFFFFFFF`, and `False` produces zero.
+A literal AND mask of `1` retains only the least-significant bit. General
+32-bit masks are also supported. Projection applies to `A_safe`; subsequent
+decoder output is governed by its separate raw output clamp.
+
+The ledger commits only after every operation in the cell or field cycle
+succeeds. It is an independent SHA3 chain. Saturated addition (`oplus`) and
+XOR (`0xA xor 0xB`) are different operations; neither alone is a cryptographic
+integrity chain.
+
+### Recursive 3D execution
+
+```python
+from jarvisx.dr_moagi_q16_field import (
+    DrMoagiQ16Config, DrMoagiQ16FieldRuntime, Q_SCALE,
+)
+
+engine = DrMoagiQ16FieldRuntime(DrMoagiQ16Config(side=1_000_000))
+engine.load({(999999, 999999, 999999): 16000})
+for _ in range(3):
+    receipt = engine.step_codec(
+        phi_kernel={(0, 0, 0): 64 * Q_SCALE},
+        theta_weights=[Q_SCALE // 4],
+    )
+    assert receipt.output[(999999, 999999, 999999)] == 16000
+    assert receipt.squared_error_raw == 0  # This identity fixture only.
+assert engine.ledger.verify(receipt.ledger_hash)
+```
+
+For a stencil `K`, the source at `s` contributes to destinations `s - k`.
+All cells read from the old state, with zero padding beyond cube boundaries;
+the completed decoder output becomes the next input in one commit. Newly
+reached halo cells are included. Explicit constraint coordinates are included
+even when their previous value is zero. Kernel/mask insertion order does not
+affect results or receipts. Missing masks enable the full word.
+
+The default budgets are 65,536 evaluated cells and 1,024 ledger entries.
+Exceeding either budget raises an error without committing a partial cycle.
+State, previous state, tick, ledger and stochastic generator remain unchanged
+on failed updates. `load` starts a fresh session, including ledger and seed.
+Runtime state is single-threaded; concurrent mutation is not supported.
+
+Per-cycle `squared_error_raw` is the exact integer sum of squared differences
+between that cycle's input and output. Divide by `2^32` for real-valued SSE.
+`processed_cells` counts actual evaluated coordinates, not the logical volume.
+The example also measures error against its immutable original source, since
+successive frames becoming similar does not prove accurate reconstruction.
+
+Run the 64-tap, three-cycle example from a source checkout:
+
+```bash
+PYTHONPATH=src python examples/dr_moagi_q16_cube.py --side 1000000 --steps 3
+```
+
+The JSON output includes reconstructed cells, exact errors, measured elapsed
+time, the logical storage calculation, all ledger receipts and the final head.
+This is a fixed-weight encoder/decoder reference; it contains no weight-training
+objective, spatial downsampling, multimedia container codec or quantum source.
 
 ## 4. Master sparse-field recurrence
 
@@ -81,6 +162,17 @@ The software discretizes the field equation as
 
 The reference implementation uses sparse dictionaries keyed by `(x,y,z)` and never allocates the full logical volume.
 
+`step_field` remains a separate continuous-time-inspired recurrence with unit
+step size. Its `psi_raw` is an additive numerical forcing, whereas the codec
+uses AND masks. `adaptive_gradient_raw` must already be a field of compatible
+shape: a parameter gradient `nabla_Theta E` cannot be subtracted from Xi without
+a defined mapping to field space. A supplied `phi_kernel` becomes a Laplacian
+only if its stencil and spatial scaling define one. `Gamma` uses the previous
+finite difference, making this an explicit surrogate for the implicitly
+velocity-dependent source equation. These choices do not establish a numerical
+solution or stability proof for the unspecified continuous PDE. Stochastic eta
+is evaluated on the bounded active support, not at every implicit zero cell.
+
 ## 5. Computational memory versus integrity memory
 
 Two distinct mechanisms are intentionally separated:
@@ -89,6 +181,45 @@ Two distinct mechanisms are intentionally separated:
 - `Omega_ledger` is an append-only SHA3-256 chain over serialized state/activation records.
 
 A hash is integrity state, not a numerical tensor value, so it is not added to Q16.16 field arithmetic.
+
+The recursive codec records five inspectable categories:
+
+| Category | Recorded evidence |
+|---|---|
+| Structural | Lattice side, encoder kernel and decoder weight fingerprints |
+| Semantic | Versioned arithmetic profile, normalization, boundary, masks and constraints |
+| Behavioral | Input/output fingerprints, processed cells and exact reconstruction error |
+| Temporal | Logical tick and the enclosing chain's previous digest |
+| Metadata | Engine designation and Matladi Maxwell Moagi attribution |
+
+Records are detached from caller-owned mutable data. Verification checks chain
+consistency and optionally an independently retained `expected_head`. A party
+that can replace the entire history and its head can construct another valid
+chain; external anchoring is necessary to detect that substitution. Replaying
+requires retaining the input, masks, constraints and weights as well as the
+receipt. Ticks are logical ordering, not externally certified timestamps.
+
+These fingerprints detect changes relative to retained evidence. They do not
+prove the truth of claims, originality, exclusive ownership or zero distortion.
+Clipping, gating, quantization and many-to-one encoding discard information;
+lossless reconstruction would require extra retained information or an
+invertible transform. Reconstruction error remains the direct numerical check.
+
+Attribution follows [the canonical provenance record](attribution/DR_MOAGI_EPHEMERAL_NOTION_FRAMEWORK.md).
+The meta-circular description is implemented as one explicit transition
+function whose output is fed back into its input. An equation does not execute
+without the interpreter, scheduling and physical compute resources.
+
+### Compatibility notes for codec v2
+
+- The legacy single-cell default has no `/64` normalization; `step_codec`
+  defaults to the new normalized law.
+- Negative Q16 products now use the documented arithmetic shift instead of
+  truncating toward zero. Negative nonintegral products can change by one LSB.
+- Codec sums saturate once after widened accumulation and normalization.
+  Overflow/cancellation cases can differ from older per-add saturation.
+- Receipts cover the completed operation, so hashes differ from old activation-only records.
+- Reload starts a new session; budgets explicitly bound cells and ledger growth.
 
 ## 6. Gamma and eta
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -74,6 +74,18 @@ The `Empirical Validation` GitHub Actions workflow publishes the machine-readabl
 
 Other long-lived draft pull requests are research branches until explicitly classified, rebased and validated.
 
+### Normalized Dr Moagi Q16.16 cube codec
+
+**Integration candidate:** `src/jarvisx/dr_moagi_q16_field.py` now provides
+`step_codec`, a bounded sparse 3D encoder/decoder recurrence with `/64`
+normalization, exact raw reconstruction errors and five-category SHA3 receipts.
+`tests/test_dr_moagi_q16_codec.py` verifies it against a separate dense averaging
+oracle, including topology, numeric limits, deterministic replay and rollback.
+The example `examples/dr_moagi_q16_cube.py` addresses a logical `10^18`-cell cube
+while evaluating only bounded sparse neighborhoods. The implementation uses
+fixed supplied weights and does not establish dense exabyte execution,
+zero-distortion compression, neural training or hardware-scale throughput.
+
 ## Separate visual-computing repository
 
 `Lord-Xido/3D-Virtual-AI-Interactive-Interface` contains browser and native visual demonstrations. Its merged `2048³` voxel-video machine is a bounded sparse renderer over a large virtual address space. It does not allocate or display every virtual voxel.

--- a/examples/dr_moagi_q16_cube.py
+++ b/examples/dr_moagi_q16_cube.py
@@ -1,0 +1,64 @@
+"""Run the Dr Moagi normalized codec on a bounded part of a virtual 10^18-cell cube."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from itertools import product
+from time import perf_counter
+
+from jarvisx.dr_moagi_q16_field import (
+    Q_SCALE,
+    DrMoagiQ16Config,
+    DrMoagiQ16FieldRuntime,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--side", type=int, default=1_000_000)
+    parser.add_argument("--steps", type=int, default=3)
+    args = parser.parse_args()
+    if args.side < 4 or not 1 <= args.steps <= 32:
+        parser.error("side must be >= 4 and steps must be in [1, 32]")
+
+    runtime = DrMoagiQ16FieldRuntime(DrMoagiQ16Config(side=args.side))
+    origin = args.side // 2 - 2
+    source = {
+        (origin + x, origin + y, origin + z): (1 + (x + y + z) % 4) * (Q_SCALE // 8)
+        for x, y, z in product(range(4), repeat=3)
+    }
+    runtime.load(source)
+    kernel = {offset: Q_SCALE for offset in product(range(-1, 3), repeat=3)}
+    cycles = []
+    started = perf_counter()
+    for _ in range(args.steps):
+        report = runtime.step_codec(phi_kernel=kernel, theta_weights=[Q_SCALE // 4])
+        record = asdict(report)
+        record["output"] = [[*coord, raw] for coord, raw in sorted(report.output.items())]
+        # Retain the immutable original target when assessing recursive distortion.
+        record["source_squared_error_raw"] = sum(
+            (report.output.get(coord, 0) - source.get(coord, 0)) ** 2
+            for coord in set(source) | set(report.output)
+        )
+        cycles.append(record)
+    print(
+        json.dumps(
+            {
+                "layout": runtime.logical_layout(),
+                "initial_cells": len(source),
+                "measured_seconds": perf_counter() - started,
+                "cycles": cycles,
+                "ledger": runtime.ledger.entries,
+                "ledger_head": runtime.ledger.head.hex(),
+                "ledger_valid": runtime.ledger.verify(),
+                "scope": "Sparse fixed-weight codec; measured work is processed_cells per cycle.",
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/dr_moagi_q16_field.py
+++ b/src/jarvisx/dr_moagi_q16_field.py
@@ -17,11 +17,11 @@ model or access a physical quantum process.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 import hashlib
 import json
 import math
 import random
+from dataclasses import dataclass, field, replace
 from typing import Mapping, Sequence
 
 Coordinate3D = tuple[int, int, int]
@@ -33,6 +33,8 @@ UINT32_MASK = (1 << 32) - 1
 Q_FRAC_BITS = 16
 Q_SCALE = 1 << Q_FRAC_BITS
 Q_OUTPUT_MAX_RAW = (1 << 16) - 1
+MAX_CODEC_TAPS = 4096
+CODEC_PROFILE = "dr-moagi-q16-codec-v2"
 
 
 def _require_int(name: str, value: int) -> int:
@@ -56,6 +58,10 @@ def q_from_float(value: float) -> int:
     value = float(value)
     if not math.isfinite(value):
         raise ValueError("value must be finite")
+    if value >= INT32_MAX / Q_SCALE:
+        return INT32_MAX
+    if value <= INT32_MIN / Q_SCALE:
+        return INT32_MIN
     return sat_i32(int(round(value * Q_SCALE)))
 
 
@@ -76,18 +82,25 @@ def q_mul(a: int, b: int) -> int:
     """Q16.16 multiply with a 64-bit-style intermediate and 16-bit rescale."""
 
     product = sat_i32(a) * sat_i32(b)
-    if product >= 0:
-        scaled = product >> Q_FRAC_BITS
-    else:
-        scaled = -((-product) >> Q_FRAC_BITS)
-    return sat_i32(scaled)
+    return sat_i32(product >> Q_FRAC_BITS)
 
 
 def q_shift_left(raw: int, bits: int) -> int:
     _require_int("bits", bits)
     if bits < 0:
         raise ValueError("bits must be non-negative")
-    return sat_i32(sat_i32(raw) << bits)
+    raw = sat_i32(raw)
+    if bits >= 31:
+        return INT32_MAX if raw > 0 else INT32_MIN if raw < 0 else 0
+    return sat_i32(raw << bits)
+
+
+def binary_intent_mask(enabled: bool) -> int:
+    """Expand a binary enable to a full 32-bit AND mask (one is not a full mask)."""
+
+    if not isinstance(enabled, bool):
+        raise TypeError("enabled must be a boolean")
+    return UINT32_MASK if enabled else 0
 
 
 def bitwise_gate(raw: int, mask: int) -> int:
@@ -114,6 +127,8 @@ class Q16Interval:
     upper: int = INT32_MAX
 
     def __post_init__(self) -> None:
+        _require_int("lower", self.lower)
+        _require_int("upper", self.upper)
         if self.lower < INT32_MIN or self.upper > INT32_MAX:
             raise ValueError("interval must fit signed 32-bit storage")
         if self.lower > self.upper:
@@ -128,42 +143,61 @@ class Sha3Ledger:
 
     GENESIS = bytes(32)
 
-    def __init__(self) -> None:
+    def __init__(self, max_entries: int = 1024) -> None:
+        if _require_int("max_entries", max_entries) <= 0:
+            raise ValueError("max_entries must be positive")
+        self.max_entries = max_entries
         self.head = self.GENESIS
         self.entries: list[dict[str, object]] = []
 
     @staticmethod
     def _record_bytes(record: Mapping[str, object]) -> bytes:
         return json.dumps(
-            dict(record), sort_keys=True, separators=(",", ":"), ensure_ascii=True
+            dict(record),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
         ).encode("utf-8")
 
     def bind(self, record: Mapping[str, object]) -> str:
-        payload = self.head + self._record_bytes(record)
+        if len(self.entries) >= self.max_entries:
+            raise ValueError("ledger entry budget exhausted")
+        if not self.verify():
+            raise ValueError("ledger is inconsistent")
+        encoded = self._record_bytes(record)
+        payload = self.head + encoded
         digest = hashlib.sha3_256(payload).digest()
         self.entries.append(
             {
                 "prev": self.head.hex(),
-                "record": dict(record),
+                "record": json.loads(encoded),
                 "hash": digest.hex(),
             }
         )
         self.head = digest
         return digest.hex()
 
-    def verify(self) -> bool:
+    def verify(self, expected_head: str | None = None) -> bool:
+        """Check consistency, optionally against an independently retained head."""
+
         previous = self.GENESIS
         for envelope in self.entries:
+            if not isinstance(envelope, dict):
+                return False
             if envelope.get("prev") != previous.hex():
                 return False
             record = envelope.get("record")
             if not isinstance(record, Mapping):
                 return False
-            digest = hashlib.sha3_256(previous + self._record_bytes(record)).digest()
+            try:
+                digest = hashlib.sha3_256(previous + self._record_bytes(record)).digest()
+            except (TypeError, ValueError, OverflowError):
+                return False
             if envelope.get("hash") != digest.hex():
                 return False
             previous = digest
-        return previous == self.head
+        return previous == self.head and (expected_head is None or previous.hex() == expected_head)
 
 
 @dataclass(frozen=True)
@@ -189,21 +223,38 @@ class FieldStepReport:
 
 
 @dataclass(frozen=True)
+class CodecStepReport:
+    tick: int
+    output: SparseRawField
+    processed_cells: int
+    squared_error_raw: int
+    max_error_raw: int
+    ledger_hash: str
+
+
+@dataclass(frozen=True)
 class DrMoagiQ16Config:
     side: int = 64
     lambda_inverse_raw: int = field(default_factory=lambda: q_from_float(1.0))
     gamma_gain_raw: int = field(default_factory=lambda: q_from_float(0.0))
     eta_amplitude_raw: int = field(default_factory=lambda: q_from_float(0.0))
     seed: int = 0
+    max_active_cells: int = 65536
+    max_ledger_entries: int = 1024
 
     def __post_init__(self) -> None:
         if isinstance(self.side, bool) or not isinstance(self.side, int) or self.side <= 0:
             raise ValueError("side must be a positive integer")
         for name in ("lambda_inverse_raw", "gamma_gain_raw", "eta_amplitude_raw"):
-            value = getattr(self, name)
+            value = _require_int(name, getattr(self, name))
             if value < INT32_MIN or value > INT32_MAX:
                 raise ValueError(f"{name} must fit signed 32-bit storage")
         _require_int("seed", self.seed)
+        if self.eta_amplitude_raw < 0:
+            raise ValueError("eta_amplitude_raw must be non-negative")
+        for name in ("max_active_cells", "max_ledger_entries"):
+            if _require_int(name, getattr(self, name)) <= 0:
+                raise ValueError(f"{name} must be positive")
 
 
 class DrMoagiQ16FieldRuntime:
@@ -211,7 +262,7 @@ class DrMoagiQ16FieldRuntime:
 
     def __init__(self, config: DrMoagiQ16Config | None = None) -> None:
         self.config = config or DrMoagiQ16Config()
-        self.ledger = Sha3Ledger()
+        self.ledger = Sha3Ledger(self.config.max_ledger_entries)
         self.rng = random.Random(self.config.seed)
         self.state: SparseRawField = {}
         self.previous_state: SparseRawField = {}
@@ -229,6 +280,8 @@ class DrMoagiQ16FieldRuntime:
         return out[0], out[1], out[2]
 
     def load(self, values: Mapping[Coordinate3D, int]) -> None:
+        if len(values) > self.config.max_active_cells:
+            raise ValueError("active cell budget exceeded")
         parsed: SparseRawField = {}
         for coordinate, raw in values.items():
             coord = self._coord(coordinate)
@@ -236,9 +289,25 @@ class DrMoagiQ16FieldRuntime:
         self.previous_state = dict(parsed)
         self.state = parsed
         self.tick = 0
+        self.ledger = Sha3Ledger(self.config.max_ledger_entries)
+        self.rng = random.Random(self.config.seed)
 
     def load_float(self, values: Mapping[Coordinate3D, float]) -> None:
+        if len(values) > self.config.max_active_cells:
+            raise ValueError("active cell budget exceeded")
         self.load({coord: q_from_float(value) for coord, value in values.items()})
+
+    def logical_layout(self) -> dict[str, int]:
+        """Describe virtual capacity; this does not allocate a dense field."""
+
+        cells = self.config.side**3
+        return {
+            "side": self.config.side,
+            "logical_cells": cells,
+            "dense_q16_bytes": 4 * cells,
+            "resident_cells": len(self.state),
+            "max_active_cells": self.config.max_active_cells,
+        }
 
     @staticmethod
     def encode_decode_cell(
@@ -251,48 +320,85 @@ class DrMoagiQ16FieldRuntime:
         constraint: Q16Interval,
         ledger: Sha3Ledger,
         tick: int = 0,
+        encoder_shift: int = 0,
     ) -> CellTrace:
         """Execute the stated discrete update law for one logical cell.
 
         G_k = V_k & Psi_k
-        C = sum_k Q16mul(G_k, W_phi_k)
+        C = sat(sum_k Q16mul(G_k, W_phi_k) >> encoder_shift)
         A = clamp(C, 0, INT32_MAX)
-        H_t = SHA3(H_{t-1} || serialize(A,t,coord))
         A_safe = project(A, Lambda_min, Lambda_max)
         U = sat(A_safe << 2)
         D = sum_j Q16mul(U, W_theta_j)
         V_out = clamp(D, 0, 2^16-1) [raw integer domain]
+        H_t = SHA3(H_{t-1} || serialize(completed_cell_receipt))
         """
 
-        if not (len(values) == len(psi_masks) == len(phi_weights)):
-            raise ValueError("values, psi_masks and phi_weights must have equal length")
-        if not theta_weights:
-            raise ValueError("theta_weights must not be empty")
-
-        gated = tuple(bitwise_gate(v, m) for v, m in zip(values, psi_masks))
-        convolution = 0
-        for g, w in zip(gated, phi_weights):
-            convolution = q_add(convolution, q_mul(g, w))
-        activation = project(convolution, 0, INT32_MAX)
+        if _require_int("tick", tick) < 0:
+            raise ValueError("tick must be non-negative")
+        trace = DrMoagiQ16FieldRuntime._evaluate_codec_cell(
+            coordinate,
+            values,
+            psi_masks,
+            phi_weights,
+            theta_weights,
+            constraint,
+            encoder_shift,
+        )
         ledger_hash = ledger.bind(
             {
-                "tick": int(tick),
+                "profile": CODEC_PROFILE,
+                "tick": tick,
                 "coordinate": list(coordinate),
-                "activation_raw": activation,
+                "values": list(values),
+                "psi_masks": list(psi_masks),
+                "phi_weights": list(phi_weights),
+                "theta_weights": list(theta_weights),
+                "encoder_shift": encoder_shift,
+                "bounds": [constraint.lower, constraint.upper],
+                "activation_raw": trace.activation_raw,
+                "output_raw": trace.output_raw,
             }
         )
+        return replace(trace, ledger_hash=ledger_hash)
+
+    @staticmethod
+    def _evaluate_codec_cell(
+        coordinate: Coordinate3D,
+        values: Sequence[int],
+        psi_masks: Sequence[int],
+        phi_weights: Sequence[int],
+        theta_weights: Sequence[int],
+        constraint: Q16Interval,
+        encoder_shift: int,
+    ) -> CellTrace:
+        if not isinstance(coordinate, tuple) or len(coordinate) != 3:
+            raise TypeError("coordinate must be a 3-tuple")
+        if any(_require_int("coordinate axis", axis) < 0 for axis in coordinate):
+            raise ValueError("coordinate axes must be non-negative")
+        if not isinstance(constraint, Q16Interval):
+            raise TypeError("constraint must be a Q16Interval")
+        if not 0 <= _require_int("encoder_shift", encoder_shift) <= 31:
+            raise ValueError("encoder_shift must be in [0, 31]")
+        if not (len(values) == len(psi_masks) == len(phi_weights)):
+            raise ValueError("values, psi_masks and phi_weights must have equal length")
+        if not 1 <= len(values) <= MAX_CODEC_TAPS or not 1 <= len(theta_weights) <= MAX_CODEC_TAPS:
+            raise ValueError(f"encoder and decoder require 1..{MAX_CODEC_TAPS} taps")
+
+        gated = tuple(bitwise_gate(v, m) for v, m in zip(values, psi_masks))
+        # Each product fits int64; sum of at most 4096 saturated Q16 terms does too.
+        convolution = sat_i32(sum(q_mul(g, w) for g, w in zip(gated, phi_weights)) >> encoder_shift)
+        activation = project(convolution, 0, INT32_MAX)
         safe = constraint.apply(activation)
         upshift = q_shift_left(safe, 2)
-        decoded = 0
-        for weight in theta_weights:
-            decoded = q_add(decoded, q_mul(upshift, weight))
+        decoded = sat_i32(sum(q_mul(upshift, weight) for weight in theta_weights))
         output = project(decoded, 0, Q_OUTPUT_MAX_RAW)
         return CellTrace(
             coordinate=coordinate,
             gated_values=gated,
             convolution_raw=convolution,
             activation_raw=activation,
-            ledger_hash=ledger_hash,
+            ledger_hash="",
             safe_activation_raw=safe,
             upshift_raw=upshift,
             decoded_raw=decoded,
@@ -302,6 +408,151 @@ class DrMoagiQ16FieldRuntime:
     @staticmethod
     def _sample(field: Mapping[Coordinate3D, int], coordinate: Coordinate3D) -> int:
         return sat_i32(field.get(coordinate, 0))
+
+    @staticmethod
+    def _kernel(kernel: Mapping[Coordinate3D, int]) -> dict[Coordinate3D, int]:
+        if not 1 <= len(kernel) <= MAX_CODEC_TAPS:
+            raise ValueError(f"kernel requires 1..{MAX_CODEC_TAPS} taps")
+        parsed: dict[Coordinate3D, int] = {}
+        for offset, raw in kernel.items():
+            if not isinstance(offset, tuple) or len(offset) != 3:
+                raise TypeError("kernel offset must be a 3-tuple")
+            for axis in offset:
+                _require_int("kernel offset axis", axis)
+            parsed[offset] = sat_i32(raw)
+        return dict(sorted(parsed.items()))
+
+    def _support(
+        self,
+        kernel: Mapping[Coordinate3D, int],
+        *extra_fields: Mapping[Coordinate3D, object],
+    ) -> set[Coordinate3D]:
+        support: set[Coordinate3D] = set()
+
+        def add(coord: Coordinate3D) -> None:
+            support.add(self._coord(coord))
+            if len(support) > self.config.max_active_cells:
+                raise ValueError("active cell budget exceeded")
+
+        for values in (self.state, *extra_fields):
+            for coord in values:
+                add(coord)
+        # Sampling at r + offset means a source at s influences r = s - offset.
+        for (x, y, z), value in self.state.items():
+            if sat_i32(value) == 0:
+                continue
+            for (dx, dy, dz), weight in kernel.items():
+                target = (x - dx, y - dy, z - dz)
+                if weight and all(0 <= axis < self.config.side for axis in target):
+                    add(target)
+        return support
+
+    @staticmethod
+    def _fingerprint(value: object) -> str:
+        encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False)
+        return hashlib.sha3_256(encoded.encode("utf-8")).hexdigest()
+
+    def step_codec(
+        self,
+        *,
+        phi_kernel: Mapping[Coordinate3D, int],
+        theta_weights: Sequence[int],
+        psi_masks: Mapping[Coordinate3D, int] | None = None,
+        constraints: Mapping[Coordinate3D, Q16Interval] | None = None,
+        encoder_shift: int = 6,
+    ) -> CodecStepReport:
+        """Run one synchronous, zero-padded 3D codec cycle and feed output back.
+
+        Only active coordinates and their stencil halo are evaluated. The
+        default encoder shift is the supplied /64 normalization; it is not an
+        additional Q16 multiplication rescale. One cycle creates one receipt.
+        Failed validation, resource limits or ledger binding leave state intact.
+        """
+
+        kernel = self._kernel(phi_kernel)
+        if not 1 <= len(theta_weights) <= MAX_CODEC_TAPS:
+            raise ValueError(f"decoder requires 1..{MAX_CODEC_TAPS} taps")
+        decoder = tuple(sat_i32(value) for value in theta_weights)
+        if not 0 <= _require_int("encoder_shift", encoder_shift) <= 31:
+            raise ValueError("encoder_shift must be in [0, 31]")
+        psi_masks = psi_masks or {}
+        constraints = constraints or {}
+        support = self._support(kernel, psi_masks, constraints)
+        masks = {
+            self._coord(c): _require_int("mask", m) & UINT32_MASK for c, m in psi_masks.items()
+        }
+        for coord, interval in constraints.items():
+            self._coord(coord)
+            if not isinstance(interval, Q16Interval):
+                raise TypeError("constraints must contain Q16Interval values")
+
+        next_state: SparseRawField = {}
+        squared_error = max_error = 0
+        weights = tuple(kernel.values())
+        for coord in sorted(support):
+            neighbors = [(coord[0] + dx, coord[1] + dy, coord[2] + dz) for dx, dy, dz in kernel]
+            trace = self._evaluate_codec_cell(
+                coord,
+                [self._sample(self.state, neighbor) for neighbor in neighbors],
+                [masks.get(neighbor, UINT32_MASK) for neighbor in neighbors],
+                weights,
+                decoder,
+                constraints.get(coord, Q16Interval(0, INT32_MAX)),
+                encoder_shift,
+            )
+            if trace.output_raw:
+                next_state[coord] = trace.output_raw
+            error = trace.output_raw - self._sample(self.state, coord)
+            squared_error += error * error
+            max_error = max(max_error, abs(error))
+
+        def rows(values: Mapping[Coordinate3D, int]) -> list[list[int]]:
+            return [[*coord, raw] for coord, raw in sorted(values.items())]
+
+        next_tick = self.tick + 1
+        ledger_hash = self.ledger.bind(
+            {
+                "structural": {
+                    "side": self.config.side,
+                    "phi_sha3": self._fingerprint(rows(kernel)),
+                    "theta_sha3": self._fingerprint(decoder),
+                },
+                "semantic": {
+                    "profile": CODEC_PROFILE,
+                    "encoder_shift": encoder_shift,
+                    "boundary": "zero",
+                    "psi_sha3": self._fingerprint(rows(masks)),
+                    "lambda_sha3": self._fingerprint(
+                        [
+                            [*coord, interval.lower, interval.upper]
+                            for coord, interval in sorted(constraints.items())
+                        ]
+                    ),
+                },
+                "behavioral": {
+                    "input_sha3": self._fingerprint(rows(self.state)),
+                    "output_sha3": self._fingerprint(rows(next_state)),
+                    "processed_cells": len(support),
+                    "squared_error_raw": squared_error,
+                    "max_error_raw": max_error,
+                },
+                "temporal": {"tick": next_tick},
+                "metadata": {
+                    "originator": "Matladi Maxwell Moagi (Lord-Xido)",
+                    "engine": "vOmegaXi-2026-DeltaS++++",
+                },
+            }
+        )
+        self.previous_state, self.state = dict(self.state), next_state
+        self.tick = next_tick
+        return CodecStepReport(
+            next_tick,
+            dict(next_state),
+            len(support),
+            squared_error,
+            max_error,
+            ledger_hash,
+        )
 
     def convolve(
         self,
@@ -338,11 +589,18 @@ class DrMoagiQ16FieldRuntime:
         """
 
         psi_raw = psi_raw or {}
-        phi_kernel = phi_kernel or {(0, 0, 0): 0}
+        phi_kernel = self._kernel(phi_kernel if phi_kernel is not None else {(0, 0, 0): 0})
         adaptive_gradient_raw = adaptive_gradient_raw or {}
         constraints = constraints or {}
 
-        support = set(self.state) | set(self.previous_state) | set(psi_raw) | set(adaptive_gradient_raw)
+        support = self._support(
+            phi_kernel, self.previous_state, psi_raw, adaptive_gradient_raw, constraints
+        )
+        for interval in constraints.values():
+            if not isinstance(interval, Q16Interval):
+                raise TypeError("constraints must contain Q16Interval values")
+        candidate_rng = random.Random()
+        candidate_rng.setstate(self.rng.getstate())
         next_state: SparseRawField = {}
         sum_abs_delta = 0
         max_abs_raw = 0
@@ -359,7 +617,7 @@ class DrMoagiQ16FieldRuntime:
             torsion = q_mul(self.config.gamma_gain_raw, q_sub(current, previous))
             eta = 0
             if self.config.eta_amplitude_raw:
-                eta_unit = q_from_float(self.rng.uniform(-1.0, 1.0))
+                eta_unit = q_from_float(candidate_rng.uniform(-1.0, 1.0))
                 eta = q_mul(self.config.eta_amplitude_raw, eta_unit)
 
             candidate = current
@@ -377,18 +635,18 @@ class DrMoagiQ16FieldRuntime:
             sum_abs_delta += delta
             max_abs_raw = max(max_abs_raw, abs(candidate))
 
-        self.previous_state = dict(self.state)
-        self.state = next_state
-        self.tick += 1
+        next_tick = self.tick + 1
         ledger_hash = self.ledger.bind(
             {
-                "tick": self.tick,
+                "tick": next_tick,
                 "cells": [
-                    [coord[0], coord[1], coord[2], raw]
-                    for coord, raw in sorted(next_state.items())
+                    [coord[0], coord[1], coord[2], raw] for coord, raw in sorted(next_state.items())
                 ],
             }
         )
+        self.previous_state, self.state = dict(self.state), next_state
+        self.tick = next_tick
+        self.rng.setstate(candidate_rng.getstate())
         mean_abs_delta = (sum_abs_delta / max(1, len(support))) / Q_SCALE
         return FieldStepReport(
             tick=self.tick,

--- a/tests/test_dr_moagi_q16_codec.py
+++ b/tests/test_dr_moagi_q16_codec.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import copy
+import random
+from itertools import product
+
+import pytest
+
+from jarvisx.dr_moagi_q16_field import (
+    INT32_MAX,
+    INT32_MIN,
+    MAX_CODEC_TAPS,
+    Q_SCALE,
+    UINT32_MASK,
+    DrMoagiQ16Config,
+    DrMoagiQ16FieldRuntime,
+    Q16Interval,
+    Sha3Ledger,
+    binary_intent_mask,
+    q_from_float,
+    q_mul,
+    q_shift_left,
+)
+
+
+def cell(**changes):
+    kwargs = dict(
+        coordinate=(0, 0, 0),
+        values=[Q_SCALE // 4] * 64,
+        psi_masks=[UINT32_MASK] * 64,
+        phi_weights=[Q_SCALE] * 64,
+        theta_weights=[Q_SCALE // 4],
+        constraint=Q16Interval(0, INT32_MAX),
+        ledger=Sha3Ledger(),
+        encoder_shift=6,
+    )
+    kwargs.update(changes)
+    return DrMoagiQ16FieldRuntime.encode_decode_cell(**kwargs)
+
+
+def snapshot(runtime):
+    return copy.deepcopy(
+        (
+            runtime.state,
+            runtime.previous_state,
+            runtime.tick,
+            runtime.rng.getstate(),
+            runtime.ledger.entries,
+            runtime.ledger.head,
+        )
+    )
+
+
+def test_shift_six_preserves_constant_64_tap_mean_and_decoder_gain():
+    trace = cell()
+    assert trace.convolution_raw == Q_SCALE // 4
+    assert trace.upshift_raw == Q_SCALE
+    assert trace.output_raw == Q_SCALE // 4
+
+
+def test_wide_sum_saturates_after_normalization_and_cancellation():
+    assert cell(values=[INT32_MAX] * 64).convolution_raw == INT32_MAX
+    trace = cell(
+        values=[INT32_MAX, INT32_MAX, -INT32_MAX],
+        psi_masks=[UINT32_MASK] * 3,
+        phi_weights=[Q_SCALE] * 3,
+        encoder_shift=0,
+    )
+    assert trace.convolution_raw == INT32_MAX
+
+
+def test_signed_product_matches_integer_floor_oracle():
+    rng = random.Random(29)
+    cases = [(INT32_MIN, INT32_MIN), (-1, 1), (-3, Q_SCALE // 2)]
+    cases += [
+        (rng.randint(INT32_MIN, INT32_MAX), rng.randint(INT32_MIN, INT32_MAX)) for _ in range(500)
+    ]
+    for a, b in cases:
+        expected = max(INT32_MIN, min(INT32_MAX, (a * b) // Q_SCALE))
+        assert q_mul(a, b) == expected
+    assert q_mul(-1, 1) == -1
+    assert q_from_float(1e308) == INT32_MAX
+    assert q_shift_left(-1, 10**9) == INT32_MIN
+
+
+def test_binary_enable_preserves_all_bits():
+    assert binary_intent_mask(True) == UINT32_MASK
+    assert binary_intent_mask(False) == 0
+    assert cell(psi_masks=[binary_intent_mask(False)] * 64).output_raw == 0
+    with pytest.raises(TypeError):
+        binary_intent_mask(1)
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"theta_weights": [0.5]},
+        {"encoder_shift": -1},
+        {"encoder_shift": True},
+        {"coordinate": (0, 0, -1)},
+        {"tick": True},
+        {"constraint": None},
+        {"theta_weights": []},
+        {"theta_weights": [1] * (MAX_CODEC_TAPS + 1)},
+    ],
+)
+def test_invalid_cell_does_not_bind_ledger(changes):
+    ledger = Sha3Ledger()
+    with pytest.raises((ValueError, TypeError)):
+        cell(ledger=ledger, **changes)
+    assert ledger.entries == []
+    assert ledger.head == Sha3Ledger.GENESIS
+
+
+def test_sparse_codec_matches_independent_dense_average_with_zero_boundaries():
+    side = 5
+    domain = list(product(range(side), repeat=3))
+    source = {coord: ((coord[0] + 2 * coord[1] + coord[2]) % 4) * 8192 for coord in domain}
+    source = {c: v for c, v in source.items() if v}
+    offsets = list(product(range(-1, 3), repeat=3))
+    runtime = DrMoagiQ16FieldRuntime(DrMoagiQ16Config(side=side))
+    runtime.load(source)
+    original = dict(source)
+    for _ in range(3):
+        # For unit encoder weights and quarter decoder, the law reduces to floor(mean).
+        dense = {}
+        for x, y, z in domain:
+            mean = sum(source.get((x + dx, y + dy, z + dz), 0) for dx, dy, dz in offsets) // 64
+            if mean:
+                dense[(x, y, z)] = mean
+        report = runtime.step_codec(
+            phi_kernel={o: Q_SCALE for o in reversed(offsets)},
+            theta_weights=[Q_SCALE // 4],
+        )
+        assert report.output == dense
+        assert report.squared_error_raw == sum(
+            (dense.get(c, 0) - source.get(c, 0)) ** 2 for c in domain
+        )
+        assert runtime.previous_state == source
+        source = dense
+    assert source != original  # The lossy filter does not establish zero distortion.
+    assert runtime.ledger.verify()
+
+
+def test_virtual_exacell_identity_loop_is_sparse_and_replayable():
+    config = DrMoagiQ16Config(side=1_000_000, max_active_cells=8)
+    data = {(999999, 999999, 999999): 16000, (0, 0, 0): 8000}
+    a, b = DrMoagiQ16FieldRuntime(config), DrMoagiQ16FieldRuntime(config)
+    a.load(data)
+    b.load(dict(reversed(list(data.items()))))
+    for _ in range(3):
+        for runtime in (a, b):
+            report = runtime.step_codec(
+                phi_kernel={(0, 0, 0): 64 * Q_SCALE}, theta_weights=[Q_SCALE // 4]
+            )
+            assert report.output == data
+            assert report.squared_error_raw == 0
+            assert report.processed_cells == 2
+        assert a.ledger.head == b.ledger.head
+    assert a.logical_layout()["logical_cells"] == 10**18
+    assert a.logical_layout()["dense_q16_bytes"] == 4 * 10**18
+
+
+def test_halo_mask_and_positive_constraint_on_absent_cell():
+    runtime = DrMoagiQ16FieldRuntime(DrMoagiQ16Config(side=8))
+    runtime.load({(3, 3, 3): 16000})
+    report = runtime.step_codec(
+        phi_kernel={(1, 0, 0): 64 * Q_SCALE},
+        theta_weights=[Q_SCALE // 4],
+        constraints={(7, 7, 7): Q16Interval(500, 500)},
+    )
+    assert report.output == {(2, 3, 3): 16000, (7, 7, 7): 500}
+    runtime.load({(3, 3, 3): 16000})
+    assert (
+        runtime.step_codec(
+            phi_kernel={(1, 0, 0): 64 * Q_SCALE},
+            theta_weights=[Q_SCALE // 4],
+            psi_masks={(3, 3, 3): 0},
+        ).output
+        == {}
+    )
+
+
+@pytest.mark.parametrize("failure", ["budget", "coordinate", "decoder", "ledger"])
+def test_failed_cycle_rolls_back_all_state(failure):
+    runtime = DrMoagiQ16FieldRuntime(
+        DrMoagiQ16Config(side=8, max_active_cells=1, max_ledger_entries=1)
+    )
+    runtime.load({(2, 2, 2): 16000})
+    kwargs = dict(phi_kernel={(0, 0, 0): 64 * Q_SCALE}, theta_weights=[Q_SCALE // 4])
+    if failure == "budget":
+        kwargs["phi_kernel"] = {(1, 0, 0): Q_SCALE}
+    elif failure == "coordinate":
+        kwargs["psi_masks"] = {(8, 0, 0): UINT32_MASK}
+    elif failure == "decoder":
+        kwargs["theta_weights"] = [0.5]
+    else:
+        runtime.step_codec(**kwargs)
+    before = snapshot(runtime)
+    with pytest.raises((ValueError, TypeError)):
+        runtime.step_codec(**kwargs)
+    assert snapshot(runtime) == before
+
+
+def test_ledger_detaches_inputs_and_requires_external_anchor_for_rewritten_history():
+    ledger = Sha3Ledger()
+    data = {"nested": [1, 2]}
+    head = ledger.bind(data)
+    data["nested"][0] = 99
+    assert ledger.verify(head)
+    replacement = Sha3Ledger()
+    replacement.bind({"nested": [99, 2]})
+    assert replacement.verify()
+    assert not replacement.verify(head)
+    ledger.entries[0]["record"]["nested"][0] = 99
+    assert not ledger.verify(head)
+    with pytest.raises(ValueError):
+        ledger.bind({"new": 1})
+
+
+def test_empty_field_still_validates_and_commits_exactly_one_receipt():
+    runtime = DrMoagiQ16FieldRuntime()
+    with pytest.raises(TypeError):
+        runtime.step_codec(phi_kernel={(0, 0, 0): Q_SCALE}, theta_weights=[None])
+    report = runtime.step_codec(phi_kernel={(0, 0, 0): Q_SCALE}, theta_weights=[Q_SCALE])
+    assert report.processed_cells == 0
+    assert len(runtime.ledger.entries) == 1
+    assert set(runtime.ledger.entries[0]["record"]) == {
+        "structural",
+        "semantic",
+        "behavioral",
+        "temporal",
+        "metadata",
+    }
+
+
+def test_master_field_support_rng_rollback_and_reload():
+    config = DrMoagiQ16Config(side=8, eta_amplitude_raw=100, seed=37, max_ledger_entries=1)
+    runtime = DrMoagiQ16FieldRuntime(config)
+    source = {(2, 2, 2): 16000}
+    runtime.load(source)
+    first = runtime.step_field(phi_kernel={(1, 0, 0): Q_SCALE})
+    assert (1, 2, 2) in first.output
+    before = snapshot(runtime)
+    with pytest.raises(ValueError, match="ledger entry budget"):
+        runtime.step_field()
+    assert snapshot(runtime) == before
+    runtime.load(source)
+    assert runtime.step_field(phi_kernel={(1, 0, 0): Q_SCALE}) == first
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"side": 0},
+        {"max_active_cells": 0},
+        {"max_ledger_entries": True},
+        {"eta_amplitude_raw": -1},
+        {"gamma_gain_raw": 0.5},
+    ],
+)
+def test_config_rejects_invalid_numeric_contract(kwargs):
+    with pytest.raises((ValueError, TypeError)):
+        DrMoagiQ16Config(**kwargs)


### PR DESCRIPTION
The supplied Dr Moagi law requires a /64 encoder normalization, defined signed fixed-point behavior, and recursive 3D execution with inspectable evidence. The existing Q16 field module omitted that normalization, saturated partial sums early, skipped newly reached stencil cells, and could mutate field state before a failed ledger commit.

This change extends the existing module with a bounded `step_codec` path: binary/bitwise intent gating, 3D encoder stencil, constraints, saturated upshift, decoder, output clamp, exact reconstruction error, SHA3 receipt, and synchronous output-to-input feedback. The virtual lattice can be configured as `1_000_000^3`; only active cells and stencil neighborhoods are evaluated.

The implementation records structural, semantic, behavioral, temporal and attribution metadata. It detaches ledger records from caller-owned mutable data and supports verification against an independently retained head. Validation failures, resource limits and ledger rejection leave the previous cycle intact.

Compatibility and numerical contract:

- `step_codec` defaults to `encoder_shift=6`; the existing single-cell API keeps its default shift of zero.
- Q16 multiplication now implements the documented arithmetic right shift. Negative nonintegral products may differ from the older truncation by one raw LSB.
- Codec sums use widened accumulation followed by normalization and saturation, with at most 4096 taps.
- The default budgets are 65,536 evaluated cells and 1,024 ledger entries. Loading a field starts a fresh ledger and seeded session.
- The continuous-inspired `step_field` remains a separate recurrence; its support propagation and failure rollback are repaired.

Local validation on Python 3.12:

- 33 focused tests passed, including an independent dense 64-tap averaging oracle over three recursive cycles, signed integer arithmetic, endpoint addressing, masks, constraints, replay, corruption and rollback.
- Repository source/test compilation and undefined-name lint passed.
- The changed runtime passed mypy; changed Python files passed Black and isort checks.
- The cube example evaluated 343, 1000 and 2197 cells over three cycles, and its final SHA3 chain verified.
- A focused GitHub Actions workflow runs the tests and example on Python 3.10 and 3.13. Remote CI status is reported separately.

Run from the source checkout:

```bash
PYTHONPATH=src python examples/dr_moagi_q16_cube.py --side 1000000 --steps 3
```

The corrected documentation distinguishes the `10^18`-cell logical volume from the 4 decimal exabytes required for one dense 32-bit field. This is a fixed-weight sparse software reference. Repeated averaging increases error against the original example input, so the implementation does not claim zero-distortion compression, trained neural generation, quantum operation, dense-volume throughput, or an ownership guarantee from hashes.

Attribution follows the existing Matladi Maxwell Moagi provenance record.