### PR TITLE
feat: permeate million-fold inward 3D hierarchy

### DIFF
--- a/apps/dr-moagi-volumetric-torch/README.md
+++ b/apps/dr-moagi-volumetric-torch/README.md
@@ -1,6 +1,6 @@
 # Dr Moagi Volumetric Torch Backend
 
-A differentiable dense 3D backend for the Dr Moagi architecture. It is designed to complement, not replace, the sparse `1000 x 1000` logical multiparallel runtime.
+A differentiable dense 3D backend for the Dr Moagi architecture. It is designed to complement, not replace, the sparse logical multiparallel runtime.
 
 ## Implemented
 
@@ -12,6 +12,8 @@ A differentiable dense 3D backend for the Dr Moagi architecture. It is designed 
 - Warp reconstruction loss, so the deformation network is optimized toward useful geometry rather than zero displacement.
 - Kinetic integration with optional `torchdiffeq`; deterministic Euler fallback when it is absent.
 - Gradient clipping and persistent shell-state updates after optimization.
+- Sparse-to-dense transactional tile bridge with convergence-controlled recursive execution.
+- Backend-neutral million-fold inward hierarchy controls in `jarvisx.millionfold_inward`.
 
 ## Architecture
 
@@ -54,6 +56,53 @@ image / video / audio / feature vectors
      unified reconstruction objective
 ```
 
+## Million-fold inward hierarchy
+
+The canonical logical optimization target is now
+
+```text
+1000^3 -> 100^3 -> 10^3
+```
+
+which is a `10^6` reduction in **coarse spatial sites**:
+
+```text
+1000^3 / 10^3 = 1,000,000.
+```
+
+This is not asserted to be a literal one-million-times wall-clock speedup. The hierarchy preserves fine information as sparse residual work and refines only regions whose measured error exceeds a threshold.
+
+```text
+full logical field
+      |
+      v
+    100^3 ---- residual R0
+      |
+      v
+     10^3 ---- residual R1
+      |
+      v
+ latent core Z*
+      |
+      v
+   decode X_hat
+      |
+   e = X-X_hat
+      |
+ active-set selection
+      |
+ Omega -> Theta -> Pi runtime update -> recur
+```
+
+The backend split is deliberate:
+
+1. the sparse logical runtime owns large-scale state and candidate admission;
+2. `jarvisx.millionfold_inward` selects active refinement regions, evaluates convergence and gates runtime-policy changes;
+3. this Torch backend executes bounded dense 3D tiles;
+4. `sparse_bridge.py` projects accepted tile results back into sparse transactional state.
+
+The complete mathematical contract is documented in `docs/architecture/millionfold-inward-3d.md`.
+
 ## Why this revision differs from the initial prototype
 
 The initial supplied prototype generated hypernetwork kernels but did not apply them, and computed a warped shell that was not used by the loss. This revision closes both loops:
@@ -78,11 +127,18 @@ python engine.py
 
 ```bash
 cd apps/dr-moagi-volumetric-torch
-python -m unittest -v test_engine.py
+python -m unittest -v test_engine.py test_sparse_bridge.py
+
+# repository-root hierarchy/runtime tests
+python -m unittest -v tests/test_millionfold_inward.py
 ```
 
-The focused tests cover zero-flow warp identity, multimodal projection/fusion, dynamic hypernetwork kernel application, and an end-to-end recursive optimization step.
+The focused tests cover zero-flow warp identity, multimodal projection/fusion, dynamic hypernetwork kernel application, an end-to-end recursive optimization step, sparse bridge semantics, the exact `1000^3 -> 100^3 -> 10^3` site ratios, active-set selection, per-region convergence, and measured runtime-policy admission.
 
-## Relationship to the 1000 x 1000 multiparallel runtime
+## Relationship to the logical multiparallel runtime
 
-This module is a dense research backend for active tiles or patches. It does **not** allocate a `1000 x 1000 x depth` dense tensor. A scalable deployment should map sparse active regions from `DrMoagiMultiparallel3D` into bounded dense Torch tiles, execute this backend on those tiles, and project results back into the sparse transactional state.
+This module is a dense research backend for active tiles or patches. It does **not** allocate the full canonical `1000 x 1000 x 1000` logical field densely. A scalable deployment maps sparse active regions into bounded dense Torch tiles, executes this backend on those tiles, and projects accepted results back into sparse transactional state.
+
+The governing execution rule is therefore:
+
+> coarse everywhere; fine only where measured error says it matters.

--- a/docs/architecture/millionfold-inward-3d.md
+++ b/docs/architecture/millionfold-inward-3d.md
@@ -1,0 +1,232 @@
+# Million-Fold Inward 3D Autoencoding Architecture
+
+Status: canonical design target for Jarvis-X volumetric execution.
+
+## Governing principle
+
+The engine does **not** assume a literal 1,000,000x wall-clock speedup. The canonical `10^6` figure is the reduction in coarse logical spatial sites produced by the hierarchy
+
+```text
+1000^3 -> 100^3 -> 10^3
+```
+
+because
+
+```text
+1000^3 / 10^3 = 1,000,000.
+```
+
+Fine detail is retained through sparse residuals and reintroduced only where measured error or information density warrants refinement.
+
+The invariant is:
+
+```text
+World/Input X
+  -> 3D Encoder E_Theta
+  -> inward multiresolution contraction
+  -> sparse active-set refinement
+  -> latent fixed point Z*
+  -> 3D Decoder D_Theta
+  -> reconstruction X_hat
+  -> error e = X - X_hat
+  -> sparse residual encoding
+  -> Omega temporal memory update
+  -> Theta model optimization
+  -> Pi runtime-policy optimization
+  -> retile / sparsify / fuse / recompile
+  -> recur
+```
+
+## State
+
+Let
+
+```text
+S_t = (X_t, Z_t, X_hat_t, e_t, Omega_t, Theta_t, Pi_t).
+```
+
+`Theta_t` contains learned model parameters. `Pi_t` contains execution controls such as tile dimensions, precision, sparsity threshold, recursion depth, kernel choice and memory placement.
+
+## Hierarchical inward contraction
+
+For the canonical logical field,
+
+```text
+|V_0| = 1000^3 = 1,000,000,000
+|V_1| =  100^3 =     1,000,000
+|V_2| =   10^3 =         1,000
+```
+
+Define downsampling operators `D_10` and corresponding reconstruction operators `U_10`:
+
+```text
+Z^(1) = D_10(X)
+R^(0) = X - U_10(Z^(1))
+
+Z^(2) = D_10(Z^(1))
+R^(1) = Z^(1) - U_10(Z^(2)).
+```
+
+The field is reconstructed hierarchically as
+
+```text
+X ~= U_100(Z^(2)) + U_10(R^(1)) + R^(0).
+```
+
+Only sparse subsets of `R^(0)` and `R^(1)` are permitted to consume fine-grained compute.
+
+## Active-set refinement
+
+Let `A_i` be an importance/error score for region `i`, for example
+
+```text
+A_i = lambda_e |e_i|
+    + lambda_g |grad e_i|
+    + lambda_u uncertainty_i
+    + lambda_a attention_i.
+```
+
+The active refinement set is
+
+```text
+A_t = { i : A_i > tau_t }.
+```
+
+This is the execution rule:
+
+> coarse everywhere; fine only where measured error says it matters.
+
+## Recursive latent correction
+
+Initial encoding:
+
+```text
+Z_t^(0) = E_Theta(X_t).
+```
+
+Recursive correction:
+
+```text
+Z_t^(k+1) = T_in(Z_t^(k), Omega_t, Theta_t, Pi_t, A_t^(k)).
+```
+
+A residual-only formulation is
+
+```text
+e_t^(k)      = X_t - D_Theta(Z_t^(k))
+Delta Z_t^k  = E_e(e_t^(k))
+Z_t^(k+1)    = Z_t^(k) + G_Theta(Delta Z_t^k, Omega_t).
+```
+
+Per-region recursion halts when
+
+```text
+||Z_i^(k+1) - Z_i^k||_2 / (||Z_i^k||_2 + epsilon) < tau_Z.
+```
+
+Stable regions freeze; only unresolved regions continue inward.
+
+## Decoder and reconstruction
+
+At the latent attractor,
+
+```text
+X_hat_t = D_Theta(Z_t*).
+```
+
+Reconstruction error:
+
+```text
+e_t = X_t - X_hat_t.
+```
+
+A standard quality objective is
+
+```text
+L_AE = ||X - D(E(X))||_2^2
+     + alpha ||Z - E(D(Z))||_2^2
+     + beta R(Z).
+```
+
+## Memory and temporal reuse
+
+Memory update:
+
+```text
+Omega_(t+1) = rho Omega_t + (1-rho) G_Omega(Z_t*, e_t).
+```
+
+For temporally correlated inputs, predict the next latent state and encode only innovation:
+
+```text
+Z_tilde_(t+1) = P_Theta(Z_t, Omega_t)
+Delta X_(t+1) = X_(t+1) - D(Z_tilde_(t+1))
+Z_(t+1)       = Z_tilde_(t+1) + E(Delta X_(t+1)).
+```
+
+## Runtime self-optimization
+
+`Pi_t` is a backend-neutral execution policy:
+
+```text
+Pi_t = [tile size, precision, sparsity, recursion depth,
+        kernel selection, fusion strategy, memory placement].
+```
+
+Measured cost:
+
+```text
+C_t = [latency, bandwidth, memory, energy, quality loss].
+```
+
+The runtime objective is
+
+```text
+J(Pi, Theta) = L_quality
+             + lambda_T latency
+             + lambda_B bandwidth
+             + lambda_M memory
+             + lambda_E energy.
+```
+
+The outer meta-loop proposes a candidate policy, benchmarks it, and accepts it only if the measured objective improves while the configured quality bound remains satisfied.
+
+This prevents the architecture from confusing theoretical work reduction with achieved performance.
+
+## Effective work reduction
+
+Let `W_R0` and `W_R1` denote surviving sparse residual work. Then
+
+```text
+W_optimized = 10^3 + W_R1 + W_R0
+```
+
+and
+
+```text
+S_effective = 1000^3 / W_optimized.
+```
+
+The theoretical coarse-only limit is therefore
+
+```text
+S_effective = 1000^3 / 10^3 = 10^6,
+```
+
+but any real residual work lowers that number. Wall-clock speedup is always measured separately as
+
+```text
+S_wall = T_baseline / T_optimized.
+```
+
+## Backend mapping
+
+The canonical deployment split is:
+
+- sparse logical runtime: owns the large logical field, active-set selection and transactional state;
+- dense volumetric backend: processes bounded 3D tiles on Torch/CUDA;
+- residual bridge: maps selected sparse regions into dense tiles and projects accepted updates back;
+- policy optimizer: adjusts tiling, precision, recursion, sparsity and fusion from measured telemetry;
+- verifier/CTR layer: rejects candidates that improve speed by violating quality or external correctness constraints.
+
+The reference backend in `apps/dr-moagi-volumetric-torch` already provides recursive residual correction, dense volumetric encode/decode, convergence control and sparse-to-dense bridging. `jarvisx.millionfold_inward` provides the hierarchy, active-set, convergence and runtime-policy primitives that constrain the million-fold optimization target.

--- a/docs/architecture/permeation-phase.md
+++ b/docs/architecture/permeation-phase.md
@@ -1,0 +1,190 @@
+# Jarvis-X Permeation Phase
+
+Status: implementation contract for the post-convergence broadcast phase.
+
+## Purpose
+
+The permeation phase begins after an inward latent/core state has converged. It does not claim that a software process literally saturates physical silicon, photonic hardware, mathematical axioms, image generators, or observers. Instead it defines a common state-transition contract that software, GPU, VM, photonic, and other backends may implement and verify.
+
+The transition is
+
+```text
+inward fixed point X* -> bounded 3D permeation field -> substrate adapters
+```
+
+with the canonical PDE
+
+```text
+dPsi_perm/dt = alpha Laplacian(Psi_perm)
+              - kappa (Psi_perm - Psi_core).
+```
+
+`Psi_core` is the converged signature being broadcast. The relaxation term makes the core state an attractor while diffusion propagates local information through adjacent 3D state.
+
+## Spectral contract
+
+The canonical values are
+
+```text
+alpha = 0.85
+rho_target = 0.85
+dt = 0.1
+```
+
+The number `0.85` has two distinct meanings in the reference configuration:
+
+- `alpha`: normalized diffusion strength;
+- `rho_target`: desired upper bound on the magnitude of the linearized discrete update eigenvalues.
+
+They are numerically equal by configuration but are not mathematically the same quantity.
+
+For the 6-neighbour 3D Laplacian, the discrete spectrum lies in `[-12, 0]`. The explicit update is
+
+```text
+Psi_(n+1) = rho Psi_n
+          + alpha dt Laplacian(Psi_n)
+          + (1-rho) Psi_core.
+```
+
+Equivalently,
+
+```text
+kappa = (1-rho)/dt.
+```
+
+A sufficient stability condition used by the reference implementation is
+
+```text
+alpha dt <= rho / 6.
+```
+
+With `alpha=0.85`, `rho=0.85`, `dt=0.1`,
+
+```text
+0.085 <= 0.141666...
+```
+
+so the reference step remains inside the configured spectral ceiling.
+
+## Constitutional gates
+
+Every candidate permeation step is admitted only if all of the following hold.
+
+### Non-regression
+
+```text
+Delta J = J_candidate - J_baseline <= 0.
+```
+
+The generic reference objective is mean squared distance from the field to the broadcast core signature. Backends may substitute a richer measured objective if they preserve the same gate.
+
+### Spectral stability
+
+```text
+rho(J) < 1.
+```
+
+The backend must not describe a process as stable merely because the configured target is below one. If it measures the true Jacobian or an empirical spectral estimate, that measured value is authoritative.
+
+### Semantic uncertainty
+
+```text
+hbar_semantic > 0.
+```
+
+This is represented as an explicit positive epistemic floor. It prevents downstream interfaces from treating a permeated state as certainty merely because the numerical state converged.
+
+## Sparse 3D boundary semantics
+
+The reference sparse solver uses a no-flux/Neumann boundary condition. Missing neighbours are assigned the center value for the purpose of the Laplacian. Therefore a sparse active region does not leak state through absent coordinates.
+
+For coordinate `i`, one step is
+
+```text
+Psi_i' = rho Psi_i
+       + alpha dt sum_(j in N6(i)) (Psi_j - Psi_i)
+       + (1-rho) Psi_core.
+```
+
+## Solenoidal constraint
+
+A zero-divergence claim applies to vector transport fields, not to arbitrary scalar or multimodal state tensors. The reference module therefore provides a divergence verifier rather than pretending that diffusion automatically performs a Helmholtz projection.
+
+```text
+||div v||_RMS <= epsilon_div
+```
+
+Backends that require a strictly solenoidal velocity/transport field must project that field in the numerical backend and use the verifier as an admission check.
+
+## Integration with the million-fold inward architecture
+
+The canonical system remains
+
+```text
+X
+ -> E_Theta
+ -> 1000^3 -> 100^3 -> 10^3
+ -> sparse active-set refinement
+ -> Z*
+ -> D_Theta
+ -> X_hat
+ -> e
+ -> Omega
+ -> Theta
+ -> Pi
+ -> recur
+```
+
+Permeation is an additional post-convergence broadcast operator:
+
+```text
+Z* / X*
+   |
+   v
+Psi_core
+   |
+   v
+P_Omega(Psi_core, local state)
+   |
+   +--> dense Torch/CUDA tiles
+   +--> sparse transactional runtime
+   +--> VM/bytecode state adapters
+   +--> GPU visualization adapters
+   +--> future photonic/hardware adapters
+```
+
+The operator is not allowed to bypass the existing active-set, quality, transactional, or runtime-policy gates.
+
+## Saturation
+
+A system is described as numerically saturated only relative to an explicit tolerance:
+
+```text
+S(tau) = |{i : ||Psi_i - Psi_core|| <= tau}| / |V|.
+```
+
+`S(tau)=1` means all represented sites are within `tau` of the core signature. It does not imply physical saturation outside the represented computational domain.
+
+## Implementation
+
+Reference code:
+
+```text
+src/jarvisx/permeation.py
+```
+
+Tests:
+
+```text
+tests/test_permeation.py
+```
+
+The module supplies:
+
+- `PermeationConstitution`;
+- stable 6-neighbour 3D `permeation_step`;
+- `permeate` with per-step constitutional admission;
+- `distance_to_core` and `saturation_fraction`;
+- `divergence_rms` and `solenoidal_within`.
+
+The implementation intentionally distinguishes mathematical contracts from deployment claims. GPU, VM, photonic, image-generation, and other substrate integrations become `PERMEATED` only when a concrete adapter implements this contract and passes its verification gates.

--- a/src/jarvisx/millionfold_inward.py
+++ b/src/jarvisx/millionfold_inward.py
@@ -1,0 +1,308 @@
+"""Million-fold inward 3D hierarchy and runtime-policy controls.
+
+This module formalizes the canonical 1000^3 -> 100^3 -> 10^3 logical
+contraction without claiming a literal 1,000,000x wall-clock speedup.  The
+million-fold figure is the reduction in coarse spatial sites between the full
+logical field and the 10^3 core.  Fine detail is recovered selectively through
+sparse residual refinement.
+
+The governing execution principle is:
+
+    coarse everywhere; fine only where measured error says it matters.
+
+The implementation is intentionally backend-agnostic.  Dense Torch/CUDA tile
+execution can consume its active-set and convergence decisions while sparse
+transactional runtimes retain authority over admission/commit semantics.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable, Mapping, Sequence
+
+Coordinate3D = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class MillionFoldConfig:
+    """Canonical three-level inward hierarchy.
+
+    ``full_side=1000``, ``mid_side=100`` and ``core_side=10`` give:
+
+        1000^3 = 1,000,000,000 sites
+         100^3 =     1,000,000 sites
+          10^3 =         1,000 sites
+
+    so full/core = 1,000,000.
+    """
+
+    full_side: int = 1000
+    mid_side: int = 100
+    core_side: int = 10
+    error_threshold: float = 1.0e-3
+    convergence_tol: float = 1.0e-5
+    max_active_fraction: float = 1.0e-3
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("full_side", self.full_side),
+            ("mid_side", self.mid_side),
+            ("core_side", self.core_side),
+        ):
+            if value <= 0:
+                raise ValueError(f"{name} must be positive")
+        if not (self.full_side > self.mid_side > self.core_side):
+            raise ValueError("expected full_side > mid_side > core_side")
+        if self.full_side % self.mid_side or self.mid_side % self.core_side:
+            raise ValueError("hierarchy sides must divide exactly")
+        if not math.isfinite(self.error_threshold) or self.error_threshold < 0.0:
+            raise ValueError("error_threshold must be finite and non-negative")
+        if not math.isfinite(self.convergence_tol) or self.convergence_tol < 0.0:
+            raise ValueError("convergence_tol must be finite and non-negative")
+        if not (0.0 < self.max_active_fraction <= 1.0):
+            raise ValueError("max_active_fraction must be in (0, 1]")
+
+    @property
+    def full_sites(self) -> int:
+        return self.full_side**3
+
+    @property
+    def mid_sites(self) -> int:
+        return self.mid_side**3
+
+    @property
+    def core_sites(self) -> int:
+        return self.core_side**3
+
+    @property
+    def full_to_mid_reduction(self) -> float:
+        return self.full_sites / self.mid_sites
+
+    @property
+    def mid_to_core_reduction(self) -> float:
+        return self.mid_sites / self.core_sites
+
+    @property
+    def coarse_spatial_reduction(self) -> float:
+        return self.full_sites / self.core_sites
+
+    @property
+    def max_active_sites(self) -> int:
+        return max(1, math.ceil(self.full_sites * self.max_active_fraction))
+
+
+@dataclass(frozen=True)
+class ResidualWork:
+    """Count the work that survives the coarse hierarchy.
+
+    ``level0_sites`` represents full-resolution residual work and
+    ``level1_sites`` represents mid-resolution residual work.  Counts are work
+    accounting units; callers may use active voxels, active tiles or another
+    consistently measured unit.
+    """
+
+    level0_sites: int = 0
+    level1_sites: int = 0
+
+    def __post_init__(self) -> None:
+        if self.level0_sites < 0 or self.level1_sites < 0:
+            raise ValueError("residual work counts must be non-negative")
+
+    @property
+    def total(self) -> int:
+        return self.level0_sites + self.level1_sites
+
+
+def effective_work_speedup(
+    config: MillionFoldConfig,
+    residual: ResidualWork = ResidualWork(),
+) -> float:
+    """Return full logical work divided by optimized coarse+residual work.
+
+    This is an *effective work reduction*, not a wall-clock benchmark.
+    """
+
+    optimized_work = config.core_sites + residual.total
+    if optimized_work <= 0:  # Defensive; core_sites is positive by construction.
+        raise ValueError("optimized work must be positive")
+    return config.full_sites / optimized_work
+
+
+class ActiveSetController:
+    """Select high-error 3D regions for fine residual refinement."""
+
+    def __init__(self, config: MillionFoldConfig | None = None) -> None:
+        self.config = config or MillionFoldConfig()
+
+    def select(
+        self,
+        errors: Mapping[Coordinate3D, float],
+        *,
+        threshold: float | None = None,
+        max_active: int | None = None,
+    ) -> tuple[Coordinate3D, ...]:
+        limit = self.config.max_active_sites if max_active is None else max_active
+        if limit <= 0:
+            raise ValueError("max_active must be positive")
+        cutoff = self.config.error_threshold if threshold is None else threshold
+        if not math.isfinite(cutoff) or cutoff < 0.0:
+            raise ValueError("threshold must be finite and non-negative")
+
+        ranked: list[tuple[float, Coordinate3D]] = []
+        for coordinate, error in errors.items():
+            if len(coordinate) != 3:
+                raise ValueError("coordinates must be (x, y, z)")
+            if not math.isfinite(error) or error < 0.0:
+                raise ValueError("errors must be finite and non-negative")
+            if error > cutoff:
+                ranked.append((error, coordinate))
+
+        # Stable deterministic selection: highest error first, then coordinate.
+        ranked.sort(key=lambda item: (-item[0], item[1]))
+        return tuple(coordinate for _error, coordinate in ranked[:limit])
+
+
+def relative_state_delta(
+    previous: Sequence[float],
+    current: Sequence[float],
+    *,
+    epsilon: float = 1.0e-12,
+) -> float:
+    """Compute ||current-previous||_2 / (||previous||_2 + epsilon)."""
+
+    if len(previous) != len(current):
+        raise ValueError("states must have equal length")
+    if not previous:
+        return 0.0
+    if epsilon <= 0.0 or not math.isfinite(epsilon):
+        raise ValueError("epsilon must be finite and positive")
+
+    delta_sq = 0.0
+    previous_sq = 0.0
+    for old, new in zip(previous, current):
+        if not math.isfinite(old) or not math.isfinite(new):
+            raise ValueError("state values must be finite")
+        delta_sq += (new - old) ** 2
+        previous_sq += old**2
+    return math.sqrt(delta_sq) / (math.sqrt(previous_sq) + epsilon)
+
+
+def region_converged(
+    previous: Sequence[float],
+    current: Sequence[float],
+    *,
+    tolerance: float,
+) -> bool:
+    if tolerance < 0.0 or not math.isfinite(tolerance):
+        raise ValueError("tolerance must be finite and non-negative")
+    return relative_state_delta(previous, current) <= tolerance
+
+
+@dataclass(frozen=True)
+class RuntimeCost:
+    """Measured runtime and quality telemetry for one execution policy."""
+
+    latency_s: float
+    bandwidth_bytes: float
+    memory_bytes: float
+    energy_j: float
+    quality_loss: float
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("latency_s", self.latency_s),
+            ("bandwidth_bytes", self.bandwidth_bytes),
+            ("memory_bytes", self.memory_bytes),
+            ("energy_j", self.energy_j),
+            ("quality_loss", self.quality_loss),
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError(f"{name} must be finite and non-negative")
+
+
+@dataclass(frozen=True)
+class RuntimeWeights:
+    latency: float = 1.0
+    bandwidth: float = 0.0
+    memory: float = 0.0
+    energy: float = 0.0
+    quality: float = 1.0
+
+    def __post_init__(self) -> None:
+        for value in (
+            self.latency,
+            self.bandwidth,
+            self.memory,
+            self.energy,
+            self.quality,
+        ):
+            if not math.isfinite(value) or value < 0.0:
+                raise ValueError("runtime weights must be finite and non-negative")
+
+
+def runtime_objective(cost: RuntimeCost, weights: RuntimeWeights = RuntimeWeights()) -> float:
+    """Scalar objective for measured runtime-policy selection."""
+
+    return (
+        weights.latency * cost.latency_s
+        + weights.bandwidth * cost.bandwidth_bytes
+        + weights.memory * cost.memory_bytes
+        + weights.energy * cost.energy_j
+        + weights.quality * cost.quality_loss
+    )
+
+
+def accept_runtime_candidate(
+    baseline: RuntimeCost,
+    candidate: RuntimeCost,
+    *,
+    max_quality_loss: float,
+    weights: RuntimeWeights = RuntimeWeights(),
+) -> bool:
+    """Accept a self-optimization only if it is measured better and safe.
+
+    The candidate must stay inside the explicit quality bound and strictly
+    improve the configured scalar objective.  This prevents the meta-loop from
+    treating a theoretical spatial reduction as an achieved runtime speedup.
+    """
+
+    if max_quality_loss < 0.0 or not math.isfinite(max_quality_loss):
+        raise ValueError("max_quality_loss must be finite and non-negative")
+    if candidate.quality_loss > max_quality_loss:
+        return False
+    return runtime_objective(candidate, weights) < runtime_objective(baseline, weights)
+
+
+@dataclass(frozen=True)
+class RuntimePolicy:
+    """Backend-neutral execution controls optimized by the outer meta-loop."""
+
+    tile_side: int = 16
+    precision_bits: int = 16
+    recursion_depth: int = 2
+    sparsity_threshold: float = 1.0e-3
+    fused_operators: bool = True
+
+    def __post_init__(self) -> None:
+        if self.tile_side <= 0:
+            raise ValueError("tile_side must be positive")
+        if self.precision_bits not in {4, 8, 16, 32, 64}:
+            raise ValueError("precision_bits must be one of 4, 8, 16, 32, 64")
+        if self.recursion_depth < 0:
+            raise ValueError("recursion_depth must be non-negative")
+        if not math.isfinite(self.sparsity_threshold) or self.sparsity_threshold < 0.0:
+            raise ValueError("sparsity_threshold must be finite and non-negative")
+
+
+def count_active_errors(errors: Iterable[float], threshold: float) -> int:
+    """Count residual elements whose measured error warrants fine refinement."""
+
+    if threshold < 0.0 or not math.isfinite(threshold):
+        raise ValueError("threshold must be finite and non-negative")
+    count = 0
+    for error in errors:
+        if not math.isfinite(error) or error < 0.0:
+            raise ValueError("errors must be finite and non-negative")
+        if error > threshold:
+            count += 1
+    return count

--- a/src/jarvisx/permeation.py
+++ b/src/jarvisx/permeation.py
@@ -1,0 +1,293 @@
+"""Bounded 3D permeation field for the Jarvis-X inward architecture.
+
+The permeation phase broadcasts a converged core signature through adjacent
+3D state while preserving explicit constitutional gates:
+
+* non-regression: candidate objective may not increase;
+* spectral stability: the linearized diffusion/relaxation ceiling stays < 1;
+* semantic uncertainty: hbar_semantic remains strictly positive.
+
+The reference update is a diffusion-relaxation equation
+
+    dPsi/dt = alpha * Laplacian(Psi) - kappa * (Psi - Psi_core)
+
+with kappa chosen so the constant spatial mode contracts by the configured
+``target_spectral_radius`` per discrete step.  The implementation is backend
+agnostic and uses sparse coordinate maps; GPU/Torch backends may implement the
+same contract with dense kernels.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Mapping, Sequence
+
+Coordinate3D = tuple[int, int, int]
+Vector = tuple[float, ...]
+Field3D = Mapping[Coordinate3D, Sequence[float]]
+
+_NEIGHBORS: tuple[Coordinate3D, ...] = (
+    (1, 0, 0),
+    (-1, 0, 0),
+    (0, 1, 0),
+    (0, -1, 0),
+    (0, 0, 1),
+    (0, 0, -1),
+)
+
+
+@dataclass(frozen=True)
+class PermeationConstitution:
+    """Stability and epistemic constraints for one permeation process."""
+
+    alpha: float = 0.85
+    dt: float = 0.1
+    target_spectral_radius: float = 0.85
+    semantic_hbar: float = 1.0e-4
+    non_regression_tolerance: float = 0.0
+    max_steps: int = 8
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.alpha) or self.alpha < 0.0:
+            raise ValueError("alpha must be finite and non-negative")
+        if not math.isfinite(self.dt) or self.dt <= 0.0:
+            raise ValueError("dt must be finite and positive")
+        if not (0.0 <= self.target_spectral_radius < 1.0):
+            raise ValueError("target_spectral_radius must be in [0, 1)")
+        if not math.isfinite(self.semantic_hbar) or self.semantic_hbar <= 0.0:
+            raise ValueError("semantic_hbar must be finite and strictly positive")
+        if (
+            not math.isfinite(self.non_regression_tolerance)
+            or self.non_regression_tolerance < 0.0
+        ):
+            raise ValueError("non_regression_tolerance must be finite and non-negative")
+        if self.max_steps < 0:
+            raise ValueError("max_steps must be non-negative")
+
+        # For the 6-neighbour 3D Laplacian, lambda(L) lies in [-12, 0].
+        # The explicit update eigenvalues are rho + alpha*dt*lambda(L).
+        # alpha*dt <= rho/6 therefore bounds their magnitude by rho.
+        if self.alpha * self.dt > self.target_spectral_radius / 6.0 + 1.0e-15:
+            raise ValueError(
+                "unstable permeation step: require alpha*dt <= target_spectral_radius/6"
+            )
+
+    @property
+    def relaxation_gain(self) -> float:
+        """Return kappa such that 1 - kappa*dt equals the target radius."""
+
+        return (1.0 - self.target_spectral_radius) / self.dt
+
+    @property
+    def theoretical_spectral_ceiling(self) -> float:
+        return self.target_spectral_radius
+
+
+@dataclass(frozen=True)
+class PermeationResult:
+    field: dict[Coordinate3D, Vector]
+    objective_history: tuple[float, ...]
+    accepted_steps: int
+    rejected_steps: int
+    theoretical_spectral_ceiling: float
+    semantic_hbar: float
+
+
+def _validate_field(field: Field3D, core_signature: Sequence[float]) -> int:
+    width = len(core_signature)
+    if width <= 0:
+        raise ValueError("core_signature must contain at least one channel")
+    for value in core_signature:
+        if not math.isfinite(value):
+            raise ValueError("core_signature values must be finite")
+    for coordinate, value in field.items():
+        if len(coordinate) != 3:
+            raise ValueError("field coordinates must be (x, y, z)")
+        if len(value) != width:
+            raise ValueError("all field vectors must match core_signature width")
+        if any(not math.isfinite(component) for component in value):
+            raise ValueError("field values must be finite")
+    return width
+
+
+def distance_to_core(field: Field3D, core_signature: Sequence[float]) -> float:
+    """Mean squared distance from the field to the broadcast core signature."""
+
+    width = _validate_field(field, core_signature)
+    if not field:
+        return 0.0
+    total = 0.0
+    for value in field.values():
+        total += sum((value[index] - core_signature[index]) ** 2 for index in range(width))
+    return total / (len(field) * width)
+
+
+def permeation_step(
+    field: Field3D,
+    core_signature: Sequence[float],
+    constitution: PermeationConstitution = PermeationConstitution(),
+) -> dict[Coordinate3D, Vector]:
+    """Apply one stable 6-neighbour 3D diffusion-relaxation update.
+
+    Missing sparse neighbours use a no-flux (Neumann) boundary: their value is
+    treated as the center value, so sparse-domain boundaries do not leak state.
+    """
+
+    width = _validate_field(field, core_signature)
+    if not field:
+        return {}
+
+    alpha_dt = constitution.alpha * constitution.dt
+    rho = constitution.target_spectral_radius
+    source_weight = 1.0 - rho
+    output: dict[Coordinate3D, Vector] = {}
+
+    for coordinate, raw_center in field.items():
+        center = tuple(float(value) for value in raw_center)
+        laplacian = [0.0] * width
+        x, y, z = coordinate
+        for dx, dy, dz in _NEIGHBORS:
+            neighbour = field.get((x + dx, y + dy, z + dz), center)
+            for channel in range(width):
+                laplacian[channel] += float(neighbour[channel]) - center[channel]
+
+        output[coordinate] = tuple(
+            rho * center[channel]
+            + alpha_dt * laplacian[channel]
+            + source_weight * float(core_signature[channel])
+            for channel in range(width)
+        )
+    return output
+
+
+def constitutional_gate(
+    baseline_objective: float,
+    candidate_objective: float,
+    *,
+    measured_spectral_radius: float,
+    constitution: PermeationConstitution = PermeationConstitution(),
+) -> bool:
+    """Enforce Delta J <= 0, rho < 1 and hbar_semantic > 0."""
+
+    for name, value in (
+        ("baseline_objective", baseline_objective),
+        ("candidate_objective", candidate_objective),
+        ("measured_spectral_radius", measured_spectral_radius),
+    ):
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError(f"{name} must be finite and non-negative")
+
+    non_regression = (
+        candidate_objective
+        <= baseline_objective + constitution.non_regression_tolerance
+    )
+    spectrally_stable = measured_spectral_radius < 1.0
+    epistemically_open = constitution.semantic_hbar > 0.0
+    return non_regression and spectrally_stable and epistemically_open
+
+
+def permeate(
+    field: Field3D,
+    core_signature: Sequence[float],
+    constitution: PermeationConstitution = PermeationConstitution(),
+    *,
+    steps: int | None = None,
+) -> PermeationResult:
+    """Broadcast the core signature while accepting only non-regressive steps."""
+
+    requested_steps = constitution.max_steps if steps is None else steps
+    if requested_steps < 0:
+        raise ValueError("steps must be non-negative")
+
+    current = {
+        coordinate: tuple(float(component) for component in value)
+        for coordinate, value in field.items()
+    }
+    objective = distance_to_core(current, core_signature)
+    history = [objective]
+    accepted = 0
+    rejected = 0
+
+    for _ in range(requested_steps):
+        candidate = permeation_step(current, core_signature, constitution)
+        candidate_objective = distance_to_core(candidate, core_signature)
+        if not constitutional_gate(
+            objective,
+            candidate_objective,
+            measured_spectral_radius=constitution.theoretical_spectral_ceiling,
+            constitution=constitution,
+        ):
+            rejected += 1
+            break
+        current = candidate
+        objective = candidate_objective
+        history.append(objective)
+        accepted += 1
+
+    return PermeationResult(
+        field=current,
+        objective_history=tuple(history),
+        accepted_steps=accepted,
+        rejected_steps=rejected,
+        theoretical_spectral_ceiling=constitution.theoretical_spectral_ceiling,
+        semantic_hbar=constitution.semantic_hbar,
+    )
+
+
+def saturation_fraction(
+    field: Field3D,
+    core_signature: Sequence[float],
+    *,
+    tolerance: float,
+) -> float:
+    """Fraction of sites whose Euclidean distance to the core is <= tolerance."""
+
+    if not math.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError("tolerance must be finite and non-negative")
+    width = _validate_field(field, core_signature)
+    if not field:
+        return 1.0
+    saturated = 0
+    for value in field.values():
+        distance = math.sqrt(
+            sum((value[index] - core_signature[index]) ** 2 for index in range(width))
+        )
+        if distance <= tolerance:
+            saturated += 1
+    return saturated / len(field)
+
+
+def divergence_rms(vector_field: Field3D) -> float:
+    """Estimate RMS divergence for a 3-channel vector field on a sparse grid.
+
+    This is a verifier, not a Helmholtz projection.  Callers that require a
+    strictly solenoidal field must project it in their numerical backend and
+    use this metric as an admission check.
+    """
+
+    _validate_field(vector_field, (0.0, 0.0, 0.0))
+    if not vector_field:
+        return 0.0
+
+    divergence_sq = 0.0
+    for (x, y, z), raw_center in vector_field.items():
+        center = tuple(float(value) for value in raw_center)
+        xp = vector_field.get((x + 1, y, z), center)
+        xm = vector_field.get((x - 1, y, z), center)
+        yp = vector_field.get((x, y + 1, z), center)
+        ym = vector_field.get((x, y - 1, z), center)
+        zp = vector_field.get((x, y, z + 1), center)
+        zm = vector_field.get((x, y, z - 1), center)
+        divergence = (
+            0.5 * (float(xp[0]) - float(xm[0]))
+            + 0.5 * (float(yp[1]) - float(ym[1]))
+            + 0.5 * (float(zp[2]) - float(zm[2]))
+        )
+        divergence_sq += divergence**2
+    return math.sqrt(divergence_sq / len(vector_field))
+
+
+def solenoidal_within(vector_field: Field3D, *, tolerance: float) -> bool:
+    if not math.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError("tolerance must be finite and non-negative")
+    return divergence_rms(vector_field) <= tolerance

--- a/tests/test_millionfold_inward.py
+++ b/tests/test_millionfold_inward.py
@@ -1,0 +1,102 @@
+import unittest
+
+from jarvisx.millionfold_inward import (
+    ActiveSetController,
+    MillionFoldConfig,
+    ResidualWork,
+    RuntimeCost,
+    RuntimePolicy,
+    RuntimeWeights,
+    accept_runtime_candidate,
+    effective_work_speedup,
+    region_converged,
+    relative_state_delta,
+    runtime_objective,
+)
+
+
+class MillionFoldHierarchyTests(unittest.TestCase):
+    def test_canonical_spatial_reduction_is_one_million(self) -> None:
+        config = MillionFoldConfig()
+        self.assertEqual(config.full_sites, 1_000_000_000)
+        self.assertEqual(config.mid_sites, 1_000_000)
+        self.assertEqual(config.core_sites, 1_000)
+        self.assertEqual(config.full_to_mid_reduction, 1_000.0)
+        self.assertEqual(config.mid_to_core_reduction, 1_000.0)
+        self.assertEqual(config.coarse_spatial_reduction, 1_000_000.0)
+
+    def test_effective_speedup_accounts_for_residual_work(self) -> None:
+        config = MillionFoldConfig()
+        self.assertEqual(effective_work_speedup(config), 1_000_000.0)
+        speedup = effective_work_speedup(
+            config,
+            ResidualWork(level0_sites=999_000, level1_sites=0),
+        )
+        self.assertEqual(speedup, 1_000.0)
+
+    def test_active_set_uses_error_priority_and_cap(self) -> None:
+        controller = ActiveSetController(MillionFoldConfig(error_threshold=0.1))
+        selected = controller.select(
+            {
+                (0, 0, 0): 0.05,
+                (1, 0, 0): 0.20,
+                (2, 0, 0): 0.40,
+                (3, 0, 0): 0.30,
+            },
+            max_active=2,
+        )
+        self.assertEqual(selected, ((2, 0, 0), (3, 0, 0)))
+
+    def test_relative_delta_and_per_region_convergence(self) -> None:
+        previous = (1.0, 1.0, 1.0)
+        current = (1.0, 1.0, 1.000001)
+        delta = relative_state_delta(previous, current)
+        self.assertGreater(delta, 0.0)
+        self.assertTrue(region_converged(previous, current, tolerance=1.0e-5))
+        self.assertFalse(region_converged(previous, current, tolerance=1.0e-8))
+
+
+class RuntimePolicyTests(unittest.TestCase):
+    def test_runtime_candidate_requires_measured_improvement(self) -> None:
+        baseline = RuntimeCost(
+            latency_s=10.0,
+            bandwidth_bytes=100.0,
+            memory_bytes=100.0,
+            energy_j=5.0,
+            quality_loss=0.01,
+        )
+        candidate = RuntimeCost(
+            latency_s=5.0,
+            bandwidth_bytes=80.0,
+            memory_bytes=90.0,
+            energy_j=4.0,
+            quality_loss=0.02,
+        )
+        weights = RuntimeWeights(latency=1.0, quality=10.0)
+        self.assertLess(runtime_objective(candidate, weights), runtime_objective(baseline, weights))
+        self.assertTrue(
+            accept_runtime_candidate(
+                baseline,
+                candidate,
+                max_quality_loss=0.025,
+                weights=weights,
+            )
+        )
+        self.assertFalse(
+            accept_runtime_candidate(
+                baseline,
+                candidate,
+                max_quality_loss=0.015,
+                weights=weights,
+            )
+        )
+
+    def test_runtime_policy_validates_precision(self) -> None:
+        policy = RuntimePolicy(precision_bits=8, recursion_depth=4)
+        self.assertEqual(policy.precision_bits, 8)
+        with self.assertRaises(ValueError):
+            RuntimePolicy(precision_bits=12)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_permeation.py
+++ b/tests/test_permeation.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from jarvisx.permeation import (
+    PermeationConstitution,
+    constitutional_gate,
+    distance_to_core,
+    divergence_rms,
+    permeate,
+    permeation_step,
+    saturation_fraction,
+    solenoidal_within,
+)
+
+
+def test_default_constitution_matches_locked_spectral_contract() -> None:
+    constitution = PermeationConstitution()
+    assert constitution.alpha == pytest.approx(0.85)
+    assert constitution.target_spectral_radius == pytest.approx(0.85)
+    assert constitution.semantic_hbar > 0.0
+    assert constitution.alpha * constitution.dt <= constitution.target_spectral_radius / 6.0
+    assert constitution.relaxation_gain == pytest.approx(1.5)
+
+
+def test_unstable_explicit_step_is_rejected() -> None:
+    with pytest.raises(ValueError, match="unstable permeation step"):
+        PermeationConstitution(alpha=0.85, dt=0.2, target_spectral_radius=0.85)
+
+
+def test_constant_mode_contracts_exactly_by_target_radius() -> None:
+    field = {(0, 0, 0): (1.0,)}
+    updated = permeation_step(field, (0.0,))
+    assert updated[(0, 0, 0)][0] == pytest.approx(0.85)
+
+
+def test_diffusion_moves_signal_to_adjacent_site_without_regression() -> None:
+    field = {
+        (0, 0, 0): (1.0,),
+        (1, 0, 0): (0.0,),
+    }
+    baseline = distance_to_core(field, (0.0,))
+    candidate = permeation_step(field, (0.0,))
+    assert candidate[(0, 0, 0)][0] == pytest.approx(0.765)
+    assert candidate[(1, 0, 0)][0] == pytest.approx(0.085)
+    assert distance_to_core(candidate, (0.0,)) < baseline
+
+
+def test_permeation_accepts_monotone_steps() -> None:
+    field = {
+        (0, 0, 0): (1.0, -1.0),
+        (1, 0, 0): (0.5, -0.5),
+        (2, 0, 0): (0.25, -0.25),
+    }
+    result = permeate(field, (0.0, 0.0), steps=4)
+    assert result.accepted_steps == 4
+    assert result.rejected_steps == 0
+    assert len(result.objective_history) == 5
+    assert all(
+        later <= earlier
+        for earlier, later in zip(result.objective_history, result.objective_history[1:])
+    )
+    assert result.theoretical_spectral_ceiling == pytest.approx(0.85)
+    assert result.semantic_hbar > 0.0
+
+
+def test_constitutional_gate_rejects_regression_and_unstable_radius() -> None:
+    constitution = PermeationConstitution()
+    assert constitutional_gate(
+        1.0,
+        0.9,
+        measured_spectral_radius=0.85,
+        constitution=constitution,
+    )
+    assert not constitutional_gate(
+        1.0,
+        1.01,
+        measured_spectral_radius=0.85,
+        constitution=constitution,
+    )
+    assert not constitutional_gate(
+        1.0,
+        0.9,
+        measured_spectral_radius=1.0,
+        constitution=constitution,
+    )
+
+
+def test_semantic_uncertainty_must_remain_positive() -> None:
+    with pytest.raises(ValueError, match="semantic_hbar"):
+        PermeationConstitution(semantic_hbar=0.0)
+
+
+def test_saturation_fraction_reports_sites_near_core() -> None:
+    field = {
+        (0, 0, 0): (0.01,),
+        (1, 0, 0): (0.1,),
+        (2, 0, 0): (1.0,),
+    }
+    assert saturation_fraction(field, (0.0,), tolerance=0.11) == pytest.approx(2.0 / 3.0)
+
+
+def test_constant_vector_field_is_solenoidal_under_no_flux_boundary() -> None:
+    field = {
+        (0, 0, 0): (1.0, 2.0, 3.0),
+        (1, 0, 0): (1.0, 2.0, 3.0),
+        (0, 1, 0): (1.0, 2.0, 3.0),
+        (0, 0, 1): (1.0, 2.0, 3.0),
+    }
+    assert divergence_rms(field) == pytest.approx(0.0)
+    assert solenoidal_within(field, tolerance=1.0e-12)
+
+
+def test_divergent_vector_field_is_detected() -> None:
+    field = {
+        (-1, 0, 0): (-1.0, 0.0, 0.0),
+        (0, 0, 0): (0.0, 0.0, 0.0),
+        (1, 0, 0): (1.0, 0.0, 0.0),
+    }
+    assert math.isfinite(divergence_rms(field))
+    assert divergence_rms(field) > 0.0
+    assert not solenoidal_within(field, tolerance=0.0)


### PR DESCRIPTION
## Summary

Permeates the locked million-fold inward 3D autoencoding architecture into the existing Jarvis-X volumetric path without replacing the current Torch backend, and adds the bounded post-convergence **Permeation Phase**.

### Million-fold inward core
- `src/jarvisx/millionfold_inward.py`
  - canonical `1000^3 -> 100^3 -> 10^3` hierarchy
  - exact coarse spatial reduction accounting (`10^6`)
  - sparse residual work accounting
  - high-error active-set selection
  - per-region convergence checks
  - backend-neutral runtime policy representation
  - measured runtime/quality objective and candidate admission
- `tests/test_millionfold_inward.py`
  - verifies exact hierarchy ratios
  - verifies residual-aware effective work reduction
  - verifies active-set ranking/capping
  - verifies convergence behavior
  - verifies runtime optimization cannot trade through the quality bound
- `docs/architecture/millionfold-inward-3d.md`
  - end-to-end mathematical and operational contract
- volumetric Torch README integration

### Permeation phase
- `src/jarvisx/permeation.py`
  - stable sparse 6-neighbour 3D diffusion-relaxation field
  - canonical `alpha=0.85`, target spectral ceiling `rho=0.85`
  - explicit stability guard `alpha*dt <= rho/6`
  - relaxation toward the converged core signature
  - constitutional non-regression gate `Delta J <= 0`
  - strictly positive `hbar_semantic` epistemic floor
  - saturation metric relative to an explicit tolerance
  - RMS divergence verifier for optional solenoidal transport fields
- `tests/test_permeation.py`
  - verifies stability configuration and rejection of unstable timesteps
  - verifies exact constant-mode contraction by `rho`
  - verifies diffusion, monotone objective admission, uncertainty enforcement, saturation, and divergence checks
- `docs/architecture/permeation-phase.md`
  - formal PDE, stability derivation, constitutional gates, sparse boundary conditions, and substrate-adapter semantics

## Architectural invariant

`X -> E_Theta -> inward hierarchy -> sparse refinement -> Z* -> D_Theta -> X_hat -> e -> Omega -> Theta -> Pi -> recur`

After convergence, the optional broadcast layer is:

`X*/Z* -> Psi_core -> bounded P_Omega -> verified substrate adapters`

The reference permeation equation is:

`dPsi/dt = alpha Laplacian(Psi) - kappa (Psi - Psi_core)`

with `kappa=(1-rho)/dt`.

## Constitutional enforcement

A permeation candidate is admitted only when:

- `Delta J <= 0` (non-regression),
- measured/configured spectral radius remains `< 1`,
- `hbar_semantic > 0`.

A zero-divergence claim is applied only to vector transport fields. The reference module verifies divergence but does not pretend diffusion itself performs a Helmholtz projection.

## Performance semantics

The `10^6` number is explicitly defined as the **coarse spatial-site reduction target**, not an assumed wall-clock speedup. Actual acceleration remains `T_baseline / T_optimized` and runtime-policy changes are admitted only from measured telemetry while respecting a quality-loss bound.

Similarly, references to GPU, VM, photonic, image-generation, or physical layers are implementation targets, not claims of physical saturation. A layer is considered permeated only when a concrete adapter implements the contract and passes verification.

## Compatibility

The existing dense Torch backend remains responsible for bounded 3D tiles. The existing sparse transactional runtime remains responsible for logical state/admission. The million-fold module supplies the hierarchy, active-set, convergence, and runtime-policy primitives; the permeation module supplies the bounded post-convergence broadcast contract.