### PR TITLE
Permeate monotone inward autoencoding intelligence contract

### DIFF
--- a/docs/adr/0015-inward-autoencoding-intelligence-engine.md
+++ b/docs/adr/0015-inward-autoencoding-intelligence-engine.md
@@ -1,0 +1,271 @@
+# ADR-015: Monotone Inward Autoencoding/Decoding Intelligence Engine
+
+**Status:** Proposed  
+**Date:** 2026-09-12  
+**Applies to:** `DM-vOmegaXi+`, Jarvis-X inward swarm, multimodal encode/decode runtimes  
+**Extends:** ADR-014 master dynamical-system operator and the reality-constrained `⟲⊙` contract
+
+## Decision
+
+Jarvis-X SHALL treat the inward loop as a measurable contraction operator, not as repeated motion or reversible bit mixing. The end-to-end architecture is
+
+```text
+X_t
+ -> Q ingest / normalize
+ -> E_Theta encode
+ -> T_in^K inward latent refinement
+ -> Psi* latent attractor
+ -> D_Theta decode / generate
+ -> C contrast
+ -> R_CTR reckon / verify / correct
+ -> U_Omega memory update
+ -> U_Theta bounded adaptive update
+ -> recur
+```
+
+The compact operator is
+
+```text
+S_(t+1) =
+    U_Theta o U_Omega o R_CTR o C o D_Theta o T_in^K o E_Theta o Q
+    (S_t, X_t)
+```
+
+with accepted terminal state
+
+```text
+S* = M_DM(S*, X_world).
+```
+
+This is a computational architecture, not a claim of consciousness or a new physical law.
+
+## 1. Discrete spatial contraction
+
+For a coordinate `p_k`, core coordinate `c`, and positive finite step `Delta`, the canonical discrete operator is
+
+```text
+p_(k+1) = p_k + sign(c - p_k) * min(abs(c - p_k), Delta).
+```
+
+Therefore
+
+```text
+abs(c - p_(k+1)) = max(0, abs(c - p_k) - Delta).
+```
+
+A raw fixed `+/- Delta` step without clipping is forbidden as a convergence primitive because it overshoots whenever `0 < abs(c-p) < Delta` and can create a period-two orbit.
+
+For a logical axis `[0, scale-1]`, the worst-case finite spatial bound is
+
+```text
+K_space = ceil(max(c, scale-1-c) / Delta).
+```
+
+At `scale=1,000,000`, `c=500,000`, and `Delta=1,000`, `K_space <= 500`.
+
+## 2. Packed latent contraction
+
+The previous reversible transform
+
+```text
+s -> s XOR (s >> 1)
+```
+
+MAY be used as a mixer but MUST NOT be labeled a fixed-point refinement operator. Over a bounded word it is periodic/invertible rather than strictly contractive.
+
+Given an explicit latent target `s*`, define
+
+```text
+d_k = s_k XOR s*
+b_k = d_k AND (-d_k)
+s_(k+1) = s_k XOR b_k.
+```
+
+`b_k` isolates one differing bit. Therefore, for Hamming distance `H`,
+
+```text
+H(s_(k+1), s*) = H(s_k, s*) - 1
+```
+
+whenever `s_k != s*`. A `w`-bit word converges in at most `w` passes.
+
+The target MUST come from an explicit encoder/objective, declared reference, learned latent optimum, or other auditable source. The contraction operator itself does not manufacture semantic truth.
+
+## 3. Joint Lyapunov-like objective
+
+For the finite materialized swarm, define
+
+```text
+L_k = alpha * sum_i ||P_i,k - C||_1
+    + beta  * sum_(i,j) H(S_i,j,k, S*_i,j)
+```
+
+with finite `alpha > 0`, `beta > 0`.
+
+Every admitted inward pass MUST satisfy
+
+```text
+L_(k+1) <= L_k,
+```
+
+and, whenever the state is not already the joint fixed point,
+
+```text
+L_(k+1) < L_k.
+```
+
+The inward operator is therefore idempotent at the fixed point and strictly decreasing away from it.
+
+The finite pass bound for one loaded swarm is
+
+```text
+K <= max(K_space_loaded, max_word_hamming).
+```
+
+A runtime MUST NOT execute an arbitrary very large loop count and call the result convergence without measuring or proving its terminal condition.
+
+## 4. Autoencoder/decoder coupling
+
+For multimodal observation `X_t`,
+
+```text
+Z_t^(0) = E_Theta(X_t)
+Z_t^(k+1) = T_in(Z_t^k; X_t, Omega_t, Theta_t)
+Psi_t = Z_t^K
+Xhat_t = D_Theta(Psi_t)
+e_t = X_t - Xhat_t.
+```
+
+A reference latent objective is
+
+```text
+L_DM(Z) =
+    lambda_r * ||D_Theta(Z) - X_t||^2
+  + lambda_c * ||E_Theta(D_Theta(Z)) - Z||^2
+  + lambda_m * ||Z - Omega_t||^2
+  + lambda_s * R(Z)
+  + lambda_v * L_CTR.
+```
+
+An implementation MAY obtain `S*`/`Z*` by an optimizer rather than bitwise correction. If so, it must expose its actual measured descent or acceptance criterion; the packed-state operator above remains the deterministic reference contraction.
+
+## 5. Memory, control, and reality correspondence
+
+The recurrent memory update remains bounded, for example
+
+```text
+Omega_(t+1) = rho * Omega_t + (1-rho) * G_Omega(Psi_t, e_t, R_t).
+```
+
+Adaptive parameters/control remain transactional, for example
+
+```text
+Theta_(t+1) = Theta_t - eta * grad_Theta L_verified.
+```
+
+Internal stability alone is insufficient. The `⟲⊙` reality-constrained layer requires both
+
+```text
+||S_(k+1) - S_k|| <= epsilon_internal
+```
+
+and
+
+```text
+d(X_t, Xhat_t) <= epsilon_external
+```
+
+before an implementation may report verified convergence. Observation provenance remains the caller's responsibility.
+
+## 6. Sparse `1,000,000^3` semantics
+
+A declaration such as
+
+```text
+V = {0, ..., 999999}^3
+```
+
+specifies a logical coordinate/address domain with `10^18` possible coordinates. It does not imply `10^18` resident GPU agents or voxels.
+
+For `N=65,536`, the accelerator materializes exactly `N` positions plus their finite packed latent states. Documentation and telemetry MUST distinguish logical address-space size from resident allocation and measured throughput.
+
+## 7. Accelerator memory layout
+
+For a kernel that processes one packed word across many agents, the preferred reference layout is structure-of-arrays:
+
+```text
+States[WORDS, N]
+Targets[WORDS, N]
+```
+
+so a fixed word index uses contiguous agent memory. An array-of-structures layout `[N, WORDS]` creates a `WORDS`-element stride between adjacent lanes for the same word and SHOULD be benchmarked before use.
+
+The reference Triton accelerator is `examples/inward_swarm_triton.py`; the dependency-free executable specification is `src/jarvisx/inward_swarm_fixed_point.py`.
+
+## 8. Image-carried source payloads
+
+An image MAY be treated as a dual state
+
+```text
+I = (V_visible, B_payload)
+```
+
+where `B_payload` is a machine-readable byte stream carried by a lossless pixel/container encoding. This is a transport/container layer, not automatic execution. A decoder/bootstrap runtime is still required to recover and run a source tree.
+
+If payload bits depend on exact pixel values, lossless storage such as PNG is required; lossy JPEG recompression, resizing, filtering, screenshots, or color conversion can destroy naive LSB payloads. Payload integrity SHOULD use an explicit length/header and cryptographic digest, with error correction when transformation tolerance is required.
+
+Image payload extraction occurs before `E_Theta` unless the model explicitly treats payload recovery as a learned modality.
+
+## 9. Verification contract
+
+An implementation may report the inward core as `converged` only if the active execution path verifies all relevant predicates:
+
+```text
+finite_state
+AND resource_bounds_ok
+AND spatial_error == 0
+AND latent_error == 0           # deterministic packed reference mode
+AND monotone_objective_ok
+AND theta_gate_ok
+AND journal_valid
+AND external_correspondence_ok  # when reality-constrained mode is enabled
+```
+
+Learned/continuous latent modes replace exact latent equality with an explicit, measured tolerance and objective acceptance rule.
+
+## 10. Canonical fixed-point form
+
+The architecture closes as
+
+```text
+Psi* = Fix[R_CTR o D_Theta o T_in^K o E_Theta](X, Omega)
+```
+
+subject to measured internal contraction and external correspondence.
+
+Conceptually:
+
+```text
+Observe
+ -> Encode
+ -> Contract inward
+ -> Psi*
+ -> Decode / Generate
+ -> Contrast
+ -> Reckon
+ -> Verify
+ -> Correct
+ -> Remember / Adapt
+ -> Recur
+```
+
+The phrase `I AM = I DESCRIBE` is retained as an architectural mnemonic for self-description/reconstruction; executable correctness is defined only by the measurable invariants above.
+
+## 11. Consequences
+
+1. The inward loop has a finite, falsifiable convergence contract.
+2. Periodic reversible transforms can no longer be mislabeled as refinement.
+3. Sparse logical-domain claims are separated from physical allocation and performance claims.
+4. CPU/reference and GPU/accelerator implementations share the same terminal invariants.
+5. Multimodal intelligence remains an encode/refine/decode/verify system; the inward operator alone is not equated with intelligence.
+6. Reality correspondence remains an independent gate, preventing internal self-consistency from being reported as external truth.

--- a/examples/inward_swarm_triton.py
+++ b/examples/inward_swarm_triton.py
@@ -1,0 +1,208 @@
+"""CUDA/Triton accelerator for the monotone inward swarm operator.
+
+This is an optional accelerator for ``jarvisx.inward_swarm_fixed_point``.  It
+preserves the same two contracts as the dependency-free reference engine:
+
+* coordinates use a clipped step and therefore cannot overshoot the core;
+* packed words correct one differing bit toward an explicit target per pass.
+
+The logical 1,000,000^3 domain is not densely allocated.  Only ``N`` sparse
+agents and their packed state words are materialized.
+
+Install CUDA PyTorch and Triton separately before running this example.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def inward_fixed_point_kernel(
+    positions_ptr,
+    states_ptr,
+    targets_ptr,
+    center_x,
+    center_y,
+    center_z,
+    num_agents,
+    SPATIAL_STEP: tl.constexpr,
+    WORDS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """One monotone spatial + latent contraction pass.
+
+    ``states_ptr`` and ``targets_ptr`` use structure-of-arrays layout ``[WORDS, N]``
+    so adjacent Triton lanes read adjacent int32 words for a fixed word index.
+    """
+
+    pid = tl.program_id(axis=0)
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < num_agents
+
+    x = tl.load(positions_ptr + idx * 3 + 0, mask=mask)
+    y = tl.load(positions_ptr + idx * 3 + 1, mask=mask)
+    z = tl.load(positions_ptr + idx * 3 + 2, mask=mask)
+
+    dx = center_x - x
+    dy = center_y - y
+    dz = center_z - z
+
+    adx = tl.where(dx < 0, -dx, dx)
+    ady = tl.where(dy < 0, -dy, dy)
+    adz = tl.where(dz < 0, -dz, dz)
+
+    sx = tl.where(adx <= SPATIAL_STEP, dx, tl.where(dx > 0, SPATIAL_STEP, -SPATIAL_STEP))
+    sy = tl.where(ady <= SPATIAL_STEP, dy, tl.where(dy > 0, SPATIAL_STEP, -SPATIAL_STEP))
+    sz = tl.where(adz <= SPATIAL_STEP, dz, tl.where(dz > 0, SPATIAL_STEP, -SPATIAL_STEP))
+
+    tl.store(positions_ptr + idx * 3 + 0, x + sx, mask=mask)
+    tl.store(positions_ptr + idx * 3 + 1, y + sy, mask=mask)
+    tl.store(positions_ptr + idx * 3 + 2, z + sz, mask=mask)
+
+    for word in range(WORDS):
+        offset = word * num_agents + idx
+        current = tl.load(states_ptr + offset, mask=mask)
+        target = tl.load(targets_ptr + offset, mask=mask)
+        diff = current ^ target
+        correction = diff & (-diff)
+        refined = current ^ correction
+        tl.store(states_ptr + offset, refined, mask=mask)
+
+
+class TritonInwardSwarm:
+    """Finite sparse accelerator over a large logical coordinate domain."""
+
+    def __init__(
+        self,
+        *,
+        num_agents: int = 65_536,
+        scale: int = 1_000_000,
+        spatial_step: int = 1_000,
+        words: int = 64,
+        word_bits: int = 31,
+        block_size: int = 256,
+        seed: int = 41,
+    ) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("this Triton example requires a CUDA device")
+        if num_agents <= 0 or scale < 2 or spatial_step <= 0:
+            raise ValueError("invalid swarm geometry")
+        if words <= 0 or not 1 <= word_bits <= 31:
+            raise ValueError("invalid packed-state configuration")
+        if block_size <= 0 or block_size & (block_size - 1):
+            raise ValueError("block_size must be a positive power of two")
+
+        self.device = torch.device("cuda")
+        self.num_agents = int(num_agents)
+        self.scale = int(scale)
+        self.center = self.scale // 2
+        self.spatial_step = int(spatial_step)
+        self.words = int(words)
+        self.word_bits = int(word_bits)
+        self.block_size = int(block_size)
+
+        generator = torch.Generator(device=self.device)
+        generator.manual_seed(seed)
+        self.positions = torch.randint(
+            0,
+            self.scale,
+            (self.num_agents, 3),
+            dtype=torch.int64,
+            device=self.device,
+            generator=generator,
+        )
+        # SoA [WORDS, N] layout: contiguous accesses across agents for each word.
+        self.states = torch.randint(
+            0,
+            1 << self.word_bits,
+            (self.words, self.num_agents),
+            dtype=torch.int32,
+            device=self.device,
+            generator=generator,
+        )
+        self.targets = torch.zeros_like(self.states)
+        self.grid = (triton.cdiv(self.num_agents, self.block_size),)
+
+    @property
+    def domain_worst_case_passes(self) -> int:
+        farthest = max(self.center, (self.scale - 1) - self.center)
+        spatial = math.ceil(farthest / self.spatial_step)
+        return max(spatial, self.word_bits)
+
+    def launch(self) -> None:
+        inward_fixed_point_kernel[self.grid](
+            self.positions,
+            self.states,
+            self.targets,
+            self.center,
+            self.center,
+            self.center,
+            self.num_agents,
+            SPATIAL_STEP=self.spatial_step,
+            WORDS=self.words,
+            BLOCK_SIZE=self.block_size,
+        )
+
+    def run_verified(self, passes: int | None = None) -> dict[str, float | int | bool]:
+        """Run a finite bound and verify the actual terminal state on device."""
+
+        count = self.domain_worst_case_passes if passes is None else int(passes)
+        if count <= 0:
+            raise ValueError("passes must be positive")
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(count):
+            self.launch()
+        end.record()
+        torch.cuda.synchronize()
+        elapsed_ms = float(start.elapsed_time(end))
+
+        spatial_ok = bool(torch.all(self.positions == self.center).item())
+        latent_ok = bool(torch.equal(self.states, self.targets))
+        return {
+            "passes": count,
+            "agents": self.num_agents,
+            "logical_scale": self.scale,
+            "elapsed_ms": elapsed_ms,
+            "mean_kernel_pass_us": elapsed_ms * 1_000.0 / count,
+            "spatial_fixed_point": spatial_ok,
+            "latent_fixed_point": latent_ok,
+            "verified_fixed_point": spatial_ok and latent_ok,
+        }
+
+
+def parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Verified Triton inward fixed-point swarm")
+    p.add_argument("--agents", type=int, default=65_536)
+    p.add_argument("--scale", type=int, default=1_000_000)
+    p.add_argument("--step", type=int, default=1_000)
+    p.add_argument("--words", type=int, default=64)
+    p.add_argument("--block-size", type=int, default=256)
+    p.add_argument("--passes", type=int)
+    return p
+
+
+def main() -> None:
+    args = parser().parse_args()
+    engine = TritonInwardSwarm(
+        num_agents=args.agents,
+        scale=args.scale,
+        spatial_step=args.step,
+        words=args.words,
+        block_size=args.block_size,
+    )
+    metrics = engine.run_verified(args.passes)
+    for key, value in metrics.items():
+        print(f"{key}: {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jarvisx/inward_swarm_fixed_point.py
+++ b/src/jarvisx/inward_swarm_fixed_point.py
@@ -1,0 +1,369 @@
+"""Monotone inward-swarm fixed-point operator for the Dr Moagi runtime.
+
+This module is the bounded, deterministic reference for the discrete inward
+contraction discussed by ADR-014.  It deliberately separates a *logical*
+``scale**3`` coordinate domain from the finite set of agents that are actually
+materialized.
+
+Two invariants are enforced on every admitted step:
+
+1. spatial L1 distance to the declared core never increases; and
+2. packed-state Hamming distance to the declared latent target never increases.
+
+If the swarm is not already at the joint fixed point, their positive weighted
+objective must decrease strictly.  This prevents the overshoot/periodic behaviour
+of an un-clipped ``+/- step`` spatial update and prevents a reversible Gray-code
+mix such as ``s ^ (s >> 1)`` from being mislabeled as contraction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from dataclasses import dataclass
+from typing import Sequence
+
+Coordinate3D = tuple[int, int, int]
+PackedWords = tuple[int, ...]
+
+
+def _require_plain_int(name: str, value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer")
+    return value
+
+
+def clipped_contract_axis(value: int, center: int, max_step: int) -> int:
+    """Move one integer coordinate toward ``center`` without overshooting."""
+
+    value = _require_plain_int("value", value)
+    center = _require_plain_int("center", center)
+    max_step = _require_plain_int("max_step", max_step)
+    if max_step <= 0:
+        raise ValueError("max_step must be positive")
+
+    delta = center - value
+    if abs(delta) <= max_step:
+        return center
+    return value + (max_step if delta > 0 else -max_step)
+
+
+def clipped_contract_position(
+    position: Coordinate3D,
+    center: Coordinate3D,
+    max_step: int,
+) -> Coordinate3D:
+    """Apply :func:`clipped_contract_axis` independently on x, y and z."""
+
+    if len(position) != 3 or len(center) != 3:
+        raise ValueError("position and center must be 3D coordinates")
+    return tuple(
+        clipped_contract_axis(int(value), int(target), max_step)
+        for value, target in zip(position, center)
+    )  # type: ignore[return-value]
+
+
+def hamming_distance_word(left: int, right: int, word_bits: int = 31) -> int:
+    """Return Hamming distance between two bounded unsigned packed words."""
+
+    left = _require_plain_int("left", left)
+    right = _require_plain_int("right", right)
+    word_bits = _require_plain_int("word_bits", word_bits)
+    if word_bits <= 0 or word_bits > 63:
+        raise ValueError("word_bits must be in [1, 63]")
+    limit = 1 << word_bits
+    if not 0 <= left < limit or not 0 <= right < limit:
+        raise ValueError("packed word is outside configured word_bits")
+    return (left ^ right).bit_count()
+
+
+def refine_word_toward_target(current: int, target: int, word_bits: int = 31) -> int:
+    """Correct exactly one differing bit, making Hamming error strictly contractive.
+
+    ``diff & -diff`` isolates the least-significant bit on which ``current`` and
+    ``target`` disagree.  XORing that bit into ``current`` makes it agree with
+    ``target``.  A non-fixed word therefore loses exactly one Hamming-error bit
+    per call and converges in at most ``word_bits`` calls.
+    """
+
+    distance = hamming_distance_word(current, target, word_bits)
+    if distance == 0:
+        return current
+    diff = current ^ target
+    correction = diff & -diff
+    refined = current ^ correction
+    if hamming_distance_word(refined, target, word_bits) != distance - 1:
+        raise RuntimeError("bit contraction invariant violated")
+    return refined
+
+
+@dataclass(frozen=True)
+class InwardSwarmConfig:
+    """Finite execution contract for a sparse swarm in a large logical domain."""
+
+    scale: int = 1_000_000
+    spatial_step: int = 1_000
+    word_bits: int = 31
+    words_per_agent: int = 64
+    max_iterations: int = 512
+    spatial_weight: float = 1.0
+    latent_weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        for name in ("scale", "spatial_step", "word_bits", "words_per_agent", "max_iterations"):
+            value = _require_plain_int(name, getattr(self, name))
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if self.scale < 2:
+            raise ValueError("scale must be at least 2")
+        if self.word_bits > 31:
+            raise ValueError("word_bits must be <= 31 for the int32 accelerator contract")
+        for name in ("spatial_weight", "latent_weight"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+
+    @property
+    def center(self) -> Coordinate3D:
+        c = self.scale // 2
+        return c, c, c
+
+    @property
+    def domain_worst_case_iterations(self) -> int:
+        """Finite upper bound for any state admitted by this configuration."""
+
+        c = self.scale // 2
+        farthest = max(c, (self.scale - 1) - c)
+        spatial = math.ceil(farthest / self.spatial_step)
+        return max(spatial, self.word_bits)
+
+
+@dataclass(frozen=True)
+class InwardSwarmReport:
+    iteration: int
+    spatial_l1_before: int
+    spatial_l1_after: int
+    latent_hamming_before: int
+    latent_hamming_after: int
+    objective_before: float
+    objective_after: float
+    strict_contraction: bool
+    spatial_converged: bool
+    latent_converged: bool
+    converged: bool
+    state_hash: str
+
+
+class InwardSwarmFixedPointEngine:
+    """Sparse joint spatial/latent contraction engine.
+
+    The encoded/decoded multimodal runtime may supply an arbitrary finite swarm
+    and explicit packed latent targets.  This class does not infer that target;
+    it guarantees only that the discrete inward operator reaches the supplied
+    target monotonically under the configured bounds.
+    """
+
+    OPERATOR = "T_in"
+    EQUATION = (
+        "P[k+1]=P[k]+sign(C-P[k])*min(abs(C-P[k]),Delta); "
+        "S[k+1]=S[k] xor LSB(S[k] xor S*)"
+    )
+
+    def __init__(self, config: InwardSwarmConfig | None = None) -> None:
+        self.config = config or InwardSwarmConfig()
+        self._positions: tuple[Coordinate3D, ...] = ()
+        self._states: tuple[PackedWords, ...] = ()
+        self._targets: tuple[PackedWords, ...] = ()
+        self._iteration = 0
+        self._loaded = False
+        self.reports: list[InwardSwarmReport] = []
+
+    def load(
+        self,
+        positions: Sequence[Coordinate3D],
+        states: Sequence[Sequence[int]],
+        targets: Sequence[Sequence[int]],
+    ) -> None:
+        if not positions:
+            raise ValueError("at least one active agent is required")
+        if len(positions) != len(states) or len(states) != len(targets):
+            raise ValueError("positions, states and targets must have the same agent count")
+
+        normalized_positions: list[Coordinate3D] = []
+        normalized_states: list[PackedWords] = []
+        normalized_targets: list[PackedWords] = []
+        limit = 1 << self.config.word_bits
+
+        for agent, (position, state, target) in enumerate(zip(positions, states, targets)):
+            if len(position) != 3:
+                raise ValueError(f"agent {agent} position must contain exactly three coordinates")
+            coordinate = tuple(_require_plain_int("coordinate", axis) for axis in position)
+            if any(axis < 0 or axis >= self.config.scale for axis in coordinate):
+                raise ValueError(f"agent {agent} position is outside the logical domain")
+            if len(state) != self.config.words_per_agent or len(target) != self.config.words_per_agent:
+                raise ValueError(
+                    f"agent {agent} requires exactly {self.config.words_per_agent} packed words"
+                )
+            state_words = tuple(_require_plain_int("state word", word) for word in state)
+            target_words = tuple(_require_plain_int("target word", word) for word in target)
+            if any(word < 0 or word >= limit for word in state_words + target_words):
+                raise ValueError(f"agent {agent} packed word is outside configured word_bits")
+            normalized_positions.append(coordinate)  # type: ignore[arg-type]
+            normalized_states.append(state_words)
+            normalized_targets.append(target_words)
+
+        self._positions = tuple(normalized_positions)
+        self._states = tuple(normalized_states)
+        self._targets = tuple(normalized_targets)
+        self._iteration = 0
+        self._loaded = True
+        self.reports.clear()
+
+    def positions(self) -> tuple[Coordinate3D, ...]:
+        self._require_loaded()
+        return self._positions
+
+    def states(self) -> tuple[PackedWords, ...]:
+        self._require_loaded()
+        return self._states
+
+    def targets(self) -> tuple[PackedWords, ...]:
+        self._require_loaded()
+        return self._targets
+
+    def _errors(self) -> tuple[int, int]:
+        center = self.config.center
+        spatial = sum(
+            abs(position[0] - center[0])
+            + abs(position[1] - center[1])
+            + abs(position[2] - center[2])
+            for position in self._positions
+        )
+        latent = sum(
+            hamming_distance_word(current, target, self.config.word_bits)
+            for state, target_state in zip(self._states, self._targets)
+            for current, target in zip(state, target_state)
+        )
+        return spatial, latent
+
+    def _objective(self, spatial: int, latent: int) -> float:
+        return self.config.spatial_weight * spatial + self.config.latent_weight * latent
+
+    def theoretical_iterations_remaining(self) -> int:
+        """Return an exact upper bound for the currently loaded finite swarm."""
+
+        self._require_loaded()
+        center = self.config.center
+        max_spatial_distance = max(
+            abs(axis - target)
+            for position in self._positions
+            for axis, target in zip(position, center)
+        )
+        spatial_steps = math.ceil(max_spatial_distance / self.config.spatial_step)
+        max_word_hamming = max(
+            (
+                hamming_distance_word(current, target, self.config.word_bits)
+                for state, target_state in zip(self._states, self._targets)
+                for current, target in zip(state, target_state)
+            ),
+            default=0,
+        )
+        return max(spatial_steps, max_word_hamming)
+
+    def step(self) -> InwardSwarmReport:
+        self._require_loaded()
+        spatial_before, latent_before = self._errors()
+        objective_before = self._objective(spatial_before, latent_before)
+        was_converged = spatial_before == 0 and latent_before == 0
+
+        center = self.config.center
+        positions = tuple(
+            clipped_contract_position(position, center, self.config.spatial_step)
+            for position in self._positions
+        )
+        states = tuple(
+            tuple(
+                refine_word_toward_target(current, target, self.config.word_bits)
+                for current, target in zip(state, target_state)
+            )
+            for state, target_state in zip(self._states, self._targets)
+        )
+
+        self._positions = positions
+        self._states = states
+        self._iteration += 1
+
+        spatial_after, latent_after = self._errors()
+        objective_after = self._objective(spatial_after, latent_after)
+        if spatial_after > spatial_before:
+            raise RuntimeError("spatial contraction invariant violated")
+        if latent_after > latent_before:
+            raise RuntimeError("latent contraction invariant violated")
+        strict = objective_after < objective_before
+        if not was_converged and not strict:
+            raise RuntimeError("joint Lyapunov objective failed to decrease strictly")
+
+        spatial_converged = spatial_after == 0
+        latent_converged = latent_after == 0
+        converged = spatial_converged and latent_converged
+        report = InwardSwarmReport(
+            iteration=self._iteration,
+            spatial_l1_before=spatial_before,
+            spatial_l1_after=spatial_after,
+            latent_hamming_before=latent_before,
+            latent_hamming_after=latent_after,
+            objective_before=objective_before,
+            objective_after=objective_after,
+            strict_contraction=strict,
+            spatial_converged=spatial_converged,
+            latent_converged=latent_converged,
+            converged=converged,
+            state_hash=self._state_hash(),
+        )
+        self.reports.append(report)
+        return report
+
+    def run_until_fixed_point(self, max_iterations: int | None = None) -> tuple[InwardSwarmReport, ...]:
+        self._require_loaded()
+        limit = self.config.max_iterations if max_iterations is None else max_iterations
+        limit = _require_plain_int("max_iterations", limit)
+        if limit <= 0:
+            raise ValueError("max_iterations must be positive")
+        for _ in range(limit):
+            report = self.step()
+            if report.converged:
+                break
+        return tuple(self.reports)
+
+    def status(self) -> dict[str, object]:
+        self._require_loaded()
+        spatial, latent = self._errors()
+        return {
+            "operator": self.OPERATOR,
+            "equation": self.EQUATION,
+            "iteration": self._iteration,
+            "agents": len(self._positions),
+            "logical_domain": f"{self.config.scale}^3",
+            "materialization": "sparse-active-agents-only",
+            "center": self.config.center,
+            "spatial_l1": spatial,
+            "latent_hamming": latent,
+            "objective": self._objective(spatial, latent),
+            "theoretical_iterations_remaining": self.theoretical_iterations_remaining(),
+            "converged": spatial == 0 and latent == 0,
+            "state_hash": self._state_hash(),
+        }
+
+    def _state_hash(self) -> str:
+        canonical = {
+            "positions": self._positions,
+            "states": self._states,
+            "targets": self._targets,
+        }
+        payload = json.dumps(canonical, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()
+
+    def _require_loaded(self) -> None:
+        if not self._loaded:
+            raise RuntimeError("load a finite swarm before inward execution")

--- a/tests/test_inward_swarm_fixed_point.py
+++ b/tests/test_inward_swarm_fixed_point.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import pytest
+
+from jarvisx.inward_swarm_fixed_point import (
+    InwardSwarmConfig,
+    InwardSwarmFixedPointEngine,
+    clipped_contract_axis,
+    hamming_distance_word,
+    refine_word_toward_target,
+)
+
+
+def _words(value: int, count: int = 64) -> tuple[int, ...]:
+    return (value,) * count
+
+
+def test_clipped_spatial_contraction_lands_on_center_without_oscillation():
+    assert clipped_contract_axis(500_123, 500_000, 1_000) == 500_000
+    assert clipped_contract_axis(499_123, 500_000, 1_000) == 500_000
+    assert clipped_contract_axis(750_000, 500_000, 1_000) == 749_000
+
+
+def test_bit_refinement_reduces_hamming_error_by_exactly_one():
+    current = 0b111101
+    target = 0b001010
+
+    before = hamming_distance_word(current, target)
+    refined = refine_word_toward_target(current, target)
+    after = hamming_distance_word(refined, target)
+
+    assert after == before - 1
+
+
+def test_bit_refinement_is_idempotent_at_fixed_point():
+    target = 0x1234567
+    assert refine_word_toward_target(target, target) == target
+
+
+def test_engine_joint_objective_contracts_strictly_until_fixed_point():
+    config = InwardSwarmConfig(max_iterations=512)
+    engine = InwardSwarmFixedPointEngine(config)
+    engine.load(
+        positions=[
+            (0, 999_999, 500_123),
+            (999_999, 1, 499_123),
+        ],
+        states=[_words(0x7FFFFFFF), _words(0x13579BDF)],
+        targets=[_words(0), _words(0x02468ACE)],
+    )
+
+    bound = engine.theoretical_iterations_remaining()
+    reports = engine.run_until_fixed_point()
+
+    assert len(reports) <= bound
+    assert reports[-1].converged
+    assert all(report.objective_after <= report.objective_before for report in reports)
+    assert all(report.strict_contraction for report in reports)
+    assert engine.positions() == ((500_000, 500_000, 500_000),) * 2
+    assert engine.states() == engine.targets()
+    assert engine.status()["converged"] is True
+
+
+def test_fixed_point_step_is_idempotent_and_does_not_claim_strict_contraction():
+    config = InwardSwarmConfig()
+    engine = InwardSwarmFixedPointEngine(config)
+    engine.load(
+        positions=[config.center],
+        states=[_words(0x42)],
+        targets=[_words(0x42)],
+    )
+
+    report = engine.step()
+
+    assert report.converged
+    assert not report.strict_contraction
+    assert report.objective_before == 0.0
+    assert report.objective_after == 0.0
+
+
+def test_logical_domain_is_sparse_metadata_not_dense_materialization():
+    config = InwardSwarmConfig(scale=1_000_000)
+    engine = InwardSwarmFixedPointEngine(config)
+    engine.load(
+        positions=[(123, 456, 789)],
+        states=[_words(0)],
+        targets=[_words(0)],
+    )
+
+    status = engine.status()
+
+    assert status["logical_domain"] == "1000000^3"
+    assert status["agents"] == 1
+    assert status["materialization"] == "sparse-active-agents-only"
+
+
+def test_validation_rejects_out_of_range_packed_words():
+    engine = InwardSwarmFixedPointEngine(InwardSwarmConfig(word_bits=31))
+    with pytest.raises(ValueError, match="packed word"):
+        engine.load(
+            positions=[(0, 0, 0)],
+            states=[_words(1 << 31)],
+            targets=[_words(0)],
+        )


### PR DESCRIPTION
## Summary

Permeates the inward-looped autoencoding/decoding architecture into an executable, falsifiable fixed-point contract.

This PR:

- adds a dependency-free `InwardSwarmFixedPointEngine` with clipped spatial contraction and explicit-target Hamming contraction;
- enforces a positive joint Lyapunov-like objective that strictly decreases away from the fixed point;
- adds tests for no-overshoot geometry, exact one-bit Hamming descent, idempotence at the fixed point, sparse-domain semantics, and finite convergence;
- adds an optional CUDA/Triton accelerator using SoA `[WORDS, N]` state layout and finite verified pass bounds instead of a blind 100,000-pass loop;
- adds ADR-015 tying the operator into the existing `Q -> E -> T_in -> D -> CTR -> Omega/Theta -> recur` stack, dual internal/external convergence, sparse `1,000,000^3` semantics, and image-carried source payloads as a transport/bootstrap layer.

## Corrected invariants

Spatial contraction:

`p[k+1] = p[k] + sign(c-p[k]) * min(abs(c-p[k]), Delta)`

Packed latent contraction:

`d = s xor s*; b = d & -d; s[k+1] = s xor b`

Joint objective:

`L[k] = alpha * sum ||P_i-C||_1 + beta * sum H(S_ij,S*_ij)`

with `L[k+1] < L[k]` whenever the state is not already at the joint fixed point.

## Scope discipline

The `1,000,000^3` value remains a logical coordinate domain, not a dense allocation or throughput claim. The accelerator materializes only the configured finite agent set. Internal fixed-point convergence is kept separate from external/reality correspondence, consistent with the existing `⟲⊙` reality-constrained layer.

## Validation

The new pure-Python tests are dependency-light and are intended to run in the existing pytest suite. The Triton example is optional and performs explicit terminal-state verification on CUDA.