### PR TITLE
feat: recursive 3D multimodal intelligence engine

### DIFF
--- a/docs/inward-folded-exavoxel-swarm.md
+++ b/docs/inward-folded-exavoxel-swarm.md
@@ -6,15 +6,16 @@ This runtime extends the bounded Jarvis-X multimodal 3D autoencoding loop with a
 `1_000_000 x 1_000_000 x 1_000_000` logical lattice (`10^18` cells).
 
 The implementation does **not** allocate `10^18` Python objects and does **not** claim a measured
-1000x hardware speedup. Instead it combines:
+`1,000,000x` hardware speedup. Instead it combines:
 
 1. a bounded multimodal encode/decode runtime,
 2. a deterministic Monte-Carlo proxy swarm,
-3. `10 x 10 x 10` inward spatial aggregation,
-4. residual-driven fine-region reactivation, and
-5. an adaptive threshold that trades refinement density against reconstruction error.
+3. recursive `10 x 10 x 10` inward spatial aggregation,
+4. residual-driven fine-region reactivation,
+5. adaptive thresholding for sparse refinement, and
+6. explicit mathematical/geometric invariant checks.
 
-## Inward loop
+## Recursive inward loop
 
 For multimodal input `X_t` and latent state `Z_t`:
 
@@ -22,8 +23,10 @@ For multimodal input `X_t` and latent state `Z_t`:
 X_t
   -> E(X_t)
   -> Z_t
-  -> A_10x10x10(Z_t)         coarse inward fold
-  -> residual R_t
+  -> A_10x10x10(Z_t)         level 1: 10^3 contraction
+  -> A_10x10x10(C_1)         level 2: another 10^3 contraction
+  -> coarse latent C_2
+  -> residual R_t = Z_t - U(C_2)
   -> mask H_t = 1(|R_t| > tau_t)
   -> selective refinement F(H_t * R_t)
   -> D(Z'_t)
@@ -33,24 +36,50 @@ X_t
   -> recur
 ```
 
-A single fold block contains
+One local fold contains:
 
 ```text
-10 x 10 x 10 = 1000
+10 x 10 x 10 = 10^3
 ```
 
-fine cells.
+fine cells. Two self-similar nested levels therefore represent:
+
+```text
+(10^3)^2 = 10^6
+```
+
+fine logical cells per top-level coarse representative.
+
+Geometrically, two levels reduce each axis by `10^2 = 100`:
+
+```text
+1,000,000 / 100 = 10,000
+```
+
+so the recursively folded coarse lattice is:
+
+```text
+10,000 x 10,000 x 10,000 = 10^12 coarse cells
+```
+
+and the exact volume identity is:
+
+```text
+10^12 coarse cells x 10^6 fine cells/coarse cell = 10^18 logical cells.
+```
+
+The runtime verifies this identity on every cycle.
 
 ## Work model
 
 Let `a` be the estimated fraction of the logical field that still requires fine-resolution work and
-let `F = 1000` be the fold volume. The normalized idealized work fraction is
+let `F = 10^6` be the recursive fold volume. The normalized idealized work fraction is:
 
 ```text
 W(a) / W_dense = 1/F + a * (1 - 1/F)
 ```
 
-and the modeled work reduction is
+and the modeled work reduction is:
 
 ```text
 S_model(a) = 1 / (1/F + a * (1 - 1/F)).
@@ -60,12 +89,44 @@ Therefore:
 
 ```text
 a = 1   -> S_model = 1x
-a -> 0  -> S_model -> 1000x
+a -> 0  -> S_model -> 1,000,000x
 ```
 
-This is an algorithmic work model, not a wall-clock benchmark. Actual acceleration depends on
-memory bandwidth, cache/SRAM locality, synchronization, kernel fusion, vectorization, GPU occupancy,
-communication costs, and the true distribution of residuals.
+This is an algorithmic work model, not a wall-clock benchmark. It means a perfectly reusable coarse
+representation with essentially no residual fine work has a theoretical work-reduction ceiling of
+`10^6`; it does not mean current hardware executes the end-to-end application one million times faster.
+
+Actual acceleration depends on memory bandwidth, cache/SRAM locality, synchronization, kernel fusion,
+vectorization, GPU occupancy, communication costs, branch sparsity, decoder cost, and the true residual
+distribution.
+
+## Operational verification
+
+Every step reports three validation flags:
+
+```text
+geometry_verified
+work_model_verified
+operational_mechanics_verified
+```
+
+`geometry_verified` requires exact integer consistency:
+
+```text
+total_fold_edge = fold_edge ^ fold_levels
+fold_volume     = (fold_edge^3) ^ fold_levels
+coarse_axis     = logical_axis / total_fold_edge
+coarse_cells * fold_volume = logical_cells
+```
+
+`work_model_verified` recomputes the sparse-work equation independently and verifies that the reported
+reduction is finite and remains in `[1, fold_volume]`.
+
+`operational_mechanics_verified` additionally requires finite reconstruction, cycle and residual metrics
+and confirms that the bounded proxy swarm remains intact.
+
+These checks verify the mechanics of the reference model. They do not substitute for physical timing
+benchmarks.
 
 ## Virtualization
 
@@ -76,9 +137,8 @@ axis          = 1_000_000
 logical cells = axis^3 = 10^18
 ```
 
-A bounded number of `ProxyAgent` samples estimate residual activity. Each proxy stands in for a
-large logical region. Increasing `--proxy-agents` improves the sampling resolution but increases real
-runtime cost.
+A bounded number of `ProxyAgent` samples estimate residual activity. Each proxy stands in for a large
+logical region. Increasing `--proxy-agents` improves sampling resolution but increases real runtime cost.
 
 ## Auto-optimization
 
@@ -97,7 +157,7 @@ not regress.
 
 ## Run
 
-From the repository root:
+Default two-level recursive fold:
 
 ```bash
 python -m jarvisx.dr_moagi_inward_swarm --cycles 8
@@ -110,9 +170,16 @@ python -m jarvisx.dr_moagi_inward_swarm \
   --cycles 16 \
   --proxy-agents 4000 \
   --fold-edge 10 \
+  --fold-levels 2 \
   --threshold 0.12 \
   --target-mse 0.25 \
   --json
+```
+
+The original single-level `1000x` ceiling remains available:
+
+```bash
+python -m jarvisx.dr_moagi_inward_swarm --fold-edge 10 --fold-levels 1
 ```
 
 Disable scheduler auto-tuning for controlled experiments:
@@ -123,7 +190,7 @@ python -m jarvisx.dr_moagi_inward_swarm --cycles 8 --no-auto-optimize
 
 ## Metrics to benchmark on hardware
 
-Do not use `modeled_work_reduction` as a performance result. For a real CPU/GPU implementation,
+Do not use `modeled_work_reduction` as a physical performance result. For a real CPU/GPU implementation,
 measure at minimum:
 
 - end-to-end wall-clock latency per cycle,
@@ -136,5 +203,6 @@ measure at minimum:
 - reconstruction MSE and cycle MSE,
 - quality-vs-throughput Pareto frontier.
 
-The 1000x target is validated only if measured elapsed time at equivalent output quality improves by
-approximately three orders of magnitude against the dense baseline on the same hardware and workload.
+The `1,000,000x` target is physically validated only if measured elapsed time at equivalent output quality
+improves by approximately six orders of magnitude against the dense baseline on the same hardware and
+workload. Until then it remains a mathematically verified recursive work-reduction ceiling.

--- a/docs/inward-folded-exavoxel-swarm.md
+++ b/docs/inward-folded-exavoxel-swarm.md
@@ -1,0 +1,140 @@
+# Inward-Folded Exavoxel Multimodal Swarm
+
+## Purpose
+
+This runtime extends the bounded Jarvis-X multimodal 3D autoencoding loop with a virtualized
+`1_000_000 x 1_000_000 x 1_000_000` logical lattice (`10^18` cells).
+
+The implementation does **not** allocate `10^18` Python objects and does **not** claim a measured
+1000x hardware speedup. Instead it combines:
+
+1. a bounded multimodal encode/decode runtime,
+2. a deterministic Monte-Carlo proxy swarm,
+3. `10 x 10 x 10` inward spatial aggregation,
+4. residual-driven fine-region reactivation, and
+5. an adaptive threshold that trades refinement density against reconstruction error.
+
+## Inward loop
+
+For multimodal input `X_t` and latent state `Z_t`:
+
+```text
+X_t
+  -> E(X_t)
+  -> Z_t
+  -> A_10x10x10(Z_t)         coarse inward fold
+  -> residual R_t
+  -> mask H_t = 1(|R_t| > tau_t)
+  -> selective refinement F(H_t * R_t)
+  -> D(Z'_t)
+  -> X_hat_t
+  -> reconstruction/cycle error
+  -> update codec + threshold
+  -> recur
+```
+
+A single fold block contains
+
+```text
+10 x 10 x 10 = 1000
+```
+
+fine cells.
+
+## Work model
+
+Let `a` be the estimated fraction of the logical field that still requires fine-resolution work and
+let `F = 1000` be the fold volume. The normalized idealized work fraction is
+
+```text
+W(a) / W_dense = 1/F + a * (1 - 1/F)
+```
+
+and the modeled work reduction is
+
+```text
+S_model(a) = 1 / (1/F + a * (1 - 1/F)).
+```
+
+Therefore:
+
+```text
+a = 1   -> S_model = 1x
+a -> 0  -> S_model -> 1000x
+```
+
+This is an algorithmic work model, not a wall-clock benchmark. Actual acceleration depends on
+memory bandwidth, cache/SRAM locality, synchronization, kernel fusion, vectorization, GPU occupancy,
+communication costs, and the true distribution of residuals.
+
+## Virtualization
+
+The logical substrate is fixed at:
+
+```text
+axis          = 1_000_000
+logical cells = axis^3 = 10^18
+```
+
+A bounded number of `ProxyAgent` samples estimate residual activity. Each proxy stands in for a
+large logical region. Increasing `--proxy-agents` improves the sampling resolution but increases real
+runtime cost.
+
+## Auto-optimization
+
+The scheduler adapts the residual threshold `tau`:
+
+```text
+if reconstruction_mse <= target_mse:
+    tau <- tau * (1 + learning_rate)  # prune more fine work
+else:
+    tau <- tau * (1 - learning_rate)  # refine more of the field
+```
+
+The threshold is clamped to configured bounds. Codec parameter updates remain transactional in the
+existing `DrMoagiMultimodal3DLoop`: parameter changes are accepted only when the local objective does
+not regress.
+
+## Run
+
+From the repository root:
+
+```bash
+python -m jarvisx.dr_moagi_inward_swarm --cycles 8
+```
+
+JSON metrics:
+
+```bash
+python -m jarvisx.dr_moagi_inward_swarm \
+  --cycles 16 \
+  --proxy-agents 4000 \
+  --fold-edge 10 \
+  --threshold 0.12 \
+  --target-mse 0.25 \
+  --json
+```
+
+Disable scheduler auto-tuning for controlled experiments:
+
+```bash
+python -m jarvisx.dr_moagi_inward_swarm --cycles 8 --no-auto-optimize
+```
+
+## Metrics to benchmark on hardware
+
+Do not use `modeled_work_reduction` as a performance result. For a real CPU/GPU implementation,
+measure at minimum:
+
+- end-to-end wall-clock latency per cycle,
+- cells/second or bytes/second processed physically,
+- encoder/decoder kernel time,
+- residual-mask construction time,
+- active refinement fraction,
+- HBM/DRAM bandwidth and cache hit rate,
+- synchronization/launch overhead,
+- reconstruction MSE and cycle MSE,
+- quality-vs-throughput Pareto frontier.
+
+The 1000x target is validated only if measured elapsed time at equivalent output quality improves by
+approximately three orders of magnitude against the dense baseline on the same hardware and workload.

--- a/docs/recursive-3d-multimodal-intelligence-engine.md
+++ b/docs/recursive-3d-multimodal-intelligence-engine.md
@@ -1,0 +1,166 @@
+# Recursive 3D Multimodal Intelligence Engine
+
+## Locked operational baseline
+
+This layer composes the bounded multimodal autoencoder with the recursive inward-folded swarm.
+The governing execution rule is:
+
+```text
+encode globally
+-> abstract inward
+-> allocate frequency to residual information
+-> refine selectively
+-> decode
+-> verify
+-> optimize
+-> recur
+```
+
+The implementation is `src/jarvisx/dr_moagi_recursive_intelligence.py`.
+
+## Local 3D codec state
+
+A logical codec voxel carries the abstract state
+
+```text
+S_i = [x_i, z_i, p_i, Omega_i, Theta_i, r_i, f_i, A_i]
+```
+
+where `x_i` is local multimodal input, `z_i` latent state, `p_i` geometry, `Omega_i` temporal
+memory, `Theta_i` control/attention state, `r_i` reconstruction or fixed-point residual, `f_i`
+allocated update frequency, and `A_i` abstraction leverage.
+
+The local codec cycle is
+
+```text
+x_i -> E_i -> z_i -> R_i -> D_i -> x_hat_i -> r_i -> recur
+```
+
+The existing `DrMoagiMultimodal3DLoop` remains responsible for bounded multimodal encoding,
+latent evolution, decoding, reconstruction/cycle metrics, and fixed-point convergence checks.
+
+## Inward recursive abstraction
+
+The scheduler uses the existing recursive fold:
+
+```text
+C_l : Z_l -> Z_(l+1)
+R_l = Z_l - U_l(C_l(Z_l))
+H_i = 1[|r_i| > tau]
+Z' = U(C(Z)) + H * F(R)
+```
+
+Stable information remains represented at coarse scale. Fine computation is reactivated only where
+residuals exceed the configured threshold.
+
+For the default two-level `10 x 10 x 10` fold:
+
+```text
+per-level volume = 10^3
+recursive fold volume = (10^3)^2 = 10^6
+```
+
+This is an analytical sparse-work ceiling, not measured acceleration.
+
+## Frequency modulation
+
+Residual magnitude controls local execution frequency:
+
+```text
+f(r) = f_min + (f_max - f_min) * sigmoid((r - tau) / kappa)
+```
+
+Therefore larger residuals receive at least as much update frequency as smaller residuals while all
+frequencies remain bounded by `[f_min, f_max]`.
+
+At the fixed point, residual-driven refinement approaches its minimum cadence rather than consuming
+maximum update frequency indefinitely.
+
+## Information-throughput model
+
+For event rate `F`, physical information mass `M` bytes/event, abstraction leverage `A`, and
+execution-efficiency factor `eta`:
+
+```text
+Q_physical = F * M * eta
+Q_represented = Q_physical * A
+```
+
+For a spatially distributed field the corresponding continuum abstraction is
+
+```text
+Phi_info(t) = integral_V rho_codec(x,t) M(x,t) f(x,t) A(x,t) eta(x,t) dV
+```
+
+This is the formal version of:
+
+```text
+space x frequency x abstraction -> effective represented information throughput
+```
+
+The runtime reports three distinct quantities so that they are not conflated:
+
+- `modeled_physical_bytes_per_second`: information mass attached to scheduled modeled events;
+- `modeled_represented_bytes_per_second`: the same scheduled work multiplied by abstraction gain;
+- `modeled_reallocated_ceiling_bytes_per_second`: an analytical ceiling if saved sparse capacity can
+  be perfectly reassigned to independent useful work.
+
+None is a wall-clock benchmark.
+
+## Verification invariants
+
+A cycle is marked `operational_mechanics_verified` only when all inherited geometry/work checks and
+all new frequency/throughput checks pass.
+
+The new invariants are:
+
+```text
+f_min <= f(r) <= f_max
+f(r_1) <= f(r_2) for r_1 <= r_2
+Q_physical = F * M * eta
+Q_represented = Q_physical * A
+```
+
+The inherited closure checks remain conceptually:
+
+```text
+Z* = R(Z*, P*, Omega*, Theta*)
+X* = D(Z*)
+G(X*) = X*
+```
+
+with actual convergence represented by bounded numerical residuals rather than banners.
+
+## Run
+
+From the repository root:
+
+```bash
+python -m jarvisx.dr_moagi_recursive_intelligence --cycles 8
+```
+
+For JSON metrics:
+
+```bash
+python -m jarvisx.dr_moagi_recursive_intelligence --cycles 8 --json
+```
+
+Example modeled capacity and abstraction configuration:
+
+```bash
+python -m jarvisx.dr_moagi_recursive_intelligence \
+  --capacity-hz 1e12 \
+  --max-frequency 144 \
+  --information-mass-bytes 512 \
+  --abstraction-gain 1000 \
+  --fold-levels 2 \
+  --json
+```
+
+## Performance boundary
+
+A modeled event capacity such as `1e12/s`, an abstraction factor such as `1e3`, or an inward
+work-reduction ceiling such as `1e6` is not evidence of equivalent physical hardware throughput.
+Promoting any modeled quantity to an empirical performance claim requires same-hardware wall-clock
+benchmarks at matched output quality, including memory bandwidth, interconnect, synchronization,
+kernel time, power, and profiler evidence.

--- a/src/jarvisx/dr_moagi_inward_swarm.py
+++ b/src/jarvisx/dr_moagi_inward_swarm.py
@@ -1,0 +1,285 @@
+"""Virtualized 3D exavoxel swarm with inward multiresolution refinement.
+
+This module models a logical 1_000_000 x 1_000_000 x 1_000_000 lattice
+(10**18 cells) without allocating one object per cell.  A bounded proxy swarm
+samples the logical field while the existing DrMoagiMultimodal3DLoop performs
+real, bounded encode/decode work.
+
+The 10 x 10 x 10 inward fold yields a *maximum modeled work reduction* of
+1000x when no fine cells require residual refinement.  This metric is not a
+claim of measured wall-clock or hardware speedup.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+from dataclasses import asdict, dataclass
+from typing import Optional, Sequence
+
+from .dr_moagi_multimodal_loop import DrMoagiMultimodal3DLoop, Modality
+
+LOGICAL_AXIS = 1_000_000
+LOGICAL_CELLS = LOGICAL_AXIS**3
+DEFAULT_FOLD_EDGE = 10
+
+
+@dataclass
+class InwardSwarmConfig:
+    """Configuration for the virtual exavoxel scheduler."""
+
+    proxy_agents: int = 2_000
+    fold_edge: int = DEFAULT_FOLD_EDGE
+    residual_threshold: float = 0.12
+    target_reconstruction_mse: float = 0.25
+    threshold_learning_rate: float = 0.04
+    min_threshold: float = 1e-4
+    max_threshold: float = 1.0
+    seed: int = 0x4D4F414749
+
+    def __post_init__(self) -> None:
+        if not 64 <= self.proxy_agents <= 1_000_000:
+            raise ValueError("proxy_agents must be in [64, 1_000_000]")
+        if self.fold_edge < 2:
+            raise ValueError("fold_edge must be >= 2")
+        if not 0.0 < self.residual_threshold <= 1.0:
+            raise ValueError("residual_threshold must be in (0, 1]")
+        if not 0.0 < self.target_reconstruction_mse:
+            raise ValueError("target_reconstruction_mse must be positive")
+        if not 0.0 < self.threshold_learning_rate <= 1.0:
+            raise ValueError("threshold_learning_rate must be in (0, 1]")
+        if not 0.0 < self.min_threshold <= self.max_threshold:
+            raise ValueError("invalid threshold bounds")
+
+    @property
+    def fold_volume(self) -> int:
+        return self.fold_edge**3
+
+
+@dataclass(frozen=True)
+class ProxyAgent:
+    """One bounded sample standing in for a region of the logical lattice."""
+
+    x: float
+    y: float
+    z: float
+    modality: Modality
+    phase: float
+
+
+@dataclass
+class InwardSwarmMetrics:
+    cycle: int
+    logical_axis: int
+    logical_cells: int
+    proxy_agents: int
+    fold_edge: int
+    fold_volume: int
+    proxy_cells_per_agent: float
+    active_refinement_fraction: float
+    active_proxy_agents: int
+    residual_threshold: float
+    aggregate_reconstruction_mse: float
+    aggregate_cycle_mse: float
+    proxy_residual_rms: float
+    modeled_work_cells: float
+    modeled_work_reduction: float
+    max_modeled_work_reduction: float
+    fixed_point_delta: float
+    converged: bool
+
+
+def modeled_work_reduction(active_fraction: float, fold_volume: int) -> float:
+    """Return baseline-work / multiresolution-work for an idealized scheduler.
+
+    Coarse work always evaluates one representative for each folded block.
+    Fine work is reactivated only for the estimated active residual fraction.
+    The result is bounded by [1, fold_volume].
+    """
+
+    if fold_volume < 1:
+        raise ValueError("fold_volume must be >= 1")
+    a = max(0.0, min(1.0, float(active_fraction)))
+    coarse_fraction = 1.0 / float(fold_volume)
+    work_fraction = coarse_fraction + a * (1.0 - coarse_fraction)
+    return 1.0 / work_fraction
+
+
+class VirtualExavoxelInwardSwarm:
+    """Sparse virtual scheduler wrapped around the bounded multimodal engine."""
+
+    def __init__(
+        self,
+        config: Optional[InwardSwarmConfig] = None,
+        codec: Optional[DrMoagiMultimodal3DLoop] = None,
+    ) -> None:
+        self.config = config or InwardSwarmConfig()
+        self.codec = codec or DrMoagiMultimodal3DLoop(edge=8, temporal_depth=4)
+        self.rng = random.Random(self.config.seed)
+        self.cycle = 0
+        self.agents = self._make_agents(self.config.proxy_agents)
+
+    def _make_agents(self, n: int) -> list[ProxyAgent]:
+        modalities = tuple(Modality)
+        agents: list[ProxyAgent] = []
+        for i in range(n):
+            agents.append(
+                ProxyAgent(
+                    x=self.rng.uniform(-1.0, 1.0),
+                    y=self.rng.uniform(-1.0, 1.0),
+                    z=self.rng.uniform(-1.0, 1.0),
+                    modality=modalities[i % len(modalities)],
+                    phase=self.rng.random() * math.tau,
+                )
+            )
+        return agents
+
+    @staticmethod
+    def _safe_delta(value: float) -> float:
+        return value if math.isfinite(value) else 0.0
+
+    def _proxy_residual(self, agent: ProxyAgent, base_error: float, cycle_error: float) -> float:
+        radius = math.sqrt(agent.x * agent.x + agent.y * agent.y + agent.z * agent.z)
+        geometry = 0.5 + 0.5 * abs(
+            math.sin(
+                2.17 * agent.x
+                + 1.73 * agent.y
+                - 1.31 * agent.z
+                + agent.phase
+                + 0.11 * self.cycle
+            )
+        )
+        shell = min(1.0, radius / math.sqrt(3.0))
+        modality_gain = {
+            Modality.VISUAL: 1.00,
+            Modality.AUDIO: 0.94,
+            Modality.TEXT: 0.88,
+            Modality.VIDEO: 1.06,
+            Modality.GENERIC: 0.91,
+        }[agent.modality]
+        return max(0.0, modality_gain * (0.72 * base_error + 0.28 * cycle_error) * geometry * (0.8 + 0.4 * shell))
+
+    def _auto_tune_threshold(self, reconstruction_mse: float) -> None:
+        cfg = self.config
+        lr = cfg.threshold_learning_rate
+        if reconstruction_mse <= cfg.target_reconstruction_mse:
+            # Fidelity is inside the target: prune more fine work.
+            candidate = cfg.residual_threshold * (1.0 + lr)
+        else:
+            # Fidelity is outside the target: refine a larger region.
+            candidate = cfg.residual_threshold * (1.0 - lr)
+        cfg.residual_threshold = min(cfg.max_threshold, max(cfg.min_threshold, candidate))
+
+    def step(self, virtual_ops: Optional[int] = None, auto_optimize: bool = True) -> InwardSwarmMetrics:
+        codec_metrics = self.codec.step(virtual_ops=virtual_ops)
+        base_error = max(0.0, codec_metrics.aggregate_reconstruction_mse)
+        cycle_error = max(0.0, codec_metrics.aggregate_cycle_mse)
+
+        residuals = [self._proxy_residual(a, base_error, cycle_error) for a in self.agents]
+        threshold = self.config.residual_threshold
+        active = sum(r > threshold for r in residuals)
+        active_fraction = active / len(residuals)
+        residual_rms = math.sqrt(sum(r * r for r in residuals) / len(residuals))
+
+        fold_volume = self.config.fold_volume
+        reduction = modeled_work_reduction(active_fraction, fold_volume)
+        modeled_work = LOGICAL_CELLS / reduction
+
+        self.cycle += 1
+        result = InwardSwarmMetrics(
+            cycle=self.cycle,
+            logical_axis=LOGICAL_AXIS,
+            logical_cells=LOGICAL_CELLS,
+            proxy_agents=len(self.agents),
+            fold_edge=self.config.fold_edge,
+            fold_volume=fold_volume,
+            proxy_cells_per_agent=LOGICAL_CELLS / len(self.agents),
+            active_refinement_fraction=active_fraction,
+            active_proxy_agents=active,
+            residual_threshold=threshold,
+            aggregate_reconstruction_mse=base_error,
+            aggregate_cycle_mse=cycle_error,
+            proxy_residual_rms=residual_rms,
+            modeled_work_cells=modeled_work,
+            modeled_work_reduction=reduction,
+            max_modeled_work_reduction=float(fold_volume),
+            fixed_point_delta=self._safe_delta(codec_metrics.fixed_point_delta),
+            converged=codec_metrics.converged,
+        )
+
+        if auto_optimize:
+            self._auto_tune_threshold(base_error)
+        return result
+
+    def run(
+        self,
+        cycles: int,
+        deterministic_virtual_stride: Optional[int] = None,
+        auto_optimize: bool = True,
+    ) -> list[InwardSwarmMetrics]:
+        if cycles < 1:
+            raise ValueError("cycles must be >= 1")
+        if deterministic_virtual_stride is not None and deterministic_virtual_stride < 0:
+            raise ValueError("deterministic_virtual_stride must be >= 0")
+        results: list[InwardSwarmMetrics] = []
+        for i in range(cycles):
+            virtual_ops = None
+            if deterministic_virtual_stride is not None:
+                virtual_ops = i * deterministic_virtual_stride
+            results.append(self.step(virtual_ops=virtual_ops, auto_optimize=auto_optimize))
+        return results
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Virtual 10^18-cell inward-folded multimodal 3D swarm"
+    )
+    p.add_argument("--cycles", type=int, default=8)
+    p.add_argument("--proxy-agents", type=int, default=2_000)
+    p.add_argument("--fold-edge", type=int, default=10)
+    p.add_argument("--threshold", type=float, default=0.12)
+    p.add_argument("--target-mse", type=float, default=0.25)
+    p.add_argument("--deterministic-stride", type=int, default=1_000_000)
+    p.add_argument("--no-auto-optimize", action="store_true")
+    p.add_argument("--json", action="store_true")
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parser().parse_args(argv)
+    config = InwardSwarmConfig(
+        proxy_agents=args.proxy_agents,
+        fold_edge=args.fold_edge,
+        residual_threshold=args.threshold,
+        target_reconstruction_mse=args.target_mse,
+    )
+    engine = VirtualExavoxelInwardSwarm(config=config)
+    metrics = engine.run(
+        args.cycles,
+        deterministic_virtual_stride=args.deterministic_stride,
+        auto_optimize=not args.no_auto_optimize,
+    )
+    if args.json:
+        print(json.dumps([asdict(m) for m in metrics], indent=2, sort_keys=True))
+    else:
+        last = metrics[-1]
+        print(
+            "cycle={cycle} logical_cells={logical_cells} proxies={proxy_agents} "
+            "active={active:.4f} residual_rms={residual:.6f} "
+            "modeled_work_reduction={reduction:.2f}x max={maximum:.0f}x".format(
+                cycle=last.cycle,
+                logical_cells=last.logical_cells,
+                proxy_agents=last.proxy_agents,
+                active=last.active_refinement_fraction,
+                residual=last.proxy_residual_rms,
+                reduction=last.modeled_work_reduction,
+                maximum=last.max_modeled_work_reduction,
+            )
+        )
+        print("note: modeled work reduction is not measured wall-clock throughput")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/jarvisx/dr_moagi_inward_swarm.py
+++ b/src/jarvisx/dr_moagi_inward_swarm.py
@@ -1,13 +1,15 @@
-"""Virtualized 3D exavoxel swarm with inward multiresolution refinement.
+"""Virtualized 3D exavoxel swarm with recursive inward multiresolution refinement.
 
 This module models a logical 1_000_000 x 1_000_000 x 1_000_000 lattice
-(10**18 cells) without allocating one object per cell.  A bounded proxy swarm
+(10**18 cells) without allocating one object per cell. A bounded proxy swarm
 samples the logical field while the existing DrMoagiMultimodal3DLoop performs
 real, bounded encode/decode work.
 
-The 10 x 10 x 10 inward fold yields a *maximum modeled work reduction* of
-1000x when no fine cells require residual refinement.  This metric is not a
-claim of measured wall-clock or hardware speedup.
+Acceleration is represented as a recursive geometric work model. A local
+10 x 10 x 10 contraction reduces one level by 1000 logical cells. Two nested
+levels therefore have a maximum idealized work-reduction ceiling of 10**6 when
+no fine cells require residual refinement. This is not a claim of measured
+wall-clock or hardware speedup; physical acceleration must be benchmarked.
 """
 from __future__ import annotations
 
@@ -23,6 +25,7 @@ from .dr_moagi_multimodal_loop import DrMoagiMultimodal3DLoop, Modality
 LOGICAL_AXIS = 1_000_000
 LOGICAL_CELLS = LOGICAL_AXIS**3
 DEFAULT_FOLD_EDGE = 10
+DEFAULT_FOLD_LEVELS = 2
 
 
 @dataclass
@@ -31,6 +34,7 @@ class InwardSwarmConfig:
 
     proxy_agents: int = 2_000
     fold_edge: int = DEFAULT_FOLD_EDGE
+    fold_levels: int = DEFAULT_FOLD_LEVELS
     residual_threshold: float = 0.12
     target_reconstruction_mse: float = 0.25
     threshold_learning_rate: float = 0.04
@@ -43,6 +47,12 @@ class InwardSwarmConfig:
             raise ValueError("proxy_agents must be in [64, 1_000_000]")
         if self.fold_edge < 2:
             raise ValueError("fold_edge must be >= 2")
+        if not 1 <= self.fold_levels <= 6:
+            raise ValueError("fold_levels must be in [1, 6]")
+        if self.total_fold_edge > LOGICAL_AXIS:
+            raise ValueError("recursive fold exceeds logical axis")
+        if LOGICAL_AXIS % self.total_fold_edge:
+            raise ValueError("logical axis must be divisible by total recursive fold edge")
         if not 0.0 < self.residual_threshold <= 1.0:
             raise ValueError("residual_threshold must be in (0, 1]")
         if not 0.0 < self.target_reconstruction_mse:
@@ -53,8 +63,24 @@ class InwardSwarmConfig:
             raise ValueError("invalid threshold bounds")
 
     @property
-    def fold_volume(self) -> int:
+    def per_level_volume(self) -> int:
         return self.fold_edge**3
+
+    @property
+    def total_fold_edge(self) -> int:
+        return self.fold_edge**self.fold_levels
+
+    @property
+    def fold_volume(self) -> int:
+        return self.total_fold_edge**3
+
+    @property
+    def coarse_axis(self) -> int:
+        return LOGICAL_AXIS // self.total_fold_edge
+
+    @property
+    def coarse_cells(self) -> int:
+        return self.coarse_axis**3
 
 
 @dataclass(frozen=True)
@@ -75,7 +101,12 @@ class InwardSwarmMetrics:
     logical_cells: int
     proxy_agents: int
     fold_edge: int
+    fold_levels: int
+    per_level_volume: int
+    total_fold_edge: int
     fold_volume: int
+    coarse_axis: int
+    coarse_cells: int
     proxy_cells_per_agent: float
     active_refinement_fraction: float
     active_proxy_agents: int
@@ -88,12 +119,15 @@ class InwardSwarmMetrics:
     max_modeled_work_reduction: float
     fixed_point_delta: float
     converged: bool
+    geometry_verified: bool
+    work_model_verified: bool
+    operational_mechanics_verified: bool
 
 
 def modeled_work_reduction(active_fraction: float, fold_volume: int) -> float:
     """Return baseline-work / multiresolution-work for an idealized scheduler.
 
-    Coarse work always evaluates one representative for each folded block.
+    Coarse work evaluates one representative for each recursively folded block.
     Fine work is reactivated only for the estimated active residual fraction.
     The result is bounded by [1, fold_volume].
     """
@@ -104,6 +138,32 @@ def modeled_work_reduction(active_fraction: float, fold_volume: int) -> float:
     coarse_fraction = 1.0 / float(fold_volume)
     work_fraction = coarse_fraction + a * (1.0 - coarse_fraction)
     return 1.0 / work_fraction
+
+
+def verify_recursive_geometry(config: InwardSwarmConfig) -> bool:
+    """Verify exact integer geometry of the nested 3D contraction."""
+
+    expected_edge = config.fold_edge**config.fold_levels
+    expected_volume = (config.fold_edge**3) ** config.fold_levels
+    return (
+        config.total_fold_edge == expected_edge
+        and config.fold_volume == expected_volume
+        and config.coarse_axis * config.total_fold_edge == LOGICAL_AXIS
+        and config.coarse_cells * config.fold_volume == LOGICAL_CELLS
+    )
+
+
+def verify_work_model(active_fraction: float, fold_volume: int, reduction: float) -> bool:
+    """Verify reduction against the normalized sparse-work equation."""
+
+    if not 0.0 <= active_fraction <= 1.0 or fold_volume < 1:
+        return False
+    expected = modeled_work_reduction(active_fraction, fold_volume)
+    return (
+        math.isfinite(reduction)
+        and 1.0 <= reduction <= float(fold_volume)
+        and math.isclose(reduction, expected, rel_tol=1e-12, abs_tol=1e-12)
+    )
 
 
 class VirtualExavoxelInwardSwarm:
@@ -158,20 +218,26 @@ class VirtualExavoxelInwardSwarm:
             Modality.VIDEO: 1.06,
             Modality.GENERIC: 0.91,
         }[agent.modality]
-        return max(0.0, modality_gain * (0.72 * base_error + 0.28 * cycle_error) * geometry * (0.8 + 0.4 * shell))
+        return max(
+            0.0,
+            modality_gain
+            * (0.72 * base_error + 0.28 * cycle_error)
+            * geometry
+            * (0.8 + 0.4 * shell),
+        )
 
     def _auto_tune_threshold(self, reconstruction_mse: float) -> None:
         cfg = self.config
         lr = cfg.threshold_learning_rate
         if reconstruction_mse <= cfg.target_reconstruction_mse:
-            # Fidelity is inside the target: prune more fine work.
             candidate = cfg.residual_threshold * (1.0 + lr)
         else:
-            # Fidelity is outside the target: refine a larger region.
             candidate = cfg.residual_threshold * (1.0 - lr)
         cfg.residual_threshold = min(cfg.max_threshold, max(cfg.min_threshold, candidate))
 
-    def step(self, virtual_ops: Optional[int] = None, auto_optimize: bool = True) -> InwardSwarmMetrics:
+    def step(
+        self, virtual_ops: Optional[int] = None, auto_optimize: bool = True
+    ) -> InwardSwarmMetrics:
         codec_metrics = self.codec.step(virtual_ops=virtual_ops)
         base_error = max(0.0, codec_metrics.aggregate_reconstruction_mse)
         cycle_error = max(0.0, codec_metrics.aggregate_cycle_mse)
@@ -182,9 +248,19 @@ class VirtualExavoxelInwardSwarm:
         active_fraction = active / len(residuals)
         residual_rms = math.sqrt(sum(r * r for r in residuals) / len(residuals))
 
-        fold_volume = self.config.fold_volume
-        reduction = modeled_work_reduction(active_fraction, fold_volume)
+        cfg = self.config
+        reduction = modeled_work_reduction(active_fraction, cfg.fold_volume)
         modeled_work = LOGICAL_CELLS / reduction
+        geometry_ok = verify_recursive_geometry(cfg)
+        work_ok = verify_work_model(active_fraction, cfg.fold_volume, reduction)
+        operational_ok = (
+            geometry_ok
+            and work_ok
+            and math.isfinite(base_error)
+            and math.isfinite(cycle_error)
+            and math.isfinite(residual_rms)
+            and len(self.agents) == cfg.proxy_agents
+        )
 
         self.cycle += 1
         result = InwardSwarmMetrics(
@@ -192,8 +268,13 @@ class VirtualExavoxelInwardSwarm:
             logical_axis=LOGICAL_AXIS,
             logical_cells=LOGICAL_CELLS,
             proxy_agents=len(self.agents),
-            fold_edge=self.config.fold_edge,
-            fold_volume=fold_volume,
+            fold_edge=cfg.fold_edge,
+            fold_levels=cfg.fold_levels,
+            per_level_volume=cfg.per_level_volume,
+            total_fold_edge=cfg.total_fold_edge,
+            fold_volume=cfg.fold_volume,
+            coarse_axis=cfg.coarse_axis,
+            coarse_cells=cfg.coarse_cells,
             proxy_cells_per_agent=LOGICAL_CELLS / len(self.agents),
             active_refinement_fraction=active_fraction,
             active_proxy_agents=active,
@@ -203,9 +284,12 @@ class VirtualExavoxelInwardSwarm:
             proxy_residual_rms=residual_rms,
             modeled_work_cells=modeled_work,
             modeled_work_reduction=reduction,
-            max_modeled_work_reduction=float(fold_volume),
+            max_modeled_work_reduction=float(cfg.fold_volume),
             fixed_point_delta=self._safe_delta(codec_metrics.fixed_point_delta),
             converged=codec_metrics.converged,
+            geometry_verified=geometry_ok,
+            work_model_verified=work_ok,
+            operational_mechanics_verified=operational_ok,
         )
 
         if auto_optimize:
@@ -233,11 +317,12 @@ class VirtualExavoxelInwardSwarm:
 
 def parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        description="Virtual 10^18-cell inward-folded multimodal 3D swarm"
+        description="Virtual 10^18-cell recursively inward-folded multimodal 3D swarm"
     )
     p.add_argument("--cycles", type=int, default=8)
     p.add_argument("--proxy-agents", type=int, default=2_000)
-    p.add_argument("--fold-edge", type=int, default=10)
+    p.add_argument("--fold-edge", type=int, default=DEFAULT_FOLD_EDGE)
+    p.add_argument("--fold-levels", type=int, default=DEFAULT_FOLD_LEVELS)
     p.add_argument("--threshold", type=float, default=0.12)
     p.add_argument("--target-mse", type=float, default=0.25)
     p.add_argument("--deterministic-stride", type=int, default=1_000_000)
@@ -251,6 +336,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     config = InwardSwarmConfig(
         proxy_agents=args.proxy_agents,
         fold_edge=args.fold_edge,
+        fold_levels=args.fold_levels,
         residual_threshold=args.threshold,
         target_reconstruction_mse=args.target_mse,
     )
@@ -266,15 +352,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         last = metrics[-1]
         print(
             "cycle={cycle} logical_cells={logical_cells} proxies={proxy_agents} "
-            "active={active:.4f} residual_rms={residual:.6f} "
-            "modeled_work_reduction={reduction:.2f}x max={maximum:.0f}x".format(
+            "fold={edge}^3x{levels} active={active:.6f} residual_rms={residual:.6f} "
+            "modeled_work_reduction={reduction:.2f}x max={maximum:.0f}x "
+            "verified={verified}".format(
                 cycle=last.cycle,
                 logical_cells=last.logical_cells,
                 proxy_agents=last.proxy_agents,
+                edge=last.fold_edge,
+                levels=last.fold_levels,
                 active=last.active_refinement_fraction,
                 residual=last.proxy_residual_rms,
                 reduction=last.modeled_work_reduction,
                 maximum=last.max_modeled_work_reduction,
+                verified=last.operational_mechanics_verified,
             )
         )
         print("note: modeled work reduction is not measured wall-clock throughput")

--- a/src/jarvisx/dr_moagi_recursive_intelligence.py
+++ b/src/jarvisx/dr_moagi_recursive_intelligence.py
@@ -1,0 +1,419 @@
+"""Recursive 3D multimodal intelligence orchestration layer.
+
+This module composes the bounded multimodal codec and recursive inward-folded
+swarm into a frequency-modulated execution model.  It keeps three quantities
+separate:
+
+1. physical/modelled codec work,
+2. represented information enabled by abstraction, and
+3. sparse-work reduction enabled by inward folding.
+
+All throughput values in this module are analytical/modelled quantities.  They
+are not wall-clock benchmark results.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from dataclasses import asdict, dataclass
+from typing import Optional, Sequence
+
+from .dr_moagi_inward_swarm import (
+    InwardSwarmConfig,
+    InwardSwarmMetrics,
+    VirtualExavoxelInwardSwarm,
+)
+
+
+@dataclass
+class RecursiveIntelligenceConfig:
+    """Frequency, information-mass, and abstraction configuration."""
+
+    modeled_codec_capacity_hz: float = 1.0e12
+    min_local_frequency_hz: float = 1.0
+    max_local_frequency_hz: float = 144.0
+    frequency_kappa: float = 0.025
+    information_mass_bytes_per_event: float = 512.0
+    abstraction_gain: float = 1_000.0
+    execution_efficiency: float = 1.0
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.modeled_codec_capacity_hz) or self.modeled_codec_capacity_hz <= 0:
+            raise ValueError("modeled_codec_capacity_hz must be finite and positive")
+        if not math.isfinite(self.min_local_frequency_hz) or self.min_local_frequency_hz < 0:
+            raise ValueError("min_local_frequency_hz must be finite and non-negative")
+        if (
+            not math.isfinite(self.max_local_frequency_hz)
+            or self.max_local_frequency_hz <= self.min_local_frequency_hz
+        ):
+            raise ValueError("max_local_frequency_hz must exceed min_local_frequency_hz")
+        if not math.isfinite(self.frequency_kappa) or self.frequency_kappa <= 0:
+            raise ValueError("frequency_kappa must be finite and positive")
+        if (
+            not math.isfinite(self.information_mass_bytes_per_event)
+            or self.information_mass_bytes_per_event <= 0
+        ):
+            raise ValueError("information_mass_bytes_per_event must be finite and positive")
+        if not math.isfinite(self.abstraction_gain) or self.abstraction_gain < 1:
+            raise ValueError("abstraction_gain must be finite and >= 1")
+        if (
+            not math.isfinite(self.execution_efficiency)
+            or not 0 < self.execution_efficiency <= 1
+        ):
+            raise ValueError("execution_efficiency must be in (0, 1]")
+
+
+@dataclass
+class RecursiveIntelligenceMetrics:
+    """One verified cycle of the recursive intelligence orchestration layer."""
+
+    cycle: int
+    residual_rms: float
+    residual_threshold: float
+    active_refinement_fraction: float
+    modeled_work_reduction: float
+    max_modeled_work_reduction: float
+    allocated_local_frequency_hz: float
+    normalized_frequency: float
+    modeled_codec_capacity_hz: float
+    modeled_scheduled_event_rate_hz: float
+    information_mass_bytes_per_event: float
+    abstraction_gain: float
+    execution_efficiency: float
+    modeled_physical_bytes_per_second: float
+    modeled_represented_bytes_per_second: float
+    modeled_reallocated_ceiling_bytes_per_second: float
+    fixed_point_delta: float
+    converged: bool
+    geometry_verified: bool
+    work_model_verified: bool
+    frequency_verified: bool
+    throughput_verified: bool
+    operational_mechanics_verified: bool
+
+
+def frequency_modulation(
+    residual: float,
+    threshold: float,
+    min_frequency_hz: float,
+    max_frequency_hz: float,
+    kappa: float,
+) -> float:
+    """Map residual magnitude to a bounded local execution frequency.
+
+    f(r) = f_min + (f_max - f_min) * sigmoid((r - tau) / kappa)
+
+    The sigmoid makes the schedule continuous while preserving monotonicity:
+    larger residuals receive at least as much update frequency as smaller ones.
+    """
+
+    values = (residual, threshold, min_frequency_hz, max_frequency_hz, kappa)
+    if not all(math.isfinite(v) for v in values):
+        raise ValueError("frequency inputs must be finite")
+    if residual < 0 or threshold < 0:
+        raise ValueError("residual and threshold must be non-negative")
+    if min_frequency_hz < 0 or max_frequency_hz <= min_frequency_hz:
+        raise ValueError("invalid frequency bounds")
+    if kappa <= 0:
+        raise ValueError("kappa must be positive")
+
+    x = max(-60.0, min(60.0, (residual - threshold) / kappa))
+    sigma = 1.0 / (1.0 + math.exp(-x))
+    return min_frequency_hz + (max_frequency_hz - min_frequency_hz) * sigma
+
+
+def modeled_information_throughput(
+    event_rate_hz: float,
+    information_mass_bytes_per_event: float,
+    abstraction_gain: float,
+    execution_efficiency: float,
+) -> tuple[float, float]:
+    """Return modeled physical and represented information rates in bytes/s."""
+
+    values = (
+        event_rate_hz,
+        information_mass_bytes_per_event,
+        abstraction_gain,
+        execution_efficiency,
+    )
+    if not all(math.isfinite(v) for v in values):
+        raise ValueError("throughput inputs must be finite")
+    if event_rate_hz < 0:
+        raise ValueError("event_rate_hz must be non-negative")
+    if information_mass_bytes_per_event <= 0:
+        raise ValueError("information_mass_bytes_per_event must be positive")
+    if abstraction_gain < 1:
+        raise ValueError("abstraction_gain must be >= 1")
+    if not 0 < execution_efficiency <= 1:
+        raise ValueError("execution_efficiency must be in (0, 1]")
+
+    physical = event_rate_hz * information_mass_bytes_per_event * execution_efficiency
+    represented = physical * abstraction_gain
+    return physical, represented
+
+
+def verify_frequency_allocation(
+    residual: float,
+    threshold: float,
+    config: RecursiveIntelligenceConfig,
+    frequency_hz: float,
+) -> bool:
+    """Verify bounds and exact agreement with the frequency law."""
+
+    expected = frequency_modulation(
+        residual,
+        threshold,
+        config.min_local_frequency_hz,
+        config.max_local_frequency_hz,
+        config.frequency_kappa,
+    )
+    return (
+        math.isfinite(frequency_hz)
+        and config.min_local_frequency_hz <= frequency_hz <= config.max_local_frequency_hz
+        and math.isclose(frequency_hz, expected, rel_tol=1e-12, abs_tol=1e-12)
+    )
+
+
+def verify_throughput(
+    metrics: RecursiveIntelligenceMetrics,
+) -> bool:
+    """Check dimensional identities for modeled physical/represented throughput."""
+
+    cfg_values = (
+        metrics.modeled_codec_capacity_hz,
+        metrics.modeled_scheduled_event_rate_hz,
+        metrics.information_mass_bytes_per_event,
+        metrics.abstraction_gain,
+        metrics.execution_efficiency,
+        metrics.modeled_physical_bytes_per_second,
+        metrics.modeled_represented_bytes_per_second,
+        metrics.modeled_reallocated_ceiling_bytes_per_second,
+    )
+    if not all(math.isfinite(v) for v in cfg_values):
+        return False
+
+    expected_physical = (
+        metrics.modeled_scheduled_event_rate_hz
+        * metrics.information_mass_bytes_per_event
+        * metrics.execution_efficiency
+    )
+    expected_represented = expected_physical * metrics.abstraction_gain
+    expected_ceiling = (
+        metrics.modeled_codec_capacity_hz
+        * metrics.normalized_frequency
+        * metrics.information_mass_bytes_per_event
+        * metrics.abstraction_gain
+        * metrics.modeled_work_reduction
+        * metrics.execution_efficiency
+    )
+    return (
+        math.isclose(
+            metrics.modeled_physical_bytes_per_second,
+            expected_physical,
+            rel_tol=1e-12,
+            abs_tol=1e-9,
+        )
+        and math.isclose(
+            metrics.modeled_represented_bytes_per_second,
+            expected_represented,
+            rel_tol=1e-12,
+            abs_tol=1e-9,
+        )
+        and math.isclose(
+            metrics.modeled_reallocated_ceiling_bytes_per_second,
+            expected_ceiling,
+            rel_tol=1e-12,
+            abs_tol=1e-9,
+        )
+    )
+
+
+class Recursive3DMultimodalIntelligenceEngine:
+    """End-to-end bounded orchestration of the inward 3D multimodal swarm.
+
+    The implementation deliberately treats large event-rate and abstraction
+    quantities as *modeled capacity/equivalent-work metrics*.  Actual hardware
+    throughput must be established with profilers and wall-clock benchmarks.
+    """
+
+    def __init__(
+        self,
+        config: Optional[RecursiveIntelligenceConfig] = None,
+        swarm: Optional[VirtualExavoxelInwardSwarm] = None,
+        swarm_config: Optional[InwardSwarmConfig] = None,
+    ) -> None:
+        self.config = config or RecursiveIntelligenceConfig()
+        if swarm is not None and swarm_config is not None:
+            raise ValueError("provide swarm or swarm_config, not both")
+        self.swarm = swarm or VirtualExavoxelInwardSwarm(config=swarm_config)
+
+    def _orchestrate(self, inward: InwardSwarmMetrics) -> RecursiveIntelligenceMetrics:
+        cfg = self.config
+        frequency = frequency_modulation(
+            inward.proxy_residual_rms,
+            inward.residual_threshold,
+            cfg.min_local_frequency_hz,
+            cfg.max_local_frequency_hz,
+            cfg.frequency_kappa,
+        )
+        normalized_frequency = frequency / cfg.max_local_frequency_hz
+
+        # The sparse work fraction is the reciprocal of the inward work reduction.
+        # This preserves a strict separation between available logical capacity and
+        # the fraction of that capacity physically scheduled in this cycle.
+        work_fraction = 1.0 / inward.modeled_work_reduction
+        scheduled_event_rate = cfg.modeled_codec_capacity_hz * normalized_frequency * work_fraction
+
+        physical, represented = modeled_information_throughput(
+            scheduled_event_rate,
+            cfg.information_mass_bytes_per_event,
+            cfg.abstraction_gain,
+            cfg.execution_efficiency,
+        )
+
+        # If saved sparse capacity were perfectly reusable for independent work,
+        # this is the analytical upper ceiling. It is not a benchmark result.
+        reallocated_ceiling = (
+            cfg.modeled_codec_capacity_hz
+            * normalized_frequency
+            * cfg.information_mass_bytes_per_event
+            * cfg.abstraction_gain
+            * inward.modeled_work_reduction
+            * cfg.execution_efficiency
+        )
+
+        frequency_ok = verify_frequency_allocation(
+            inward.proxy_residual_rms,
+            inward.residual_threshold,
+            cfg,
+            frequency,
+        )
+
+        result = RecursiveIntelligenceMetrics(
+            cycle=inward.cycle,
+            residual_rms=inward.proxy_residual_rms,
+            residual_threshold=inward.residual_threshold,
+            active_refinement_fraction=inward.active_refinement_fraction,
+            modeled_work_reduction=inward.modeled_work_reduction,
+            max_modeled_work_reduction=inward.max_modeled_work_reduction,
+            allocated_local_frequency_hz=frequency,
+            normalized_frequency=normalized_frequency,
+            modeled_codec_capacity_hz=cfg.modeled_codec_capacity_hz,
+            modeled_scheduled_event_rate_hz=scheduled_event_rate,
+            information_mass_bytes_per_event=cfg.information_mass_bytes_per_event,
+            abstraction_gain=cfg.abstraction_gain,
+            execution_efficiency=cfg.execution_efficiency,
+            modeled_physical_bytes_per_second=physical,
+            modeled_represented_bytes_per_second=represented,
+            modeled_reallocated_ceiling_bytes_per_second=reallocated_ceiling,
+            fixed_point_delta=inward.fixed_point_delta,
+            converged=inward.converged,
+            geometry_verified=inward.geometry_verified,
+            work_model_verified=inward.work_model_verified,
+            frequency_verified=frequency_ok,
+            throughput_verified=False,
+            operational_mechanics_verified=False,
+        )
+        result.throughput_verified = verify_throughput(result)
+        result.operational_mechanics_verified = (
+            inward.operational_mechanics_verified
+            and result.frequency_verified
+            and result.throughput_verified
+        )
+        return result
+
+    def step(
+        self,
+        virtual_ops: Optional[int] = None,
+        auto_optimize: bool = True,
+    ) -> RecursiveIntelligenceMetrics:
+        inward = self.swarm.step(virtual_ops=virtual_ops, auto_optimize=auto_optimize)
+        return self._orchestrate(inward)
+
+    def run(
+        self,
+        cycles: int,
+        deterministic_virtual_stride: Optional[int] = None,
+        auto_optimize: bool = True,
+    ) -> list[RecursiveIntelligenceMetrics]:
+        if cycles < 1:
+            raise ValueError("cycles must be >= 1")
+        if deterministic_virtual_stride is not None and deterministic_virtual_stride < 0:
+            raise ValueError("deterministic_virtual_stride must be >= 0")
+        out: list[RecursiveIntelligenceMetrics] = []
+        for i in range(cycles):
+            virtual_ops = None
+            if deterministic_virtual_stride is not None:
+                virtual_ops = i * deterministic_virtual_stride
+            out.append(self.step(virtual_ops=virtual_ops, auto_optimize=auto_optimize))
+        return out
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Recursive 3D multimodal intelligence engine")
+    p.add_argument("--cycles", type=int, default=8)
+    p.add_argument("--capacity-hz", type=float, default=1.0e12)
+    p.add_argument("--min-frequency", type=float, default=1.0)
+    p.add_argument("--max-frequency", type=float, default=144.0)
+    p.add_argument("--information-mass-bytes", type=float, default=512.0)
+    p.add_argument("--abstraction-gain", type=float, default=1_000.0)
+    p.add_argument("--efficiency", type=float, default=1.0)
+    p.add_argument("--proxy-agents", type=int, default=2_000)
+    p.add_argument("--fold-edge", type=int, default=10)
+    p.add_argument("--fold-levels", type=int, default=2)
+    p.add_argument("--threshold", type=float, default=0.12)
+    p.add_argument("--deterministic-stride", type=int, default=1_000_000)
+    p.add_argument("--no-auto-optimize", action="store_true")
+    p.add_argument("--json", action="store_true")
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parser().parse_args(argv)
+    config = RecursiveIntelligenceConfig(
+        modeled_codec_capacity_hz=args.capacity_hz,
+        min_local_frequency_hz=args.min_frequency,
+        max_local_frequency_hz=args.max_frequency,
+        information_mass_bytes_per_event=args.information_mass_bytes,
+        abstraction_gain=args.abstraction_gain,
+        execution_efficiency=args.efficiency,
+    )
+    swarm_config = InwardSwarmConfig(
+        proxy_agents=args.proxy_agents,
+        fold_edge=args.fold_edge,
+        fold_levels=args.fold_levels,
+        residual_threshold=args.threshold,
+    )
+    engine = Recursive3DMultimodalIntelligenceEngine(config=config, swarm_config=swarm_config)
+    metrics = engine.run(
+        args.cycles,
+        deterministic_virtual_stride=args.deterministic_stride,
+        auto_optimize=not args.no_auto_optimize,
+    )
+
+    if args.json:
+        print(json.dumps([asdict(m) for m in metrics], indent=2, sort_keys=True))
+    else:
+        last = metrics[-1]
+        print(
+            "cycle={cycle} active={active:.6f} f={frequency:.3f}Hz "
+            "work_reduction={reduction:.3f}x scheduled={scheduled:.6e}/s "
+            "physical={physical:.6e}B/s represented={represented:.6e}B/s "
+            "verified={verified}".format(
+                cycle=last.cycle,
+                active=last.active_refinement_fraction,
+                frequency=last.allocated_local_frequency_hz,
+                reduction=last.modeled_work_reduction,
+                scheduled=last.modeled_scheduled_event_rate_hz,
+                physical=last.modeled_physical_bytes_per_second,
+                represented=last.modeled_represented_bytes_per_second,
+                verified=last.operational_mechanics_verified,
+            )
+        )
+        print("note: throughput values are analytical/modelled, not wall-clock benchmarks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dr_moagi_inward_swarm.py
+++ b/tests/test_dr_moagi_inward_swarm.py
@@ -6,6 +6,8 @@ from jarvisx.dr_moagi_inward_swarm import (
     InwardSwarmConfig,
     VirtualExavoxelInwardSwarm,
     modeled_work_reduction,
+    verify_recursive_geometry,
+    verify_work_model,
 )
 
 
@@ -14,32 +16,65 @@ def test_logical_exavoxel_geometry():
     assert LOGICAL_CELLS == 10**18
 
 
-def test_modeled_work_reduction_bounds():
-    assert modeled_work_reduction(1.0, 1000) == 1.0
-    assert modeled_work_reduction(0.0, 1000) == 1000.0
-    mid = modeled_work_reduction(0.1, 1000)
-    assert 1.0 < mid < 1000.0
+def test_recursive_default_geometry_reaches_million_fold_ceiling():
+    cfg = InwardSwarmConfig(proxy_agents=128)
+    assert cfg.fold_edge == 10
+    assert cfg.fold_levels == 2
+    assert cfg.per_level_volume == 1000
+    assert cfg.total_fold_edge == 100
+    assert cfg.fold_volume == 1_000_000
+    assert cfg.coarse_axis == 10_000
+    assert cfg.coarse_cells == 10**12
+    assert verify_recursive_geometry(cfg)
 
 
-def test_swarm_step_is_bounded_and_virtualized():
-    cfg = InwardSwarmConfig(proxy_agents=128, fold_edge=10, residual_threshold=0.12)
+def test_modeled_work_reduction_bounds_for_million_fold():
+    fold_volume = 1_000_000
+    assert modeled_work_reduction(1.0, fold_volume) == 1.0
+    assert modeled_work_reduction(0.0, fold_volume) == 1_000_000.0
+    mid = modeled_work_reduction(0.1, fold_volume)
+    assert 1.0 < mid < 1_000_000.0
+    assert verify_work_model(0.1, fold_volume, mid)
+
+
+def test_single_level_remains_compatible_with_original_thousand_fold():
+    cfg = InwardSwarmConfig(proxy_agents=128, fold_edge=10, fold_levels=1)
+    assert cfg.fold_volume == 1000
+    assert cfg.total_fold_edge == 10
+    assert verify_recursive_geometry(cfg)
+
+
+def test_swarm_step_is_bounded_virtualized_and_verified():
+    cfg = InwardSwarmConfig(
+        proxy_agents=128,
+        fold_edge=10,
+        fold_levels=2,
+        residual_threshold=0.12,
+    )
     engine = VirtualExavoxelInwardSwarm(config=cfg)
     metrics = engine.step(virtual_ops=0, auto_optimize=False)
 
     assert metrics.logical_cells == 10**18
     assert metrics.proxy_agents == 128
-    assert metrics.fold_volume == 1000
+    assert metrics.per_level_volume == 1000
+    assert metrics.fold_volume == 1_000_000
+    assert metrics.coarse_axis == 10_000
+    assert metrics.coarse_cells == 10**12
     assert 0.0 <= metrics.active_refinement_fraction <= 1.0
-    assert 1.0 <= metrics.modeled_work_reduction <= 1000.0
+    assert 1.0 <= metrics.modeled_work_reduction <= 1_000_000.0
     assert math.isfinite(metrics.proxy_residual_rms)
     assert math.isfinite(metrics.aggregate_reconstruction_mse)
     assert math.isfinite(metrics.aggregate_cycle_mse)
+    assert metrics.geometry_verified
+    assert metrics.work_model_verified
+    assert metrics.operational_mechanics_verified
 
 
 def test_auto_optimizer_keeps_threshold_in_bounds():
     cfg = InwardSwarmConfig(
         proxy_agents=128,
         fold_edge=10,
+        fold_levels=2,
         residual_threshold=0.12,
         min_threshold=0.05,
         max_threshold=0.20,
@@ -54,3 +89,12 @@ def test_deterministic_run_length_and_cycle_count():
     engine = VirtualExavoxelInwardSwarm(config=cfg)
     metrics = engine.run(3, deterministic_virtual_stride=10)
     assert [m.cycle for m in metrics] == [1, 2, 3]
+
+
+def test_invalid_recursive_geometry_is_rejected():
+    try:
+        InwardSwarmConfig(proxy_agents=128, fold_edge=7, fold_levels=2)
+    except ValueError as exc:
+        assert "divisible" in str(exc)
+    else:
+        raise AssertionError("expected invalid recursive geometry to be rejected")

--- a/tests/test_dr_moagi_inward_swarm.py
+++ b/tests/test_dr_moagi_inward_swarm.py
@@ -1,0 +1,56 @@
+import math
+
+from jarvisx.dr_moagi_inward_swarm import (
+    LOGICAL_AXIS,
+    LOGICAL_CELLS,
+    InwardSwarmConfig,
+    VirtualExavoxelInwardSwarm,
+    modeled_work_reduction,
+)
+
+
+def test_logical_exavoxel_geometry():
+    assert LOGICAL_AXIS == 1_000_000
+    assert LOGICAL_CELLS == 10**18
+
+
+def test_modeled_work_reduction_bounds():
+    assert modeled_work_reduction(1.0, 1000) == 1.0
+    assert modeled_work_reduction(0.0, 1000) == 1000.0
+    mid = modeled_work_reduction(0.1, 1000)
+    assert 1.0 < mid < 1000.0
+
+
+def test_swarm_step_is_bounded_and_virtualized():
+    cfg = InwardSwarmConfig(proxy_agents=128, fold_edge=10, residual_threshold=0.12)
+    engine = VirtualExavoxelInwardSwarm(config=cfg)
+    metrics = engine.step(virtual_ops=0, auto_optimize=False)
+
+    assert metrics.logical_cells == 10**18
+    assert metrics.proxy_agents == 128
+    assert metrics.fold_volume == 1000
+    assert 0.0 <= metrics.active_refinement_fraction <= 1.0
+    assert 1.0 <= metrics.modeled_work_reduction <= 1000.0
+    assert math.isfinite(metrics.proxy_residual_rms)
+    assert math.isfinite(metrics.aggregate_reconstruction_mse)
+    assert math.isfinite(metrics.aggregate_cycle_mse)
+
+
+def test_auto_optimizer_keeps_threshold_in_bounds():
+    cfg = InwardSwarmConfig(
+        proxy_agents=128,
+        fold_edge=10,
+        residual_threshold=0.12,
+        min_threshold=0.05,
+        max_threshold=0.20,
+    )
+    engine = VirtualExavoxelInwardSwarm(config=cfg)
+    engine.run(3, deterministic_virtual_stride=1_000, auto_optimize=True)
+    assert cfg.min_threshold <= cfg.residual_threshold <= cfg.max_threshold
+
+
+def test_deterministic_run_length_and_cycle_count():
+    cfg = InwardSwarmConfig(proxy_agents=128, seed=1234)
+    engine = VirtualExavoxelInwardSwarm(config=cfg)
+    metrics = engine.run(3, deterministic_virtual_stride=10)
+    assert [m.cycle for m in metrics] == [1, 2, 3]

--- a/tests/test_dr_moagi_recursive_intelligence.py
+++ b/tests/test_dr_moagi_recursive_intelligence.py
@@ -1,0 +1,51 @@
+import math
+
+from jarvisx.dr_moagi_inward_swarm import InwardSwarmConfig
+from jarvisx.dr_moagi_recursive_intelligence import (
+    Recursive3DMultimodalIntelligenceEngine,
+    RecursiveIntelligenceConfig,
+    frequency_modulation,
+    modeled_information_throughput,
+)
+
+
+def test_frequency_law_is_bounded_and_monotonic():
+    values = [frequency_modulation(r, 0.12, 1.0, 144.0, 0.025) for r in (0.0, 0.12, 1.0)]
+    assert values == sorted(values)
+    assert all(1.0 <= value <= 144.0 for value in values)
+    assert math.isclose(values[1], 72.5)
+
+
+def test_information_throughput_identity():
+    physical, represented = modeled_information_throughput(1.0e6, 512.0, 1_000.0, 1.0)
+    assert physical == 512.0e6
+    assert represented == 512.0e9
+
+
+def test_engine_cycle_verifies_mechanics():
+    config = RecursiveIntelligenceConfig(
+        modeled_codec_capacity_hz=1.0e6,
+        abstraction_gain=1_000.0,
+        execution_efficiency=0.9,
+    )
+    swarm_config = InwardSwarmConfig(proxy_agents=128, fold_levels=2, seed=1234)
+    engine = Recursive3DMultimodalIntelligenceEngine(config=config, swarm_config=swarm_config)
+    metrics = engine.step(virtual_ops=0, auto_optimize=False)
+
+    assert metrics.geometry_verified
+    assert metrics.work_model_verified
+    assert metrics.frequency_verified
+    assert metrics.throughput_verified
+    assert metrics.operational_mechanics_verified
+    assert 1.0 <= metrics.allocated_local_frequency_hz <= 144.0
+    assert 1.0 <= metrics.modeled_work_reduction <= 1.0e6
+    assert metrics.modeled_represented_bytes_per_second >= metrics.modeled_physical_bytes_per_second
+
+
+def test_run_cycle_count():
+    engine = Recursive3DMultimodalIntelligenceEngine(
+        swarm_config=InwardSwarmConfig(proxy_agents=128, seed=7)
+    )
+    metrics = engine.run(3, deterministic_virtual_stride=10, auto_optimize=False)
+    assert [m.cycle for m in metrics] == [1, 2, 3]
+    assert all(m.operational_mechanics_verified for m in metrics)


### PR DESCRIPTION
## Summary

Extends Jarvis-X into a bounded recursive 3D multimodal intelligence engine built from the existing multimodal codec, inward-folded virtual swarm, residual-driven frequency modulation, and explicit information-throughput accounting.

### Locked execution baseline

`encode globally -> abstract inward -> allocate frequency to residual information -> refine selectively -> decode -> verify -> optimize -> recur`

### What this implements
- Logical `1_000_000 x 1_000_000 x 1_000_000` (`10^18`) 3D substrate without allocating `10^18` objects.
- Bounded multimodal encode/decode loop for visual, audio, text, video, and generic payloads.
- Deterministic proxy-agent sampling of the logical field.
- Two nested `10 x 10 x 10` inward folds by default.
- Per-level contraction `10^3 = 1000`; recursive sparse-work ceiling `(10^3)^2 = 10^6`.
- Residual-threshold selective refinement and adaptive threshold tuning.
- Frequency modulation from residual magnitude:
  `f(r) = f_min + (f_max-f_min) * sigmoid((r-tau)/kappa)`.
- Separation of modeled event capacity, scheduled physical work, represented information, abstraction gain, and sparse-work reuse.
- End-to-end verification flags for geometry, work model, frequency law, throughput identities, and operational mechanics.

### Mathematical / geometric verification

With `fold_edge = 10`, `fold_levels = 2`:

- total edge contraction = `10^2 = 100` per axis,
- fold volume = `100^3 = 10^6`,
- coarse axis = `1,000,000 / 100 = 10,000`,
- coarse cells = `10,000^3 = 10^12`,
- invariant = `10^12 * 10^6 = 10^18` logical cells.

The inward scheduler retains:
- `geometry_verified`
- `work_model_verified`
- `operational_mechanics_verified`

The orchestration layer adds:
- `frequency_verified`
- `throughput_verified`
- combined `operational_mechanics_verified`

### Information-throughput law

For modeled codec-event rate `F`, information mass `M` bytes/event, abstraction gain `A`, and efficiency `eta`:

`Q_physical = F * M * eta`

`Q_represented = Q_physical * A`

The field form is:

`Phi_info(t) = integral_V rho_codec(x,t) M(x,t) f(x,t) A(x,t) eta(x,t) dV`

This implements the architecture-level invariant:

`space x frequency x abstraction -> effective represented information throughput`

### Performance semantics

The `10^6` sparse-work quantity, capacities such as `10^12 events/s`, and abstraction gains are **analytical/modelled quantities**, not measured hardware throughput.

The recursive fold work law remains:

`S_model(a) = 1 / (1/10^6 + a * (1 - 1/10^6))`

Real acceleration must be established independently with same-hardware wall-clock benchmarks at equivalent output quality.

### Files
- `src/jarvisx/dr_moagi_inward_swarm.py`
- `src/jarvisx/dr_moagi_recursive_intelligence.py`
- `tests/test_dr_moagi_inward_swarm.py`
- `tests/test_dr_moagi_recursive_intelligence.py`
- `docs/inward-folded-exavoxel-swarm.md`
- `docs/recursive-3d-multimodal-intelligence-engine.md`

### Validation
Tests cover logical geometry, recursive fold identities, `10^6` work-model bounds, bounded virtualization, optimizer threshold bounds, deterministic cycle accounting, frequency bounds/monotonicity, mass-frequency-abstraction throughput identities, and combined operational verification.

### Next physical acceleration layer
Map active residual blocks to fused CUDA/Triton kernels, add dense-vs-sparse same-hardware benchmarks, instrument memory/interconnect/power costs, and promote modeled reductions to measured speedups only when profiling at equivalent output quality supports the claim.